### PR TITLE
UI Enhancement - Add Spouse to Person Panel

### DIFF
--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -73,6 +73,8 @@ public class PersonViewPanel extends javax.swing.JPanel {
 	private javax.swing.JLabel lblImplants2;
 	private javax.swing.JLabel lblAdvancedMedical1;
 	private javax.swing.JLabel lblAdvancedMedical2;
+	private javax.swing.JLabel lblSpouse1;
+    private javax.swing.JLabel lblSpouse2;
 	
 	
 	public PersonViewPanel(Person p, Campaign c, DirectoryItems portraits) {
@@ -269,6 +271,8 @@ public class PersonViewPanel extends javax.swing.JPanel {
 		lblImplants2 = new JLabel();
 		lblAdvancedMedical1 = new JLabel();
 		lblAdvancedMedical2 = new JLabel();
+		lblSpouse1 = new JLabel();
+        lblSpouse2 = new JLabel();
     	
     	java.awt.GridBagConstraints gridBagConstraints;
 		pnlStats.setLayout(new GridBagLayout());
@@ -451,6 +455,30 @@ public class PersonViewPanel extends javax.swing.JPanel {
 			secondy = firsty;
 		}
 			
+		if (null != person.getSpouseID()) {
+            secondy++;
+            lblSpouse1.setName("lblSpouse1"); // NOI18N
+            lblSpouse1.setText(resourceMap.getString("lblSpouse1.text"));
+            gridBagConstraints = new GridBagConstraints();
+            gridBagConstraints.gridx = 0;
+            gridBagConstraints.gridy = secondy;
+            gridBagConstraints.fill = GridBagConstraints.NONE;
+            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+            pnlStats.add(lblSpouse1, gridBagConstraints);
+               
+            lblSpouse2.setName("lblSpouse2"); // NOI18N
+            lblSpouse2.setText(person.getSpouse().getFullName());
+            gridBagConstraints = new GridBagConstraints();
+            gridBagConstraints.gridx = 1;
+            gridBagConstraints.gridy = secondy;
+            gridBagConstraints.gridwidth = 3;
+            gridBagConstraints.weightx = 1.0;
+            gridBagConstraints.insets = new Insets(0, 10, 0, 0);
+            gridBagConstraints.fill = GridBagConstraints.NONE;
+            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+            pnlStats.add(lblSpouse2, gridBagConstraints);
+        }
+		
 		if(campaign.getCampaignOptions().useAbilities() && person.countOptions(PilotOptions.LVL3_ADVANTAGES) > 0) {
 			secondy++;
 			lblAbility1.setName("lblAbility1"); // NOI18N

--- a/MekHQ/src/mekhq/resources/PersonViewPanel.properties
+++ b/MekHQ/src/mekhq/resources/PersonViewPanel.properties
@@ -14,3 +14,4 @@ lblImplants1.text=<html><b>Implants:</b></html>;
 lblAdvancedMedical1.text=<html><b>Injury Penalties:</b></html>;
 lblInjuries.text=<html><b>Injuries:</b></html>;
 lblEdge1.text=<html><b>Edge:</b></html>;
+lblSpouse1.text=<html><b>Spouse:</b></html>;


### PR DESCRIPTION
Allows the user easier access to who a selected persons spouse is over searching long logs or when a marriage log entry has already been deleted.