### PR TITLE
Point at github bug trackers, mention zipping the attached files.

### DIFF
--- a/MekHQ/SubmitBug.html
+++ b/MekHQ/SubmitBug.html
@@ -10,23 +10,25 @@ you find them.</p>
 
 <p>MekHQ uses both MegaMek and MegaMekLab. If you encounter a problem while playing a game, you
 should report that to the MegaMek bug tracker, rather than the MekHQ bug tracker. Similarly, if you
-encounter a bug while trying to customize a unit within the MekLab, you should report that bug to the
-MegaMekLab bug tracker. Here are the links for all three bug tackers:</p>
+encounter a bug while trying to customize a unit within the Mek Lab, you should report that bug to the
+MegaMekLab bug tracker. Here are the links for all three bug trackers:</p>
 
 <p><a href="https://sourceforge.net/p/megamek/wiki/bug_report_howto/">Bug Reporting Policy</a></p>
-<p><a href="https://sourceforge.net/p/mekhq/bugs/">MekHQ Bug Tracker</a></p>
-<p><a href="https://sourceforge.net/p/megamek/bugs/">MegaMek Bug Tracker</a></p>
-<p><a href="https://sourceforge.net/p/megameklab/bugs/">MegaMekLab Bug Tracker</a></p>
+<p><a href="https://github.com/MegaMek/mekhq/issues">MekHQ Bug Tracker</a>
+    (<a href="http://sourceforge.net/p/mekhq/bugs/">sf.net</a>)</p>
+<p><a href="https://github.com/MegaMek/megamek/issues">MegaMek Bug Tracker</a> 
+    (<a href="http://sourceforge.net/p/megamek/bugs/">sf.net</a>)</p>
+<p><a href="https://github.com/MegaMek/megameklab/issues">MegaMekLab Bug Tracker</a>
+    (<a href="http://sourceforge.net/p/megameklab/bugs/">sf.net</a>)</p>
 
-<p>To submit a new bug to the bug tracker at sourceforge.net. You can also attach
-two additional items to this report that will greatly assist us in finding
-the bug:
+<p>To submit a new bug to the bug tracker at github.com. To assist us in finding
+the bug, you should also attach a .zip file containing the following files to this report:
 <ol>
-<li>A copy of the game where the bug occurred, saved in XML format.</li>
-<li>A copy of the mekhqlog.txt file located in the logs directory.
-If you are reporting a MegaMek or MegaMekLab bug encountered while running from within MekHQ,
-then you should attach the mekhq log. Otherwise, attach the log for the specific program.</li>
+<li>The game save file where the bug occurred.</li>
+<li>The mekhqlog.txt file located in the logs directory.</li>
 </ol>
+If you are reporting a MegaMek or MegaMekLab bug encountered while running from within MekHQ,
+then you should attach the mekhq log. Otherwise, attach the log for the specific program.
 </p>
 
 <p>Thanks for your help, and good hunting!</p>


### PR DESCRIPTION
Left in links to the old sf.net bug reporting pages, so people can look there for duplicate issues.  Might want to take them out to avoid potential confusion.

Removed the part specifying the save file be in XML format, as I don't see that option anywhere.  (The .cpnx file is basically just an XML file, but is a .cpnx file.)