### PR TITLE
fixed references to MapSettings and EntityVerifier

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -108,7 +108,7 @@ public class AtBGameThread extends GameThread {
     				Thread.sleep(campaign.getCampaignOptions().getStartGameDelay());
                 }
 
-                MapSettings mapSettings = new MapSettings();
+                MapSettings mapSettings = MapSettings.getInstance();
                 File mapgenFile = new File("data/mapgen/" + scenario.getMap() + ".xml");
                 if (campaign.getCampaignOptions().getUseAltMapgen()) {
                 	File alt = new File("data/mapgen/" + scenario.getMap() + " - Jazz.xml");
@@ -117,7 +117,7 @@ public class AtBGameThread extends GameThread {
                 	}
                 }
                  try {
-                	mapSettings.load(new FileInputStream(mapgenFile));
+                	mapSettings = MapSettings.getInstance(new FileInputStream(mapgenFile));
                 } catch (FileNotFoundException ex) {
                 	MekHQ.logError("Could not load map file data/mapgen/" + scenario.getMap() + ".xml");
                 	MekHQ.logError(ex);

--- a/MekHQ/src/mekhq/gui/MekLabPanel.java
+++ b/MekHQ/src/mekhq/gui/MekLabPanel.java
@@ -104,7 +104,7 @@ public class MekLabPanel extends JPanel {
     
     public MekLabPanel(CampaignGUI gui) {
     	campaignGUI = gui;
-		entityVerifier = new EntityVerifier(new File("data/mechfiles/UnitVerifierOptions.xml"));
+		entityVerifier = EntityVerifier.getInstance(new File("data/mechfiles/UnitVerifierOptions.xml"));
         UnitUtil.loadFonts();
         new CConfig();
         MekHQ.logMessage("Staring MegaMekLab version: " + MegaMekLab.VERSION);


### PR DESCRIPTION
Related to https://github.com/MegaMek/megamek/pull/57.  The constructors for EntityVerifier and MapSettings are now private, however, there are new static methods to call to get an instance.