### PR TITLE
Fixing most of the issues with the buttons in "parts in use" tab

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -445,7 +445,7 @@ public class MekHQ implements GameListener {
             campaigngui.filterPersonnel();
             campaigngui.refreshDoctorsList();
             campaigngui.refreshPatientList();
-            campaigngui.refreshReport();
+            campaigngui.initReport();
             campaigngui.changeMission();
             campaigngui.refreshFinancialTransactions();
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -172,7 +172,9 @@ import org.w3c.dom.NodeList;
  * @author Taharqa The main campaign class, keeps track of teams and units
  */
 public class Campaign implements Serializable {
-    private static final long serialVersionUID = -6312434701389973056L;
+    private static final String REPORT_LINEBREAK = "<br/><br/>"; //$NON-NLS-1$
+
+	private static final long serialVersionUID = -6312434701389973056L;
 
     // we have three things to track: (1) teams, (2) units, (3) repair tasks
     // we will use the same basic system (borrowed from MegaMek) for tracking
@@ -236,6 +238,7 @@ public class Campaign implements Serializable {
 
     private ArrayList<String> currentReport;
     private transient String currentReportHTML;
+    private transient List<String> newReports;
 
     private boolean overtime;
     private boolean gmMode;
@@ -274,6 +277,7 @@ public class Campaign implements Serializable {
         game.addPlayer(0, player);
         currentReport = new ArrayList<String>();
         currentReportHTML = "";
+        newReports = new ArrayList<String>();
         calendar = new GregorianCalendar(3067, Calendar.JANUARY, 1);
         dateFormat = new SimpleDateFormat("EEEE, MMMM d yyyy");
         shortDateFormat = new SimpleDateFormat("yyyyMMdd");
@@ -1181,6 +1185,12 @@ public class Campaign implements Serializable {
     	return currentReportHTML;
     }
 
+    public List<String> fetchAndClearNewReports() {
+    	List<String> oldReports = newReports;
+    	newReports = new ArrayList<String>();
+    	return oldReports;
+    }
+    
 	/**
 	 * Finds the active person in a particular role with the highest level
 	 * in a given, with an optional secondary skill to break ties.
@@ -1944,6 +1954,7 @@ public class Campaign implements Serializable {
         calendar.add(Calendar.DAY_OF_MONTH, 1);
         currentReport.clear();
         currentReportHTML = "";
+        newReports.clear();
         addReport("<b>" + getDateAsString() + "</b>");
 
         if (calendar.get(Calendar.DAY_OF_YEAR) == 1) {
@@ -2936,9 +2947,12 @@ public class Campaign implements Serializable {
     public void addReport(String r) {
         currentReport.add(r);
         if( currentReportHTML.length() > 0 ) {
-        	currentReportHTML = currentReportHTML + "<br/><br/>" + r;
+        	currentReportHTML = currentReportHTML + REPORT_LINEBREAK + r;
+            newReports.add(REPORT_LINEBREAK);
+            newReports.add(r);
         } else {
         	currentReportHTML = r;
+            newReports.add(r);
         }
     }
 
@@ -4749,7 +4763,18 @@ public class Campaign implements Serializable {
             retVal.ranks = new Ranks(rankSystem);
             retVal.ranks.setOldRankSystem(rankSystem);
         }
-        retVal.currentReportHTML = Utilities.combineString(retVal.currentReport, "<br/><br/>");
+        retVal.currentReportHTML = Utilities.combineString(retVal.currentReport, REPORT_LINEBREAK);
+        // Everything's new
+        retVal.newReports = new ArrayList<String>(retVal.currentReport.size() * 2);
+        boolean firstReport = true;
+        for(String report : retVal.currentReport) {
+        	if(firstReport) {
+        		firstReport = false;
+        	} else {
+        		retVal.newReports.add(REPORT_LINEBREAK);
+        	}
+        	retVal.newReports.add(report);
+        }
     }
 
     private static void processLanceNodes(Campaign retVal, Node wn) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1171,7 +1171,8 @@ public class Campaign implements Serializable {
             PartInUse newPiu = getPartInUse((Part) maybePart);
             if(piu.equals(newPiu)) {
                 piu.setPlannedCount(piu.getPlannedCount()
-                    + getQuantity((Part) maybePart) * maybePart.getQuantity());
+                    + getQuantity((maybePart instanceof MissingPart) ? ((MissingPart) maybePart).getNewPart() : (Part) maybePart)
+                    * maybePart.getQuantity());
             }
         }
     }
@@ -1202,7 +1203,8 @@ public class Campaign implements Serializable {
                 inUse.put(piu, piu);
             }
             piu.setPlannedCount(piu.getPlannedCount()
-                + getQuantity((Part) maybePart) * maybePart.getQuantity());
+                + getQuantity((maybePart instanceof MissingPart) ? ((MissingPart) maybePart).getNewPart() : (Part) maybePart)
+                * maybePart.getQuantity());
             
         }
         return inUse.keySet();

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1126,7 +1126,7 @@ public class Campaign implements Serializable {
     public Set<PartInUse> getPartsInUse() {
         // java.util.Set doesn't supply a get(Object) method, so we have to use a java.util.Map
         Map<PartInUse, PartInUse> inUse = new HashMap<PartInUse, PartInUse>();
-        for (Part p : parts) {
+        for(Part p : parts) {
             // SI isn't a proper "part"
             if (p instanceof StructuralIntegrity) {
                 continue;
@@ -1149,6 +1149,24 @@ public class Campaign implements Serializable {
                 int quantity = (p instanceof Armor) ? ((Armor)p).getAmount() : p.getQuantity();
                 piu.setStoreCount(piu.getStoreCount() + quantity);
             }
+        }
+        for(IAcquisitionWork maybePart : shoppingList.getPartList()) {
+            if(!(maybePart instanceof Part)) {
+                continue;
+            }
+            Part p = (Part) maybePart;
+            if(p instanceof MissingPart) {
+                p = ((MissingPart) p).getNewPart();
+            }
+            PartInUse piu = new PartInUse(p);
+            if( inUse.containsKey(piu) ) {
+                piu = inUse.get(piu);
+            } else {
+                inUse.put(piu, piu);
+            }
+            int quantity = ((p instanceof Armor) ? ((Armor)p).getAmount() : 1) * maybePart.getQuantity();
+            piu.setTransferCount(piu.getTransferCount() + quantity);
+            
         }
         return inUse.keySet();
     }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1124,32 +1124,33 @@ public class Campaign implements Serializable {
     }
 
     public Set<PartInUse> getPartsInUse() {
-    	// java.util.Set doesn't supply a get(Object) method, so we have to use a java.util.Map
-    	Map<PartInUse, PartInUse> inUse = new HashMap<PartInUse, PartInUse>();
-    	for (Part p : parts) {
-    		// SI isn't a proper "part"
-    		if (p instanceof StructuralIntegrity) {
-    			continue;
-    		}
-			// Replace a "missing" part with a corresponding "new" one.
-			boolean missingPart = (p instanceof MissingPart);
-    		if(missingPart) {
-    			p = ((MissingPart) p).getNewPart();
-    		}
-    		PartInUse piu = new PartInUse(p);
-    		if( inUse.containsKey(piu) ) {
-    			piu = inUse.get(piu);
-    		} else {
-    			inUse.put(piu, piu);
-    		}
-    		int quantity = (p instanceof Armor) ? ((Armor)p).getAmount() : 1;
-    		if ((p.getUnit() != null) || (p.getUnitId() != null) || missingPart) {
-    			piu.setUseCount(piu.getUseCount() + quantity);
-    		} else {
-    			piu.setStoreCount(piu.getStoreCount() + p.getQuantity());
-    		}
-    	}
-    	return inUse.keySet();
+        // java.util.Set doesn't supply a get(Object) method, so we have to use a java.util.Map
+        Map<PartInUse, PartInUse> inUse = new HashMap<PartInUse, PartInUse>();
+        for (Part p : parts) {
+            // SI isn't a proper "part"
+            if (p instanceof StructuralIntegrity) {
+                continue;
+            }
+            // Replace a "missing" part with a corresponding "new" one.
+            boolean missingPart = (p instanceof MissingPart);
+            if(missingPart) {
+                p = ((MissingPart) p).getNewPart();
+            }
+            PartInUse piu = new PartInUse(p);
+            if( inUse.containsKey(piu) ) {
+                piu = inUse.get(piu);
+            } else {
+                inUse.put(piu, piu);
+            }
+            if ((p.getUnit() != null) || (p.getUnitId() != null) || missingPart) {
+                int quantity = (p instanceof Armor) ? ((Armor)p).getAmount() : 1;
+                piu.setUseCount(piu.getUseCount() + quantity);
+            } else {
+                int quantity = (p instanceof Armor) ? ((Armor)p).getAmount() : p.getQuantity();
+                piu.setStoreCount(piu.getStoreCount() + quantity);
+            }
+        }
+        return inUse.keySet();
     }
 
     public Part getPart(int id) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1120,7 +1120,11 @@ public class Campaign implements Serializable {
     		if (p instanceof StructuralIntegrity) {
     			continue;
     		}
-
+			// Replace a "missing" part with a corresponding "new" one.
+			boolean missingPart = (p instanceof MissingPart);
+    		if(missingPart) {
+    			p = ((MissingPart) p).getNewPart();
+    		}
     		String pname = p.getName();
 			Unit u = p.getUnit();
 			if (!(p instanceof MissingBattleArmorSuit)) {
@@ -1146,7 +1150,7 @@ public class Campaign implements Serializable {
     			ProtomekArmor a = (ProtomekArmor) p;
     			q = a.getAmount();
     		}
-    		if (p.getUnit() != null || p.getUnitId() != null) {
+    		if ((p.getUnit() != null) || (p.getUnitId() != null) || missingPart) {
     			if (inUse.containsKey(pname)) {
     				int temp = inUse.get(pname);
     				temp += q;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -39,7 +39,6 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
@@ -54,6 +53,12 @@ import java.util.logging.Logger;
 import javax.swing.JOptionPane;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import megamek.client.RandomNameGenerator;
 import megamek.client.RandomUnitGenerator;
@@ -123,7 +128,6 @@ import mekhq.campaign.parts.BaArmor;
 import mekhq.campaign.parts.EnginePart;
 import mekhq.campaign.parts.MekActuator;
 import mekhq.campaign.parts.MekLocation;
-import mekhq.campaign.parts.MissingBattleArmorSuit;
 import mekhq.campaign.parts.MissingEnginePart;
 import mekhq.campaign.parts.MissingMekActuator;
 import mekhq.campaign.parts.MissingPart;
@@ -165,12 +169,6 @@ import mekhq.campaign.work.IMedicalWork;
 import mekhq.campaign.work.IPartWork;
 import mekhq.campaign.work.Modes;
 import mekhq.gui.utilities.PortraitFileFactory;
-
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * @author Taharqa The main campaign class, keeps track of teams and units

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -235,6 +235,7 @@ public class Campaign implements Serializable {
     private Ranks ranks;
 
     private ArrayList<String> currentReport;
+    private transient String currentReportHTML;
 
     private boolean overtime;
     private boolean gmMode;
@@ -272,6 +273,7 @@ public class Campaign implements Serializable {
         player = new Player(0, "self");
         game.addPlayer(0, player);
         currentReport = new ArrayList<String>();
+        currentReportHTML = "";
         calendar = new GregorianCalendar(3067, Calendar.JANUARY, 1);
         dateFormat = new SimpleDateFormat("EEEE, MMMM d yyyy");
         shortDateFormat = new SimpleDateFormat("yyyyMMdd");
@@ -1176,12 +1178,7 @@ public class Campaign implements Serializable {
     }
 
     public String getCurrentReportHTML() {
-        String toReturn = "";
-        // lets do the report backwards
-        for (String s : currentReport) {
-            toReturn += s + "<br/><br/>";
-        }
-        return toReturn;
+    	return currentReportHTML;
     }
 
 	/**
@@ -1946,6 +1943,7 @@ public class Campaign implements Serializable {
     public void newDay() {
         calendar.add(Calendar.DAY_OF_MONTH, 1);
         currentReport.clear();
+        currentReportHTML = "";
         addReport("<b>" + getDateAsString() + "</b>");
 
         if (calendar.get(Calendar.DAY_OF_YEAR) == 1) {
@@ -2937,6 +2935,11 @@ public class Campaign implements Serializable {
 
     public void addReport(String r) {
         currentReport.add(r);
+        if( currentReportHTML.length() > 0 ) {
+        	currentReportHTML = currentReportHTML + "<br/><br/>" + r;
+        } else {
+        	currentReportHTML = r;
+        }
     }
 
     public void addReports(ArrayList<String> reports) {
@@ -4746,6 +4749,7 @@ public class Campaign implements Serializable {
             retVal.ranks = new Ranks(rankSystem);
             retVal.ranks.setOldRankSystem(rankSystem);
         }
+        retVal.currentReportHTML = Utilities.combineString(retVal.currentReport, "<br/><br/>");
     }
 
     private static void processLanceNodes(Campaign retVal, Node wn) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1136,11 +1136,18 @@ public class Campaign implements Serializable {
         if (p instanceof StructuralIntegrity) {
             return null;
         }
+        // Makes no sense buying those separately from the chasis
+        if((p instanceof EquipmentPart)
+            && (((EquipmentPart) p).getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION)))
+        {
+            return null;
+        }
         // Replace a "missing" part with a corresponding "new" one.
         if(p instanceof MissingPart) {
             p = ((MissingPart) p).getNewPart();
         }
-        return new PartInUse(p);
+        PartInUse result = new PartInUse(p);
+        return (null != result.getPartToBuy()) ? result : null;
     }
     
     private void updatePartInUseData(PartInUse piu, Part p) {

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -509,6 +509,8 @@ public class PartsStore implements Serializable {
 					    //for(int ctype = Mech.COCKPIT_STANDARD; ctype < Mech.COCKPIT_STRING.length; ctype++) {
 					        parts.add(new MekLocation(loc, ton, type, false, false, true, true, c));
 	                        parts.add(new MekLocation(loc, ton, type, true, false, true, true, c));
+					        parts.add(new MekLocation(loc, ton, type, false, false, false, false, c));
+	                        parts.add(new MekLocation(loc, ton, type, true, false, false, false, c));
 				        //}
 					} else {
     				    parts.add(new MekLocation(loc, ton, type, false, false, false, false, c));

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -27,6 +27,10 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.UUID;
 
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import megamek.common.EquipmentType;
 import megamek.common.TargetRoll;
 import megamek.common.TechConstants;
@@ -41,10 +45,6 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
 import mekhq.campaign.work.Modes;
-
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * Parts do the lions share of the work of repairing, salvaging, reloading, refueling, etc.
@@ -1282,7 +1282,16 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     
     @Override
     public String toString() {
-        return getName() + " " + getDetails();
+        StringBuilder sb = new StringBuilder(getName());
+        sb.append(" "); //$NON-NLS-1$
+        sb.append(getDetails());
+        sb.append(", q: "); //$NON-NLS-1$
+        sb.append(quantity);
+        if(null != unit) {
+            sb.append(", mounted: "); //$NON-NLS-1$
+            sb.append(unit);
+        }
+        return sb.toString();
     }
 }
 

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1280,5 +1280,9 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     		&& getLocation() == getUnit().getEntity().getLocationFromAbbr(loc);
     }
     
+    @Override
+    public String toString() {
+        return getName() + " " + getDetails();
+    }
 }
 

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 import megamek.common.AmmoType;
-import megamek.common.EquipmentType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
 

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -24,7 +24,7 @@ public class PartInUse {
         if(!(part instanceof MissingBattleArmorSuit)) {
             part.setUnit(null);
         }
-        if(!(part instanceof Armor)) {
+        if(!(part instanceof Armor) && !(part instanceof AmmoStorage)) {
             String details = part.getDetails();
             details = cleanUp1.matcher(details).replaceFirst(""); //$NON-NLS-1$
             details = cleanUp2.matcher(details).replaceFirst(""); //$NON-NLS-1$
@@ -35,7 +35,11 @@ public class PartInUse {
         part.setUnit(u);
         this.description = sb.toString();
         this.partToBuy = part.getAcquisitionWork();
-        this.cost = partToBuy.getBuyCost();
+        if(null == partToBuy) {
+            System.err.println(String.format("Registeing part without a corresponding acquisition work: %s", part.getPartName())); //$NON-NLS-1$
+        } else {
+            this.cost = partToBuy.getBuyCost();
+        }
     }
     
     public PartInUse(String description, IAcquisitionWork partToBuy, long cost) {

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -61,7 +61,7 @@ public class PartInUse {
             this.tonnagePerItem = 1.0 / ((Armor) part).getArmorPointsPerTon();
         }
         if(null == partToBuy) {
-            System.err.println(String.format("Registeing part without a corresponding acquisition work: %s", part.getPartName())); //$NON-NLS-1$
+            System.err.println(String.format("Registering part without a corresponding acquisition work: %s", part.getPartName())); //$NON-NLS-1$
         } else {
             this.cost = partToBuy.getBuyCost();
         }

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -18,6 +18,15 @@ public class PartInUse {
     private int plannedCount;
     private long cost;
     
+    private void appendDetails(StringBuilder sb, Part part) {
+        String details = part.getDetails();
+        details = cleanUp1.matcher(details).replaceFirst(""); //$NON-NLS-1$
+        details = cleanUp2.matcher(details).replaceFirst(""); //$NON-NLS-1$
+        if(details.length() > 0) {
+            sb.append(" (").append(details).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+    
     public PartInUse(Part part) {
         StringBuilder sb = new StringBuilder(part.getName());
         Unit u = part.getUnit();
@@ -25,16 +34,19 @@ public class PartInUse {
             part.setUnit(null);
         }
         if(!(part instanceof Armor) && !(part instanceof AmmoStorage)) {
-            String details = part.getDetails();
-            details = cleanUp1.matcher(details).replaceFirst(""); //$NON-NLS-1$
-            details = cleanUp2.matcher(details).replaceFirst(""); //$NON-NLS-1$
-            if(details.length() > 0) {
-                sb.append(" (").append(details).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
-            }
+            appendDetails(sb, part);
         }
         part.setUnit(u);
         this.description = sb.toString();
         this.partToBuy = part.getAcquisitionWork();
+        // AmmoBin are special: They aren't buyable (yet?), but instead buy you the ammo inside
+        // We redo the description based on that
+        if(partToBuy instanceof AmmoStorage) {
+            sb.setLength(0);
+            sb.append(((AmmoStorage) partToBuy).getName());
+            appendDetails(sb, (Part) ((AmmoStorage) partToBuy).getAcquisitionWork());
+            this.description = sb.toString();
+        }
         if(null == partToBuy) {
             System.err.println(String.format("Registeing part without a corresponding acquisition work: %s", part.getPartName())); //$NON-NLS-1$
         } else {

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -60,9 +60,7 @@ public class PartInUse {
             // Armor needs different tonnage values
             this.tonnagePerItem = 1.0 / ((Armor) part).getArmorPointsPerTon();
         }
-        if(null == partToBuy) {
-            System.err.println(String.format("Registering part without a corresponding acquisition work: %s", part.getPartName())); //$NON-NLS-1$
-        } else {
+        if(null != partToBuy) {
             this.cost = partToBuy.getBuyCost();
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -1,0 +1,127 @@
+package mekhq.campaign.parts;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import mekhq.campaign.unit.Unit;
+import mekhq.campaign.work.IAcquisitionWork;
+
+public class PartInUse {
+    private static final Pattern cleanUp1 = Pattern.compile("\\d+\\shit\\(s\\),\\s"); //$NON-NLS-1$
+    private static final Pattern cleanUp2 = Pattern.compile("\\d+\\shit\\(s\\)"); //$NON-NLS-1$
+
+    private String description;
+    private IAcquisitionWork partToBuy;
+    private int useCount;
+    private int storeCount;
+    private int transferCount;
+    private int plannedCount;
+    private long cost;
+    
+    public PartInUse(Part part) {
+        StringBuilder sb = new StringBuilder(part.getName());
+        Unit u = part.getUnit();
+        if(!(part instanceof MissingBattleArmorSuit)) {
+            part.setUnit(null);
+        }
+        if(!(part instanceof Armor)) {
+            String details = part.getDetails();
+            details = cleanUp1.matcher(details).replaceFirst(""); //$NON-NLS-1$
+            details = cleanUp2.matcher(details).replaceFirst(""); //$NON-NLS-1$
+            if(details.length() > 0) {
+                sb.append(" (").append(details).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+        }
+        part.setUnit(u);
+        this.description = sb.toString();
+        this.partToBuy = part.getAcquisitionWork();
+        this.cost = partToBuy.getBuyCost();
+    }
+    
+    public PartInUse(String description, IAcquisitionWork partToBuy, long cost) {
+        this.description = Objects.requireNonNull(description);
+        this.partToBuy = Objects.requireNonNull(partToBuy);
+        this.cost = cost;
+    }
+    
+    public PartInUse(String description, IAcquisitionWork partToBuy) {
+        this(description, partToBuy, partToBuy.getBuyCost());
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public IAcquisitionWork getPartToBuy() {
+        return partToBuy;
+    }
+    
+    public int getUseCount() {
+        return useCount;
+    }
+    
+    public void setUseCount(int useCount) {
+        this.useCount = useCount;
+    }
+    
+    public void incUseCount() {
+        ++ useCount;
+    }
+    
+    public int getStoreCount() {
+        return storeCount;
+    }
+    
+    public void setStoreCount(int storeCount) {
+        this.storeCount = storeCount;
+    }
+    
+    public void incStoreCount() {
+        ++ storeCount;
+    }
+    
+    public int getTransferCount() {
+        return transferCount;
+    }
+    
+    public void incTransferCount() {
+        ++ transferCount;
+    }
+    
+    public void setTransferCount(int transferCount) {
+        this.transferCount = transferCount;
+    }
+    
+    public int getPlannedCount() {
+        return plannedCount;
+    }
+    
+    public void setPlannedCount(int plannedCount) {
+        this.plannedCount = plannedCount;
+    }
+    
+    public void incPlannedCount() {
+        ++ plannedCount;
+    }
+    
+    public long getCost() {
+        return cost;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(description);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(this == obj) {
+            return true;
+        }
+        if((null == obj) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        final PartInUse other = (PartInUse) obj;
+        return Objects.equals(description, other.description);
+    }
+}

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -60,6 +60,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.AbstractAction;
+import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DropMode;
@@ -155,6 +156,7 @@ import mekhq.campaign.parts.MekLifeSupport;
 import mekhq.campaign.parts.MekLocation;
 import mekhq.campaign.parts.MekSensor;
 import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.PartInUse;
 import mekhq.campaign.parts.ProtomekArmor;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.parts.TankLocation;
@@ -225,6 +227,7 @@ import mekhq.gui.model.DocTableModel;
 import mekhq.gui.model.FinanceTableModel;
 import mekhq.gui.model.LoanTableModel;
 import mekhq.gui.model.OrgTreeModel;
+import mekhq.gui.model.PartsInUseTableModel;
 import mekhq.gui.model.PartsTableModel;
 import mekhq.gui.model.PatientTableModel;
 import mekhq.gui.model.PersonnelTableModel;
@@ -505,6 +508,8 @@ public class CampaignGUI extends JPanel {
     private LoanTableModel loanModel;
     private ScenarioTableModel scenarioModel;
     private OrgTreeModel orgModel;
+	private PartsInUseTableModel overviewPartsModel;
+
 
     /* table sorters for tables that can be filtered */
     private TableRowSorter<PersonnelTableModel> personnelSorter;
@@ -515,6 +520,7 @@ public class CampaignGUI extends JPanel {
     private TableRowSorter<TaskTableModel> taskSorter;
     private TableRowSorter<TechTableModel> techSorter;
     private TableRowSorter<TechTableModel> whTechSorter;
+    private TableRowSorter<PartsInUseTableModel> partsInUseSorter;
 
     // Start Overview Tab
     private JPanel panOverview;
@@ -522,6 +528,7 @@ public class CampaignGUI extends JPanel {
     // Overview Parts In Use
     private JScrollPane scrollOverviewParts;
     private JPanel overviewPartsPanel;
+	private JTable overviewPartsInUseTable;
     // Overview Transport
     private JScrollPane scrollOverviewTransport;
     // Overview Personnel
@@ -1224,7 +1231,7 @@ public class CampaignGUI extends JPanel {
 		panOverview = new JPanel();
 		setTabOverview(new JTabbedPane());
 		scrollOverviewParts = new JScrollPane();
-		overviewPartsPanel = new JPanel(new GridBagLayout());
+		initOverviewPartsInUse();
 		scrollOverviewTransport = new JScrollPane();
 		scrollOverviewCombatPersonnel = new JScrollPane();
 		scrollOverviewSupportPersonnel = new JScrollPane();
@@ -4754,123 +4761,114 @@ public class CampaignGUI extends JPanel {
         refreshOverviewPartsInUse();
     }
 
+    public void initOverviewPartsInUse() {
+		overviewPartsPanel = new JPanel(new GridBagLayout());
+		
+        overviewPartsModel = new PartsInUseTableModel();
+        overviewPartsInUseTable = new JTable(overviewPartsModel);
+        overviewPartsInUseTable.setRowSelectionAllowed(false);
+        overviewPartsInUseTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+        TableColumn column = null;
+        for(int i = 0; i < overviewPartsModel.getColumnCount(); ++ i) {
+            column = overviewPartsInUseTable.getColumnModel().getColumn(i);
+            column.setCellRenderer(overviewPartsModel.getRenderer());
+            column.setPreferredWidth(overviewPartsModel.getPreferredWidth(i));
+        }
+        overviewPartsInUseTable.setIntercellSpacing(new Dimension(0, 0));
+        overviewPartsInUseTable.setShowGrid(false);
+        partsInUseSorter = new TableRowSorter<PartsInUseTableModel>(overviewPartsModel);
+        overviewPartsInUseTable.setRowSorter(partsInUseSorter);
+        
+        // Add buttons and actions
+        @SuppressWarnings("serial")
+		Action buy = new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				int row = Integer.valueOf(e.getActionCommand());
+				PartInUse piu = overviewPartsModel.getPartInUse(row);
+            	getCampaign().getShoppingList().addShoppingItem(piu.getPartToBuy(), 1, getCampaign());
+            	refreshReport();
+        		refreshAcquireList();
+        		refreshPartsList();
+        		refreshOverviewPartsInUse();
+			}
+		};
+		@SuppressWarnings("serial")
+		Action buyInBulk = new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				int row = Integer.valueOf(e.getActionCommand());
+				PartInUse piu = overviewPartsModel.getPartInUse(row);
+            	int quantity = 1;
+            	PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(getFrame(), true, "How Many " + piu.getPartToBuy().getAcquisitionName(), quantity, 1, 100);
+    			pcd.setVisible(true);
+    			quantity = pcd.getValue();
+            	getCampaign().getShoppingList().addShoppingItem(piu.getPartToBuy(), quantity, getCampaign());
+            	refreshReport();
+        		refreshAcquireList();
+        		refreshPartsList();
+        		refreshOverviewPartsInUse();
+			}
+		};
+        @SuppressWarnings("serial")
+		Action add = new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				int row = Integer.valueOf(e.getActionCommand());
+				PartInUse piu = overviewPartsModel.getPartInUse(row);
+            	getCampaign().addPart((Part) piu.getPartToBuy().getNewEquipment(), 0);
+        		refreshAcquireList();
+        		refreshPartsList();
+        		refreshOverviewPartsInUse();
+			}
+		};
+        @SuppressWarnings("serial")
+		Action addInBulk = new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				int row = Integer.valueOf(e.getActionCommand());
+				PartInUse piu = overviewPartsModel.getPartInUse(row);
+            	int quantity = 1;
+            	PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(getFrame(), true, "How Many " + piu.getPartToBuy().getAcquisitionName(), quantity, 1, 100);
+    			pcd.setVisible(true);
+    			quantity = pcd.getValue();
+    			while(quantity > 0) {
+                	getCampaign().addPart((Part) piu.getPartToBuy().getNewEquipment(), 0);
+    		        -- quantity;
+    		    }
+        		refreshAcquireList();
+        		refreshPartsList();
+        		refreshOverviewPartsInUse();
+			}
+		};
+
+        new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable,
+        	buy, PartsInUseTableModel.COL_BUTTON_BUY);
+        new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable,
+        	buyInBulk, PartsInUseTableModel.COL_BUTTON_BUY_BULK);
+        new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable,
+            add, PartsInUseTableModel.COL_BUTTON_GMADD);
+        new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable,
+        	addInBulk, PartsInUseTableModel.COL_BUTTON_GMADD_BULK);
+
+        GridBagConstraints gridBagConstraints = new GridBagConstraints();
+
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.fill = GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 1.0;
+
+        overviewPartsPanel.add(new JScrollPane(overviewPartsInUseTable), gridBagConstraints);
+    }
+    
     public void refreshOverviewPartsInUse() {
-    	overviewPartsPanel.removeAll();
-    	int i = 0;
-    	int j = 0;
-    	GridBagConstraints gbc;
-    	JLabel partName;
-    	JLabel partNum;
-    	JButton partBuy;
-    	JButton partBuyInBulk;
-    	JButton partAddGM;
-    	JButton partAddBulkGM;
-    	Color bgc = new Color(255, 255, 255);
-    	boolean opaque;
-    	Hashtable<String, Integer> pinu = getCampaign().getPartsInUse();
-    	String[] keys = (String[]) pinu.keySet().toArray(new String[0]);
-    	Arrays.sort(keys);
-    	for (String pname : keys) {
-    		final String pn = pname;
-    		j++;
-    		if (i % 2 == 0) {
-    			opaque = false;
-    		} else {
-    			opaque = true;
-    		}
-    		int pnum = pinu.get(pname);
-    		partName = new JLabel("<html>&nbsp;&nbsp;&nbsp;"+pname+"&nbsp;&nbsp;&nbsp;</html>");
-    		partName.setBackground(bgc);
-    		partName.setOpaque(opaque);
-    		partName.setVerticalAlignment(SwingConstants.CENTER);
-    		gbc = new java.awt.GridBagConstraints();
-    		gbc.gridx = 0;
-    		gbc.gridy = i;
-    		gbc.anchor = java.awt.GridBagConstraints.NORTHWEST;
-    		gbc.fill = GridBagConstraints.BOTH;
-    		gbc.weightx = 1.0;
-            if(j == pinu.size()) {
-            	gbc.weighty = 1.0;
-            }
-            overviewPartsPanel.add(partName, gbc);
-    		partNum = new JLabel("  "+Integer.toString(pnum)+"  ");
-    		partNum.setBackground(bgc);
-    		partNum.setOpaque(opaque);
-    		partNum.setVerticalAlignment(SwingConstants.CENTER);
-    		partNum.setHorizontalAlignment(SwingConstants.TRAILING);
-    		gbc.gridx = 1;
-    		gbc.weightx = 0.0;
-    		overviewPartsPanel.add(partNum, gbc);
-    		partBuy = new JButton("Buy");
-    		partBuy.addActionListener(new java.awt.event.ActionListener() {
-	            public void actionPerformed(java.awt.event.ActionEvent evt) {
-	            	Part p = getPartByNameAndDetails(pn);
-	            	getCampaign().getShoppingList().addShoppingItem(p.getAcquisitionWork(), 1, getCampaign());
-	            	refreshReport();
-	        		refreshAcquireList();
-	        		refreshPartsList();
-	        		//refreshFinancialTransactions();
-	                //refreshOverview();
-	            }
-	        });
-    		gbc.gridx = 2;
-    		overviewPartsPanel.add(partBuy, gbc);
-    		partBuyInBulk = new JButton("Buy in Bulk");
-    		partBuyInBulk.addActionListener(new java.awt.event.ActionListener() {
-	            public void actionPerformed(java.awt.event.ActionEvent evt) {
-	            	Part p = getPartByNameAndDetails(pn);
-	            	int quantity = 1;
-	            	PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(getFrame(), true, "How Many " + p.getName(), quantity, 1, 100);
-	    			pcd.setVisible(true);
-	    			quantity = pcd.getValue();
-	            	getCampaign().getShoppingList().addShoppingItem(p.getAcquisitionWork(), quantity, getCampaign());
-	            	refreshReport();
-	        		refreshAcquireList();
-	        		refreshPartsList();
-	        		//refreshFinancialTransactions();
-	                //refreshOverview();
-	            }
-	        });
-    		gbc.gridx = 3;
-    		overviewPartsPanel.add(partBuyInBulk, gbc);
-    		partAddGM = new JButton("Add (GM)");
-    		partAddGM.setEnabled(getCampaign().isGM());
-    		partAddGM.addActionListener(new java.awt.event.ActionListener() {
-	            public void actionPerformed(java.awt.event.ActionEvent evt) {
-	            	Part p = getPartByNameAndDetails(pn);
-	            	getCampaign().addPart(p.clone(), 0);
-	            	//refreshReport();
-	        		refreshAcquireList();
-	        		refreshPartsList();
-	        		//refreshFinancialTransactions();
-	                //refreshOverview();
-	            }
-	        });
-    		gbc.gridx = 4;
-    		overviewPartsPanel.add(partAddGM, gbc);
-    		partAddBulkGM = new JButton("Add in Bulk (GM)");
-    		partAddBulkGM.setEnabled(getCampaign().isGM());
-    		partAddBulkGM.addActionListener(new java.awt.event.ActionListener() {
-	            public void actionPerformed(java.awt.event.ActionEvent evt) {
-	            	Part p = getPartByNameAndDetails(pn);
-	            	int quantity = 1;
-	            	PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(getFrame(), true, "How Many " + p.getName(), quantity, 1, 100);
-	    			pcd.setVisible(true);
-	    			quantity = pcd.getValue();
-	    			while(quantity > 0) {
-	    				getCampaign().addPart(p.clone(), 0);
-	    		        quantity--;
-	    		    }
-	            	//refreshReport();
-	        		refreshAcquireList();
-	        		refreshPartsList();
-	        		//refreshFinancialTransactions();
-	                //refreshOverview();
-	            }
-	        });
-    		gbc.gridx = 5;
-    		overviewPartsPanel.add(partAddBulkGM, gbc);
-            i++;
+    	overviewPartsModel.setData(getCampaign().getPartsInUse());
+    	if( getCampaign().isGM() ) {
+    		// TODO
+    	} else {
+    		// TODO
     	}
     }
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -4779,6 +4779,19 @@ public class CampaignGUI extends JPanel {
         overviewPartsInUseTable.setIntercellSpacing(new Dimension(0, 0));
         overviewPartsInUseTable.setShowGrid(false);
         partsInUseSorter = new TableRowSorter<PartsInUseTableModel>(overviewPartsModel);
+        // Don't sort the buttons
+        partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_BUY, false);
+        partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_BUY_BULK, false);
+        partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_GMADD, false);
+        partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_GMADD_BULK, false);
+        // Numeric columns
+        partsInUseSorter.setComparator(PartsInUseTableModel.COL_IN_USE, new FormattedNumberSorter());
+        partsInUseSorter.setComparator(PartsInUseTableModel.COL_STORED, new FormattedNumberSorter());
+        // Needs a special sorter for the parentheses
+        // partsInUseSorter.setComparator(PartsInUseTableModel.COL_IN_TRANSFER, new FormattedNumberSorter());
+        partsInUseSorter.setComparator(PartsInUseTableModel.COL_COST, new FormattedNumberSorter());
+        // Default starting sort
+        partsInUseSorter.setSortKeys(Arrays.asList(new RowSorter.SortKey(0, SortOrder.ASCENDING)));
         overviewPartsInUseTable.setRowSorter(partsInUseSorter);
         
         // Add buttons and actions

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -250,6 +250,7 @@ import mekhq.gui.sorter.RankSorter;
 import mekhq.gui.sorter.TargetSorter;
 import mekhq.gui.sorter.TaskSorter;
 import mekhq.gui.sorter.TechSorter;
+import mekhq.gui.sorter.TwoNumbersSorter;
 import mekhq.gui.sorter.UnitStatusSorter;
 import mekhq.gui.sorter.UnitTypeSorter;
 import mekhq.gui.sorter.WeightClassSorter;
@@ -4783,8 +4784,7 @@ public class CampaignGUI extends JPanel {
         // Numeric columns
         partsInUseSorter.setComparator(PartsInUseTableModel.COL_IN_USE, new FormattedNumberSorter());
         partsInUseSorter.setComparator(PartsInUseTableModel.COL_STORED, new FormattedNumberSorter());
-        // Needs a special sorter for the parentheses
-        // partsInUseSorter.setComparator(PartsInUseTableModel.COL_IN_TRANSFER, new FormattedNumberSorter());
+        partsInUseSorter.setComparator(PartsInUseTableModel.COL_IN_TRANSFER, new TwoNumbersSorter());
         partsInUseSorter.setComparator(PartsInUseTableModel.COL_COST, new FormattedNumberSorter());
         // Default starting sort
         partsInUseSorter.setSortKeys(Arrays.asList(new RowSorter.SortKey(0, SortOrder.ASCENDING)));

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -4771,7 +4771,12 @@ public class CampaignGUI extends JPanel {
         for(int i = 0; i < overviewPartsModel.getColumnCount(); ++ i) {
             column = overviewPartsInUseTable.getColumnModel().getColumn(i);
             column.setCellRenderer(overviewPartsModel.getRenderer());
-            column.setPreferredWidth(overviewPartsModel.getPreferredWidth(i));
+            if(overviewPartsModel.hasConstantWidth(i)) {
+                column.setMinWidth(overviewPartsModel.getWidth(i));
+                column.setMaxWidth(overviewPartsModel.getWidth(i));
+            } else {
+                column.setPreferredWidth(overviewPartsModel.getPreferredWidth(i));
+            }
         }
         overviewPartsInUseTable.setIntercellSpacing(new Dimension(0, 0));
         overviewPartsInUseTable.setShowGrid(false);
@@ -4784,6 +4789,7 @@ public class CampaignGUI extends JPanel {
         // Numeric columns
         partsInUseSorter.setComparator(PartsInUseTableModel.COL_IN_USE, new FormattedNumberSorter());
         partsInUseSorter.setComparator(PartsInUseTableModel.COL_STORED, new FormattedNumberSorter());
+        partsInUseSorter.setComparator(PartsInUseTableModel.COL_TONNAGE, new FormattedNumberSorter());
         partsInUseSorter.setComparator(PartsInUseTableModel.COL_IN_TRANSFER, new TwoNumbersSorter());
         partsInUseSorter.setComparator(PartsInUseTableModel.COL_COST, new FormattedNumberSorter());
         // Default starting sort

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -720,6 +720,17 @@ public class CampaignGUI extends JPanel {
                 resourceMap.getString("panOverview.TabConstraints.tabTitle"),
                 panOverview); // NOI18N
 
+        // The finance tab can be a pain to update when dealing with large units.
+        // Refresh it on tab change to that panel instead.
+        tabMain.addChangeListener(new ChangeListener() {
+			@Override
+			public void stateChanged(ChangeEvent e) {
+				if(tabMain.getSelectedComponent() == panFinances) { // Yes, identity check
+					refreshFinancialReport();
+				}
+				
+			}
+		});
         initMain();
         initTopButtons();
         initStatusBar();
@@ -4798,7 +4809,7 @@ public class CampaignGUI extends JPanel {
 	            	refreshReport();
 	        		refreshAcquireList();
 	        		refreshPartsList();
-	        		refreshFinancialTransactions();
+	        		//refreshFinancialTransactions();
 	                //refreshOverview();
 	            }
 	        });
@@ -4816,7 +4827,7 @@ public class CampaignGUI extends JPanel {
 	            	refreshReport();
 	        		refreshAcquireList();
 	        		refreshPartsList();
-	        		refreshFinancialTransactions();
+	        		//refreshFinancialTransactions();
 	                //refreshOverview();
 	            }
 	        });
@@ -4828,10 +4839,10 @@ public class CampaignGUI extends JPanel {
 	            public void actionPerformed(java.awt.event.ActionEvent evt) {
 	            	Part p = getPartByNameAndDetails(pn);
 	            	getCampaign().addPart(p.clone(), 0);
-	            	refreshReport();
+	            	//refreshReport();
 	        		refreshAcquireList();
 	        		refreshPartsList();
-	        		refreshFinancialTransactions();
+	        		//refreshFinancialTransactions();
 	                //refreshOverview();
 	            }
 	        });
@@ -4850,10 +4861,10 @@ public class CampaignGUI extends JPanel {
 	    				getCampaign().addPart(p.clone(), 0);
 	    		        quantity--;
 	    		    }
-	            	refreshReport();
+	            	//refreshReport();
 	        		refreshAcquireList();
 	        		refreshPartsList();
-	        		refreshFinancialTransactions();
+	        		//refreshFinancialTransactions();
 	                //refreshOverview();
 	            }
 	        });
@@ -6560,8 +6571,6 @@ public class CampaignGUI extends JPanel {
 
     public void refreshReport() {
         panLog.refreshLog(getCampaign().getCurrentReportHTML());
-        // scrLog.setViewportView(panLog);
-        logDialog.refreshLog();
     }
 
     public void refreshOrganization() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -21,7 +21,6 @@
 package mekhq.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -52,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.ResourceBundle;
 import java.util.UUID;
 import java.util.Vector;
@@ -93,7 +91,6 @@ import javax.swing.RowFilter;
 import javax.swing.RowSorter;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SortOrder;
-import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
@@ -112,6 +109,12 @@ import javax.swing.tree.TreeSelectionModel;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import chat.ChatClient;
 import megamek.client.RandomNameGenerator;
 import megamek.client.RandomUnitGenerator;
 import megamek.client.ui.swing.GameOptionsDialog;
@@ -262,13 +265,6 @@ import mekhq.gui.view.PersonViewPanel;
 import mekhq.gui.view.PlanetViewPanel;
 import mekhq.gui.view.ScenarioViewPanel;
 import mekhq.gui.view.UnitViewPanel;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import chat.ChatClient;
 
 /**
  * The application's main frame.
@@ -4763,7 +4759,7 @@ public class CampaignGUI extends JPanel {
         refreshOverviewPartsInUse();
     }
 
-    public void initOverviewPartsInUse() {
+    private void initOverviewPartsInUse() {
         overviewPartsPanel = new JPanel(new GridBagLayout());
         
         overviewPartsModel = new PartsInUseTableModel();
@@ -4794,7 +4790,7 @@ public class CampaignGUI extends JPanel {
         partsInUseSorter.setSortKeys(Arrays.asList(new RowSorter.SortKey(0, SortOrder.ASCENDING)));
         overviewPartsInUseTable.setRowSorter(partsInUseSorter);
         
-        // Add buttons and actions
+        // Add buttons and actions. TODO: Only refresh the row we are working on, not the whole table
         @SuppressWarnings("serial")
         Action buy = new AbstractAction() {
             @Override

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -106,6 +106,7 @@ import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableRowSorter;
 import javax.swing.tree.TreeSelectionModel;
 import javax.xml.parsers.DocumentBuilder;
@@ -228,6 +229,7 @@ import mekhq.gui.model.FinanceTableModel;
 import mekhq.gui.model.LoanTableModel;
 import mekhq.gui.model.OrgTreeModel;
 import mekhq.gui.model.PartsInUseTableModel;
+import mekhq.gui.model.PartsInUseTableModel.ButtonColumn;
 import mekhq.gui.model.PartsTableModel;
 import mekhq.gui.model.PatientTableModel;
 import mekhq.gui.model.PersonnelTableModel;
@@ -4762,8 +4764,8 @@ public class CampaignGUI extends JPanel {
     }
 
     public void initOverviewPartsInUse() {
-		overviewPartsPanel = new JPanel(new GridBagLayout());
-		
+        overviewPartsPanel = new JPanel(new GridBagLayout());
+        
         overviewPartsModel = new PartsInUseTableModel();
         overviewPartsInUseTable = new JTable(overviewPartsModel);
         overviewPartsInUseTable.setRowSelectionAllowed(false);
@@ -4781,75 +4783,75 @@ public class CampaignGUI extends JPanel {
         
         // Add buttons and actions
         @SuppressWarnings("serial")
-		Action buy = new AbstractAction() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				int row = Integer.valueOf(e.getActionCommand());
-				PartInUse piu = overviewPartsModel.getPartInUse(row);
-            	getCampaign().getShoppingList().addShoppingItem(piu.getPartToBuy(), 1, getCampaign());
-            	refreshReport();
-        		refreshAcquireList();
-        		refreshPartsList();
-        		refreshOverviewPartsInUse();
-			}
-		};
-		@SuppressWarnings("serial")
-		Action buyInBulk = new AbstractAction() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				int row = Integer.valueOf(e.getActionCommand());
-				PartInUse piu = overviewPartsModel.getPartInUse(row);
-            	int quantity = 1;
-            	PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(getFrame(), true, "How Many " + piu.getPartToBuy().getAcquisitionName(), quantity, 1, 100);
-    			pcd.setVisible(true);
-    			quantity = pcd.getValue();
-            	getCampaign().getShoppingList().addShoppingItem(piu.getPartToBuy(), quantity, getCampaign());
-            	refreshReport();
-        		refreshAcquireList();
-        		refreshPartsList();
-        		refreshOverviewPartsInUse();
-			}
-		};
+        Action buy = new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int row = Integer.valueOf(e.getActionCommand());
+                PartInUse piu = overviewPartsModel.getPartInUse(row);
+                getCampaign().getShoppingList().addShoppingItem(piu.getPartToBuy(), 1, getCampaign());
+                refreshReport();
+                refreshAcquireList();
+                refreshPartsList();
+                refreshOverviewPartsInUse();
+            }
+        };
         @SuppressWarnings("serial")
-		Action add = new AbstractAction() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				int row = Integer.valueOf(e.getActionCommand());
-				PartInUse piu = overviewPartsModel.getPartInUse(row);
-            	getCampaign().addPart((Part) piu.getPartToBuy().getNewEquipment(), 0);
-        		refreshAcquireList();
-        		refreshPartsList();
-        		refreshOverviewPartsInUse();
-			}
-		};
+        Action buyInBulk = new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int row = Integer.valueOf(e.getActionCommand());
+                PartInUse piu = overviewPartsModel.getPartInUse(row);
+                int quantity = 1;
+                PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(getFrame(), true, "How Many " + piu.getPartToBuy().getAcquisitionName(), quantity, 1, 100);
+                pcd.setVisible(true);
+                quantity = pcd.getValue();
+                getCampaign().getShoppingList().addShoppingItem(piu.getPartToBuy(), quantity, getCampaign());
+                refreshReport();
+                refreshAcquireList();
+                refreshPartsList();
+                refreshOverviewPartsInUse();
+            }
+        };
         @SuppressWarnings("serial")
-		Action addInBulk = new AbstractAction() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				int row = Integer.valueOf(e.getActionCommand());
-				PartInUse piu = overviewPartsModel.getPartInUse(row);
-            	int quantity = 1;
-            	PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(getFrame(), true, "How Many " + piu.getPartToBuy().getAcquisitionName(), quantity, 1, 100);
-    			pcd.setVisible(true);
-    			quantity = pcd.getValue();
-    			while(quantity > 0) {
-                	getCampaign().addPart((Part) piu.getPartToBuy().getNewEquipment(), 0);
-    		        -- quantity;
-    		    }
-        		refreshAcquireList();
-        		refreshPartsList();
-        		refreshOverviewPartsInUse();
-			}
-		};
+        Action add = new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int row = Integer.valueOf(e.getActionCommand());
+                PartInUse piu = overviewPartsModel.getPartInUse(row);
+                getCampaign().addPart((Part) piu.getPartToBuy().getNewEquipment(), 0);
+                refreshAcquireList();
+                refreshPartsList();
+                refreshOverviewPartsInUse();
+            }
+        };
+        @SuppressWarnings("serial")
+        Action addInBulk = new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int row = Integer.valueOf(e.getActionCommand());
+                PartInUse piu = overviewPartsModel.getPartInUse(row);
+                int quantity = 1;
+                PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(getFrame(), true, "How Many " + piu.getPartToBuy().getAcquisitionName(), quantity, 1, 100);
+                pcd.setVisible(true);
+                quantity = pcd.getValue();
+                while(quantity > 0) {
+                    getCampaign().addPart((Part) piu.getPartToBuy().getNewEquipment(), 0);
+                    -- quantity;
+                }
+                refreshAcquireList();
+                refreshPartsList();
+                refreshOverviewPartsInUse();
+            }
+        };
 
         new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable,
-        	buy, PartsInUseTableModel.COL_BUTTON_BUY);
+            buy, PartsInUseTableModel.COL_BUTTON_BUY);
         new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable,
-        	buyInBulk, PartsInUseTableModel.COL_BUTTON_BUY_BULK);
+            buyInBulk, PartsInUseTableModel.COL_BUTTON_BUY_BULK);
         new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable,
             add, PartsInUseTableModel.COL_BUTTON_GMADD);
         new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable,
-        	addInBulk, PartsInUseTableModel.COL_BUTTON_GMADD_BULK);
+            addInBulk, PartsInUseTableModel.COL_BUTTON_GMADD_BULK);
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
 
@@ -4864,12 +4866,12 @@ public class CampaignGUI extends JPanel {
     }
     
     public void refreshOverviewPartsInUse() {
-    	overviewPartsModel.setData(getCampaign().getPartsInUse());
-    	if( getCampaign().isGM() ) {
-    		// TODO
-    	} else {
-    		// TODO
-    	}
+        overviewPartsModel.setData(getCampaign().getPartsInUse());
+        TableColumnModel tcm = overviewPartsInUseTable.getColumnModel();
+        PartsInUseTableModel.ButtonColumn column = (ButtonColumn)tcm.getColumn(PartsInUseTableModel.COL_BUTTON_GMADD).getCellRenderer();
+        column.setEnabled(getCampaign().isGM());
+        column = (ButtonColumn)tcm.getColumn(PartsInUseTableModel.COL_BUTTON_GMADD_BULK).getCellRenderer();
+        column.setEnabled(getCampaign().isGM());
     }
 
     public void refreshPersonnelView() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -752,7 +752,7 @@ public class CampaignGUI extends JPanel {
         refreshDoctorsList();
         refreshPartsList();
         refreshCalendar();
-        refreshReport();
+        initReport();
         refreshFunds();
         refreshRating();
         refreshFinancialTransactions();
@@ -3977,7 +3977,7 @@ public class CampaignGUI extends JPanel {
         refreshCalendar();
         refreshLocation();
         refreshOrganization();
-        refreshReport();
+        initReport();
         refreshFunds();
         refreshFinancialTransactions();
         refreshOverview();
@@ -6570,7 +6570,13 @@ public class CampaignGUI extends JPanel {
     }
 
     public void refreshReport() {
-        panLog.refreshLog(getCampaign().getCurrentReportHTML());
+        //panLog.refreshLog(getCampaign().getCurrentReportHTML());
+    	panLog.appendLog(getCampaign().fetchAndClearNewReports());
+    }
+    
+    public void initReport() {
+    	panLog.refreshLog(getCampaign().getCurrentReportHTML());
+    	getCampaign().fetchAndClearNewReports();
     }
 
     public void refreshOrganization() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -4719,20 +4719,7 @@ public class CampaignGUI extends JPanel {
     }
 
     public Part getPartByNameAndDetails(String pnd) {
-    	ArrayList<Part> store = getCampaign().getPartsStore().getInventory();
-    	for (Part p : store) {
-    		String pname = p.getName();
-			String details = p.getDetails();
-			details = details.replaceFirst("\\d+\\shit\\(s\\),\\s", "");
-		    details = details.replaceFirst("\\d+\\shit\\(s\\)", "");
-		    if (details.length() > 0 && !(p instanceof Armor || p instanceof BaArmor || p instanceof ProtomekArmor)) {
-		    	pname +=  " (" + details + ")";
-		    }
-		    if (pname.equals(pnd)) {
-		    	return p;
-		    }
-    	}
-    	return null;
+    	return getCampaign().getPartsStore().getByNameAndDetails(pnd);
     }
 
     public void refreshOverview() {
@@ -4812,7 +4799,7 @@ public class CampaignGUI extends JPanel {
 	        		refreshAcquireList();
 	        		refreshPartsList();
 	        		refreshFinancialTransactions();
-	                refreshOverview();
+	                //refreshOverview();
 	            }
 	        });
     		gbc.gridx = 2;
@@ -4830,7 +4817,7 @@ public class CampaignGUI extends JPanel {
 	        		refreshAcquireList();
 	        		refreshPartsList();
 	        		refreshFinancialTransactions();
-	                refreshOverview();
+	                //refreshOverview();
 	            }
 	        });
     		gbc.gridx = 3;
@@ -4845,7 +4832,7 @@ public class CampaignGUI extends JPanel {
 	        		refreshAcquireList();
 	        		refreshPartsList();
 	        		refreshFinancialTransactions();
-	                refreshOverview();
+	                //refreshOverview();
 	            }
 	        });
     		gbc.gridx = 4;
@@ -4867,7 +4854,7 @@ public class CampaignGUI extends JPanel {
 	        		refreshAcquireList();
 	        		refreshPartsList();
 	        		refreshFinancialTransactions();
-	                refreshOverview();
+	                //refreshOverview();
 	            }
 	        });
     		gbc.gridx = 5;

--- a/MekHQ/src/mekhq/gui/DailyReportLogPanel.java
+++ b/MekHQ/src/mekhq/gui/DailyReportLogPanel.java
@@ -26,6 +26,7 @@ import java.awt.BorderLayout;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
@@ -36,8 +37,11 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultCaret;
 import javax.swing.text.DefaultStyledDocument;
 import javax.swing.text.Document;
+import javax.swing.text.Element;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLEditorKit;
+
+import mekhq.Utilities;
 
 /**
  * This is a panel for displaying the reporting log for each day. We are putting it into
@@ -84,6 +88,9 @@ public class DailyReportLogPanel extends JPanel {
     }
 
     public void refreshLog(String s) {
+    	if(logText.equals(s)) {
+    		return;
+    	}
         logText = s;
         //txtLog.setText(logText); -- NO. BAD. DON'T DO THIS.
         Reader stringReader = new StringReader(logText);
@@ -95,7 +102,22 @@ public class DailyReportLogPanel extends JPanel {
 			// Ignore
 		}
         txtLog.setDocument(blank);
+		txtLog.setCaretPosition(blank.getLength());
     }
+
+	public void appendLog(List<String> newReports) {
+		String addedText = Utilities.combineString(newReports, ""); //$NON-NLS-1$
+		if((null != addedText) && (addedText.length() > 0)) {
+			HTMLDocument doc = (HTMLDocument) txtLog.getDocument();
+			try {
+				// Element 0 is <head>, Element 1 is <body>
+				doc.insertBeforeEnd(doc.getDefaultRootElement().getElement(1), addedText);
+			} catch (BadLocationException | IOException e) {
+				// Shouldn't happen
+			}
+			txtLog.setCaretPosition(doc.getLength());
+		}
+	}
 
     public String getLogText() {
         return logText;

--- a/MekHQ/src/mekhq/gui/DailyReportLogPanel.java
+++ b/MekHQ/src/mekhq/gui/DailyReportLogPanel.java
@@ -23,13 +23,21 @@ package mekhq.gui;
 
 
 import java.awt.BorderLayout;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
 import javax.swing.border.EmptyBorder;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultCaret;
+import javax.swing.text.DefaultStyledDocument;
+import javax.swing.text.Document;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
 
 /**
  * This is a panel for displaying the reporting log for each day. We are putting it into
@@ -77,7 +85,16 @@ public class DailyReportLogPanel extends JPanel {
 
     public void refreshLog(String s) {
         logText = s;
-        txtLog.setText(logText);
+        //txtLog.setText(logText); -- NO. BAD. DON'T DO THIS.
+        Reader stringReader = new StringReader(logText);
+        HTMLEditorKit htmlKit = new HTMLEditorKit();
+        HTMLDocument blank = (HTMLDocument) htmlKit.createDefaultDocument();
+        try {
+			htmlKit.read(stringReader, blank, 0);
+		} catch (Exception e) {
+			// Ignore
+		}
+        txtLog.setDocument(blank);
     }
 
     public String getLogText() {

--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -99,7 +99,7 @@ public class AdvanceDaysDialog extends JDialog implements ActionListener {
             gui.refreshCalendar();
             gui.refreshLocation();
             gui.refreshOrganization();
-            gui.refreshReport();
+            gui.initReport();
             gui.refreshFunds();
             gui.refreshFinancialTransactions();
             gui.refreshOverview();

--- a/MekHQ/src/mekhq/gui/dialog/DailyReportLogDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DailyReportLogDialog.java
@@ -10,6 +10,7 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.util.List;
 
 import javax.swing.JDialog;
 
@@ -55,4 +56,7 @@ public class DailyReportLogDialog extends JDialog {
         panLog.refreshLog(gui.getCampaign().getCurrentReportHTML());
     }
     
+    public void appendLog(List<String> newReports) {
+    	panLog.appendLog(newReports);
+    }
 }

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -18,7 +18,6 @@ import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
-import javax.swing.border.LineBorder;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableCellRenderer;
@@ -96,13 +95,13 @@ public class PartsInUseTableModel extends DataTableModel {
             case COL_COST:
                 return FORMATTER.format(piu.getCost());
             case COL_BUTTON_BUY:
-            	return "Buy";
+                return "Buy";
             case COL_BUTTON_BUY_BULK:
-            	return "Buy in Bulk";
+                return "Buy in Bulk";
             case COL_BUTTON_GMADD:
-            	return "Add (GM)";
+                return "Add (GM)";
             case COL_BUTTON_GMADD_BULK:
-            	return "Add in Bulk (GM)";
+                return "Add in Bulk (GM)";
             default:
                 return EMPTY_CELL;
         }
@@ -115,15 +114,15 @@ public class PartsInUseTableModel extends DataTableModel {
 
     @Override
     public boolean isCellEditable(int row, int col) {
-    	switch(col) {
-	    	case COL_BUTTON_BUY:
-	        case COL_BUTTON_BUY_BULK:
-	        case COL_BUTTON_GMADD:
-	        case COL_BUTTON_GMADD_BULK:
-	        	return true;
-        	default:
-        		return false;
-    	}
+        switch(col) {
+            case COL_BUTTON_BUY:
+            case COL_BUTTON_BUY_BULK:
+            case COL_BUTTON_GMADD:
+            case COL_BUTTON_GMADD_BULK:
+                return true;
+            default:
+                return false;
+        }
     }
     
     public void setData(Set<PartInUse> data) {
@@ -142,7 +141,7 @@ public class PartsInUseTableModel extends DataTableModel {
             case COL_STORED:
             case COL_IN_TRANSFER:
             case COL_COST:
-            	return SwingConstants.RIGHT;
+                return SwingConstants.RIGHT;
             default:
                 return SwingConstants.CENTER;
         }
@@ -156,13 +155,13 @@ public class PartsInUseTableModel extends DataTableModel {
             case COL_STORED:
             case COL_IN_TRANSFER:
             case COL_COST:
-            	return 20;
+                return 20;
             case COL_BUTTON_BUY:
-            	return 50;
+                return 50;
             case COL_BUTTON_GMADD:
-            	return 70;
+                return 70;
             case COL_BUTTON_BUY_BULK:
-            	return 80;
+                return 80;
             default:
                 return 100;
         }
@@ -199,123 +198,135 @@ public class PartsInUseTableModel extends DataTableModel {
     }
     
     public static class ButtonColumn extends AbstractCellEditor
-    	implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
+        implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
 
-		private static final long serialVersionUID = 5632710519408125751L;
-		
-		private JTable table;
-    	private Action action;
-    	private Border originalBorder;
-    	private Border focusBorder;
+        private static final long serialVersionUID = 5632710519408125751L;
+        
+        private JTable table;
+        private Action action;
+        private Border originalBorder;
+        private Border focusBorder;
 
-    	private JButton renderButton;
-    	private JButton editButton;
-    	private Object editorValue;
-    	private boolean isButtonColumnEditor;
+        private JButton renderButton;
+        private JButton editButton;
+        private Object editorValue;
+        private boolean isButtonColumnEditor;
+        private boolean enabled;
 
-    	public ButtonColumn(JTable table, Action action, int column) {
-    		this.table = table;
-    		this.action = action;
+        public ButtonColumn(JTable table, Action action, int column) {
+            this.table = table;
+            this.action = action;
 
-    		renderButton = new JButton();
-    		editButton = new JButton();
-    		editButton.setFocusPainted(false);
-    		editButton.addActionListener(this);
-    		originalBorder = editButton.getBorder();
-    		setFocusBorder(new LineBorder(Color.BLUE));
+            renderButton = new JButton();
+            editButton = new JButton();
+            editButton.setFocusPainted(false);
+            editButton.addActionListener(this);
+            originalBorder = editButton.getBorder();
+            enabled = true;
 
-    		TableColumnModel columnModel = table.getColumnModel();
-    		columnModel.getColumn(column).setCellRenderer(this);
-    		columnModel.getColumn(column).setCellEditor(this);
-    		table.addMouseListener(this);
-    	}
-    	
-    	public Border getFocusBorder()
-    	{
-    		return focusBorder;
-    	}
+            TableColumnModel columnModel = table.getColumnModel();
+            columnModel.getColumn(column).setCellRenderer(this);
+            columnModel.getColumn(column).setCellEditor(this);
+            table.addMouseListener(this);
+        }
+        
+        public Border getFocusBorder()
+        {
+            return focusBorder;
+        }
 
-    	public void setFocusBorder(Border focusBorder)
-    	{
-    		this.focusBorder = focusBorder;
-    		editButton.setBorder( focusBorder );
-    	}
+        public void setFocusBorder(Border focusBorder)
+        {
+            this.focusBorder = focusBorder;
+            editButton.setBorder(focusBorder);
+        }
 
-		@Override
-		public Object getCellEditorValue() {
-			return editorValue;
-		}
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+            editButton.setEnabled(enabled);
+            renderButton.setEnabled(enabled);
+        }
+        
+        @Override
+        public Object getCellEditorValue() {
+            return editorValue;
+        }
 
-		@Override public void mousePressed(MouseEvent e) {
-	    	if(table.isEditing() && (this == table.getCellEditor())) {
-	    		isButtonColumnEditor = true;
-	    	}
-		}
+        @Override
+        public void mousePressed(MouseEvent e) {
+            if(table.isEditing() && (this == table.getCellEditor())) {
+                isButtonColumnEditor = true;
+            }
+        }
 
-		@Override public void mouseReleased(MouseEvent e) {
-	    	if(isButtonColumnEditor && table.isEditing()) {
-	    		table.getCellEditor().stopCellEditing();
-	    	}
-	    	isButtonColumnEditor = false;
-		}
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            if(isButtonColumnEditor && table.isEditing()) {
+                table.getCellEditor().stopCellEditing();
+            }
+            isButtonColumnEditor = false;
+        }
 
-		@Override public void mouseClicked(MouseEvent e) {}
-		@Override public void mouseEntered(MouseEvent e) {}
-		@Override public void mouseExited(MouseEvent e) {}
+        @Override public void mouseClicked(MouseEvent e) {}
+        @Override public void mouseEntered(MouseEvent e) {}
+        @Override public void mouseExited(MouseEvent e) {}
 
-		@Override public void actionPerformed(ActionEvent e) {
-			int row = table.convertRowIndexToModel(table.getEditingRow());
-			fireEditingStopped();
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            int row = table.convertRowIndexToModel(table.getEditingRow());
+            fireEditingStopped();
 
-			//  Invoke the Action
-			ActionEvent event = new ActionEvent(table, ActionEvent.ACTION_PERFORMED, "" + row); //$NON-NLS-1$
-			action.actionPerformed(event);
-		}
+            //  Invoke the Action
+            ActionEvent event = new ActionEvent(table, ActionEvent.ACTION_PERFORMED, "" + row); //$NON-NLS-1$
+            action.actionPerformed(event);
+        }
 
-		@Override public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
-			if(value == null) {
-				editButton.setText(EMPTY_CELL);
-				editButton.setIcon(null);
-			} else if(value instanceof Icon) {
-				editButton.setText(EMPTY_CELL);
-				editButton.setIcon((Icon)value);
-			} else {
-				editButton.setText(value.toString());
-				editButton.setIcon(null);
-			}
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+            if(value == null) {
+                editButton.setText(EMPTY_CELL);
+                editButton.setIcon(null);
+            } else if(value instanceof Icon) {
+                editButton.setText(EMPTY_CELL);
+                editButton.setIcon((Icon)value);
+            } else {
+                editButton.setText(value.toString());
+                editButton.setIcon(null);
+            }
 
-			this.editorValue = value;
-			return editButton;
-		}
+            this.editorValue = value;
+            return editButton;
+        }
 
-		@Override public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
-			if(isSelected) {
-				renderButton.setForeground(table.getSelectionForeground());
-		 		renderButton.setBackground(table.getSelectionBackground());
-			} else {
-				renderButton.setForeground(table.getForeground());
-				renderButton.setBackground(UIManager.getColor("Button.background")); //$NON-NLS-1$
-			}
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+            if(isSelected && enabled) {
+                renderButton.setForeground(table.getSelectionForeground());
+                 renderButton.setBackground(table.getSelectionBackground());
+            } else {
+                renderButton.setForeground(table.getForeground());
+                renderButton.setBackground(UIManager.getColor("Button.background")); //$NON-NLS-1$
+            }
 
-			if(hasFocus) {
-				renderButton.setBorder(focusBorder);
-			} else {
-				renderButton.setBorder(originalBorder);
-			}
+            if(hasFocus && enabled) {
+                renderButton.setBorder(focusBorder);
+            } else {
+                renderButton.setBorder(originalBorder);
+            }
 
-			if(value == null)
-			{
-				renderButton.setText(EMPTY_CELL);
-				renderButton.setIcon(null);
-			} else if (value instanceof Icon) {
-				renderButton.setText(EMPTY_CELL);
-				renderButton.setIcon((Icon)value);
-			} else {
-				renderButton.setText(value.toString());
-				renderButton.setIcon(null);
-			}
+            if(value == null)
+            {
+                renderButton.setText(EMPTY_CELL);
+                renderButton.setIcon(null);
+            } else if (value instanceof Icon) {
+                renderButton.setText(EMPTY_CELL);
+                renderButton.setIcon((Icon)value);
+            } else {
+                renderButton.setText(value.toString());
+                renderButton.setIcon(null);
+            }
 
-			return renderButton;
-		}
+            return renderButton;
+        }
     }
 }

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -151,7 +151,12 @@ public class PartsInUseTableModel extends DataTableModel {
         if((row < 0) || (row >= data.size())) {
             return null;
         }
-        return (PartInUse)data.get(row);
+        return (PartInUse) data.get(row);
+    }
+    
+    public boolean isBuyable(int row) {
+        return (row >= 0) && (row < data.size())
+            && (null != ((PartInUse) data.get(row)).getPartToBuy());
     }
 
     public int getAlignment(int column) {
@@ -332,6 +337,8 @@ public class PartsInUseTableModel extends DataTableModel {
 
         @Override
         public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+            boolean buyable = ((PartsInUseTableModel) table.getModel()).isBuyable(table.getRowSorter().convertRowIndexToModel(row));
+            
             if(value == null) {
                 editButton.setText(EMPTY_CELL);
                 editButton.setIcon(null);
@@ -342,14 +349,17 @@ public class PartsInUseTableModel extends DataTableModel {
                 editButton.setText(value.toString());
                 editButton.setIcon(null);
             }
-
+            editButton.setEnabled(enabled && buyable);
+            
             this.editorValue = value;
             return editButton;
         }
 
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
-            if(isSelected && enabled) {
+            boolean buyable = ((PartsInUseTableModel) table.getModel()).isBuyable(table.getRowSorter().convertRowIndexToModel(row));
+            
+            if(isSelected && enabled && buyable) {
                 renderButton.setForeground(table.getSelectionForeground());
                  renderButton.setBackground(table.getSelectionBackground());
             } else {
@@ -357,7 +367,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 renderButton.setBackground(UIManager.getColor("Button.background")); //$NON-NLS-1$
             }
 
-            if(hasFocus && enabled) {
+            if(hasFocus && enabled && buyable) {
                 renderButton.setBorder(focusBorder);
             } else {
                 renderButton.setBorder(originalBorder);
@@ -374,7 +384,8 @@ public class PartsInUseTableModel extends DataTableModel {
                 renderButton.setText(value.toString());
                 renderButton.setIcon(null);
             }
-
+            renderButton.setEnabled(enabled && buyable);
+            
             return renderButton;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -1,0 +1,321 @@
+package mekhq.gui.model;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Set;
+
+import javax.swing.AbstractCellEditor;
+import javax.swing.Action;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JTable;
+import javax.swing.SwingConstants;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+import javax.swing.border.LineBorder;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumnModel;
+
+import mekhq.campaign.parts.PartInUse;
+
+public class PartsInUseTableModel extends DataTableModel {
+    private static final long serialVersionUID = -7166100476703184175L;
+    
+    private static final DecimalFormat FORMATTER = new DecimalFormat();
+    private static final String EMPTY_CELL = ""; //$NON-NLS-1$
+
+    public final static int COL_PART = 0;
+    public final static int COL_IN_USE = 1;
+    public final static int COL_STORED = 2;
+    public final static int COL_IN_TRANSFER  = 3;
+    public final static int COL_COST = 4;
+    public final static int COL_BUTTON_BUY  = 5;
+    public final static int COL_BUTTON_BUY_BULK  = 6;
+    public final static int COL_BUTTON_GMADD  = 7;
+    public final static int COL_BUTTON_GMADD_BULK  = 8;
+
+    public PartsInUseTableModel () {
+        data = new ArrayList<PartInUse>();
+    }
+    
+    @Override
+    public int getRowCount() {
+        return data.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COL_BUTTON_GMADD_BULK + 1;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        switch(column) {
+        case COL_PART:
+            return "Part";
+        case COL_IN_USE:
+            return "In use";
+        case COL_STORED:
+            return "Stored";
+        case COL_IN_TRANSFER:
+            return "Ordered";
+        case COL_COST:
+            return "Cost";
+        default:
+            return EMPTY_CELL;
+        }
+    }
+
+    @Override
+    public Object getValueAt(int row, int column) {
+        PartInUse piu = getPartInUse(row);
+        switch(column) {
+            case COL_PART:
+                return piu.getDescription();
+            case COL_IN_USE:
+                return FORMATTER.format(piu.getUseCount());
+            case COL_STORED:
+                return (piu.getStoreCount() > 0) ? FORMATTER.format(piu.getStoreCount()) : EMPTY_CELL;
+            case COL_IN_TRANSFER:
+                if( piu.getTransferCount() > 0 || piu.getPlannedCount() > 0 ) {
+                    return String.format("%s (%s)", //$NON-NLS-1$
+                        FORMATTER.format(piu.getTransferCount()), FORMATTER.format(piu.getPlannedCount()));
+                } else if( piu.getTransferCount() > 0 ) {
+                    return FORMATTER.format(piu.getTransferCount());
+                } else {
+                    return EMPTY_CELL;
+                }
+            case COL_COST:
+                return FORMATTER.format(piu.getCost());
+            case COL_BUTTON_BUY:
+            	return "Buy";
+            case COL_BUTTON_BUY_BULK:
+            	return "Buy in Bulk";
+            case COL_BUTTON_GMADD:
+            	return "Add (GM)";
+            case COL_BUTTON_GMADD_BULK:
+            	return "Add in Bulk (GM)";
+            default:
+                return EMPTY_CELL;
+        }
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int col) {
+    	switch(col) {
+	    	case COL_BUTTON_BUY:
+	        case COL_BUTTON_BUY_BULK:
+	        case COL_BUTTON_GMADD:
+	        case COL_BUTTON_GMADD_BULK:
+	        	return true;
+        	default:
+        		return false;
+    	}
+    }
+    
+    public void setData(Set<PartInUse> data) {
+        setData(new ArrayList<PartInUse>(data));
+    }
+
+    public PartInUse getPartInUse(int row) {
+        return (PartInUse)data.get(row);
+    }
+
+    public int getAlignment(int column) {
+        switch(column) {
+            case COL_PART:
+                return SwingConstants.LEFT;
+            case COL_IN_USE:
+            case COL_STORED:
+            case COL_IN_TRANSFER:
+            case COL_COST:
+            	return SwingConstants.RIGHT;
+            default:
+                return SwingConstants.CENTER;
+        }
+    }
+    
+    public int getPreferredWidth(int column) {
+        switch(column) {
+            case COL_PART:
+                return 300;
+            case COL_IN_USE:
+            case COL_STORED:
+            case COL_IN_TRANSFER:
+            case COL_COST:
+            	return 20;
+            case COL_BUTTON_BUY:
+            	return 50;
+            case COL_BUTTON_GMADD:
+            	return 70;
+            case COL_BUTTON_BUY_BULK:
+            	return 80;
+            default:
+                return 100;
+        }
+    }
+    
+    public PartsInUseTableModel.Renderer getRenderer() {
+        return new PartsInUseTableModel.Renderer();
+    }
+
+    public static class Renderer extends DefaultTableCellRenderer {
+        private static final long serialVersionUID = 1403740113670268591L;
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                boolean isSelected, boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            setOpaque(true);
+            setHorizontalAlignment(((PartsInUseTableModel)table.getModel()).getAlignment(column));
+
+            setForeground(Color.BLACK);
+            if (isSelected) {
+                setBackground(Color.DARK_GRAY);
+                setForeground(Color.WHITE);
+            } else {
+                // tiger stripes
+                if (row % 2 == 1) {
+                    setBackground(new Color(230,230,230));
+                } else {
+                    setBackground(Color.WHITE);
+                }
+            }
+            return this;
+        }
+    }
+    
+    public static class ButtonColumn extends AbstractCellEditor
+    	implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
+
+		private static final long serialVersionUID = 5632710519408125751L;
+		
+		private JTable table;
+    	private Action action;
+    	private Border originalBorder;
+    	private Border focusBorder;
+
+    	private JButton renderButton;
+    	private JButton editButton;
+    	private Object editorValue;
+    	private boolean isButtonColumnEditor;
+
+    	public ButtonColumn(JTable table, Action action, int column) {
+    		this.table = table;
+    		this.action = action;
+
+    		renderButton = new JButton();
+    		editButton = new JButton();
+    		editButton.setFocusPainted(false);
+    		editButton.addActionListener(this);
+    		originalBorder = editButton.getBorder();
+    		setFocusBorder(new LineBorder(Color.BLUE));
+
+    		TableColumnModel columnModel = table.getColumnModel();
+    		columnModel.getColumn(column).setCellRenderer(this);
+    		columnModel.getColumn(column).setCellEditor(this);
+    		table.addMouseListener(this);
+    	}
+    	
+    	public Border getFocusBorder()
+    	{
+    		return focusBorder;
+    	}
+
+    	public void setFocusBorder(Border focusBorder)
+    	{
+    		this.focusBorder = focusBorder;
+    		editButton.setBorder( focusBorder );
+    	}
+
+		@Override
+		public Object getCellEditorValue() {
+			return editorValue;
+		}
+
+		@Override public void mousePressed(MouseEvent e) {
+	    	if(table.isEditing() && (this == table.getCellEditor())) {
+	    		isButtonColumnEditor = true;
+	    	}
+		}
+
+		@Override public void mouseReleased(MouseEvent e) {
+	    	if(isButtonColumnEditor && table.isEditing()) {
+	    		table.getCellEditor().stopCellEditing();
+	    	}
+	    	isButtonColumnEditor = false;
+		}
+
+		@Override public void mouseClicked(MouseEvent e) {}
+		@Override public void mouseEntered(MouseEvent e) {}
+		@Override public void mouseExited(MouseEvent e) {}
+
+		@Override public void actionPerformed(ActionEvent e) {
+			int row = table.convertRowIndexToModel(table.getEditingRow());
+			fireEditingStopped();
+
+			//  Invoke the Action
+			ActionEvent event = new ActionEvent(table, ActionEvent.ACTION_PERFORMED, "" + row); //$NON-NLS-1$
+			action.actionPerformed(event);
+		}
+
+		@Override public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+			if(value == null) {
+				editButton.setText(EMPTY_CELL);
+				editButton.setIcon(null);
+			} else if(value instanceof Icon) {
+				editButton.setText(EMPTY_CELL);
+				editButton.setIcon((Icon)value);
+			} else {
+				editButton.setText(value.toString());
+				editButton.setIcon(null);
+			}
+
+			this.editorValue = value;
+			return editButton;
+		}
+
+		@Override public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+			if(isSelected) {
+				renderButton.setForeground(table.getSelectionForeground());
+		 		renderButton.setBackground(table.getSelectionBackground());
+			} else {
+				renderButton.setForeground(table.getForeground());
+				renderButton.setBackground(UIManager.getColor("Button.background")); //$NON-NLS-1$
+			}
+
+			if(hasFocus) {
+				renderButton.setBorder(focusBorder);
+			} else {
+				renderButton.setBorder(originalBorder);
+			}
+
+			if(value == null)
+			{
+				renderButton.setText(EMPTY_CELL);
+				renderButton.setIcon(null);
+			} else if (value instanceof Icon) {
+				renderButton.setText(EMPTY_CELL);
+				renderButton.setIcon((Icon)value);
+			} else {
+				renderButton.setText(value.toString());
+				renderButton.setIcon(null);
+			}
+
+			return renderButton;
+		}
+    }
+}

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -87,7 +87,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 if( piu.getTransferCount() > 0 && piu.getPlannedCount() <= 0 ) {
                     return FORMATTER.format(piu.getTransferCount());
                 } else if( piu.getPlannedCount() > 0 ) {
-                    return String.format("%s (%s)", //$NON-NLS-1$
+                    return String.format("%s [+%s]", //$NON-NLS-1$
                         FORMATTER.format(piu.getTransferCount()), FORMATTER.format(piu.getPlannedCount()));
                 } else {
                     return EMPTY_CELL;

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -34,12 +34,13 @@ public class PartsInUseTableModel extends DataTableModel {
     public final static int COL_PART = 0;
     public final static int COL_IN_USE = 1;
     public final static int COL_STORED = 2;
-    public final static int COL_IN_TRANSFER  = 3;
-    public final static int COL_COST = 4;
-    public final static int COL_BUTTON_BUY  = 5;
-    public final static int COL_BUTTON_BUY_BULK  = 6;
-    public final static int COL_BUTTON_GMADD  = 7;
-    public final static int COL_BUTTON_GMADD_BULK  = 8;
+    public final static int COL_TONNAGE = 3;
+    public final static int COL_IN_TRANSFER  = 4;
+    public final static int COL_COST = 5;
+    public final static int COL_BUTTON_BUY  = 6;
+    public final static int COL_BUTTON_BUY_BULK  = 7;
+    public final static int COL_BUTTON_GMADD  = 8;
+    public final static int COL_BUTTON_GMADD_BULK  = 9;
 
     public PartsInUseTableModel () {
         data = new ArrayList<PartInUse>();
@@ -64,6 +65,8 @@ public class PartsInUseTableModel extends DataTableModel {
             return "In use";
         case COL_STORED:
             return "Stored";
+        case COL_TONNAGE:
+            return "Tonnage";
         case COL_IN_TRANSFER:
             return "Ordered";
         case COL_COST:
@@ -83,6 +86,8 @@ public class PartsInUseTableModel extends DataTableModel {
                 return FORMATTER.format(piu.getUseCount());
             case COL_STORED:
                 return (piu.getStoreCount() > 0) ? FORMATTER.format(piu.getStoreCount()) : EMPTY_CELL;
+            case COL_TONNAGE:
+                return (piu.getStoreTonnage() > 0) ? FORMATTER.format(piu.getStoreTonnage()) : EMPTY_CELL;
             case COL_IN_TRANSFER:
                 if( piu.getTransferCount() > 0 && piu.getPlannedCount() <= 0 ) {
                     return FORMATTER.format(piu.getTransferCount());
@@ -130,6 +135,9 @@ public class PartsInUseTableModel extends DataTableModel {
     }
 
     public PartInUse getPartInUse(int row) {
+        if((row < 0) || (row >= data.size())) {
+            return null;
+        }
         return (PartInUse)data.get(row);
     }
 
@@ -139,6 +147,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 return SwingConstants.LEFT;
             case COL_IN_USE:
             case COL_STORED:
+            case COL_TONNAGE:
             case COL_IN_TRANSFER:
             case COL_COST:
                 return SwingConstants.RIGHT;
@@ -153,6 +162,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 return 300;
             case COL_IN_USE:
             case COL_STORED:
+            case COL_TONNAGE:
             case COL_IN_TRANSFER:
             case COL_COST:
                 return 20;
@@ -164,6 +174,32 @@ public class PartsInUseTableModel extends DataTableModel {
                 return 80;
             default:
                 return 100;
+        }
+    }
+    
+    public boolean hasConstantWidth(int col) {
+        switch(col) {
+            case COL_BUTTON_BUY:
+            case COL_BUTTON_BUY_BULK:
+            case COL_BUTTON_GMADD:
+            case COL_BUTTON_GMADD_BULK:
+                return true;
+            default:
+                return false;
+        }
+    }
+    
+    public int getWidth(int col) {
+        switch(col) {
+            case COL_BUTTON_BUY:
+            case COL_BUTTON_BUY_BULK:
+            case COL_BUTTON_GMADD:
+            case COL_BUTTON_GMADD_BULK:
+                // Calculate from button width, respecting style
+                JButton btn = new JButton(getValueAt(0, col).toString());
+                return btn.getPreferredSize().width;
+            default:
+                return Integer.MAX_VALUE;
         }
     }
     

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -140,6 +140,12 @@ public class PartsInUseTableModel extends DataTableModel {
     public void setData(Set<PartInUse> data) {
         setData(new ArrayList<PartInUse>(data));
     }
+    
+    @SuppressWarnings("unchecked")
+    public void updateRow(int row, PartInUse piu) {
+        ((ArrayList<PartInUse>) data).set(row, piu);
+        fireTableRowsUpdated(row, row);
+    }
 
     public PartInUse getPartInUse(int row) {
         if((row < 0) || (row >= data.size())) {

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -84,11 +84,11 @@ public class PartsInUseTableModel extends DataTableModel {
             case COL_STORED:
                 return (piu.getStoreCount() > 0) ? FORMATTER.format(piu.getStoreCount()) : EMPTY_CELL;
             case COL_IN_TRANSFER:
-                if( piu.getTransferCount() > 0 || piu.getPlannedCount() > 0 ) {
+                if( piu.getTransferCount() > 0 && piu.getPlannedCount() <= 0 ) {
+                    return FORMATTER.format(piu.getTransferCount());
+                } else if( piu.getPlannedCount() > 0 ) {
                     return String.format("%s (%s)", //$NON-NLS-1$
                         FORMATTER.format(piu.getTransferCount()), FORMATTER.format(piu.getPlannedCount()));
-                } else if( piu.getTransferCount() > 0 ) {
-                    return FORMATTER.format(piu.getTransferCount());
                 } else {
                     return EMPTY_CELL;
                 }

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -29,6 +29,9 @@ public class PartsInUseTableModel extends DataTableModel {
     private static final long serialVersionUID = -7166100476703184175L;
     
     private static final DecimalFormat FORMATTER = new DecimalFormat();
+    static {
+        FORMATTER.setMaximumFractionDigits(3);
+    }
     private static final String EMPTY_CELL = ""; //$NON-NLS-1$
 
     public final static int COL_PART = 0;

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -8,6 +8,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.ResourceBundle;
 import java.util.Set;
 
 import javax.swing.AbstractCellEditor;
@@ -45,7 +46,10 @@ public class PartsInUseTableModel extends DataTableModel {
     public final static int COL_BUTTON_GMADD  = 8;
     public final static int COL_BUTTON_GMADD_BULK  = 9;
 
+    private ResourceBundle resourceMap;
+
     public PartsInUseTableModel () {
+        resourceMap = ResourceBundle.getBundle("mekhq.resources.PartsInUseTableModel"); //$NON-NLS-1$
         data = new ArrayList<PartInUse>();
     }
     
@@ -63,17 +67,17 @@ public class PartsInUseTableModel extends DataTableModel {
     public String getColumnName(int column) {
         switch(column) {
         case COL_PART:
-            return "Part";
+            return resourceMap.getString("part.heading"); //$NON-NLS-1$
         case COL_IN_USE:
-            return "In use";
+            return resourceMap.getString("inUse.heading"); //$NON-NLS-1$
         case COL_STORED:
-            return "Stored";
+            return resourceMap.getString("stored.heading"); //$NON-NLS-1$
         case COL_TONNAGE:
-            return "Tonnage";
+            return resourceMap.getString("storedTonnage.heading"); //$NON-NLS-1$
         case COL_IN_TRANSFER:
-            return "Ordered";
+            return resourceMap.getString("ordered.heading"); //$NON-NLS-1$
         case COL_COST:
-            return "Cost";
+            return resourceMap.getString("cost.heading"); //$NON-NLS-1$
         default:
             return EMPTY_CELL;
         }
@@ -103,13 +107,13 @@ public class PartsInUseTableModel extends DataTableModel {
             case COL_COST:
                 return FORMATTER.format(piu.getCost());
             case COL_BUTTON_BUY:
-                return "Buy";
+                return resourceMap.getString("buy.text"); //$NON-NLS-1$
             case COL_BUTTON_BUY_BULK:
-                return "Buy in Bulk";
+                return resourceMap.getString("buyInBulk.text"); //$NON-NLS-1$
             case COL_BUTTON_GMADD:
-                return "Add (GM)";
+                return resourceMap.getString("add.text"); //$NON-NLS-1$
             case COL_BUTTON_GMADD_BULK:
-                return "Add in Bulk (GM)";
+                return resourceMap.getString("addInBulk.text"); //$NON-NLS-1$
             default:
                 return EMPTY_CELL;
         }

--- a/MekHQ/src/mekhq/gui/sorter/FormattedNumberSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/FormattedNumberSorter.java
@@ -11,25 +11,43 @@ import java.util.Comparator;
      *
      */
     public class FormattedNumberSorter implements Comparator<String> {
+        private static final String PLUS_SIGN = "+"; //$NON-NLS-1$
+        private static final DecimalFormat FORMAT = new DecimalFormat();
 
         @Override
         public int compare(String s0, String s1) {
+            // Cut off leading "+" sign if there
+            if(s0.startsWith(PLUS_SIGN)) {
+                s0 = s0.substring(1);
+            }
+            if(s1.startsWith(PLUS_SIGN)) {
+                s1 = s1.substring(1);
+            }
+            // Empty cells are smaller than all numbers
+            if((s0.length() == 0) && (s1.length() == 0)) {
+                return 0;
+            }
+            if(s0.length() == 0) {
+                return -1;
+            }
+            if(s1.length() == 0) {
+                return 1;
+            }
             //lets find the weight class integer for each name
-            DecimalFormat format = new DecimalFormat();
             long l0 = 0;
             try {
-                l0 = format.parse(s0).longValue();
+                l0 = FORMAT.parse(s0).longValue();
             } catch (java.text.ParseException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
             }
             long l1 = 0;
             try {
-                l1 = format.parse(s1).longValue();
+                l1 = FORMAT.parse(s1).longValue();
             } catch (java.text.ParseException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
             }
-            return ((Comparable<Long>)l0).compareTo(l1);
+            return Long.compare(l0, l1);
         }
     }

--- a/MekHQ/src/mekhq/gui/sorter/TwoNumbersSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/TwoNumbersSorter.java
@@ -1,0 +1,52 @@
+package mekhq.gui.sorter;
+
+import java.util.Comparator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A comparator for two numbers formatted like: "123 [54]"
+ * <p>
+ * Sorts by first number, then if available second number.
+ * Numbers without a second number are sorted before all those with them,
+ * the same way FormattedNumberSorter would do so.
+ */
+public final class TwoNumbersSorter implements Comparator<String>{
+    private static final Comparator<String> NUM_SORTER = new FormattedNumberSorter();
+    private static final Pattern NUM_PATTERN =
+        Pattern.compile("^([+-]?\\d*)\\s+\\[([+-]?\\d*)\\]\\s*$"); //$NON-NLS-1$
+
+    @Override public int compare(String s1, String s2) {
+        Matcher match1 = NUM_PATTERN.matcher(s1);
+        Matcher match2 = NUM_PATTERN.matcher(s2);
+        boolean hasSecondNumber1 = match1.matches();
+        boolean hasSecondNumber2 = match2.matches();
+        if(!hasSecondNumber1 && !hasSecondNumber2) {
+            return NUM_SORTER.compare(s1, s2);
+        }
+        
+        String firstNum1 = s1;
+        String firstNum2 = s2;
+        if(hasSecondNumber1) {
+            firstNum1 = match1.group(1);
+        }
+        if(hasSecondNumber2) {
+            firstNum2 = match2.group(1);
+        }
+        
+        int result = NUM_SORTER.compare(firstNum1, firstNum2);
+        if(result != 0) {
+            return result;
+        }
+        
+        // Sort numbers without a second number before those with
+        if(hasSecondNumber1 && !hasSecondNumber2) {
+            return -1;
+        }
+        if(!hasSecondNumber1 && hasSecondNumber2) {
+            return 1;
+        }
+        // Else, sort by second number
+        return NUM_SORTER.compare(match1.group(2), match2.group(2));
+    }
+}

--- a/MekHQ/src/mekhq/resources/PartsInUseTableModel.properties
+++ b/MekHQ/src/mekhq/resources/PartsInUseTableModel.properties
@@ -1,0 +1,10 @@
+add.text=Add (GM)
+addInBulk.text=Add in Bulk (GM)
+buy.text=Buy
+buyInBulk.text=Buy in Bulk
+cost.heading=Cost
+inUse.heading=In use
+ordered.heading=Ordered
+part.heading=Part
+stored.heading=Stored
+storedTonnage.heading=Tonnage


### PR DESCRIPTION
Fixing most of the issues with the buttons in "parts in use" tab:

* The buttons refreshhng themselves, blocking the UI
* General speedup of the parts lookup via caching

It's not a 100% fix yet. In particular, mech heads are cached as `Mech Head (XX tons, (100%, [Sensors, Cockpit]))` and similar and queried as `Mech Head (XX tons, (100%)`. That probably needs additional caching in the `PartStore` to work properly, but I'm out of time ATM.

Will update once I'll find some time, probably tomorrow. Feel free to comment and point to other obvious solutions I missed.
