### PR TITLE
Event system

### DIFF
--- a/MekHQ/src/mekhq/event/EventBus.java
+++ b/MekHQ/src/mekhq/event/EventBus.java
@@ -1,0 +1,133 @@
+package mekhq.event;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class EventBus {
+    private static final Object INSTANCE_LOCK = new Object[0];
+    private static final Object REGISTER_LOCK = new Object[0];
+    
+    private static EventBus instance;
+    private static final EventSorter EVENT_SORTER = new EventSorter();
+    
+    private ConcurrentHashMap<Object, List<EventListener>> handlerMap
+        = new ConcurrentHashMap<Object, List<EventListener>>();
+    private ConcurrentHashMap<Class<? extends HQEvent<?>>, List<EventListener>> eventMap
+        = new ConcurrentHashMap<Class<? extends HQEvent<?>>, List<EventListener>>();
+    
+    public static EventBus getInstance() {
+        synchronized(INSTANCE_LOCK) {
+            if(null == instance) {
+                instance = new EventBus();
+            }
+        }
+        return instance;
+    }
+    
+    public static void registerHandler(Object handler) {
+        getInstance().register(handler);
+    }
+    
+    public static void unregisterHandler(Object handler) {
+        getInstance().unregister(handler);
+    }
+    
+    private EventBus() {}
+    
+    private List<Class<?>> getClasses(Class<?> leaf) {
+        List<Class<?>> result = new ArrayList<Class<?>>();
+        while(null != leaf) {
+            result.add(leaf);
+            leaf = leaf.getSuperclass();
+        }
+        return result;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public void register(Object handler) {
+        if(handlerMap.containsKey(handler)) {
+            return;
+        }
+        
+        for(Method method : handler.getClass().getMethods()) {
+            for(Class<?> cls : getClasses(handler.getClass())) {
+                try {
+                    Method realMethod = cls.getDeclaredMethod(method.getName(), method.getParameterTypes());
+                    if(realMethod.isAnnotationPresent(Subscribe.class)) {
+                        Class<?>[] parameterTypes = method.getParameterTypes();
+                        if(parameterTypes.length != 1) {
+                            throw new IllegalArgumentException(
+                                String.format("@Subscribe annotation requires single-argument method; %s has %d", //$NON-NLS-1$
+                                    method, parameterTypes.length));
+                        }
+                        Class<?> eventType = parameterTypes[0];
+                        if(!HQEvent.class.isAssignableFrom(eventType)) {
+                            throw new IllegalArgumentException(
+                                String.format("@Subscribe annotation of %s requires the argument type to be some subtype of HQEvent, not %s", //$NON-NLS-1$
+                                    method, eventType));
+                        }
+                        internalRegister(handler, realMethod, (Class<? extends HQEvent<?>>) eventType);
+                    }
+                } catch (NoSuchMethodException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    private void internalRegister(Object handler, Method method, Class<? extends HQEvent<?>> eventType) {
+        synchronized(REGISTER_LOCK) {
+            EventListener listener = new EventListener(handler, method, eventType);
+            List<EventListener> handlerListeners = handlerMap.get(handler);
+            if(null == handlerListeners) {
+                handlerListeners = new ArrayList<EventListener>();
+                handlerMap.put(handler, handlerListeners);
+            }
+            handlerListeners.add(listener);
+            List<EventListener> eventListeners = eventMap.get(eventType);
+            if(null == eventListeners) {
+                eventListeners = new ArrayList<EventListener>();
+                eventMap.put(eventType, eventListeners);
+            }
+            eventListeners.add(listener);
+        }
+    }
+    
+    public void unregister(Object handler) {
+        synchronized(REGISTER_LOCK) {
+            List<EventListener> listenerList = handlerMap.remove(handler);
+            if(null != listenerList) {
+                for(EventListener listener : listenerList) {
+                    List<EventListener> eventListeners = eventMap.get(listener.getEventType());
+                    if(null != eventListeners) {
+                        eventListeners.remove(listener);
+                    }
+                }
+            }
+        }
+    }
+    
+    /** @return true if the event was cancelled along the way */
+    public boolean trigger(HQEvent<?> event) {
+        List<EventListener> eventListeners = eventMap.get(event.getClass());
+        if(null != eventListeners) {
+            Collections.sort(eventListeners, EVENT_SORTER);
+            for(EventListener listener : eventListeners) {
+                listener.trigger(event);
+            }
+        }
+        return event.isCancellable() ? event.isCancelled() : false;
+    }
+    
+    private static class EventSorter implements Comparator<EventListener> {
+        @Override
+        public int compare(EventListener el1, EventListener el2) {
+            // Highest to lowest, by priority
+            return Integer.compare(el2.getPriority(), el1.getPriority());
+        }
+    }
+}

--- a/MekHQ/src/mekhq/event/EventBus.java
+++ b/MekHQ/src/mekhq/event/EventBus.java
@@ -9,10 +9,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public final class EventBus {
     private static final Object INSTANCE_LOCK = new Object[0];
-    private static final Object REGISTER_LOCK = new Object[0];
     
     private static EventBus instance;
     private static final EventSorter EVENT_SORTER = new EventSorter();
+    
+    private final Object REGISTER_LOCK = new Object[0];
     
     private ConcurrentHashMap<Object, List<EventListener>> handlerMap
         = new ConcurrentHashMap<Object, List<EventListener>>();
@@ -36,7 +37,11 @@ public final class EventBus {
         getInstance().unregister(handler);
     }
     
-    private EventBus() {}
+    public static boolean triggerEvent(HQEvent<?> event) {
+        return getInstance().trigger(event);
+    }
+    
+    public EventBus() {}
     
     private List<Class<?>> getClasses(Class<?> leaf) {
         List<Class<?>> result = new ArrayList<Class<?>>();

--- a/MekHQ/src/mekhq/event/EventBus.java
+++ b/MekHQ/src/mekhq/event/EventBus.java
@@ -17,8 +17,8 @@ public final class EventBus {
     
     private ConcurrentHashMap<Object, List<EventListener>> handlerMap
         = new ConcurrentHashMap<Object, List<EventListener>>();
-    private ConcurrentHashMap<Class<? extends HQEvent<?>>, List<EventListener>> eventMap
-        = new ConcurrentHashMap<Class<? extends HQEvent<?>>, List<EventListener>>();
+    private ConcurrentHashMap<Class<? extends HQEvent>, List<EventListener>> eventMap
+        = new ConcurrentHashMap<Class<? extends HQEvent>, List<EventListener>>();
     
     public static EventBus getInstance() {
         synchronized(INSTANCE_LOCK) {
@@ -37,7 +37,7 @@ public final class EventBus {
         getInstance().unregister(handler);
     }
     
-    public static boolean triggerEvent(HQEvent<?> event) {
+    public static boolean triggerEvent(HQEvent event) {
         return getInstance().trigger(event);
     }
     
@@ -75,7 +75,7 @@ public final class EventBus {
                                 String.format("@Subscribe annotation of %s requires the argument type to be some subtype of HQEvent, not %s", //$NON-NLS-1$
                                     method, eventType));
                         }
-                        internalRegister(handler, realMethod, (Class<? extends HQEvent<?>>) eventType);
+                        internalRegister(handler, realMethod, (Class<? extends HQEvent>) eventType);
                     }
                 } catch (NoSuchMethodException e) {
                     // ignore
@@ -84,7 +84,7 @@ public final class EventBus {
         }
     }
 
-    private void internalRegister(Object handler, Method method, Class<? extends HQEvent<?>> eventType) {
+    private void internalRegister(Object handler, Method method, Class<? extends HQEvent> eventType) {
         synchronized(REGISTER_LOCK) {
             method.setAccessible(true);
             EventListener listener = new EventListener(handler, method, eventType);
@@ -118,7 +118,7 @@ public final class EventBus {
     }
     
     /** @return true if the event was cancelled along the way */
-    public boolean trigger(HQEvent<?> event) {
+    public boolean trigger(HQEvent event) {
         List<EventListener> eventListeners = eventMap.get(event.getClass());
         if(null != eventListeners) {
             Collections.sort(eventListeners, EVENT_SORTER);

--- a/MekHQ/src/mekhq/event/EventBus.java
+++ b/MekHQ/src/mekhq/event/EventBus.java
@@ -81,6 +81,7 @@ public final class EventBus {
 
     private void internalRegister(Object handler, Method method, Class<? extends HQEvent<?>> eventType) {
         synchronized(REGISTER_LOCK) {
+            method.setAccessible(true);
             EventListener listener = new EventListener(handler, method, eventType);
             List<EventListener> handlerListeners = handlerMap.get(handler);
             if(null == handlerListeners) {

--- a/MekHQ/src/mekhq/event/EventListener.java
+++ b/MekHQ/src/mekhq/event/EventListener.java
@@ -1,0 +1,41 @@
+package mekhq.event;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+class EventListener {
+    private final Object handler;
+    private final Method method;
+    private final Class<? extends HQEvent<?>> eventType;
+    private final Subscribe info;
+
+    public EventListener(Object handler, Method method, Class<? extends HQEvent<?>> eventType) {
+        this.handler = Objects.requireNonNull(handler);
+        this.method = Objects.requireNonNull(method);
+        this.eventType = Objects.requireNonNull(eventType);
+        this.info = method.getAnnotation(Subscribe.class);
+    }
+    
+    public void trigger(HQEvent<?> event) {
+        if(!event.isCancellable() || !event.isCancelled()) {
+            try {
+                method.invoke(handler, event);
+            } catch(IllegalAccessException e) {
+                e.printStackTrace();
+            } catch(IllegalArgumentException e) {
+                e.printStackTrace();
+            } catch(InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+    
+    public int getPriority() {
+        return info.priority();
+    }
+
+    public Class<? extends HQEvent<?>> getEventType() {
+        return eventType;
+    }
+}

--- a/MekHQ/src/mekhq/event/EventListener.java
+++ b/MekHQ/src/mekhq/event/EventListener.java
@@ -7,17 +7,17 @@ import java.util.Objects;
 class EventListener {
     private final Object handler;
     private final Method method;
-    private final Class<? extends HQEvent<?>> eventType;
+    private final Class<? extends HQEvent> eventType;
     private final Subscribe info;
 
-    public EventListener(Object handler, Method method, Class<? extends HQEvent<?>> eventType) {
+    public EventListener(Object handler, Method method, Class<? extends HQEvent> eventType) {
         this.handler = Objects.requireNonNull(handler);
         this.method = Objects.requireNonNull(method);
         this.eventType = Objects.requireNonNull(eventType);
         this.info = method.getAnnotation(Subscribe.class);
     }
     
-    public void trigger(HQEvent<?> event) {
+    public void trigger(HQEvent event) {
         if(!event.isCancellable() || !event.isCancelled()) {
             try {
                 method.invoke(handler, event);
@@ -35,7 +35,7 @@ class EventListener {
         return info.priority();
     }
 
-    public Class<? extends HQEvent<?>> getEventType() {
+    public Class<? extends HQEvent> getEventType() {
         return eventType;
     }
 }

--- a/MekHQ/src/mekhq/event/HQEvent.java
+++ b/MekHQ/src/mekhq/event/HQEvent.java
@@ -1,16 +1,12 @@
 package mekhq.event;
 
-import java.util.Objects;
-
 /**
  * Base class for all events
  */
-public abstract class HQEvent<T> {
-    protected T source;
+public abstract class HQEvent {
     protected boolean cancelled = false;
     
-    public HQEvent(T source) {
-        this.source = Objects.requireNonNull(source);
+    public HQEvent() {
     }
     
     /** @return true if the event can be cancelled (aborted) */

--- a/MekHQ/src/mekhq/event/HQEvent.java
+++ b/MekHQ/src/mekhq/event/HQEvent.java
@@ -1,0 +1,31 @@
+package mekhq.event;
+
+import java.util.Objects;
+
+/**
+ * Base class for all events
+ */
+public abstract class HQEvent<T> {
+    protected T source;
+    protected boolean cancelled = false;
+    
+    public HQEvent(T source) {
+        this.source = Objects.requireNonNull(source);
+    }
+    
+    /** @return true if the event can be cancelled (aborted) */
+    public boolean isCancellable() {
+        return false;
+    }
+    
+    /** @return true if the event is cancelled */
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void cancel() {
+        if(isCancellable()) {
+            cancelled = true;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/event/Subscribe.java
+++ b/MekHQ/src/mekhq/event/Subscribe.java
@@ -6,18 +6,21 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to put on methods which wish to receive events.
+ * Annotation to put on public methods which wish to receive events.
  * <p>
  * A method annotated with this needs to have exactly one argument,
  * this being some subclass of {@link HQEvent}.
  * An instance of that class then needs to be registered with the event bus
  * via {@link EventBus#registerHandler(Object)} for it to work. The exact
  * name of the method is not important, and neither is how many of
- * such mathods are packed into a single class.
+ * such methods are packed into a single class.
  * <p>
  * It's a good idea (but not required) to keep a reference to
  * the instance containing the event handlers yourself after registering it,
  * if only to avoid registering it multiple times.
+ * <p>
+ * To avoid resource leaks, event handlers need to unregister themselves
+ * explicitly.
  */
 @Retention(value=RetentionPolicy.RUNTIME)
 @Target(value=ElementType.METHOD)

--- a/MekHQ/src/mekhq/event/Subscribe.java
+++ b/MekHQ/src/mekhq/event/Subscribe.java
@@ -1,0 +1,27 @@
+package mekhq.event;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to put on methods which wish to receive events.
+ * <p>
+ * A method annotated with this needs to have exactly one argument,
+ * this being some subclass of {@link HQEvent}.
+ * An instance of that class then needs to be registered with the event bus
+ * via {@link EventBus#registerHandler(Object)} for it to work. The exact
+ * name of the method is not important, and neither is how many of
+ * such mathods are packed into a single class.
+ * <p>
+ * It's a good idea (but not required) to keep a reference to
+ * the instance containing the event handlers yourself after registering it,
+ * if only to avoid registering it multiple times.
+ */
+@Retention(value=RetentionPolicy.RUNTIME)
+@Target(value=ElementType.METHOD)
+public @interface Subscribe {
+    /** Priority of the event handler, default 0 */
+    public int priority() default 0;
+}


### PR DESCRIPTION
This is a simple, stand-alone event system. Its functions are modelled after the one in MinecraftForge, though it doesn't need to meet its performance or mod loading requirements, so no ASM and class loader trickery is required.

Example usage is marking event handling instance methods somewhere. This could be a separate class, but doesn't have to be - they work anywhere.

```
public class MyEventHandler {
    @Subscribe
    public void someEventHandler(ScenarioStartedEvent event) {
        // Do something with event.getScenario() or whatever
    }

    private boolean someNonHandlerMethod() {
        /* do stuff */
        return maybe;
    }

    @Subscribe
    public void IRanOutOfMethodNames(PlanetaryEvent event) {
        // Something happened on event.getPlanet()!
    }

    @Subscribe
    public void nope(UnitBoughtEvent wantToBuySomething) {
        wantToBuySomething.cancel(); // Not today!
    }
}

```

The event classes are (to be defined) subclasses of `mekhq.event.HQEvent`. Registering the handler is simple enough:

    EventBus.registerHandler(new MyEventHandler());

And so is firing events:

    EventBus.triggerEvent(new ScenarioStartedEvent(scenario));

And checking if it got cancelled:

    boolean eventWasCancelled = EventBus.triggerEvent(new UnitBoughtEvent(getCampaign(), unit));

And you can have your own private EventBus too for specific needs:

    private static final EventBus CAMPAIGN_EVENT_BUS = new EventBus();
    /* ... */
    CAMPAIGN_EVENT_BUS.trigger(new UnitBoughtEvent(campaign, unit));


Impact on other code: Exactly zero - it doesn't modify any existing class. This is meant to ease further development (in particular of the planetary and stellar events, but anywhere you need an event you can use it), and possibly moved whole into MegaMek if it is deemed a suitable replacement or enhancement of the existing systems there.
