### PR TITLE
Replacing personnel's kill and event log displays with tables

### DIFF
--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -1,0 +1,131 @@
+package mekhq.gui.model;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.ResourceBundle;
+
+import javax.swing.JTable;
+import javax.swing.SwingConstants;
+import javax.swing.table.DefaultTableCellRenderer;
+
+import mekhq.campaign.Kill;
+import mekhq.campaign.LogEntry;
+
+public class PersonnelEventLogModel extends DataTableModel {
+    private static final long serialVersionUID = 2930826794853379579L;
+
+    private static final String EMPTY_CELL = ""; //$NON-NLS-1$
+
+    public final static int COL_DATE = 0;
+    public final static int COL_TEXT = 1;
+
+    private ResourceBundle resourceMap;
+    private SimpleDateFormat shortDateFormat;
+
+    public PersonnelEventLogModel() {
+        resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonnelEventLogModel"); //$NON-NLS-1$
+        shortDateFormat = new SimpleDateFormat(resourceMap.getString("date.format")); //$NON-NLS-1$
+        data = new ArrayList<Kill>();
+    }
+   
+    @Override
+    public int getRowCount() {
+        return data.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COL_TEXT + 1;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        switch(column) {
+            case COL_DATE:
+                return resourceMap.getString("date.heading"); //$NON-NLS-1$
+            case COL_TEXT:
+                return resourceMap.getString("event.heading"); //$NON-NLS-1$
+            default:
+                return EMPTY_CELL;
+        }
+    }
+    
+    @Override
+    public Object getValueAt(int row, int column) {
+        LogEntry event = getEvent(row);
+        switch(column) {
+            case COL_DATE:
+                return shortDateFormat.format(event.getDate());
+            case COL_TEXT:
+                return event.getDesc();
+            default:
+                return EMPTY_CELL;
+        }
+    }
+    
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+    
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        return false;
+    }
+    
+    public LogEntry getEvent(int row) {
+        if((row < 0) || (row >= data.size())) {
+            return null;
+        }
+        return (LogEntry) data.get(row);
+    }
+    
+    public int getAlignment(int column) {
+        switch(column) {
+            case COL_DATE:
+                return SwingConstants.RIGHT;
+            case COL_TEXT:
+                return SwingConstants.LEFT;
+            default:
+                return SwingConstants.CENTER;
+        }
+    }
+    
+    public int getPreferredWidth(int column) {
+        switch(column) {
+            case COL_DATE:
+                return 80;
+            case COL_TEXT:
+                return 300;
+            default:
+                return 100;
+        }
+    }
+    
+    public PersonnelEventLogModel.Renderer getRenderer() {
+        return new PersonnelEventLogModel.Renderer();
+    }
+    
+    public static class Renderer extends DefaultTableCellRenderer {
+        private static final long serialVersionUID = -2201201114822098877L;
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                boolean isSelected, boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            setOpaque(true);
+            setHorizontalAlignment(((PersonnelEventLogModel)table.getModel()).getAlignment(column));
+
+            setForeground(Color.BLACK);
+            // tiger stripes
+            if (row % 2 == 0) {
+                setBackground(new Color(230,230,230));
+            } else {
+                setBackground(Color.WHITE);
+            }
+            return this;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -1,0 +1,132 @@
+package mekhq.gui.model;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.ResourceBundle;
+
+import javax.swing.JTable;
+import javax.swing.SwingConstants;
+import javax.swing.table.DefaultTableCellRenderer;
+
+import mekhq.campaign.Kill;
+
+public class PersonnelKillLogModel extends DataTableModel {
+    private static final long serialVersionUID = 2930826794853379579L;
+
+    private static final String EMPTY_CELL = ""; //$NON-NLS-1$
+
+    public final static int COL_DATE = 0;
+    public final static int COL_TEXT = 1;
+
+    private ResourceBundle resourceMap;
+    private SimpleDateFormat shortDateFormat;
+
+    public PersonnelKillLogModel() {
+        resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonnelKillLogModel"); //$NON-NLS-1$
+        shortDateFormat = new SimpleDateFormat(resourceMap.getString("date.format")); //$NON-NLS-1$
+        data = new ArrayList<Kill>();
+    }
+   
+    @Override
+    public int getRowCount() {
+        return data.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COL_TEXT + 1;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        switch(column) {
+            case COL_DATE:
+                return resourceMap.getString("date.heading"); //$NON-NLS-1$
+            case COL_TEXT:
+                return resourceMap.getString("kill.heading"); //$NON-NLS-1$
+            default:
+                return EMPTY_CELL;
+        }
+    }
+    
+    @Override
+    public Object getValueAt(int row, int column) {
+        Kill kill = getKill(row);
+        switch(column) {
+            case COL_DATE:
+                return shortDateFormat.format(kill.getDate());
+            case COL_TEXT:
+                return String.format(
+                    resourceMap.getString("killDetail.format"), //$NON-NLS-1$
+                    kill.getWhatKilled(), kill.getKilledByWhat());
+            default:
+                return EMPTY_CELL;
+        }
+    }
+    
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+    
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        return false;
+    }
+    
+    public Kill getKill(int row) {
+        if((row < 0) || (row >= data.size())) {
+            return null;
+        }
+        return (Kill) data.get(row);
+    }
+    
+    public int getAlignment(int column) {
+        switch(column) {
+            case COL_DATE:
+                return SwingConstants.RIGHT;
+            case COL_TEXT:
+                return SwingConstants.LEFT;
+            default:
+                return SwingConstants.CENTER;
+        }
+    }
+    
+    public int getPreferredWidth(int column) {
+        switch(column) {
+            case COL_DATE:
+                return 80;
+            case COL_TEXT:
+                return 300;
+            default:
+                return 100;
+        }
+    }
+    
+    public PersonnelKillLogModel.Renderer getRenderer() {
+        return new PersonnelKillLogModel.Renderer();
+    }
+    
+    public static class Renderer extends DefaultTableCellRenderer {
+        private static final long serialVersionUID = -2201201114822098877L;
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                boolean isSelected, boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            setOpaque(true);
+            setHorizontalAlignment(((PersonnelKillLogModel)table.getModel()).getAlignment(column));
+
+            setForeground(Color.BLACK);
+            // tiger stripes
+            if (row % 2 == 0) {
+                setBackground(new Color(230,230,230));
+            } else {
+                setBackground(Color.WHITE);
+            }
+            return this;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -7,19 +7,23 @@
 package mekhq.gui.view;
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Image;
 import java.awt.Insets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTable;
 import javax.swing.JTextArea;
+import javax.swing.table.TableColumn;
 
 import megamek.common.Crew;
 import megamek.common.options.PilotOptions;
@@ -30,6 +34,8 @@ import mekhq.campaign.LogEntry;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.gui.model.PersonnelEventLogModel;
+import mekhq.gui.model.PersonnelKillLogModel;
 
 /**
  * A custom panel that gets filled in with goodies from a Person record
@@ -553,40 +559,32 @@ public class PersonViewPanel extends javax.swing.JPanel {
     }
     
     private void fillLog() {
-        SimpleDateFormat shortDateFormat = new SimpleDateFormat(resourceMap.getString("format.date")); //$NON-NLS-1$
-        GridBagConstraints gridBagConstraints;
-        pnlLog.setLayout(new GridBagLayout());
-        JLabel lblDate;
-        JTextArea txtLog;
-        int row = 0;
         ArrayList<LogEntry> logs = person.getPersonnelLog();
-        for(LogEntry entry : logs) {
-            lblDate = new JLabel(shortDateFormat.format(entry.getDate()));
-            txtLog = new JTextArea(entry.getDesc());
-            txtLog.setEditable(false);
-            txtLog.setLineWrap(true);
-            txtLog.setWrapStyleWord(true);
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 0;
-            gridBagConstraints.gridy = row;
-            gridBagConstraints.weightx = 0.0;
-            gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-            gridBagConstraints.fill = GridBagConstraints.NONE;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            pnlLog.add(lblDate, gridBagConstraints);
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 1;
-            gridBagConstraints.gridy = row;
-            gridBagConstraints.weightx = 1.0;
-            if(row == (logs.size()-1)) {
-                gridBagConstraints.weighty = 1.0;
-            }
-            gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-            gridBagConstraints.fill = GridBagConstraints.BOTH;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            pnlLog.add(txtLog, gridBagConstraints);
-            row++;
+        pnlLog.setLayout(new GridBagLayout());
+        PersonnelEventLogModel eventModel = new PersonnelEventLogModel();
+        eventModel.setData(logs);
+        JTable eventTable = new JTable(eventModel);
+        eventTable.setRowSelectionAllowed(false);
+        eventTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+        TableColumn column = null;
+        for(int i = 0; i < eventModel.getColumnCount(); ++ i) {
+            column = eventTable.getColumnModel().getColumn(i);
+            column.setCellRenderer(eventModel.getRenderer());
+            column.setPreferredWidth(eventModel.getPreferredWidth(i));
         }
+        eventTable.setIntercellSpacing(new Dimension(10, 0));
+        eventTable.setShowGrid(false);
+        eventTable.setTableHeader(null);
+        GridBagConstraints gridBagConstraints = new GridBagConstraints();
+
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.fill = GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 1.0;
+
+        pnlLog.add(eventTable, gridBagConstraints);
     }
     
     private void fillInjuries() {
@@ -631,50 +629,40 @@ public class PersonViewPanel extends javax.swing.JPanel {
     
     private void fillKillRecord() {
         ArrayList<Kill> kills = campaign.getKillsFor(person.getId());
-        SimpleDateFormat shortDateFormat = new SimpleDateFormat(resourceMap.getString("format.date")); //$NON-NLS-1$
-        GridBagConstraints gridBagConstraints;
         pnlKills.setLayout(new GridBagLayout());
-        JLabel lblDate;
-        JTextArea txtKill;
+        
         JLabel lblRecord = new JLabel(String.format(resourceMap.getString("format.kills"), kills.size())); //$NON-NLS-1$
-        gridBagConstraints = new GridBagConstraints();
+        GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.gridwidth = 2;
         gridBagConstraints.insets = new Insets(0, 5, 0, 0);
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlKills.add(lblRecord, gridBagConstraints);
-        int row = 1;
-        for(Kill k : kills) {
-            lblDate = new JLabel(shortDateFormat.format(k.getDate()));
-            txtKill = new JTextArea(String.format(
-                resourceMap.getString("format.killDetail"), //$NON-NLS-1$
-                k.getWhatKilled(), k.getKilledByWhat()));
-            txtKill.setEditable(false);
-            txtKill.setLineWrap(true);
-            txtKill.setWrapStyleWord(true);
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 0;
-            gridBagConstraints.gridy = row;
-            gridBagConstraints.weightx = 0.0;
-            gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-            gridBagConstraints.fill = GridBagConstraints.NONE;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            pnlKills.add(lblDate, gridBagConstraints);
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 1;
-            gridBagConstraints.gridy = row;
-            gridBagConstraints.weightx = 1.0;
-            if(row == kills.size()) {
-                gridBagConstraints.weighty = 1.0;
-            }
-            gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-            gridBagConstraints.fill = GridBagConstraints.BOTH;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            pnlKills.add(txtKill, gridBagConstraints);
-            row++;
+
+        PersonnelKillLogModel killModel = new PersonnelKillLogModel();
+        killModel.setData(kills);
+        JTable killTable = new JTable(killModel);
+        killTable.setRowSelectionAllowed(false);
+        killTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+        TableColumn column = null;
+        for(int i = 0; i < killModel.getColumnCount(); ++ i) {
+            column = killTable.getColumnModel().getColumn(i);
+            column.setCellRenderer(killModel.getRenderer());
+            column.setPreferredWidth(killModel.getPreferredWidth(i));
         }
+        killTable.setIntercellSpacing(new Dimension(10, 0));
+        killTable.setShowGrid(false);
+        killTable.setTableHeader(null);
+        gridBagConstraints = new GridBagConstraints();
+
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.fill = GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 1.0;
+
+        pnlKills.add(killTable, gridBagConstraints);
     }
 }

--- a/MekHQ/src/mekhq/resources/PersonnelEventLogModel.properties
+++ b/MekHQ/src/mekhq/resources/PersonnelEventLogModel.properties
@@ -1,0 +1,3 @@
+event.heading=Kill
+date.heading=Date
+date.format=MM/dd/yyyy

--- a/MekHQ/src/mekhq/resources/PersonnelKillLogModel.properties
+++ b/MekHQ/src/mekhq/resources/PersonnelKillLogModel.properties
@@ -1,0 +1,4 @@
+kill.heading=Kill
+date.heading=Date
+killDetail.format=%s with %s
+date.format=MM/dd/yyyy


### PR DESCRIPTION
This replaces the personnel log entries (personal events/history and kills) with tables, to vastly improve its performance. I'm not 100% sure it works with all log entries until now (were there some with HTML code or interactive elements?), thus a PR and not a direct push, but for text-only entries, it works like a charm.
