### PR TITLE
Making admin XP gain into a generic event handler for NewDayEvent

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -63,6 +63,7 @@ import megamek.common.util.EncodeControl;
 import megamek.server.Server;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.ResolveScenarioTracker;
+import mekhq.campaign.handler.XPHandler;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.Scenario;
@@ -145,6 +146,7 @@ public class MekHQ implements GameListener {
         //read in preferences
     	readPreferences();
     	setLookAndFeel();
+    	initEventHandlers();
         //create a start up frame and display it
         StartUpGUI sud = new StartUpGUI(this);
         sud.setVisible(true);
@@ -507,5 +509,10 @@ public class MekHQ implements GameListener {
 
 	public IconPackage getIconPackage() {
 	    return iconPackage;
+	}
+	
+	// TODO: This needs to be way more flexible, but it will do for now.
+	private void initEventHandlers() {
+	    EVENT_BUS.register(new XPHandler());
 	}
 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2160,14 +2160,6 @@ public class Campaign implements Serializable {
             					" requirements resulted in " + deficit +
             					((deficit==1)?" minor contract breach":" minor contract breaches"));
             		}
-            		// Administrator Weekly XP
-            		if (campaignOptions.getAdminWeeklyXP() > 0) {
-                		for (Person p : this.getPersonnel()) {
-                		    if (p.isAdminPrimary()) {
-                		        p.awardXP(campaignOptions.getAdminWeeklyXP());
-                		    }
-                		}
-            		}
             	}
 
         		for (Scenario s : m.getScenarios()) {

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -168,7 +168,8 @@ public class CampaignOptions implements Serializable {
     private int targetIdleXP;
     private int monthsIdleXP;
     private int contractNegotiationXP;
-    private int adminWeeklyXP;
+    private int adminXP;
+    private int adminXPPeriod;
 
     //repair related
     private boolean destroyByMargin;
@@ -316,7 +317,8 @@ public class CampaignOptions implements Serializable {
         targetIdleXP = 10;
         monthsIdleXP = 2;
         contractNegotiationXP = 0;
-        adminWeeklyXP = 0;
+        adminXP = 0;
+        adminXPPeriod = 1;
         unitRatingMethod = UnitRatingMethod.INTERSTELLAR_OPS;
         waitingPeriod = 7;
         acquisitionSkill = S_TECH;
@@ -1010,12 +1012,20 @@ public class CampaignOptions implements Serializable {
         contractNegotiationXP = m;
     }
 
-    public int getAdminWeeklyXP() {
-        return adminWeeklyXP;
+    public int getAdminXP() {
+        return adminXP;
     }
 
-    public void setAdminWeeklyXP(int m) {
-        adminWeeklyXP = m;
+    public void setAdminXP(int m) {
+        adminXP = m;
+    }
+
+    public int getAdminXPPeriod() {
+        return adminXPPeriod;
+    }
+
+    public void setAdminXPPeriod(int m) {
+        adminXPPeriod = m;
     }
 
     public int getWaitingPeriod() {
@@ -1772,7 +1782,8 @@ public class CampaignOptions implements Serializable {
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "targetIdleXP", targetIdleXP);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "monthsIdleXP", monthsIdleXP);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "contractNegotiationXP", contractNegotiationXP);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "adminWeeklyXP", adminWeeklyXP);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "adminWeeklyXP", adminXP);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "adminXPPeriod", adminXPPeriod);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "limitByYear", limitByYear);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "disallowExtinctStuff", disallowExtinctStuff);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "allowClanPurchases", allowClanPurchases);
@@ -2038,7 +2049,9 @@ public class CampaignOptions implements Serializable {
             } else if (wn2.getNodeName().equalsIgnoreCase("contractNegotiationXP")) {
                 retVal.contractNegotiationXP = Integer.parseInt(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("adminWeeklyXP")) {
-                retVal.adminWeeklyXP = Integer.parseInt(wn2.getTextContent().trim());
+                retVal.adminXP = Integer.parseInt(wn2.getTextContent().trim());
+            } else if (wn2.getNodeName().equalsIgnoreCase("adminXPPeriod")) {
+                retVal.adminXPPeriod = Integer.parseInt(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("waitingPeriod")) {
                 retVal.waitingPeriod = Integer.parseInt(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("healWaitingPeriod")) {

--- a/MekHQ/src/mekhq/campaign/handler/XPHandler.java
+++ b/MekHQ/src/mekhq/campaign/handler/XPHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.handler;
+
+import java.util.Calendar;
+
+import megamek.common.Compute;
+import megamek.common.event.Subscribe;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.ExtraData;
+import mekhq.campaign.event.NewDayEvent;
+import mekhq.campaign.personnel.Person;
+
+/**
+ * Event handler for all kind of XP calculations
+ */
+public class XPHandler {
+    private static final ExtraData.Key<Integer> NEXT_ADMIN_XP_DELAY = new ExtraData.IntKey("next_admin_xp_delay");
+    
+    @Subscribe
+    public void processAdminXP(NewDayEvent event) {
+        final Campaign campaign = event.getCampaign();
+        final CampaignOptions opts = campaign.getCampaignOptions();
+        final int xp = opts.getAdminXP();
+        final int weeksBetweenGains = opts.getAdminXPPeriod();
+        if((xp <= 0)
+                || (campaign.getCalendar().get(Calendar.DAY_OF_WEEK) != Calendar.MONDAY)) {
+            return;
+        }
+        for (Person person : campaign.getPersonnel()) {
+            if (person.isAdminPrimary()) {
+                if(weeksBetweenGains > 1) {
+                    Integer weeksLeft = person.getExtraData().get(NEXT_ADMIN_XP_DELAY);
+                    if(null == weeksLeft) {
+                        // Assign a random value between 1 and the max
+                        weeksLeft = Compute.randomInt(weeksBetweenGains) + 1;
+                    }
+                    -- weeksLeft;
+                    if(weeksLeft == 0) {
+                        person.awardXP(xp);
+                        weeksLeft = weeksBetweenGains;
+                    }
+                    person.getExtraData().set(NEXT_ADMIN_XP_DELAY, weeksLeft);
+                } else {
+                    person.awardXP(xp);
+                }
+            }
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -283,6 +283,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
     private JSpinner spnMonthsIdleXP;
     private JSpinner spnContractNegotiationXP;
     private JSpinner spnAdminWeeklyXP;
+    private JSpinner spnAdminWeeklyXPPeriod;
 
     private JCheckBox chkSupportStaffOnly;
     private JSpinner spnAcquireWaitingPeriod;
@@ -2088,7 +2089,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panXP.add(new JLabel("XP awarded to the selected negotiator for a new contract"), gridBagConstraints);
 
-        spnAdminWeeklyXP = new JSpinner(new SpinnerNumberModel(options.getAdminWeeklyXP(), 0, 10000, 1));
+        spnAdminWeeklyXP = new JSpinner(new SpinnerNumberModel(options.getAdminXP(), 0, 10000, 1));
         ((JSpinner.DefaultEditor) spnAdminWeeklyXP.getEditor()).getTextField().setEditable(false);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -2103,7 +2104,24 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
-        panXP.add(new JLabel("XP awarded to each administrator every Monday for the work of the previous week"), gridBagConstraints);
+        panXP.add(new JLabel("XP awarded to each administrator every Monday for the work of the previous"), gridBagConstraints);
+
+        spnAdminWeeklyXPPeriod = new JSpinner(new SpinnerNumberModel(options.getAdminXPPeriod(), 1, 100, 1));
+        ((JSpinner.DefaultEditor) spnAdminWeeklyXPPeriod.getEditor()).getTextField().setEditable(false);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 7;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
+        panXP.add(spnAdminWeeklyXPPeriod, gridBagConstraints);
+
+        gridBagConstraints.gridx = 3;
+        gridBagConstraints.gridy = 7;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
+        panXP.add(new JLabel("week(s)"), gridBagConstraints);
 
         txtInstructionsXP = new JTextArea();
         txtInstructionsXP.setText(resourceMap.getString("txtInstructionsXP.text"));
@@ -4156,7 +4174,8 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         options.setIdleXP((Integer) spnIdleXP.getModel().getValue());
         options.setMonthsIdleXP((Integer) spnMonthsIdleXP.getModel().getValue());
         options.setContractNegotiationXP((Integer) spnContractNegotiationXP.getModel().getValue());
-        options.setAdminWeeklyXP((Integer) spnAdminWeeklyXP.getModel().getValue());
+        options.setAdminXP((Integer) spnAdminWeeklyXP.getModel().getValue());
+        options.setAdminXPPeriod((Integer) spnAdminWeeklyXPPeriod.getModel().getValue());
         options.setTargetIdleXP((Integer) spnTargetIdleXP.getModel().getValue());
 
         options.setLimitByYear(limitByYearBox.isSelected());


### PR DESCRIPTION
Turning admin XP gain into an event handler for NewDayEvent, and making it work all the time, as opposed to just when AtB is turned on.

Also added a delay to the XP gain to make it be given less often than once per week, as per RFE #43.