### PR TITLE
Issue #68: IndexOutOfBoundsException when advancing day

### DIFF
--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -15,6 +15,7 @@ v0.3.28-git
 + Bug [#925]: Issues with reload of MHQ and Settings
 + [AtB] When failure to deploy results in defeat, replace generated entities with stubs.
 + Issue #40: [ATB] 3.25 : Enemy reinforcements incorrectly set to deploy at the start of the game
++ Issue #68: IndexOutOfBoundsException when advancing day
 
 v0.3.27 (2016-04-16 00:30 UTC)
 + Updated MegaMek.jar to 0.41.17

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -6683,7 +6683,11 @@ public class CampaignGUI extends JPanel {
             return patients;
         }
         for (int idx : indices) {
-            patients.add((Person) unassignedPatientModel.getElementAt(idx));
+            Person p = assignedPatientModel.getElementAt(idx);
+            if (p == null) {
+                continue;
+            }
+            patients.add(p);
         }
         return patients;
     }
@@ -6695,7 +6699,11 @@ public class CampaignGUI extends JPanel {
             return patients;
         }
         for (int idx : indices) {
-            patients.add((Person) assignedPatientModel.getElementAt(idx));
+            Person p = assignedPatientModel.getElementAt(idx);
+            if (p == null) {
+                continue;
+            }
+            patients.add(p);
         }
         return patients;
     }

--- a/MekHQ/src/mekhq/gui/model/PatientTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PatientTableModel.java
@@ -35,6 +35,9 @@ public class PatientTableModel extends AbstractListModel<Person> {
 
     @Override
     public Person getElementAt(int index) {
+        if (index < 0 || index >= patients.size()) {
+            return null;
+        }
         return patients.get(index);
     }
 


### PR DESCRIPTION
Added protection against PatientTableModel being given a bad index when attempting to retrieve an index. In such an instance, the model will return a NULL value. Also added null handling to the calling methods.