### PR TITLE
Fix for Issue #113 - MekHQ 0.3.29 Dates are cut off in Personnel log …

### DIFF
--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -104,7 +104,7 @@ public class PersonnelEventLogModel extends DataTableModel {
             case COL_DATE:
                 return 90;
             case COL_TEXT:
-                return 290;
+                return 300;
             default:
                 return 100;
         }

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -102,7 +102,7 @@ public class PersonnelEventLogModel extends DataTableModel {
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_DATE:
-                return 80;
+                return 90;
             case COL_TEXT:
                 return 300;
             default:

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -104,7 +104,7 @@ public class PersonnelEventLogModel extends DataTableModel {
             case COL_DATE:
                 return 90;
             case COL_TEXT:
-                return 300;
+                return 290;
             default:
                 return 100;
         }

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -103,9 +103,9 @@ public class PersonnelKillLogModel extends DataTableModel {
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_DATE:
-                return 80;
+                return 90;
             case COL_TEXT:
-                return 300;
+                return 290;
             default:
                 return 100;
         }

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -103,9 +103,9 @@ public class PersonnelKillLogModel extends DataTableModel {
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_DATE:
-                return 90;
+                return 80;
             case COL_TEXT:
-                return 290;
+                return 300;
             default:
                 return 100;
         }


### PR DESCRIPTION
…display

This is a fix for Issue #113.  This only seemed to be affecting Mac OSX. The default font, Lucida Grande in this case, seems to render wider on OSX than it does on other OS's. The solution is to widen the column slightly to accomodate the wider font.  Will need to test that this doesn't have an adverse effect on other OS's.