### PR TITLE
Fix for Issue #113 Dates are cut off in Personnel log

### DIFF
--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -104,7 +104,7 @@ public class PersonnelEventLogModel extends DataTableModel {
             case COL_DATE:
                 return 90;
             case COL_TEXT:
-                return 290;
+                return 300;
             default:
                 return 100;
         }

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -102,7 +102,7 @@ public class PersonnelEventLogModel extends DataTableModel {
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_DATE:
-                return 80;
+                return 90;
             case COL_TEXT:
                 return 300;
             default:

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -104,7 +104,7 @@ public class PersonnelEventLogModel extends DataTableModel {
             case COL_DATE:
                 return 90;
             case COL_TEXT:
-                return 300;
+                return 290;
             default:
                 return 100;
         }

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -103,9 +103,9 @@ public class PersonnelKillLogModel extends DataTableModel {
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_DATE:
-                return 80;
+                return 90;
             case COL_TEXT:
-                return 300;
+                return 290;
             default:
                 return 100;
         }

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -103,9 +103,9 @@ public class PersonnelKillLogModel extends DataTableModel {
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_DATE:
-                return 90;
+                return 80;
             case COL_TEXT:
-                return 290;
+                return 300;
             default:
                 return 100;
         }


### PR DESCRIPTION
Resubmitting my previous pull request.  I'm still new to how things work on Github, so bear with me.  Anyway, this will fix an issue with MekHQ on OS X where the font on the Personnel log for events are getting cutoff.  I've tested this on other platforms, and it does not seem to have an adverse affect on them.
