### PR TITLE
Should be counting Doctors rather than Medics as admin personnel for …

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -259,7 +259,7 @@ class CampaignOpsReputation extends AbstractUnitRating {
         setNonAdminPersonnelCount(0);
         List<Person> personnelList = new ArrayList<>(getCampaign().getPersonnel());
         for (Person p : personnelList) {
-            if (p.isAdmin() || p.isMedic()) {
+            if (p.isAdmin() || p.isDoctor()) {
                 continue;
             }
             if (p.isTech()) {


### PR DESCRIPTION
Should be using Doctors rather than Medics as admin personnel for Campaign Ops Unit Rating.