### PR TITLE
Issue #221: CO Incorrect Campaign Ops Transport Rating with No Dropships

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -417,16 +417,16 @@ class CampaignOpsReputation extends AbstractUnitRating {
         boolean doubleCapacity = true;
         boolean fullCapacity = true;
         int heavyVeeBays = getHeavyVeeBayCount();
-        if (getMechBayCount() < super.getMechCount()) {
+        if (getMechBayCount() < getMechCount()) {
             fullCapacity = false;
             doubleCapacity = false;
-        } else if (getMechBayCount() < super.getMechCount() * 2) {
+        } else if (getMechBayCount() < getMechCount() * 2) {
             doubleCapacity = false;
         }
-        if (getProtoBayCount() < super.getProtoCount()) {
+        if (getProtoBayCount() < getProtoCount()) {
             fullCapacity = false;
             doubleCapacity = false;
-        } else if (getProtoBayCount() < super.getProtoCount() * 2) {
+        } else if (getProtoBayCount() < getProtoCount() * 2) {
             doubleCapacity = false;
         }
         if (getHeavyVeeBayCount() < getHeavyVeeCount()) {
@@ -437,28 +437,28 @@ class CampaignOpsReputation extends AbstractUnitRating {
         }
         heavyVeeBays -= getHeavyVeeBayCount();
         int lightVeeBays = getLightVeeBayCount() + heavyVeeBays;
-        if (getLightVeeBayCount() < lightVeeBays) {
+        if (lightVeeBays < getLightVeeCount()) {
             fullCapacity = false;
             doubleCapacity = false;
-        } else if (getLightVeeBayCount() < lightVeeBays * 2) {
+        } else if (lightVeeBays < getLightVeeCount() * 2) {
             doubleCapacity = false;
         }
-        if (getFighterBayCount() < super.getFighterCount()) {
+        if (getFighterBayCount() < getFighterCount()) {
             fullCapacity = false;
             doubleCapacity = false;
-        } else if (getFighterBayCount() < super.getFighterCount() * 2) {
+        } else if (getFighterBayCount() < getFighterCount() * 2) {
             doubleCapacity = false;
         }
-        if ((getBaBayCount()) < super.getBattleArmorCount() / 5) {
+        if ((getBaBayCount()) < getBattleArmorCount() / 5) {
             fullCapacity = false;
             doubleCapacity = false;
-        } else if ((getBaBayCount() * 2) < 2 * super.getBattleArmorCount() / 5) {
+        } else if ((getBaBayCount() * 2) < 2 * getBattleArmorCount() / 5) {
             doubleCapacity = false;
         }
-        if (getInfantryBayCount() < super.getInfantryCount() / 28) {
+        if (getInfantryBayCount() < getInfantryCount() / 28) {
             fullCapacity = false;
             doubleCapacity = false;
-        } else if (getInfantryBayCount() < super.getInfantryCount() / 14) {
+        } else if (getInfantryBayCount() < getInfantryCount() / 14) {
             doubleCapacity = false;
         }
         if (getSmallCraftBayCount() < getSmallCraftCount()) {
@@ -500,7 +500,7 @@ class CampaignOpsReputation extends AbstractUnitRating {
                 totalValue += 5;
             }
         }
-        if (getDockingCollarCount() >= getDropshipCount()) {
+        if ((getDropshipCount() > 0) && (getDockingCollarCount() >= getDropshipCount())) {
             totalValue += 5;
         }
 

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -848,6 +848,18 @@ public class CampaignOpsReputationTest {
         spyReputation.initValues();
         assertEquals(20, spyReputation.getTransportValue());
 
+        // Test not having any dropships (though we still have a jumpship).
+        doReturn(0).when(spyReputation).getDropshipCount();
+        doReturn(0).when(spyReputation).getMechBayCount();
+        doReturn(0).when(spyReputation).getInfantryBayCount();
+        doReturn(0).when(spyReputation).getLightVeeBayCount();
+        doReturn(0).when(spyReputation).getHeavyVeeBayCount();
+        doReturn(0).when(spyReputation).getBaBayCount();
+        doReturn(0).when(spyReputation).getFighterBayCount();
+        doReturn(0).when(spyReputation).getProtoBayCount();
+        doReturn(0).when(spyReputation).getSmallCraftBayCount();
+        assertEquals(0, spyReputation.getTransportValue());
+
         // Test a brand new campaign.
         buildFreshCampaign();
         spyReputation.initValues();


### PR DESCRIPTION
Light Vehicles are not Light Vehicle Bays and docking collars don't matter if you don't have dropships to attach to them.