### PR TITLE
Autogenerate AtB contract name in Contract market

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -411,7 +411,9 @@ public class ContractMarket implements Serializable {
         contract.calculateContract(campaign);
 
         contract.setName(Faction.getFaction(employer).getShortName() + "-" + String.format("%1$tY%1$tm", contract.getStartDate()) 
-        				 + "-" + AtBContract.missionTypeNames[contract.getMissionType()] + "-" + contract.getLength());
+        				 + "-" + AtBContract.missionTypeNames[contract.getMissionType()] 
+        				 + "-" + Faction.getFaction(contract.getEnemyCode()).getShortName()
+        				 + "-" + contract.getLength());
         
 		return contract;
 	}

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -409,6 +409,10 @@ public class ContractMarket implements Serializable {
 
         contract.initContractDetails(campaign);
         contract.calculateContract(campaign);
+
+        contract.setName(Faction.getFaction(employer).getShortName() + "-" + String.format("%1$tY%1$tm", contract.getStartDate()) 
+        				 + "-" + AtBContract.missionTypeNames[contract.getMissionType()] + "-" + contract.getLength());
+        
 		return contract;
 	}
 


### PR DESCRIPTION
Autogenerate AtB contract name in Contract market with "Faction_short_name-yyyymm-mission_type-length" format.
Ex: "CC-306701-Recon Raid-3"
