### PR TITLE
Fixes #257 Cannot open context menu on children

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Ancestors.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Ancestors.java
@@ -105,9 +105,14 @@ public class Ancestors implements Serializable, MekHqXmlSerializable {
 		if (depth > 4) {
 			return false;
 		}
-		
+
 		depth++;
-		
+
+        // Don't forget the null check on anc
+        if (anc == null) {
+            return false;
+        }
+
 		// Nulls means we can't possibly have a match, eh?
 		if ((fatherID == null && motherID == null)
 				|| (anc.getFatherID() == null && anc.getMotherID() == null)){


### PR DESCRIPTION
In this case a null ancestor was being passed that caused the NPE. Added a null check and return and everything seems to be working again.