### PR TITLE
Date format changes - fix for #259

### DIFF
--- a/MekHQ/.gitignore
+++ b/MekHQ/.gitignore
@@ -17,3 +17,4 @@ MekHQ.jar
 /*.tar.bz2
 /*.blame
 /.classpath
+/mekhqOptions.xml

--- a/MekHQ/src/mekhq/MekHQOptions.java
+++ b/MekHQ/src/mekhq/MekHQOptions.java
@@ -24,6 +24,12 @@ public class MekHQOptions {
 
 	public static final String DATE_PATTERN_ISO_LONG = "yyyy-MM-dd";
 	public static final String DATE_PATTERN_ISO_SHORT = "yyyy-MM-dd";
+	
+	public static final String DATE_PATTERN_BIG_ENDIAN_LONG = "yyyy MMMM dd, EEEE";
+	public static final String DATE_PATTERN_BIG_ENDIAN_SHORT = "yyyy-MM-dd";
+	
+	public static final String DATE_PATTERN_MIDDLE_ENDIAN_LONG = "EEEE, MMMM dd yyyy";
+	public static final String DATE_PATTERN_MIDDLE_ENDIAN_SHORT = "MM/dd/yyyy";
 
 	public static final String DATE_PATTERN_LITTLE_ENDIAN_LONG = "EEEE, dd MMMM yyyy";
 	public static final String DATE_PATTERN_LITTLE_ENDIAN_SHORT = "dd-MM-yyyy";
@@ -66,8 +72,8 @@ public class MekHQOptions {
 
 	private void initWithDefaults() {
 		dateFormatDataStorage = new SimpleDateFormat(DATE_TIME_PATTERN_ISO);
-		dateFormatLong = new SimpleDateFormat(DATE_PATTERN_ISO_LONG);
-		dateFormatShort = new SimpleDateFormat(DATE_PATTERN_ISO_SHORT);
+		dateFormatLong = new SimpleDateFormat(DATE_PATTERN_BIG_ENDIAN_LONG);
+		dateFormatShort = new SimpleDateFormat(DATE_PATTERN_BIG_ENDIAN_SHORT);
 	}
 
 	public SimpleDateFormat getDateFormatDataStorage() {

--- a/MekHQ/src/mekhq/MekHQOptions.java
+++ b/MekHQ/src/mekhq/MekHQOptions.java
@@ -1,0 +1,176 @@
+package mekhq;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class MekHQOptions {
+	private static final MekHQOptions instance = new MekHQOptions();
+
+	public static final String MEKHQ_OPTIONS_FILE_NAME = "mekhqOptions.xml";
+
+	public static final String DATE_TIME_PATTERN_ISO = "yyyy-MM-dd HH:mm:ss";
+
+	public static final String DATE_PATTERN_ISO_LONG = "yyyy-MM-dd";
+	public static final String DATE_PATTERN_ISO_SHORT = "yyyy-MM-dd";
+
+	public static final String DATE_PATTERN_LITTLE_ENDIAN_LONG = "EEEE, dd MMMM yyyy";
+	public static final String DATE_PATTERN_LITTLE_ENDIAN_SHORT = "dd-MM-yyyy";
+
+	private SimpleDateFormat dateFormatDataStorage;
+	private SimpleDateFormat dateFormatLong;
+	private SimpleDateFormat dateFormatShort;
+
+	public static MekHQOptions getInstance() {
+		return instance;
+	}
+
+	private MekHQOptions() {
+		initWithDefaults();
+
+		// attempt to autoload saved options
+		try {
+			load();
+		} catch (FileNotFoundException e) {
+			// if options file does not exist, create it using current defaults
+			MekHQ.logMessage("MekHQ options file is missing. Creating a new one.");
+			try {
+				save();
+			} catch (FileNotFoundException e1) {
+				// we cannot write here. nothing to be done really.
+				MekHQ.logError(e1);
+			}
+		} catch (Exception e) {
+			// the options file is invalid, recreate it using current defauts
+			MekHQ.logMessage("MekHQ options file is corrupt. Creating a new one.");
+			try {
+				save();
+			} catch (FileNotFoundException e1) {
+				// we cannot write here. nothing to be done really.
+				MekHQ.logError(e1);
+			}
+		}
+
+	}
+
+	private void initWithDefaults() {
+		dateFormatDataStorage = new SimpleDateFormat(DATE_TIME_PATTERN_ISO);
+		dateFormatLong = new SimpleDateFormat(DATE_PATTERN_ISO_LONG);
+		dateFormatShort = new SimpleDateFormat(DATE_PATTERN_ISO_SHORT);
+	}
+
+	public SimpleDateFormat getDateFormatDataStorage() {
+		return dateFormatDataStorage;
+	}
+
+	public void setDateFormatDataStorage(SimpleDateFormat dateFormatDataStorage) {
+		this.dateFormatDataStorage = dateFormatDataStorage;
+	}
+
+	public SimpleDateFormat getDateFormatLong() {
+		return dateFormatLong;
+	}
+
+	public void setDateFormatLong(SimpleDateFormat dateFormatLong) {
+		this.dateFormatLong = dateFormatLong;
+	}
+
+	public SimpleDateFormat getDateFormatShort() {
+		return dateFormatShort;
+	}
+
+	public void setDateFormatShort(SimpleDateFormat dateFormatShort) {
+		this.dateFormatShort = dateFormatShort;
+	}
+
+	/*
+	 * Shortcut method that will load xml using default filename
+	 */
+	public void load() throws FileNotFoundException, IllegalArgumentException {
+		FileInputStream optionsInput = new FileInputStream(new File(MEKHQ_OPTIONS_FILE_NAME));
+		this.loadFromXml(optionsInput);
+
+		try {
+			optionsInput.close();
+		} catch (IOException e) {
+			// this should not happen. ever. how can closing a read-only stream fail?
+			MekHQ.logError(e);
+		}
+	}
+
+	public void save() throws FileNotFoundException {
+		PrintWriter optionsOutput = new PrintWriter(new File(MEKHQ_OPTIONS_FILE_NAME));
+		this.writeToXml(optionsOutput, 0);
+		optionsOutput.close();
+	}
+
+	public void writeToXml(PrintWriter pw, int indent) {
+		pw.println(MekHqXmlUtil.indentStr(indent) + "<mekhqOptions>");
+
+		MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "dateFormatDataStorage", dateFormatDataStorage.toPattern());
+		MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "dateFormatLong", dateFormatLong.toPattern());
+		MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "dateFormatShort", dateFormatShort.toPattern());
+
+		pw.println(MekHqXmlUtil.indentStr(indent) + "</mekhqOptions>");
+	}
+
+	public void loadFromXml(FileInputStream fis) throws IllegalArgumentException {
+		MekHQ.logMessage("Loading MekHQ Options from XML...", 4);
+
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		Document xmlDoc = null;
+
+		try {
+			// Using factory get an instance of document builder
+			DocumentBuilder db = dbf.newDocumentBuilder();
+
+			// Parse using builder to get DOM representation of the XML file
+			xmlDoc = db.parse(fis);
+		} catch (Exception ex) {
+			MekHQ.logError(ex);
+		}
+
+		Element optionsEle = xmlDoc.getDocumentElement();
+		optionsEle.normalize();
+		if (optionsEle.getTagName() != "mekhqOptions") {
+			throw new IllegalArgumentException("Invalid MekHQ Options File!");
+		}
+
+		NodeList wList = optionsEle.getChildNodes();
+
+		for (int x = 0; x < wList.getLength(); x++) {
+			Node wn = wList.item(x);
+
+			// If it's not an element node, we ignore it.
+			if (wn.getNodeType() != Node.ELEMENT_NODE) {
+				continue;
+			}
+
+			MekHQ.logMessage("---", 5);
+			MekHQ.logMessage(wn.getNodeName(), 5);
+			MekHQ.logMessage("\t" + wn.getTextContent(), 5);
+
+			if (wn.getNodeName().equalsIgnoreCase("dateFormatDataStorage")) {
+				this.dateFormatDataStorage = new SimpleDateFormat(wn.getTextContent().trim());
+			} else if (wn.getNodeName().equalsIgnoreCase("dateFormatLong")) {
+				this.dateFormatLong = new SimpleDateFormat(wn.getTextContent().trim());
+			} else if (wn.getNodeName().equalsIgnoreCase("dateFormatShort")) {
+				this.dateFormatShort = new SimpleDateFormat(wn.getTextContent().trim());
+			}
+		}
+
+		MekHQ.logMessage("Load MekHQ Options Complete!", 4);
+	}
+
+}

--- a/MekHQ/src/mekhq/adapter/DateAdapter.java
+++ b/MekHQ/src/mekhq/adapter/DateAdapter.java
@@ -18,8 +18,6 @@
  */
 package mekhq.adapter;
 
-import java.time.format.DateTimeParseException;
-
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 import org.joda.time.DateTime;
@@ -32,17 +30,21 @@ import mekhq.MekHQOptions;
 public class DateAdapter extends XmlAdapter<String, DateTime> {
 	private final static DateTimeFormatter FORMATTER =
 			DateTimeFormat.forPattern(MekHQOptions.getInstance().getDateFormatDataStorage().toPattern())
-			.withChronology(GJChronology.getInstanceUTC());
+			.withChronology(GJChronology.getInstanceUTC());	
 	private final static DateTimeFormatter FORMATTER_FALLBACK =
-			DateTimeFormat.forPattern("yyyy-MM-dd").withChronology(GJChronology.getInstanceUTC());
+			DateTimeFormat.forPattern("yyyy-MM-dd").withChronology(GJChronology.getInstanceUTC());	
 
 	@Override
 	public DateTime unmarshal(final String xml) throws Exception {
-		try {
-			return FORMATTER.parseDateTime(xml);
-		} catch (DateTimeParseException e) {
-			return FORMATTER_FALLBACK.parseDateTime(xml);
+		DateTime result = null;
+		
+		if(xml.length() > 10) {
+			result = FORMATTER.parseDateTime(xml);
+		} else {
+			result = FORMATTER_FALLBACK.parseDateTime(xml);
 		}
+		
+		return result;
 	}
 
 	@Override

--- a/MekHQ/src/mekhq/adapter/DateAdapter.java
+++ b/MekHQ/src/mekhq/adapter/DateAdapter.java
@@ -28,22 +28,22 @@ import org.joda.time.format.DateTimeFormatter;
 import mekhq.MekHQOptions;
 
 public class DateAdapter extends XmlAdapter<String, DateTime> {
-	private final static DateTimeFormatter FORMATTER =
-			DateTimeFormat.forPattern(MekHQOptions.getInstance().getDateFormatDataStorage().toPattern())
-			.withChronology(GJChronology.getInstanceUTC());	
-	private final static DateTimeFormatter FORMATTER_FALLBACK =
-			DateTimeFormat.forPattern("yyyy-MM-dd").withChronology(GJChronology.getInstanceUTC());	
+	private final static DateTimeFormatter FORMATTER = DateTimeFormat
+			.forPattern(MekHQOptions.getInstance().getDateFormatDataStorage().toPattern())
+			.withChronology(GJChronology.getInstanceUTC());
+	private final static DateTimeFormatter FORMATTER_FALLBACK = DateTimeFormat.forPattern("yyyy-MM-dd")
+			.withChronology(GJChronology.getInstanceUTC());
 
 	@Override
 	public DateTime unmarshal(final String xml) throws Exception {
 		DateTime result = null;
-		
-		if(xml.length() > 10) {
+
+		if (xml.length() > 10) {
 			result = FORMATTER.parseDateTime(xml);
 		} else {
 			result = FORMATTER_FALLBACK.parseDateTime(xml);
 		}
-		
+
 		return result;
 	}
 

--- a/MekHQ/src/mekhq/adapter/DateAdapter.java
+++ b/MekHQ/src/mekhq/adapter/DateAdapter.java
@@ -18,6 +18,8 @@
  */
 package mekhq.adapter;
 
+import java.time.format.DateTimeParseException;
+
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 import org.joda.time.DateTime;
@@ -25,17 +27,26 @@ import org.joda.time.chrono.GJChronology;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public class DateAdapter extends XmlAdapter<String, DateTime> {
-    private final static DateTimeFormatter FORMATTER =
-        DateTimeFormat.forPattern("yyyy-MM-dd").withChronology(GJChronology.getInstanceUTC());
-    
-    @Override
-    public DateTime unmarshal(final String xml) throws Exception {
-        return FORMATTER.parseDateTime(xml);
-    }
+import mekhq.MekHQOptions;
 
-    @Override
-    public String marshal(final DateTime object) throws Exception {
-        return object.toString(FORMATTER);
-    }
+public class DateAdapter extends XmlAdapter<String, DateTime> {
+	private final static DateTimeFormatter FORMATTER =
+			DateTimeFormat.forPattern(MekHQOptions.getInstance().getDateFormatDataStorage().toPattern())
+			.withChronology(GJChronology.getInstanceUTC());
+	private final static DateTimeFormatter FORMATTER_FALLBACK =
+			DateTimeFormat.forPattern("yyyy-MM-dd").withChronology(GJChronology.getInstanceUTC());
+
+	@Override
+	public DateTime unmarshal(final String xml) throws Exception {
+		try {
+			return FORMATTER.parseDateTime(xml);
+		} catch (DateTimeParseException e) {
+			return FORMATTER_FALLBACK.parseDateTime(xml);
+		}
+	}
+
+	@Override
+	public String marshal(final DateTime object) throws Exception {
+		return object.toString(FORMATTER);
+	}
 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -242,8 +242,6 @@ public class Campaign implements Serializable {
 
     // calendar stuff
     public GregorianCalendar calendar;
-    private SimpleDateFormat dateFormatLong;
-    private SimpleDateFormat dateFormatShort;
 
     private String factionCode;
     private String retainerEmployerCode; //AtB
@@ -298,8 +296,6 @@ public class Campaign implements Serializable {
         currentReportHTML = "";
         newReports = new ArrayList<String>();
         calendar = new GregorianCalendar(3067, Calendar.JANUARY, 1);
-        dateFormatLong = MekHQOptions.getInstance().getDateFormatLong();
-        dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
         name = "My Campaign";
         rng = new RandomNameGenerator();
         rng.populateNames();
@@ -590,7 +586,7 @@ public class Campaign implements Serializable {
 					report.append(shipSearchResult)
 						.append(" is available for purchase for ")
 						.append(NumberFormat.getInstance().format(ms.getCost()))
-						.append(" C-bills until ").append(dateFormatLong.format(shipSearchExpiration.getTime()));
+						.append(" C-bills until ").append(MekHQOptions.getInstance().getDateFormatLong().format(shipSearchExpiration.getTime()));
 				} else {
 					report.append(" <font color=\"red\">Could not determine ship type.</font>");
 				}
@@ -2927,11 +2923,11 @@ public class Campaign implements Serializable {
     }
 
     public String getDateAsString() {
-        return dateFormatLong.format(calendar.getTime());
+        return MekHQOptions.getInstance().getDateFormatLong().format(calendar.getTime());
     }
 
     public String getShortDateAsString() {
-        return dateFormatShort.format(calendar.getTime());
+        return MekHQOptions.getInstance().getDateFormatShort().format(calendar.getTime());
     }
 
     public void restore() {
@@ -3400,13 +3396,13 @@ public class Campaign implements Serializable {
             retirementDefectionTracker.writeToXml(pw1, 1);
             if (shipSearchStart != null) {
             	MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchStart",
-            			dateFormatShort.format(shipSearchStart.getTime()));
+            			MekHQOptions.getInstance().getDateFormatDataStorage().format(shipSearchStart.getTime()));
             }
             MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchType", shipSearchType);
             MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchResult", shipSearchResult);
             if (shipSearchExpiration != null) {
             	MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchExpiration",
-            			dateFormatShort.format(shipSearchExpiration.getTime()));
+            			MekHQOptions.getInstance().getDateFormatDataStorage().format(shipSearchExpiration.getTime()));
             }
         }
         
@@ -3725,14 +3721,22 @@ public class Campaign implements Serializable {
                 	retVal.retirementDefectionTracker = RetirementDefectionTracker.generateInstanceFromXML(wn, retVal);
                 } else if (xn.equalsIgnoreCase("shipSearchStart")) {
                 	retVal.shipSearchStart = new GregorianCalendar();
-                	retVal.shipSearchStart.setTime(retVal.dateFormatShort.parse(wn.getTextContent()));
+                	try {
+                		retVal.shipSearchStart.setTime(MekHQOptions.getInstance().getDateFormatDataStorage().parse(wn.getTextContent()));
+                	} catch (ParseException e) {
+                		retVal.shipSearchStart.setTime(new SimpleDateFormat("yyyyMMdd").parse(wn.getTextContent()));
+                	}
                 } else if (xn.equalsIgnoreCase("shipSearchType")) {
                 	retVal.shipSearchType = Integer.parseInt(wn.getTextContent());
                 } else if (xn.equalsIgnoreCase("shipSearchResult")) {
                 	retVal.shipSearchResult = wn.getTextContent();
                 } else if (xn.equalsIgnoreCase("shipSearchExpiration")) {
                 	retVal.shipSearchExpiration = new GregorianCalendar();
-                	retVal.shipSearchExpiration.setTime(retVal.dateFormatShort.parse(wn.getTextContent()));
+                	try {
+                		retVal.shipSearchExpiration.setTime(MekHQOptions.getInstance().getDateFormatDataStorage().parse(wn.getTextContent()));
+                	} catch (ParseException e) {
+                		retVal.shipSearchStart.setTime(new SimpleDateFormat("yyyyMMdd").parse(wn.getTextContent()));
+                	}
                 } else if (xn.equalsIgnoreCase("customPlanetaryEvents")) {
                     updatePlanetaryEventsFromXML(wn);
                 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -105,6 +105,7 @@ import megamek.common.util.BuildingBlock;
 import megamek.common.util.DirectoryItems;
 import megamek.common.weapons.BayWeapon;
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.NullEntityException;
@@ -241,8 +242,8 @@ public class Campaign implements Serializable {
 
     // calendar stuff
     public GregorianCalendar calendar;
-    private SimpleDateFormat dateFormat;
-    private SimpleDateFormat shortDateFormat;
+    private SimpleDateFormat dateFormatLong;
+    private SimpleDateFormat dateFormatShort;
 
     private String factionCode;
     private String retainerEmployerCode; //AtB
@@ -297,8 +298,8 @@ public class Campaign implements Serializable {
         currentReportHTML = "";
         newReports = new ArrayList<String>();
         calendar = new GregorianCalendar(3067, Calendar.JANUARY, 1);
-        dateFormat = new SimpleDateFormat("EEEE, MMMM d yyyy");
-        shortDateFormat = new SimpleDateFormat("yyyyMMdd");
+        dateFormatLong = MekHQOptions.getInstance().getDateFormatLong();
+        dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
         name = "My Campaign";
         rng = new RandomNameGenerator();
         rng.populateNames();
@@ -589,7 +590,7 @@ public class Campaign implements Serializable {
 					report.append(shipSearchResult)
 						.append(" is available for purchase for ")
 						.append(NumberFormat.getInstance().format(ms.getCost()))
-						.append(" C-bills until ").append(dateFormat.format(shipSearchExpiration.getTime()));
+						.append(" C-bills until ").append(dateFormatLong.format(shipSearchExpiration.getTime()));
 				} else {
 					report.append(" <font color=\"red\">Could not determine ship type.</font>");
 				}
@@ -2926,11 +2927,11 @@ public class Campaign implements Serializable {
     }
 
     public String getDateAsString() {
-        return dateFormat.format(calendar.getTime());
+        return dateFormatLong.format(calendar.getTime());
     }
 
     public String getShortDateAsString() {
-        return shortDateFormat.format(calendar.getTime());
+        return dateFormatShort.format(calendar.getTime());
     }
 
     public void restore() {
@@ -3306,7 +3307,7 @@ public class Campaign implements Serializable {
         MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "lastForceId", lastForceId);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "lastMissionId", lastMissionId);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "lastScenarioId", lastScenarioId);
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
         MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "calendar",
                                        df.format(calendar.getTime()));
         MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "fatigueLevel", fatigueLevel);
@@ -3399,13 +3400,13 @@ public class Campaign implements Serializable {
             retirementDefectionTracker.writeToXml(pw1, 1);
             if (shipSearchStart != null) {
             	MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchStart",
-            			shortDateFormat.format(shipSearchStart.getTime()));
+            			dateFormatShort.format(shipSearchStart.getTime()));
             }
             MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchType", shipSearchType);
             MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchResult", shipSearchResult);
             if (shipSearchExpiration != null) {
             	MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchExpiration",
-            			shortDateFormat.format(shipSearchExpiration.getTime()));
+            			dateFormatShort.format(shipSearchExpiration.getTime()));
             }
         }
         
@@ -3724,14 +3725,14 @@ public class Campaign implements Serializable {
                 	retVal.retirementDefectionTracker = RetirementDefectionTracker.generateInstanceFromXML(wn, retVal);
                 } else if (xn.equalsIgnoreCase("shipSearchStart")) {
                 	retVal.shipSearchStart = new GregorianCalendar();
-                	retVal.shipSearchStart.setTime(retVal.shortDateFormat.parse(wn.getTextContent()));
+                	retVal.shipSearchStart.setTime(retVal.dateFormatShort.parse(wn.getTextContent()));
                 } else if (xn.equalsIgnoreCase("shipSearchType")) {
                 	retVal.shipSearchType = Integer.parseInt(wn.getTextContent());
                 } else if (xn.equalsIgnoreCase("shipSearchResult")) {
                 	retVal.shipSearchResult = wn.getTextContent();
                 } else if (xn.equalsIgnoreCase("shipSearchExpiration")) {
                 	retVal.shipSearchExpiration = new GregorianCalendar();
-                	retVal.shipSearchExpiration.setTime(retVal.shortDateFormat.parse(wn.getTextContent()));
+                	retVal.shipSearchExpiration.setTime(retVal.dateFormatShort.parse(wn.getTextContent()));
                 } else if (xn.equalsIgnoreCase("customPlanetaryEvents")) {
                     updatePlanetaryEventsFromXML(wn);
                 }
@@ -4858,12 +4859,17 @@ public class Campaign implements Serializable {
                 // handle it.
                 // They're all primitives anyway...
                 if (xn.equalsIgnoreCase("calendar")) {
-                    SimpleDateFormat df = new SimpleDateFormat(
-                            "yyyy-MM-dd hh:mm:ss");
-                    retVal.calendar = (GregorianCalendar) GregorianCalendar
-                            .getInstance();
-                    retVal.calendar.setTime(df
-                                                    .parse(wn.getTextContent().trim()));
+                	SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+                    SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+                    retVal.calendar = (GregorianCalendar) GregorianCalendar.getInstance();
+                    Date date = null;
+                    try {
+                    	date = df.parse(wn.getTextContent().trim());
+                        retVal.calendar.setTime(date);
+                    } catch(ParseException pe) {
+                    	date = fallbackFormat.parse(wn.getTextContent().trim());
+                        retVal.calendar.setTime(date);
+                    }
                 } else if (xn.equalsIgnoreCase("camoCategory")) {
                     String val = wn.getTextContent().trim();
 

--- a/MekHQ/src/mekhq/campaign/Kill.java
+++ b/MekHQ/src/mekhq/campaign/Kill.java
@@ -23,12 +23,14 @@ package mekhq.campaign;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.UUID;
 
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlUtil;
 import mekhq.Version;
 
@@ -118,8 +120,13 @@ public class Kill implements Serializable {
 				} else if (wn2.getNodeName().equalsIgnoreCase("killer")) {
 					retVal.killer = (wn2.getTextContent());
 				} else if (wn2.getNodeName().equalsIgnoreCase("date")) {
-					SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-					retVal.date = df.parse(wn2.getTextContent().trim());
+					SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+					SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+					try {
+						retVal.date = df.parse(wn2.getTextContent().trim());
+					} catch (ParseException pe) {
+						retVal.date = fallbackFormat.parse(wn2.getTextContent().trim());
+					}
 				}
 			}
 		} catch (Exception ex) {
@@ -145,7 +152,7 @@ public class Kill implements Serializable {
 				+"<killer>"
 				+MekHqXmlUtil.escape(killer)
 				+"</killer>");
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+		SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
 		pw1.println(MekHqXmlUtil.indentStr(indent+1)
 				+"<date>"
 				+df.format(date)

--- a/MekHQ/src/mekhq/campaign/LogEntry.java
+++ b/MekHQ/src/mekhq/campaign/LogEntry.java
@@ -23,6 +23,7 @@
 package mekhq.campaign;
 
 import java.io.PrintWriter;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
@@ -43,7 +44,6 @@ public class LogEntry implements MekHqXmlSerializable {
     private String type;
     private Date date;
     private String desc;
-    private static final SimpleDateFormat DATE_FORMAT = MekHQOptions.getInstance().getDateFormatDataStorage();
 
     public LogEntry() {
         this(null, "", null);
@@ -92,7 +92,7 @@ public class LogEntry implements MekHqXmlSerializable {
         StringBuilder sb = new StringBuilder();
         sb.append(MekHqXmlUtil.indentStr(indent)).append("<logEntry>");
         if(null != date) {
-            sb.append("<date>").append(DATE_FORMAT.format(date)).append("</date>");
+            sb.append("<date>").append(MekHQOptions.getInstance().getDateFormatDataStorage().format(date)).append("</date>");
         }
         sb.append("<desc>").append(MekHqXmlUtil.escape(desc)).append("</desc>");
         if(null != type) {
@@ -117,7 +117,11 @@ public class LogEntry implements MekHqXmlSerializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("type")) {
                     retVal.type = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("date")) {
-                    retVal.date = DATE_FORMAT.parse(wn2.getTextContent().trim());
+                	try {
+                		retVal.date = MekHQOptions.getInstance().getDateFormatDataStorage().parse(wn2.getTextContent().trim());
+                	} catch (ParseException e) {
+                		retVal.date = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse(wn2.getTextContent().trim());
+                	}
                 }
             }
         } catch (Exception ex) {
@@ -132,7 +136,7 @@ public class LogEntry implements MekHqXmlSerializable {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         if(null != date) {
-            sb.append("[").append(DATE_FORMAT.format(date)).append("] ");
+            sb.append("[").append(MekHQOptions.getInstance().getDateFormatDataStorage().format(date)).append("] ");
         }
         sb.append(desc);
         return sb.toString();

--- a/MekHQ/src/mekhq/campaign/LogEntry.java
+++ b/MekHQ/src/mekhq/campaign/LogEntry.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.Objects;
 
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 
@@ -42,7 +43,7 @@ public class LogEntry implements MekHqXmlSerializable {
     private String type;
     private Date date;
     private String desc;
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+    private static final SimpleDateFormat DATE_FORMAT = MekHQOptions.getInstance().getDateFormatDataStorage();
 
     public LogEntry() {
         this(null, "", null);

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -30,6 +30,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -178,7 +180,7 @@ public class Finances implements Serializable {
             asset.writeToXml(pw1, indent+1);
         }
 		if(null != wentIntoDebt) {
-    		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+    		SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "wentIntoDebt", df.format(wentIntoDebt));
 		}
 		pw1.println(MekHqXmlUtil.indentStr(indent) + "</finances>");
@@ -202,16 +204,19 @@ public class Finances implements Serializable {
                  retVal.loanDefaults = Integer.parseInt(wn2.getTextContent().trim());
              }
 			 else if (wn2.getNodeName().equalsIgnoreCase("wentIntoDebt")) {
-			     SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-			     try {
-			         retVal.wentIntoDebt = df.parse(wn2.getTextContent().trim());
-			     } catch (DOMException e) {
-			         // TODO Auto-generated catch block
-			         e.printStackTrace();
-			     } catch (ParseException e) {
-			         // TODO Auto-generated catch block
-			         e.printStackTrace();
-			     }
+				 try {
+					 SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+				     SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+				     try {
+				         retVal.wentIntoDebt = df.parse(wn2.getTextContent().trim());
+				     } catch (ParseException pe) {
+				         retVal.wentIntoDebt = fallbackFormat.parse(wn2.getTextContent().trim());
+				     }
+				 } catch (ParseException e) {
+					 MekHQ.logError(e);
+				 } catch (DOMException e) {
+					 MekHQ.logError(e);
+				 }
 			 }
 		}
 

--- a/MekHQ/src/mekhq/campaign/finances/Loan.java
+++ b/MekHQ/src/mekhq/campaign/finances/Loan.java
@@ -31,6 +31,8 @@ import java.util.GregorianCalendar;
 import java.util.List;
 
 import megamek.common.Compute;
+import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
@@ -396,7 +398,7 @@ public class Loan implements MekHqXmlSerializable {
                 +"<overdue>"
                 +overdue
                 +"</overdue>");
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "nextPayment", df.format(nextPayment.getTime()));
         pw1.println(MekHqXmlUtil.indentStr(indent) + "</loan>");
     }
@@ -430,16 +432,19 @@ public class Loan implements MekHqXmlSerializable {
             } else if (wn2.getNodeName().equalsIgnoreCase("nPayments")) {
                 retVal.nPayments = Integer.parseInt(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("nextPayment")) {
-                SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-                retVal.nextPayment = (GregorianCalendar) GregorianCalendar.getInstance();
                 try {
-                    retVal.nextPayment.setTime(df.parse(wn2.getTextContent().trim()));
+                	SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+                    SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+                    retVal.nextPayment = (GregorianCalendar) GregorianCalendar.getInstance();
+                    try {
+                        retVal.nextPayment.setTime(df.parse(wn2.getTextContent().trim()));
+                    } catch (ParseException e) {
+                    	retVal.nextPayment.setTime(fallbackFormat.parse(wn2.getTextContent().trim()));
+                    }
                 } catch (DOMException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                	MekHQ.logError(e);
                 } catch (ParseException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                	MekHQ.logError(e);
                 }
             } else if (wn2.getNodeName().equalsIgnoreCase("overdue")) {
                 if (wn2.getTextContent().equalsIgnoreCase("true"))

--- a/MekHQ/src/mekhq/campaign/finances/Transaction.java
+++ b/MekHQ/src/mekhq/campaign/finances/Transaction.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Vector;
 
+import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlUtil;
 
 import org.w3c.dom.DOMException;
@@ -182,7 +184,7 @@ public class Transaction implements Serializable {
 				+"<category>"
 				+category
 				+"</category>");
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+		SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
 		pw1.println(MekHqXmlUtil.indentStr(indent+1)
 				+"<date>"
 				+df.format(date)
@@ -203,15 +205,18 @@ public class Transaction implements Serializable {
 			} else if (wn2.getNodeName().equalsIgnoreCase("description")) {
 				retVal.description = wn2.getTextContent();
 			} else if (wn2.getNodeName().equalsIgnoreCase("date")) {
-				SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 				try {
-					retVal.date = df.parse(wn2.getTextContent().trim());
+					SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+					SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");					
+					try {
+						retVal.date = df.parse(wn2.getTextContent().trim());
+					} catch (ParseException e) {
+						retVal.date = fallbackFormat.parse(wn2.getTextContent().trim());
+					}
 				} catch (DOMException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					MekHQ.logError(e);
 				} catch (ParseException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					MekHQ.logError(e);
 				}
 			}
 		}
@@ -229,6 +234,6 @@ public class Transaction implements Serializable {
     }
 
     public String toText() {
-        return new SimpleDateFormat("MM/dd/yyyy").format(getDate()) + ", " + getCategoryName() + ", " + getDescription() + ", " + getAmount();
+        return MekHQOptions.getInstance().getDateFormatShort().format(getDate()) + ", " + getCategoryName() + ", " + getDescription() + ", " + getAmount();
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -41,6 +41,7 @@ import megamek.common.Player;
 import megamek.common.UnitType;
 import megamek.common.loaders.EntityLoadingException;
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.market.UnitMarket;
@@ -1103,7 +1104,7 @@ public class AtBContract extends Contract implements Serializable {
 		if (null != routEnd) {
 			pw1.println(MekHqXmlUtil.indentStr(indent+1)
 					+"<routEnd>"
-					+ new SimpleDateFormat("yyyy-MM-dd").format(routEnd)
+					+ MekHQOptions.getInstance().getDateFormatDataStorage().format(routEnd)
 					+"</routEnd>");
 		}
 		pw1.println(MekHqXmlUtil.indentStr(indent+1)
@@ -1198,7 +1199,13 @@ public class AtBContract extends Contract implements Serializable {
 			} else if (wn2.getNodeName().equalsIgnoreCase("moraleLevel")) {
 				moraleLevel = Integer.parseInt(wn2.getTextContent());
 			} else if (wn2.getNodeName().equalsIgnoreCase("routEnd")) {
-				routEnd = new SimpleDateFormat("yyyy-MM-dd").parse(wn2.getTextContent());
+				SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+				SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd");
+				try {
+					routEnd = df.parse(wn2.getTextContent());
+				} catch (ParseException e) {
+					routEnd = fallbackFormat.parse(wn2.getTextContent());
+				}
 			} else if (wn2.getNodeName().equalsIgnoreCase("partsAvailabilityLevel")) {
 				partsAvailabilityLevel = Integer.parseInt(wn2.getTextContent());
 			} else if (wn2.getNodeName().equalsIgnoreCase("extensionLength")) {
@@ -1218,7 +1225,13 @@ public class AtBContract extends Contract implements Serializable {
 			} else if (wn2.getNodeName().equalsIgnoreCase("nextWeekBattleTypeMod")) {
 				nextWeekBattleTypeMod = Integer.parseInt(wn2.getTextContent());
 			} else if (wn2.getNodeName().equalsIgnoreCase("specialEventScenarioDate")) {
-				specialEventScenarioDate = new SimpleDateFormat("yyyy-MM-dd").parse(wn2.getTextContent());
+				SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+				SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd");
+				try {
+					specialEventScenarioDate = df.parse(wn2.getTextContent());
+				} catch (ParseException e) {
+					specialEventScenarioDate = fallbackFormat.parse(wn2.getTextContent());
+				}
 			} else if (wn2.getNodeName().equalsIgnoreCase("specialEventScenarioType")) {
 				specialEventScenarioType = Integer.parseInt(wn2.getTextContent());
 			}

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -33,6 +33,7 @@ import org.w3c.dom.NodeList;
 
 import megamek.common.BattleArmor;
 import megamek.common.Infantry;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
@@ -463,7 +464,7 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 
 	protected void writeToXmlBegin(PrintWriter pw1, int indent) {
 		super.writeToXmlBegin(pw1, indent);
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+		SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
 		pw1.println(MekHqXmlUtil.indentStr(indent+1)
 				+"<nMonths>"
 				+nMonths
@@ -565,7 +566,8 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 	public void loadFieldsFromXmlNode(Node wn) throws ParseException {
 		// Okay, now load mission-specific fields!
 		NodeList nl = wn.getChildNodes();
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+		SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+		SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 
 		for (int x=0; x<nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
@@ -574,10 +576,18 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 				employer = wn2.getTextContent();
 			}
 			else if (wn2.getNodeName().equalsIgnoreCase("startDate")) {
-				startDate = df.parse(wn2.getTextContent().trim());
+				try {
+					startDate = df.parse(wn2.getTextContent().trim());
+				} catch (ParseException e) {
+					startDate = fallbackFormat.parse(wn2.getTextContent().trim());
+				}
 			}
 			else if (wn2.getNodeName().equalsIgnoreCase("endDate")) {
-				endDate = df.parse(wn2.getTextContent().trim());
+				try {
+					endDate = df.parse(wn2.getTextContent().trim());
+				} catch (ParseException e) {
+					endDate = fallbackFormat.parse(wn2.getTextContent().trim());
+				}
 			}
 			else if (wn2.getNodeName().equalsIgnoreCase("nMonths")) {
 				nMonths = Integer.parseInt(wn2.getTextContent().trim());

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.UUID;
 
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlUtil;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
@@ -259,7 +260,7 @@ public class Scenario implements Serializable {
     }
     
     protected void writeToXmlBegin(PrintWriter pw1, int indent) {
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
         pw1.println(MekHqXmlUtil.indentStr(indent) + "<scenario id=\""
                 +id
                 +"\" type=\""
@@ -316,7 +317,8 @@ public class Scenario implements Serializable {
         NamedNodeMap attrs = wn.getAttributes();
         Node classNameNode = attrs.getNamedItem("type");
         String className = classNameNode.getTextContent();
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+        SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
         
         try {
             // Instantiate the correct child class, and call its parsing function.
@@ -342,7 +344,11 @@ public class Scenario implements Serializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("forceStub")) {
                     retVal.stub = ForceStub.generateInstanceFromXML(wn2);
                 } else if (wn2.getNodeName().equalsIgnoreCase("date")) {
-                    retVal.date = df.parse(wn2.getTextContent().trim());
+                	try {
+                		retVal.date = df.parse(wn2.getTextContent().trim());
+                	} catch (ParseException e) {
+                		retVal.date = fallbackFormat.parse(wn2.getTextContent().trim());
+                	}
                 } else if (wn2.getNodeName().equalsIgnoreCase("loots")) {
                     NodeList nl2 = wn2.getChildNodes();
                     for (int y=0; y<nl2.getLength(); y++) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -23,6 +23,7 @@ package mekhq.campaign.personnel;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -68,6 +69,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.PilotOptions;
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
@@ -1121,7 +1123,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
 
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
 
         pw1.println(MekHqXmlUtil.indentStr(indent) + "<person id=\""
                     + id.toString()
@@ -1449,9 +1451,14 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("spouse")) {
                     retVal.spouse = UUID.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("duedate")) {
-                    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-                    retVal.dueDate = (GregorianCalendar) GregorianCalendar.getInstance();
-                    retVal.dueDate.setTime(df.parse(wn2.getTextContent().trim()));
+                    SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+                    SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+                    retVal.dueDate = (GregorianCalendar) GregorianCalendar.getInstance();                    
+                    try {
+                    	retVal.dueDate.setTime(df.parse(wn2.getTextContent().trim()));
+                    } catch (ParseException e) {
+                    	retVal.dueDate.setTime(fallbackFormat.parse(wn2.getTextContent().trim()));
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("teamId")) {
                     retVal.teamId = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("portraitCategory")) {
@@ -1514,13 +1521,23 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("overtimeLeft")) {
                     retVal.overtimeLeft = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("birthday")) {
-                    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-                    retVal.birthday = (GregorianCalendar) GregorianCalendar.getInstance();
-                    retVal.birthday.setTime(df.parse(wn2.getTextContent().trim()));
+                    SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+                    SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+                    retVal.birthday = (GregorianCalendar) GregorianCalendar.getInstance();              
+                    try {
+                    	retVal.birthday.setTime(df.parse(wn2.getTextContent().trim()));
+                    } catch (ParseException e) {
+                    	retVal.birthday.setTime(fallbackFormat.parse(wn2.getTextContent().trim()));
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("deathday")) {
-                    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-                    retVal.deathday = (GregorianCalendar) GregorianCalendar.getInstance();
-                    retVal.deathday.setTime(df.parse(wn2.getTextContent().trim()));
+                    SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+                    SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+                    retVal.deathday = (GregorianCalendar) GregorianCalendar.getInstance();              
+                    try {
+                    	retVal.deathday.setTime(df.parse(wn2.getTextContent().trim()));
+                    } catch (ParseException e) {
+                    	retVal.deathday.setTime(fallbackFormat.parse(wn2.getTextContent().trim()));
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("advantages")) {
                     advantages = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("edge")) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -24,6 +24,7 @@ package mekhq.campaign.personnel;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.text.DecimalFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -40,6 +41,7 @@ import megamek.common.TargetRoll;
 import megamek.common.options.IOption;
 import megamek.common.options.PilotOptions;
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
@@ -624,7 +626,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
         pw1.println(MekHqXmlUtil.indentStr(indent + 1)
         		+ "</payouts>");
 
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1,
         		"lastRetirementRoll", df.format(lastRetirementRoll.getTime()));
         pw1.println(MekHqXmlUtil.indentStr(indent) + "</retirementDefectionTracker>");		
@@ -709,8 +711,13 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
                 		}
                 	}
                 } else if (wn2.getNodeName().equalsIgnoreCase("lastRetirementRoll")) {
-                    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-                    retVal.lastRetirementRoll.setTime(df.parse(wn2.getTextContent().trim()));
+                    SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+                    SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd");
+                    try {
+                    	retVal.lastRetirementRoll.setTime(df.parse(wn2.getTextContent().trim()));
+                    } catch (ParseException e) {
+                    	retVal.lastRetirementRoll.setTime(fallbackFormat.parse(wn2.getTextContent().trim()));
+                    }
                 }
             }
         } catch (Exception ex) {

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -45,6 +45,7 @@ import org.w3c.dom.NodeList;
 
 import megamek.common.Compute;
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.Utilities;
 import mekhq.campaign.CampaignOptions;
 
@@ -215,11 +216,13 @@ public class RandomFactionGenerator implements Serializable {
 		Element rootElement = xmlDoc.getDocumentElement();
 		NodeList nl = rootElement.getChildNodes();
 		rootElement.normalize();
+
+		SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+		SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd");
+		final Date epoch_start = df.parse("0001-01-01 00:00:00");
+		final Date epoch_end = df.parse("9999-12-31 23:59:59");
 		
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
 		for (int i = 0; i < nl.getLength(); i++) {
-			final Date epoch_start = df.parse("0001-01-01");
-			final Date epoch_end = df.parse("9999-12-31");
 			Node wn = nl.item(i);
 			
 			if (wn.getParentNode() != rootElement)
@@ -266,10 +269,18 @@ public class RandomFactionGenerator implements Serializable {
 					String inner = "UND";
 					ArrayList<String> opponents = null;
 					if (wn.getAttributes().getNamedItem("start") != null) {
-						start = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+						try {
+							start = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+						} catch (ParseException e) {
+							start = fallbackFormat.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+						}
 					}
 					if (wn.getAttributes().getNamedItem("end") != null) {
-						end = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+						try {
+							end = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+						} catch (ParseException e) {
+							end = fallbackFormat.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+						}
 					}
 					for (int j = 0; j < wn.getChildNodes().getLength(); j++) {
 						Node wn2 = wn.getChildNodes().item(j);
@@ -306,9 +317,10 @@ public class RandomFactionGenerator implements Serializable {
 	
 	private void setFactionHint(HashMap<String, HashMap<String, ArrayList<FactionHint>>> hint,
 			Node node) throws DOMException, ParseException {
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-		final Date epoch_start = df.parse("0001-01-01");
-		final Date epoch_end = df.parse("9999-12-31");
+		SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+		SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd");
+		final Date epoch_start = df.parse("0001-01-01 00:00:00");
+		final Date epoch_end = df.parse("9999-12-31 23:59:59");
 
 		String name = null;
 		Date start = epoch_start;
@@ -317,10 +329,18 @@ public class RandomFactionGenerator implements Serializable {
 			name = node.getAttributes().getNamedItem("name").getTextContent().trim();
 		}
 		if (node.getAttributes().getNamedItem("start") != null) {
-			start = df.parse(node.getAttributes().getNamedItem("start").getTextContent().trim());
+			try {
+				start = df.parse(node.getAttributes().getNamedItem("start").getTextContent().trim());
+			} catch (ParseException e) {
+				start = fallbackFormat.parse(node.getAttributes().getNamedItem("start").getTextContent().trim());
+			}
 		}
 		if (node.getAttributes().getNamedItem("end") != null) {
-			end = df.parse(node.getAttributes().getNamedItem("end").getTextContent().trim());
+			try {
+				end = df.parse(node.getAttributes().getNamedItem("end").getTextContent().trim());
+			} catch (ParseException e) {
+				end = fallbackFormat.parse(node.getAttributes().getNamedItem("end").getTextContent().trim());
+			}
 		}
 		for (int n = 0; n < node.getChildNodes().getLength(); n++) {
 			Node wn = node.getChildNodes().item(n);
@@ -328,10 +348,18 @@ public class RandomFactionGenerator implements Serializable {
 				Date localStart = start;
 				Date localEnd = end;
 				if (wn.getAttributes().getNamedItem("start") != null) {
-					localStart = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+					try {
+						localStart = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+					} catch (ParseException e) {
+						localStart = fallbackFormat.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+					}
 				}
 				if (wn.getAttributes().getNamedItem("end") != null) {
-					localEnd = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+					try {
+						localEnd = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+					} catch (ParseException e) {
+						localEnd = fallbackFormat.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+					}
 				}
 				
 				String[] parties = wn.getTextContent().trim().split(",");
@@ -360,14 +388,19 @@ public class RandomFactionGenerator implements Serializable {
 	}
 	
 	private void addNeutralExceptions(String faction, Node node) throws DOMException, ParseException {
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-		final Date epoch_start = df.parse("0001-01-01");
-		final Date epoch_end = df.parse("9999-12-31");
+		SimpleDateFormat df = MekHQOptions.getInstance().getDateFormatDataStorage();
+		SimpleDateFormat fallbackFormat = new SimpleDateFormat("yyyy-MM-dd");
+		final Date epoch_start = df.parse("0001-01-01 00:00:00");
+		final Date epoch_end = df.parse("9999-12-31 23:59:59");
 
 		Date start = epoch_start;
 		Date end = epoch_end;
 		if (node.getAttributes().getNamedItem("end") != null) {
-			end = df.parse(node.getAttributes().getNamedItem("end").getTextContent().trim());
+			try {
+				end = df.parse(node.getAttributes().getNamedItem("end").getTextContent().trim());
+			} catch (ParseException e) {
+				end = fallbackFormat.parse(node.getAttributes().getNamedItem("end").getTextContent().trim());				
+			}
 		}
 		for (int n = 0; n < node.getChildNodes().getLength(); n++) {
 			Node wn = node.getChildNodes().item(n);
@@ -375,10 +408,18 @@ public class RandomFactionGenerator implements Serializable {
 				Date localStart = start;
 				Date localEnd = end;
 				if (wn.getAttributes().getNamedItem("start") != null) {
-					localStart = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+					try {
+						localStart = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+					} catch (ParseException e) {
+						localStart = fallbackFormat.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());				
+					}
 				}
 				if (wn.getAttributes().getNamedItem("end") != null) {
-					localEnd = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+					try {
+						localEnd = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+					} catch (ParseException e) {
+						localEnd = fallbackFormat.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());				
+					}
 				}
 				
 				String[] parties = wn.getTextContent().trim().split(",");

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -218,6 +218,7 @@ import mekhq.gui.dialog.MaintenanceReportDialog;
 import mekhq.gui.dialog.ManageAssetsDialog;
 import mekhq.gui.dialog.MassRepairSalvageDialog;
 import mekhq.gui.dialog.MekHQAboutBox;
+import mekhq.gui.dialog.MekHQOptionsDialog;
 import mekhq.gui.dialog.MercRosterDialog;
 import mekhq.gui.dialog.MissionTypeDialog;
 import mekhq.gui.dialog.NewLoanDialog;
@@ -2858,6 +2859,17 @@ public class CampaignGUI extends JPanel {
         });
 
         menuFile.add(menuOptionsMM);
+        
+        JMenuItem menuOptionsMHQ = new JMenuItem(
+                resourceMap.getString("menuOptionsMHQ.text")); // NOI18N
+        menuOptionsMHQ.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            	menuOptionsMHQActionPerformed(evt);
+            }
+        });
+
+        menuFile.add(menuOptionsMHQ);
 
         menuThemes = new JMenu("Themes");
         refreshThemeChoices();
@@ -4683,6 +4695,13 @@ public class CampaignGUI extends JPanel {
             refreshOverview();
         }
     }// GEN-LAST:event_menuOptionsActionPerformed
+    
+    private void menuOptionsMHQActionPerformed(java.awt.event.ActionEvent evt) {
+    	MekHQOptionsDialog mhqod = new MekHQOptionsDialog(getFrame(), false);
+    	mhqod.refreshOptions();
+    	mhqod.setVisible(true);
+    	
+    }
 
     private void miLoadForcesActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_miLoadForcesActionPerformed
         try {

--- a/MekHQ/src/mekhq/gui/StartUpGUI.java
+++ b/MekHQ/src/mekhq/gui/StartUpGUI.java
@@ -27,6 +27,7 @@ import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.gui.dialog.DataLoadingDialog;
+import mekhq.gui.dialog.MekHQOptionsDialog;
 /**
  *
  * @author Jay
@@ -89,6 +90,19 @@ public class StartUpGUI extends javax.swing.JPanel {
             	loadCampaign(lastSave);
             }
         });
+        
+        btnOptions = new javax.swing.JButton(resourceMap.getString("btnOptions.text"));
+        btnOptions.setMinimumSize(new Dimension(200, 25));
+        btnOptions.setPreferredSize(new Dimension(200, 25));
+        btnOptions.setMaximumSize(new Dimension(200, 25));
+        btnOptions.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            	MekHQOptionsDialog mhqod = new MekHQOptionsDialog(frame, true);
+            	mhqod.refreshOptions();
+            	mhqod.setVisible(true);
+            }
+        });
+        
         btnQuit = new javax.swing.JButton(resourceMap.getString("btnQuit.text"));
         btnQuit.setMinimumSize(new Dimension(200, 25));
         btnQuit.setPreferredSize(new Dimension(200, 25));
@@ -97,7 +111,7 @@ public class StartUpGUI extends javax.swing.JPanel {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 System.exit(0);
             }
-        });
+        }); 
         
         // initialize splash image
         imgSplash = getToolkit().getImage("data/images/misc/mekhq-splash.png"); //$NON-NLS-1$
@@ -118,6 +132,8 @@ public class StartUpGUI extends javax.swing.JPanel {
         add(btnLoadGame);
         add(Box.createRigidArea(new Dimension(0,5)));
         add(btnLastSave);
+        add(Box.createRigidArea(new Dimension(0,5)));
+        add(btnOptions);
         add(Box.createRigidArea(new Dimension(0,5)));
         add(btnQuit);
                 
@@ -183,5 +199,6 @@ public class StartUpGUI extends javax.swing.JPanel {
     private javax.swing.JButton btnNewGame;
     private javax.swing.JButton btnLoadGame;
     private javax.swing.JButton btnLastSave;
+    private javax.swing.JButton btnOptions;
     private javax.swing.JButton btnQuit;
 }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -92,6 +92,7 @@ import megamek.common.options.PilotOptions;
 import megamek.common.util.DirectoryItems;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
@@ -122,7 +123,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
     private CampaignOptions options;
     private RandomSkillPreferences rskillPrefs;
     private GregorianCalendar date;
-    private SimpleDateFormat dateFormat;
+    private SimpleDateFormat dateFormatLong;
     private Frame frame;
     private String camoCategory;
     private String camoFileName;
@@ -427,7 +428,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         //this is a hack but I have no idea what is going on here
         this.frame = parent;
         this.date = campaign.calendar;
-        dateFormat = new SimpleDateFormat("EEEE, MMMM d yyyy");
+        dateFormatLong = MekHQOptions.getInstance().getDateFormatLong();
         this.camoCategory = campaign.getCamoCategory();
         this.camoFileName = campaign.getCamoFileName();
         this.colorIndex = campaign.getColorIndex();
@@ -4553,7 +4554,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
     }
 
     public String getDateAsString() {
-        return dateFormat.format(date.getTime());
+        return dateFormatLong.format(date.getTime());
     }
 
     public void setCamoIcon() {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -44,6 +44,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.PilotOptions;
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.Person;
@@ -69,7 +70,7 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
     private Hashtable<String, JCheckBox> skillChks = new Hashtable<String, JCheckBox>();
     private PilotOptions options;
     private GregorianCalendar birthdate;
-    private SimpleDateFormat dateFormat;
+    private SimpleDateFormat dateFormatLong;
     private Frame frame;
     
     private javax.swing.JButton btnClose;
@@ -115,7 +116,7 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
         super(parent, modal);
         this.campaign = campaign;
         this.frame = parent;
-        this.dateFormat = new SimpleDateFormat("MMMM d yyyy");
+        this.dateFormatLong = MekHQOptions.getInstance().getDateFormatLong();
         this.person = person;
         initializePilotAndOptions();
         setLocationRelativeTo(parent);
@@ -886,7 +887,7 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
     }
     
     private String getDateAsString() {
-        return dateFormat.format(birthdate.getTime());
+        return dateFormatLong.format(birthdate.getTime());
     }
     
     private void changeSkillValue(String type) {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -44,6 +44,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.table.TableColumn;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.Loot;
@@ -63,7 +64,7 @@ public class CustomizeScenarioDialog extends javax.swing.JDialog {
     private Campaign campaign;
     private boolean newScenario;
     private Date date;
-    private SimpleDateFormat dateFormatter;
+    private SimpleDateFormat dateFormatShort;
 
     private LootTableModel lootModel;
     
@@ -105,7 +106,7 @@ public class CustomizeScenarioDialog extends javax.swing.JDialog {
         if(null == date) {
         	date = campaign.getCalendar().getTime();
         }
-        dateFormatter = new SimpleDateFormat("MM/dd/yyyy");
+        dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
         loots = new ArrayList<Loot>();
         for(Loot loot : scenario.getLoot()) {
             loots.add((Loot)loot.clone());
@@ -182,7 +183,7 @@ public class CustomizeScenarioDialog extends javax.swing.JDialog {
         }
         if (!scenario.isCurrent() || (campaign.getCampaignOptions().getUseAtB() && scenario instanceof AtBScenario)) {
 	        btnDate = new javax.swing.JButton();
-	        btnDate.setText(dateFormatter.format(date));
+	        btnDate.setText(dateFormatShort.format(date));
 	        btnDate.addActionListener(new java.awt.event.ActionListener() {
 	            public void actionPerformed(java.awt.event.ActionEvent evt) {
 	                changeDate();
@@ -353,7 +354,7 @@ public class CustomizeScenarioDialog extends javax.swing.JDialog {
         		return;
         	}
             date = dc.getDate().getTime();
-            btnDate.setText(dateFormatter.format(date));
+            btnDate.setText(dateFormatShort.format(date));
         }
     }
     

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -37,6 +37,7 @@ import javax.swing.text.DateFormatter;
 import javax.swing.text.DefaultFormatterFactory;
 
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 
 /**
  * Hovanes Gambaryan Henry Demirchian CSUN, CS 585 Professor Mike Barnes
@@ -70,8 +71,10 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
     public static final int OK_OPTION = 1;
     public static final int CANCEL_OPTION = 2;
 
-    private final DateFormat MMDDYYYY = new SimpleDateFormat("MM/dd/yyyy");
-    private final DateFormat ISO8601 = new SimpleDateFormat("yyyy-MM-dd");
+    private final DateFormat ISO8601 = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_SHORT);
+    private final DateFormat DDMMYYY = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_SHORT);
+    
+    private final DateFormat dateFormatShort;
 
     private static final ArrayList<String> monthNames;
     static {
@@ -113,6 +116,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         super(owner, "Date Chooser", true);
         date = d;
         workingDate = date;
+        dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
 
         Container contentPane = getContentPane();
         contentPane.setLayout(new BorderLayout());
@@ -175,7 +179,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
             dateField = new JFormattedTextField();
             dateField.addFocusListener(this);
             dateField.addKeyListener(this);
-            dateField.setFormatterFactory(new DefaultFormatterFactory(new DateFormatter(MMDDYYYY)));
+            dateField.setFormatterFactory(new DefaultFormatterFactory(new DateFormatter(dateFormatShort)));
             dateField.setText(dateField.getFormatter().valueToString(date.getTime()));
             dateField.setToolTipText("Date of the transaction.");
             dateField.setName("dateField");
@@ -269,7 +273,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
             ready = true;
 
             //Set the date field to the new date.
-            dateField.setText(MMDDYYYY.format(date.getTime()));
+            dateField.setText(dateFormatShort.format(date.getTime()));
             setVisible(false);
         }
     }
@@ -285,7 +289,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         ready = true;
         monthLabel.setText(monthNames.get(cal.get(Calendar.MONTH)));
         yearLabel.setText("" + cal.get(Calendar.YEAR));
-        dateField.setText(MMDDYYYY.format(date.getTime()));
+        dateField.setText(dateFormatShort.format(date.getTime()));
         updateDayGrid(fromDateField);
 
     }
@@ -387,7 +391,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         //Update the date field with the newly selected date.
         if (dateField != null && !fromDateField) {
             workingDate = new GregorianCalendar(y, m, workingDay);
-            String textDate = MMDDYYYY.format(workingDate.getTime());
+            String textDate = dateFormatShort.format(workingDate.getTime());
             dateField.setText(textDate);
         }
 
@@ -492,8 +496,9 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
                 DateFormat.getDateInstance(DateFormat.FULL),
                 DateFormat.getDateInstance(DateFormat.DEFAULT),
                 DateFormat.getDateInstance(DateFormat.MEDIUM),
-                MMDDYYYY,
-                ISO8601
+                dateFormatShort,
+                ISO8601,
+                DDMMYYY,
         };
         for (DateFormat format : dateFormats) {
             try {

--- a/MekHQ/src/mekhq/gui/dialog/EditKillLogDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditKillLogDialog.java
@@ -40,6 +40,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Kill;
 import mekhq.campaign.personnel.Person;
@@ -256,8 +257,7 @@ public class EditKillLogDialog extends javax.swing.JDialog {
 	        	kill = (Kill)data.get(row);
 	        }
 			if(col == COL_DATE) {
-				SimpleDateFormat shortDateFormat = new SimpleDateFormat("MM/dd/yyyy");
-				return shortDateFormat.format(kill.getDate());
+				return MekHQOptions.getInstance().getDateFormatShort().format(kill.getDate());
 			}
 			if(col == COL_KILLED) {
 				return kill.getWhatKilled();

--- a/MekHQ/src/mekhq/gui/dialog/EditKillLogDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditKillLogDialog.java
@@ -26,7 +26,6 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GridLayout;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 

--- a/MekHQ/src/mekhq/gui/dialog/EditLogEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditLogEntryDialog.java
@@ -26,7 +26,6 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.ResourceBundle;

--- a/MekHQ/src/mekhq/gui/dialog/EditLogEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditLogEntryDialog.java
@@ -34,6 +34,7 @@ import java.util.ResourceBundle;
 import javax.swing.BorderFactory;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.LogEntry;
 
 /**
@@ -168,7 +169,6 @@ public class EditLogEntryDialog extends javax.swing.JDialog {
     }
     
     private String getDateAsString() {
-    	SimpleDateFormat dateFormat = new SimpleDateFormat("MMMM d yyyy");
-        return dateFormat.format(date);
+        return MekHQOptions.getInstance().getDateFormatShort().format(date);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelLogDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelLogDialog.java
@@ -26,7 +26,6 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GridLayout;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelLogDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelLogDialog.java
@@ -40,6 +40,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.LogEntry;
 import mekhq.campaign.personnel.Person;
@@ -246,8 +247,7 @@ public class EditPersonnelLogDialog extends javax.swing.JDialog {
 	        	entry = (LogEntry)data.get(row);
 	        }
 			if(col == COL_DATE) {
-				SimpleDateFormat shortDateFormat = new SimpleDateFormat("MM/dd/yyyy");
-				return shortDateFormat.format(entry.getDate());
+				return MekHQOptions.getInstance().getDateFormatShort().format(entry.getDate());
 			}
 			if(col == COL_DESC) {
 				return entry.getDesc();

--- a/MekHQ/src/mekhq/gui/dialog/EditTransactionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditTransactionDialog.java
@@ -11,9 +11,9 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.GregorianCalendar;
 import java.util.ResourceBundle;
 
@@ -31,6 +31,7 @@ import javax.swing.text.NumberFormatter;
 
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.campaign.finances.Transaction;
 
 public class EditTransactionDialog extends JDialog implements ActionListener, FocusListener, MouseListener {
@@ -40,7 +41,7 @@ public class EditTransactionDialog extends JDialog implements ActionListener, Fo
      */
     private static final long serialVersionUID = -8742160448355293487L;
 
-    private final DateFormat LONG_DATE = DateFormat.getDateInstance(DateFormat.LONG);
+    private SimpleDateFormat dateFormatLong = MekHQOptions.getInstance().getDateFormatLong();
 
     private ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AddFundsDialog", new EncodeControl()); //$NON-NLS-1$
 
@@ -127,7 +128,7 @@ public class EditTransactionDialog extends JDialog implements ActionListener, Fo
         panel.add(amountField);
 
         c.gridx++;
-        dateButton = new JButton(LONG_DATE.format(newTransaction.getDate()));
+        dateButton = new JButton(dateFormatLong.format(newTransaction.getDate()));
         dateButton.addActionListener(this);
         l.setConstraints(dateButton, c);
         panel.add(dateButton);
@@ -183,7 +184,7 @@ public class EditTransactionDialog extends JDialog implements ActionListener, Fo
             newTransaction.setCategory(Transaction.getCategoryIndex((String) categoryCombo.getSelectedItem()));
             newTransaction.setDescription(descriptionField.getText());
             try {
-                newTransaction.setDate(LONG_DATE.parse(dateButton.getText()));
+                newTransaction.setDate(dateFormatLong.parse(dateButton.getText()));
             } catch (ParseException e1) {
                 e1.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
             }
@@ -196,7 +197,7 @@ public class EditTransactionDialog extends JDialog implements ActionListener, Fo
             calendar.setTime(newTransaction.getDate());
             DateChooser chooser = new DateChooser(parent, calendar);
             chooser.showDateChooser();
-            dateButton.setText(LONG_DATE.format(chooser.getDate().getTime()));
+            dateButton.setText(dateFormatLong.format(chooser.getDate().getTime()));
             chooser.dispose();
         }
     }

--- a/MekHQ/src/mekhq/gui/dialog/KillDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/KillDialog.java
@@ -28,6 +28,7 @@ import java.util.GregorianCalendar;
 import java.util.ResourceBundle;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Kill;
 
 
@@ -201,8 +202,7 @@ public class KillDialog extends javax.swing.JDialog {
     }
     
     private String getDateAsString() {
-    	SimpleDateFormat dateFormat = new SimpleDateFormat("MMMM d yyyy");
-        return dateFormat.format(date);
+        return MekHQOptions.getInstance().getDateFormatShort().format(date);
     }
     
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/MekHQ/src/mekhq/gui/dialog/KillDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/KillDialog.java
@@ -22,7 +22,6 @@
 package mekhq.gui.dialog;
 
 import java.awt.Frame;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.ResourceBundle;

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -72,6 +72,7 @@ import org.joda.time.format.DateTimeFormatter;
 import megamek.common.util.EncodeControl;
 import mekhq.IconPackage;
 import mekhq.MekHQ;
+import mekhq.MekHQOptions;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.ExtraData;
@@ -87,9 +88,9 @@ import mekhq.gui.view.Paperdoll;
 public class MedicalViewDialog extends JDialog {
     private static final long serialVersionUID = 6178230374580087883L;
     private static final String MENU_CMD_SEPARATOR = ","; //$NON-NLS-1$
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd"); //$NON-NLS-1$
-    private final static DateTimeFormatter DATE_FORMATTER =
-        DateTimeFormat.forPattern("yyyy-MM-dd").withChronology(GJChronology.getInstanceUTC()); //$NON-NLS-1$
+    private static final DateTimeFormatter DATE_FORMATTER =	DateTimeFormat
+    		.forPattern(MekHQOptions.getInstance().getDateFormatShort().toPattern())
+    		.withChronology(GJChronology.getInstanceUTC());
 
     private static final ExtraData.Key<String> DOCTOR_NOTES = new ExtraData.StringKey("doctor_notes"); //$NON-NLS-1$
     // TODO: Custom paper dolls
@@ -350,8 +351,7 @@ public class MedicalViewDialog extends JDialog {
         }
         
         GregorianCalendar birthday = (GregorianCalendar) p.getBirthday().clone();
-        DATE_FORMAT.setCalendar(birthday);
-        String birthdayString = DATE_FORMAT.format(birthday.getTime());
+        String birthdayString = MekHQOptions.getInstance().getDateFormatShort().format(birthday.getTime());
         GregorianCalendar now = (GregorianCalendar) c.getCalendar().clone();
         int ageInMonths = (now.get(Calendar.YEAR) - birthday.get(Calendar.YEAR)) * 12
             + now.get(Calendar.MONTH) - birthday.get(Calendar.MONTH);
@@ -397,7 +397,7 @@ public class MedicalViewDialog extends JDialog {
         Map<String, List<LogEntry>> groupedEntries = p.getPersonnelLog().stream()
             .filter(entry -> entry.isType(Person.LOGTYPE_MEDICAL))
             .sorted((entry1, entry2) -> entry1.getDate().compareTo(entry2.getDate()))
-            .collect(Collectors.groupingBy(entry -> DATE_FORMAT.format(entry.getDate())));
+            .collect(Collectors.groupingBy(entry -> MekHQOptions.getInstance().getDateFormatShort().format(entry.getDate())));
         groupedEntries.entrySet().stream()
             .filter(e -> !e.getValue().isEmpty())
             .sorted((e1, e2) -> e1.getKey().compareTo(e2.getKey()))

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -37,7 +37,6 @@ import java.awt.event.MouseEvent;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -65,10 +64,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.UIManager;
 
-import org.joda.time.chrono.GJChronology;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-
 import megamek.common.util.EncodeControl;
 import mekhq.IconPackage;
 import mekhq.MekHQ;
@@ -88,14 +83,11 @@ import mekhq.gui.view.Paperdoll;
 public class MedicalViewDialog extends JDialog {
     private static final long serialVersionUID = 6178230374580087883L;
     private static final String MENU_CMD_SEPARATOR = ","; //$NON-NLS-1$
-    private static final DateTimeFormatter DATE_FORMATTER =	DateTimeFormat
-    		.forPattern(MekHQOptions.getInstance().getDateFormatShort().toPattern())
-    		.withChronology(GJChronology.getInstanceUTC());
 
     private static final ExtraData.Key<String> DOCTOR_NOTES = new ExtraData.StringKey("doctor_notes"); //$NON-NLS-1$
     // TODO: Custom paper dolls
     private static final ExtraData.Key<String> PAPERDOLL = new ExtraData.StringKey("paperdoll_xml_file"); //$NON-NLS-1$
-
+    
     private final Campaign campaign;
     private final Person person;
     private ResourceBundle resourceMap = null;
@@ -481,13 +473,13 @@ public class MedicalViewDialog extends JDialog {
                     JLabel injLabel = null;
                     if(inj.getType().isPermanent()) {
                         injLabel = genWrittenText(String.format(resourceMap.getString("injuriesText.format"), //$NON-NLS-1$
-                            inj.getType().getSimpleName(), inj.getStart().toString(DATE_FORMATTER)));
+                            inj.getType().getSimpleName(), MekHQOptions.getInstance().getDateFormatShort().format(inj.getStart())));
                     } else if(inj.isPermanent() || (inj.getTime() <= 0)) {
                         injLabel = genWrittenText(String.format(resourceMap.getString("injuriesPermanent.format"), //$NON-NLS-1$
-                            inj.getType().getSimpleName(), inj.getStart().toString(DATE_FORMATTER)));
+                            inj.getType().getSimpleName(), MekHQOptions.getInstance().getDateFormatShort().format(inj.getStart())));
                     } else {
                         injLabel = genWrittenText(String.format(resourceMap.getString("injuriesTextAndDuration.format"), //$NON-NLS-1$
-                            inj.getType().getSimpleName(), inj.getStart().toString(DATE_FORMATTER), genTimePeriod(inj.getTime())));
+                            inj.getType().getSimpleName(), MekHQOptions.getInstance().getDateFormatShort().format(inj.getStart()), genTimePeriod(inj.getTime())));
                     }
                     if(isGMMode()) {
                         injLabel.addMouseListener(new InjuryLabelMouseAdapter(injLabel, p, inj));

--- a/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
@@ -4,22 +4,28 @@ import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.io.FileNotFoundException;
+import java.text.SimpleDateFormat;
 import java.util.ResourceBundle;
 
 import javax.swing.ButtonGroup;
+import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQ;
 import mekhq.MekHQOptions;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.unit.Unit;
-import mekhq.gui.CampaignGUI;
 
 public class MekHQOptionsDialog extends JDialog {
 	private static final long serialVersionUID = 5509865952125603676L;
+
+	private JButton btnCancel;
+	private JButton btnSave;
 
 	private JLabel lblDateFormat;
 
@@ -33,7 +39,7 @@ public class MekHQOptionsDialog extends JDialog {
 	public MekHQOptionsDialog(java.awt.Frame parent, boolean modal) {
 		super(parent, modal);
 		initComponents();
-		updateSelectedOptions();
+		refreshOptions();
 		setLocationRelativeTo(parent);
 	}
 
@@ -46,6 +52,9 @@ public class MekHQOptionsDialog extends JDialog {
 
 		GridBagConstraints gridBagConstraints;
 		getContentPane().setLayout(new GridBagLayout());
+
+		btnCancel = new JButton();
+		btnSave = new JButton();
 
 		lblDateFormat = new JLabel();
 		lblDateFormat.setText(resourceMap.getString("lblDateFormat.text"));
@@ -77,16 +86,80 @@ public class MekHQOptionsDialog extends JDialog {
 		gridBagConstraints.insets = new Insets(10, 0, 10, 10);
 		getContentPane().add(pnlDateFormat, gridBagConstraints);
 
+		btnSave.setText(resourceMap.getString("btnSave.text"));
+		btnSave.setName("btnSave");
+		btnSave.addActionListener(new java.awt.event.ActionListener() {
+			@Override
+			public void actionPerformed(java.awt.event.ActionEvent evt) {
+				btnSaveActionPerformed();
+			}
+		});
+		gridBagConstraints = new java.awt.GridBagConstraints();
+		gridBagConstraints.gridx = 0;
+		gridBagConstraints.gridy = 1;
+		gridBagConstraints.anchor = java.awt.GridBagConstraints.CENTER;
+		getContentPane().add(btnSave, gridBagConstraints);
+
+		btnCancel.setText(resourceMap.getString("btnCancel.text"));
+		btnCancel.setName("btnCancel");
+		btnCancel.addActionListener(new java.awt.event.ActionListener() {
+			@Override
+			public void actionPerformed(java.awt.event.ActionEvent evt) {
+				btnCancelActionPerformed(evt);
+			}
+		});
+		gridBagConstraints = new java.awt.GridBagConstraints();
+		gridBagConstraints.gridx = 1;
+		gridBagConstraints.gridy = 1;
+		gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
+		getContentPane().add(btnCancel, gridBagConstraints);
+
 		pack();
 	}
 
-	private void updateSelectedOptions() {
+	protected void btnCancelActionPerformed(ActionEvent evt) {
+		this.setVisible(false);
+	}
+
+	protected void btnSaveActionPerformed() {
+		MekHQOptions options = MekHQOptions.getInstance();
+
+		// initialize with default ISO
+		SimpleDateFormat dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_SHORT);
+		SimpleDateFormat dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_LONG);
+
+		if (rbtnDateFormatISO.isSelected()) {
+			dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_SHORT);
+			dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_LONG);
+		} else {
+			dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_SHORT);
+			dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_LONG);
+		}
+
+		options.setDateFormatShort(dateFormatShort);
+		options.setDateFormatLong(dateFormatLong);
+
+		try {
+			options.save();
+		} catch (FileNotFoundException e) {
+			MekHQ.logError(e);
+			JOptionPane.showMessageDialog(null,
+					"For some reason MekHQ options could not be saved. (no write permissions in game directory?)",
+					"Could not save MekHQ options", JOptionPane.ERROR_MESSAGE);
+		}
+
+		this.setVisible(false);
+	}
+
+	public void refreshOptions() {
 		MekHQOptions options = MekHQOptions.getInstance();
 
 		if (options.getDateFormatLong().toPattern() == MekHQOptions.DATE_PATTERN_ISO_LONG) {
-			rbtnDateFormatISO.setSelected(true);
+			rbtnDateFormatISO.doClick();
 		} else if (options.getDateFormatLong().toPattern() == MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_LONG) {
-			rbtnDateFormatLittleEndian.setSelected(true);
+			rbtnDateFormatLittleEndian.doClick();
+		} else {
+			/// ? nothing selected?
 		}
 	}
 

--- a/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
@@ -131,7 +131,7 @@ public class MekHQOptionsDialog extends JDialog {
 		if (rbtnDateFormatISO.isSelected()) {
 			dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_SHORT);
 			dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_LONG);
-		} else {
+		} else if (rbtnDateFormatLittleEndian.isSelected()) {
 			dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_SHORT);
 			dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_LONG);
 		}

--- a/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
@@ -1,0 +1,93 @@
+package mekhq.gui.dialog;
+
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.ResourceBundle;
+
+import javax.swing.ButtonGroup;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+
+import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.CampaignGUI;
+
+public class MekHQOptionsDialog extends JDialog {
+	private static final long serialVersionUID = 5509865952125603676L;
+
+	private JLabel lblDateFormat;
+
+	private JRadioButton rbtnDateFormatISO;
+	private JRadioButton rbtnDateFormatLittleEndian;
+
+	private ButtonGroup bgroupDateFormat;
+
+	private JPanel pnlDateFormat;
+
+	public MekHQOptionsDialog(java.awt.Frame parent, boolean modal) {
+		super(parent, modal);
+		initComponents();
+		updateSelectedOptions();
+		setLocationRelativeTo(parent);
+	}
+
+	private void initComponents() {
+		setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
+		ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MekHQOptionsDialog",
+				new EncodeControl());
+
+		setTitle(resourceMap.getString("title.text"));
+
+		GridBagConstraints gridBagConstraints;
+		getContentPane().setLayout(new GridBagLayout());
+
+		lblDateFormat = new JLabel();
+		lblDateFormat.setText(resourceMap.getString("lblDateFormat.text"));
+		gridBagConstraints = new java.awt.GridBagConstraints();
+		gridBagConstraints.gridx = 0;
+		gridBagConstraints.gridy = 0;
+		gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+		gridBagConstraints.insets = new Insets(10, 10, 10, 0);
+		getContentPane().add(lblDateFormat, gridBagConstraints);
+
+		rbtnDateFormatISO = new JRadioButton();
+		rbtnDateFormatISO.setText(resourceMap.getString("rbtnDateFormatISO.text"));
+
+		rbtnDateFormatLittleEndian = new JRadioButton();
+		rbtnDateFormatLittleEndian.setText(resourceMap.getString("rbtnDateFormatLittleEndian.text"));
+
+		bgroupDateFormat = new ButtonGroup();
+		bgroupDateFormat.add(rbtnDateFormatISO);
+		bgroupDateFormat.add(rbtnDateFormatLittleEndian);
+
+		pnlDateFormat = new JPanel(new FlowLayout(FlowLayout.LEFT));
+		pnlDateFormat.add(rbtnDateFormatISO);
+		pnlDateFormat.add(rbtnDateFormatLittleEndian);
+
+		gridBagConstraints = new java.awt.GridBagConstraints();
+		gridBagConstraints.gridx = 1;
+		gridBagConstraints.gridy = 0;
+		gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+		gridBagConstraints.insets = new Insets(10, 0, 10, 10);
+		getContentPane().add(pnlDateFormat, gridBagConstraints);
+
+		pack();
+	}
+
+	private void updateSelectedOptions() {
+		MekHQOptions options = MekHQOptions.getInstance();
+
+		if (options.getDateFormatLong().toPattern() == MekHQOptions.DATE_PATTERN_ISO_LONG) {
+			rbtnDateFormatISO.setSelected(true);
+		} else if (options.getDateFormatLong().toPattern() == MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_LONG) {
+			rbtnDateFormatLittleEndian.setSelected(true);
+		}
+	}
+
+}

--- a/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
@@ -30,6 +30,8 @@ public class MekHQOptionsDialog extends JDialog {
 	private JLabel lblDateFormat;
 
 	private JRadioButton rbtnDateFormatISO;
+	private JRadioButton rbtnDateFormatBigEndian;
+	private JRadioButton rbtnDateFormatMiddleEndian;
 	private JRadioButton rbtnDateFormatLittleEndian;
 
 	private ButtonGroup bgroupDateFormat;
@@ -68,15 +70,25 @@ public class MekHQOptionsDialog extends JDialog {
 		rbtnDateFormatISO = new JRadioButton();
 		rbtnDateFormatISO.setText(resourceMap.getString("rbtnDateFormatISO.text"));
 
+		rbtnDateFormatBigEndian = new JRadioButton();
+		rbtnDateFormatBigEndian.setText(resourceMap.getString("rbtnDateFormatBigEndian.text"));
+
+		rbtnDateFormatMiddleEndian = new JRadioButton();
+		rbtnDateFormatMiddleEndian.setText(resourceMap.getString("rbtnDateFormatMiddleEndian.text"));
+
 		rbtnDateFormatLittleEndian = new JRadioButton();
 		rbtnDateFormatLittleEndian.setText(resourceMap.getString("rbtnDateFormatLittleEndian.text"));
 
 		bgroupDateFormat = new ButtonGroup();
 		bgroupDateFormat.add(rbtnDateFormatISO);
+		bgroupDateFormat.add(rbtnDateFormatBigEndian);
+		bgroupDateFormat.add(rbtnDateFormatMiddleEndian);
 		bgroupDateFormat.add(rbtnDateFormatLittleEndian);
 
 		pnlDateFormat = new JPanel(new FlowLayout(FlowLayout.LEFT));
 		pnlDateFormat.add(rbtnDateFormatISO);
+		pnlDateFormat.add(rbtnDateFormatBigEndian);
+		pnlDateFormat.add(rbtnDateFormatMiddleEndian);
 		pnlDateFormat.add(rbtnDateFormatLittleEndian);
 
 		gridBagConstraints = new java.awt.GridBagConstraints();
@@ -124,13 +136,19 @@ public class MekHQOptionsDialog extends JDialog {
 	protected void btnSaveActionPerformed() {
 		MekHQOptions options = MekHQOptions.getInstance();
 
-		// initialize with default ISO
+		// initialize with default big endian
 		SimpleDateFormat dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_SHORT);
 		SimpleDateFormat dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_LONG);
 
 		if (rbtnDateFormatISO.isSelected()) {
 			dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_SHORT);
 			dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_ISO_LONG);
+		} else if (rbtnDateFormatBigEndian.isSelected()) {
+			dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_BIG_ENDIAN_SHORT);
+			dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_BIG_ENDIAN_LONG);
+		} else if (rbtnDateFormatMiddleEndian.isSelected()) {
+			dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_MIDDLE_ENDIAN_SHORT);
+			dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_MIDDLE_ENDIAN_LONG);
 		} else if (rbtnDateFormatLittleEndian.isSelected()) {
 			dateFormatShort = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_SHORT);
 			dateFormatLong = new SimpleDateFormat(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_LONG);
@@ -155,13 +173,18 @@ public class MekHQOptionsDialog extends JDialog {
 		MekHQOptions options = MekHQOptions.getInstance();
 
 		String datePattern = options.getDateFormatLong().toPattern();
-		
+
 		if (datePattern.equals(MekHQOptions.DATE_PATTERN_ISO_LONG)) {
 			rbtnDateFormatISO.doClick();
+		} else if (datePattern.equals(MekHQOptions.DATE_PATTERN_BIG_ENDIAN_LONG)) {
+			rbtnDateFormatBigEndian.doClick();
+		} else if (datePattern.equals(MekHQOptions.DATE_PATTERN_MIDDLE_ENDIAN_LONG)) {
+			rbtnDateFormatMiddleEndian.doClick();
 		} else if (datePattern.equals(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_LONG)) {
 			rbtnDateFormatLittleEndian.doClick();
 		} else {
-			/// ? nothing selected?
+			// other pattern? should never get here.
+			MekHQ.logError("MekHQOptionsDialog: Currently set date format pattern does not correspond to any presets.");
 		}
 	}
 

--- a/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQOptionsDialog.java
@@ -154,9 +154,11 @@ public class MekHQOptionsDialog extends JDialog {
 	public void refreshOptions() {
 		MekHQOptions options = MekHQOptions.getInstance();
 
-		if (options.getDateFormatLong().toPattern() == MekHQOptions.DATE_PATTERN_ISO_LONG) {
+		String datePattern = options.getDateFormatLong().toPattern();
+		
+		if (datePattern.equals(MekHQOptions.DATE_PATTERN_ISO_LONG)) {
 			rbtnDateFormatISO.doClick();
-		} else if (options.getDateFormatLong().toPattern() == MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_LONG) {
+		} else if (datePattern.equals(MekHQOptions.DATE_PATTERN_LITTLE_ENDIAN_LONG)) {
 			rbtnDateFormatLittleEndian.doClick();
 		} else {
 			/// ? nothing selected?

--- a/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
@@ -48,6 +48,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Transaction;
 import mekhq.campaign.mission.Contract;
@@ -66,7 +67,7 @@ public class NewContractDialog extends javax.swing.JDialog {
     protected Contract contract;
     protected Campaign campaign;
     protected DecimalFormat formatter;
-    protected SimpleDateFormat dateFormatter;
+    protected SimpleDateFormat dateFormatLong;
     private JComboBox<Person> cboNegotiator;
 
     
@@ -78,7 +79,7 @@ public class NewContractDialog extends javax.swing.JDialog {
         contract = new Contract("New Contract", "New Employer");
         contract.calculateContract(campaign);
         formatter = new DecimalFormat();
-        dateFormatter = new SimpleDateFormat("EEEE, MMMM d yyyy");
+        dateFormatLong = MekHQOptions.getInstance().getDateFormatLong();
         initComponents();
         setLocationRelativeTo(parent);
     }
@@ -593,7 +594,7 @@ public class NewContractDialog extends javax.swing.JDialog {
         
         
         btnDate = new javax.swing.JButton();
-        btnDate.setText(dateFormatter.format(contract.getStartDate()));
+        btnDate.setText(dateFormatLong.format(contract.getStartDate()));
         //btnDate.setMinimumSize(new java.awt.Dimension(400, 30));
         btnDate.setName("btnDate"); // NOI18N
         //btnDate.setPreferredSize(new java.awt.Dimension(400, 30));
@@ -939,7 +940,7 @@ public class NewContractDialog extends javax.swing.JDialog {
         	}
             contract.setStartDate(dc.getDate().getTime());
             contract.calculateContract(campaign);
-            btnDate.setText(dateFormatter.format(contract.getStartDate()));
+            btnDate.setText(dateFormatLong.format(contract.getStartDate()));
         }
     }
     
@@ -1068,7 +1069,7 @@ public class NewContractDialog extends javax.swing.JDialog {
 
         contract.calculateContract(campaign);
         refreshTotals();
-        btnDate.setText(dateFormatter.format(contract.getStartDate()));
+        btnDate.setText(dateFormatLong.format(contract.getStartDate()));
     }
 
     // End of variables declaration//GEN-END:variables

--- a/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
@@ -48,6 +48,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.finances.Loan;
@@ -576,7 +577,7 @@ public class NewLoanDialog extends javax.swing.JDialog implements ActionListener
         lblYears.setText(loan.getYears() + " years");
         lblSchedule.setText(Finances.getScheduleName(loan.getPaymentSchedule()));
         lblPrincipal.setText(formatter.format(loan.getPrincipal()));
-        lblFirstPayment.setText(SimpleDateFormat.getDateInstance().format(loan.getNextPayDate()));
+        lblFirstPayment.setText(MekHQOptions.getInstance().getDateFormatShort().format(loan.getNextPayDate()));
         lblPayAmount.setText(formatter.format(loan.getPaymentAmount()));
         lblNPayment.setText(formatter.format(loan.getRemainingPayments()));
         lblTotalPayment.setText(formatter.format(loan.getRemainingValue()));

--- a/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
@@ -29,7 +29,6 @@ import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
 import java.util.GregorianCalendar;
 import java.util.ResourceBundle;
 

--- a/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
@@ -37,12 +37,11 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 import megamek.common.EquipmentType;
 import megamek.common.PlanetaryConditions;
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.Utilities;
 import mekhq.adapter.SocioIndustrialDataAdapter;
 import mekhq.campaign.Campaign;
@@ -78,7 +77,6 @@ public class NewPlanetaryEventDialog extends JDialog {
     private static final String FIELD_GOVERNMENT = "government"; //$NON-NLS-1$
     private static final String FIELD_CONTROL = "control"; //$NON-NLS-1$
     
-    private final static DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd"); //$NON-NLS-1$
     private final static SocioIndustrialDataAdapter SOCIO_INDUSTRIAL_ADAPTER = new SocioIndustrialDataAdapter();
     
     ResourceBundle resourceMap;
@@ -836,7 +834,7 @@ public class NewPlanetaryEventDialog extends JDialog {
     }
     
     private void updateDate() {
-        dateButton.setText(date.toString(DATE_FORMATTER));
+        dateButton.setText(MekHQOptions.getInstance().getDateFormatShort().format(date));
         Planet.PlanetaryEvent event = getCurrentEvent();
 
         messageField.setText((null != event) ? event.message : null);

--- a/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
@@ -3,7 +3,6 @@ package mekhq.gui.model;
 import java.awt.Color;
 import java.awt.Component;
 import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 
 import javax.swing.JTable;

--- a/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
@@ -10,6 +10,7 @@ import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
 
+import mekhq.MekHQOptions;
 import mekhq.campaign.finances.Transaction;
 
 /**
@@ -91,8 +92,7 @@ public class FinanceTableModel extends DataTableModel {
             return formatter.format(balance);
         }
         if(col == COL_DATE) {
-            SimpleDateFormat shortDateFormat = new SimpleDateFormat("MM/dd/yyyy");
-            return shortDateFormat.format(transaction.getDate());
+            return MekHQOptions.getInstance().getDateFormatShort().format(transaction.getDate());
         }
         return "?";
     }

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -17,6 +17,7 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Kill;
 import mekhq.campaign.LogEntry;
 
@@ -29,14 +30,14 @@ public class PersonnelEventLogModel extends DataTableModel {
     public final static int COL_TEXT = 1;
 
     private ResourceBundle resourceMap;
-    private SimpleDateFormat shortDateFormat;
+    private SimpleDateFormat dateFormatShort;
     private final int dateTextWidth;
 
     public PersonnelEventLogModel() {
         resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonnelEventLogModel", new EncodeControl()); //$NON-NLS-1$
-        shortDateFormat = new SimpleDateFormat(resourceMap.getString("date.format")); //$NON-NLS-1$
+        dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
         data = new ArrayList<Kill>();
-        dateTextWidth = getRenderer().metrics.stringWidth(shortDateFormat.format(new Date())) + 10;
+        dateTextWidth = getRenderer().metrics.stringWidth(dateFormatShort.format(new Date())) + 10;
     }
    
     @Override
@@ -66,7 +67,7 @@ public class PersonnelEventLogModel extends DataTableModel {
         LogEntry event = getEvent(row);
         switch(column) {
             case COL_DATE:
-                return shortDateFormat.format(event.getDate());
+                return dateFormatShort.format(event.getDate());
             case COL_TEXT:
                 return event.getDesc();
             default:

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -17,6 +17,7 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Kill;
 
 public class PersonnelKillLogModel extends DataTableModel {
@@ -28,14 +29,14 @@ public class PersonnelKillLogModel extends DataTableModel {
     public final static int COL_TEXT = 1;
 
     private ResourceBundle resourceMap;
-    private SimpleDateFormat shortDateFormat;
+    private SimpleDateFormat dateFormatShort;
     private final int dateTextWidth;
 
     public PersonnelKillLogModel() {
         resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonnelKillLogModel", new EncodeControl()); //$NON-NLS-1$
-        shortDateFormat = new SimpleDateFormat(resourceMap.getString("date.format")); //$NON-NLS-1$
+        dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
         data = new ArrayList<Kill>();
-        dateTextWidth = getRenderer().metrics.stringWidth(shortDateFormat.format(new Date())) + 10;
+        dateTextWidth = getRenderer().metrics.stringWidth(dateFormatShort.format(new Date())) + 10;
     }
    
     @Override
@@ -65,7 +66,7 @@ public class PersonnelKillLogModel extends DataTableModel {
         Kill kill = getKill(row);
         switch(column) {
             case COL_DATE:
-                return shortDateFormat.format(kill.getDate());
+                return dateFormatShort.format(kill.getDate());
             case COL_TEXT:
                 return String.format(
                     resourceMap.getString("killDetail.format"), //$NON-NLS-1$

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 
 import javax.swing.SwingConstants;

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 
 import javax.swing.SwingConstants;
 
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Scenario;
 
@@ -64,8 +65,7 @@ public class ScenarioTableModel extends DataTableModel {
             if(null == scenario.getDate()) {
                 return "-";
             } else {
-                SimpleDateFormat shortDateFormat = new SimpleDateFormat("MM/dd/yyyy");
-                return shortDateFormat.format(scenario.getDate());
+                return MekHQOptions.getInstance().getDateFormatShort().format(scenario.getDate());
             }
         }
         if(col == COL_ASSIGN) {

--- a/MekHQ/src/mekhq/gui/view/AtBContractViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBContractViewPanel.java
@@ -35,6 +35,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextArea;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Contract;
@@ -161,7 +162,7 @@ public class AtBContractViewPanel extends JPanel {
         GridBagConstraints gridBagConstraints;
         pnlStats.setLayout(new GridBagLayout());
         
-        SimpleDateFormat shortDateFormat = new SimpleDateFormat("MM/dd/yyyy");
+        SimpleDateFormat dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
         
         int y = 0;
         
@@ -329,7 +330,7 @@ public class AtBContractViewPanel extends JPanel {
         pnlStats.add(lblStartDate, gridBagConstraints);
         
         txtStartDate.setName("txtStartDate"); // NOI18N
-        txtStartDate.setText(shortDateFormat.format(contract.getStartDate()));
+        txtStartDate.setText(dateFormatShort.format(contract.getStartDate()));
         txtStartDate.setEditable(false);
         txtStartDate.setLineWrap(true);
         txtStartDate.setWrapStyleWord(true);
@@ -352,7 +353,7 @@ public class AtBContractViewPanel extends JPanel {
         pnlStats.add(lblEndDate, gridBagConstraints);
         
         txtEndDate.setName("txtEndDate"); // NOI18N
-        txtEndDate.setText(shortDateFormat.format(contract.getEndingDate()));
+        txtEndDate.setText(dateFormatShort.format(contract.getEndingDate()));
         txtEndDate.setEditable(false);
         txtEndDate.setLineWrap(true);
         txtEndDate.setWrapStyleWord(true);

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -36,6 +36,7 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
@@ -206,7 +207,7 @@ public class ContractSummaryPanel extends JPanel {
 		java.awt.GridBagConstraints gridBagConstraints;
 		mainPanel.setLayout(new java.awt.GridBagLayout());
 
-		SimpleDateFormat shortDateFormat = new SimpleDateFormat("MM/dd/yyyy");
+		SimpleDateFormat dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
 
 		int y = 0;
 
@@ -417,7 +418,7 @@ public class ContractSummaryPanel extends JPanel {
 		mainPanel.add(lblStartDate, gridBagConstraints);
 
 		txtStartDate.setName("txtStartDate"); // NOI18N
-		txtStartDate.setText(shortDateFormat.format(contract.getStartDate()));
+		txtStartDate.setText(dateFormatShort.format(contract.getStartDate()));
 		txtStartDate.setEditable(false);
 		txtStartDate.setLineWrap(true);
 		txtStartDate.setWrapStyleWord(true);

--- a/MekHQ/src/mekhq/gui/view/ContractViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractViewPanel.java
@@ -32,6 +32,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextArea;
 
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQOptions;
 import mekhq.campaign.mission.Contract;
 
 /**
@@ -124,7 +125,7 @@ public class ContractViewPanel extends JPanel {
         GridBagConstraints gridBagConstraints;
         pnlStats.setLayout(new GridBagLayout());
         
-        SimpleDateFormat shortDateFormat = new SimpleDateFormat("MM/dd/yyyy");
+        SimpleDateFormat dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
         
         lblStatus.setName("lblOwner"); // NOI18N
         lblStatus.setText("<html><b>" + contract.getStatusName() + "</b></html>");
@@ -219,7 +220,7 @@ public class ContractViewPanel extends JPanel {
         pnlStats.add(lblStartDate, gridBagConstraints);
         
         txtStartDate.setName("txtStartDate"); // NOI18N
-        txtStartDate.setText(shortDateFormat.format(contract.getStartDate()));
+        txtStartDate.setText(dateFormatShort.format(contract.getStartDate()));
         txtStartDate.setEditable(false);
         txtStartDate.setLineWrap(true);
         txtStartDate.setWrapStyleWord(true);
@@ -242,7 +243,7 @@ public class ContractViewPanel extends JPanel {
         pnlStats.add(lblEndDate, gridBagConstraints);
         
         txtEndDate.setName("txtEndDate"); // NOI18N
-        txtEndDate.setText(shortDateFormat.format(contract.getEndingDate()));
+        txtEndDate.setText(dateFormatShort.format(contract.getEndingDate()));
         txtEndDate.setEditable(false);
         txtEndDate.setLineWrap(true);
         txtEndDate.setWrapStyleWord(true);

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -32,6 +32,7 @@ import megamek.common.options.PilotOptions;
 import megamek.common.util.DirectoryItems;
 import megamek.common.util.EncodeControl;
 import mekhq.IconPackage;
+import mekhq.MekHQOptions;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Kill;
 import mekhq.campaign.LogEntry;
@@ -395,8 +396,8 @@ public class PersonViewPanel extends JPanel {
         pnlStats.add(lblStatus2, gridBagConstraints);
 
         if (person.getDueDate() != null) {
-            SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-            String DueDate = df.format(person.getDueDate().getTime());
+            SimpleDateFormat dateFormatShort = MekHQOptions.getInstance().getDateFormatShort();
+            String DueDate = dateFormatShort.format(person.getDueDate().getTime());
 
             firsty++;
             lblDuedate1.setName("lblDuedate1");

--- a/MekHQ/src/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/src/mekhq/resources/CampaignGUI.properties
@@ -110,6 +110,7 @@ btnShowAllTechs.text=Show All Tech Types
 btnGMMode.text=GM Mode
 menuOptions.text=Campaign Options
 menuOptionsMM.text=MegaMek Options
+menuOptionsMHQ.text=MekHQ Options
 btnRetrieveUnits.toolTipText=<html>Retrieve deployed units from a MUL file (including salvage)<br><b>NOTE:</b> This method will not load new pilots. Use Manage > Load Units from A MUL File to load new pilots.</html>
 btnRetrieveUnits.text=Retrieve Units
 menuManage.text=Manage

--- a/MekHQ/src/mekhq/resources/MekHQOptionsDialog.properties
+++ b/MekHQ/src/mekhq/resources/MekHQOptionsDialog.properties
@@ -1,0 +1,4 @@
+title.text=MekHQ Options
+lblDateFormat.text=Date Format:
+rbtnDateFormatISO.text=ISO
+rbtnDateFormatLittleEndian.text=Little Endian

--- a/MekHQ/src/mekhq/resources/MekHQOptionsDialog.properties
+++ b/MekHQ/src/mekhq/resources/MekHQOptionsDialog.properties
@@ -2,3 +2,5 @@ title.text=MekHQ Options
 lblDateFormat.text=Date Format:
 rbtnDateFormatISO.text=ISO
 rbtnDateFormatLittleEndian.text=Little Endian
+btnSave.text=Save
+btnCancel.text=Cancel

--- a/MekHQ/src/mekhq/resources/MekHQOptionsDialog.properties
+++ b/MekHQ/src/mekhq/resources/MekHQOptionsDialog.properties
@@ -1,6 +1,8 @@
 title.text=MekHQ Options
 lblDateFormat.text=Date Format:
 rbtnDateFormatISO.text=ISO
+rbtnDateFormatBigEndian.text=Big Endian
+rbtnDateFormatMiddleEndian.text=Middle Endian
 rbtnDateFormatLittleEndian.text=Little Endian
 btnSave.text=Save
 btnCancel.text=Cancel

--- a/MekHQ/src/mekhq/resources/StartUpDialog.properties
+++ b/MekHQ/src/mekhq/resources/StartUpDialog.properties
@@ -1,4 +1,5 @@
 btnNewGame.text=Start a New Campaign
 btnLoadGame.text=Load a Campaign
 btnLastSave.text=Load Last Save
+btnOptions.text=MekHQ Options
 btnQuit.text=Quit


### PR DESCRIPTION
This is a fix for date format inconsistencies.

Changes:
- new class MekHQOptions that stores settings that are relevant to application itself, rather then campaign
- MekHQOptions is a singleton
- currently only stores selected date format
- defaults to ISO format (both short and long date representations 
- new Dialog to accompany MekHQOptions, accessible from startup GUI and menu bar (File->MekHQ Options)
- saving/loading MekHQOptions to/from .xml
- replaced all instances of locally formatted dates with MekHQOptions.getInstance().getDateFormat<Short/Long>() for display
- replaced all instances of locally formatted dates withMekHQOptions.getInstance().getDateFormatDataStorage() when saving/loading data
- all dates saved in ISO format ( yyyy-MM-dd HH:mm:ss )
- ensured previously saved files will load properly by attempting to parse date with old pattern if new pattern failed

**Issues:**
- **Daily report log is being saved as a set of html strings. because of that, changing date format in options has no effect on currently displayed report, or on report in saved campaign. Only new reports (advance day) will display date in new format.**
- ~~**I was unsure as to what is the role of mekhq.adapter.DateAdapter so i left it untouched. There is an instance of locally created date format there.**~~

Other info
Because MekHQOptions can be accessed anywhere via getInstance(), there should be no more problems with date formats - whenever someone needs to format a date, appropriate format is avaliable via
- getDateFormatDataStorage() for ISO date/time format when saving/loading data
- getDateFormatShort() for short date representation (year number, month number and day number)
- getDateFormatLong() for long date representation (year number, month full name, day number and day of the week name)

Tested on several saved campaigns and a new campaign and didn't encounter any errors.