### PR TITLE
Bug #266 PayForTransport option ignored when estimating total contract profit

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -370,7 +370,9 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 		profit -= c.getMaintenanceCosts() * getLength();
 		profit -= c.getPayRoll() * getLength();
 		if(null != c.getPlanet(planetName)) {
-			profit -= 2 * c.calculateCostPerJump(true) * c.calculateJumpPath(c.getCurrentPlanet(), getPlanet()).getJumps();
+		    if (c.getCampaignOptions().payForTransport()) {
+		        profit -= 2 * c.calculateCostPerJump(true) * c.calculateJumpPath(c.getCurrentPlanet(), getPlanet()).getJumps();
+		    }
 		}
 		return profit;
 	}


### PR DESCRIPTION
Simple fix for the issue. Advancing to a new day correctly handles the issue but estimated profit did not. This should also fix the odd issue some people have when using AtB and not understanding when the profit shows as a negative. Will largely depend on if the option is unchecked or not.