### PR TITLE
Reset Flawed Cooling System after battle

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6764,9 +6764,8 @@ public class Campaign implements Serializable {
         entity.setNeverDeployed(true);
         entity.setStuck(false);
         entity.resetCoolantFailureAmount();
-        if (entity.hasQuirk("flawed_cooling")) {
-            entity.setCoolingFlawActive(false);
-        }
+        entity.setCoolingFlawActive(false);
+
         if (!entity.getSensors().isEmpty()) {
             entity.setNextSensor(entity.getSensors().firstElement());
         }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6764,6 +6764,9 @@ public class Campaign implements Serializable {
         entity.setNeverDeployed(true);
         entity.setStuck(false);
         entity.resetCoolantFailureAmount();
+        if (entity.hasQuirk("flawed_cooling")) {
+            entity.setCoolingFlawActive(false);
+        }
         if (!entity.getSensors().isEmpty()) {
             entity.setNextSensor(entity.getSensors().firstElement());
         }


### PR DESCRIPTION
Merge with MegaMek/megamek#518

Keeps flawed cooling from being carried over to the next battle.

Per arlith (possible optional application)

>  I suppose the quirk doesn't specify how it's fixed.  The easiest thing to do would be to just clear the flag in MHQ's resetEntity method. We could also add like a 5 or 15 minute repair task too.

As it is a quirk I don't know how easy it might be or if its currently possible.