### PR TITLE
Bugfix: Medics counted as Admin instead of Doctors

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -752,7 +752,7 @@ class CampaignOpsReputation extends AbstractUnitRating {
     }
 
     private int getTotalAdmins() {
-        return getCampaign().getAdmins().size() + getCampaign().getNumberMedics();
+        return getCampaign().getAdmins().size() + getCampaign().getDoctors().size();
     }
 
     @Override


### PR DESCRIPTION
Calculation for admin staff incorrectly used medics instead of doctors. This has been corrected.