### PR TITLE
Fix MRMS-MW issues

### DIFF
--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -14,6 +14,8 @@ v0.43.2-git
 + Fix #377: Advance Day Dialog not showing daily reports beyond the first.
 + Fix #343: Graphics Issue: MMLab screen does not fit in its MHQ window
 + Fix #298: Medical Details Window Size
++ Fix #382: MR-Warehouse no longer works
++ Fix #385: MRMS no longer fixes units with bad hip/shoulder
 
 v0.43.1 (2017-03-31 01:15 UTC)
 + Change to require GM Mode for the add/remove pregnancy context menu commands

--- a/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
@@ -756,14 +756,14 @@ public class MassRepairSalvageDialog extends JDialog {
 		optionItemBox.setToolTipText(toolTipText);
 		optionItemBox.setName(name);
 		optionItemBox.setSelected(selected);
-		if (name.equals("massRepairItemPod")) {
+		if (name.equals("massRepairItemPod") && !isModeWarehouse()) {
             replacePodPartsBox.setEnabled(selected);
 		}
 		optionItemBox.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				mroOptionChecked();
-				if (((JCheckBox)e.getSource()).getName().equals("massRepairItemPod")) {
+				if (((JCheckBox)e.getSource()).getName().equals("massRepairItemPod") && !isModeWarehouse()) {
 				    replacePodPartsBox.setEnabled(((JCheckBox)e.getSource()).isSelected());
 				}
 			}
@@ -1463,7 +1463,7 @@ public class MassRepairSalvageDialog extends JDialog {
 
 			for (IPartWork partWork : parts) {
 				if ((partWork instanceof MekLocation) && ((MekLocation)partWork).onBadHipOrShoulder()) {
-					locationMap.put(partWork.getLocation(), (MekLocation)partWork);
+					locationMap.put(((MekLocation)partWork).getLoc(), (MekLocation)partWork);
 				} else if (partWork instanceof MissingMekLocation) {
 					locationMap.put(partWork.getLocation(), (MissingMekLocation)partWork);
 				}
@@ -1494,6 +1494,9 @@ public class MassRepairSalvageDialog extends JDialog {
 				for (IPartWork partWork : partsTemp) {
 					if (!(partWork instanceof MekLocation) && !(partWork instanceof MissingMekLocation)
 							&& locationMap.containsKey(partWork.getLocation()) && partWork.isSalvaging()) {
+						campaign.addReport(
+								String.format("Planning to remove a %s due to a bad location.", partWork.getPartName()));
+						
 						partsToBeRemoved.add(partWork);
 
 						int count = 0;


### PR DESCRIPTION
#382: MR-Warehouse no longer works
- The addition of OmniPods broke the MR-W dialog and caused and NPE when
it tried to launch

#385: MRMS no longer fixes units with bad hip/shoulder
- getLocation() on missing locations no longer returned the proper
location index. Changed to ((MekLocation)partWork).getLoc()