### PR TITLE
Fix assertion failure when undeploying a unit from a special operation

### DIFF
--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -16,6 +16,7 @@ v0.43.2-git
 + Fix #298: Medical Details Window Size
 + Fix #382: MR-Warehouse no longer works
 + Fix #385: MRMS no longer fixes units with bad hip/shoulder
++ Fix #387: Fix assertion failure when undeploying a unit from a special operation
 
 v0.43.1 (2017-03-31 01:15 UTC)
 + Change to require GM Mode for the add/remove pregnancy context menu commands

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2959,7 +2959,10 @@ public class CampaignGUI extends JPanel {
                 prevId = parent.getId();
             }
         }
-        MekHQ.triggerEvent(new DeploymentChangedEvent(f, scenario));
+        
+        if (null != scenario) {
+        	MekHQ.triggerEvent(new DeploymentChangedEvent(f, scenario));
+        }
     }
 
     public JTabbedPane getTabMain() {


### PR DESCRIPTION
Fix #387 - Don't call the DeploymentChangedEvent if it has a null scenario

When calling undeployUnit(), the downstream call to undeployForce() results in a null scenario and thus an assertion failure.