### PR TITLE
Fixed remove all personnel

### DIFF
--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -17,6 +17,7 @@ v0.43.2-git
 + Fix #382: MR-Warehouse no longer works
 + Fix #385: MRMS no longer fixes units with bad hip/shoulder
 + Fix #387: Fix assertion failure when undeploying a unit from a special operation
++ Fix #389: Remove all personnel tried to remove the tech only if it didn't have a tech
 
 v0.43.1 (2017-03-31 01:15 UTC)
 + Change to require GM Mode for the add/remove pregnancy context menu commands

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3015,7 +3015,7 @@ public class Unit implements MekHqXmlSerializable {
     }
 
     public void removeTech() {
-        if (tech == null) {
+        if (tech != null) {
             MekHQ.triggerEvent(new PersonTechAssignmentEvent(campaign.getPerson(tech), this));
             tech = null;
         }


### PR DESCRIPTION
#389: Remove all personnel tried to remove the tech only if it didn't have a tech instead of if it did have a tech