### PR TITLE
Fix for incorrect treatment of tornadoes

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -1675,10 +1675,6 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 light = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("weather")) {
                 weather = Integer.parseInt(wn2.getTextContent());
-                if(weather > PlanetaryConditions.WE_SIZE || weather < PlanetaryConditions.WE_NONE)
-                {
-                	weather = PlanetaryConditions.WE_NONE;
-                }
             } else if (wn2.getNodeName().equalsIgnoreCase("wind")) {
                 wind = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("fog")) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -1675,6 +1675,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 light = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("weather")) {
                 weather = Integer.parseInt(wn2.getTextContent());
+                if(weather > PlanetaryConditions.WE_SIZE || weather < PlanetaryConditions.WE_NONE)
+                {
+                	weather = PlanetaryConditions.WE_NONE;
+                }
             } else if (wn2.getNodeName().equalsIgnoreCase("wind")) {
                 wind = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("fog")) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -386,8 +386,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             else if (r2 == 2) weather = PlanetaryConditions.WE_DOWNPOUR;
             else if (r2 == 3) weather = PlanetaryConditions.WE_SLEET;
             else if (r2 == 4) weather = PlanetaryConditions.WE_ICE_STORM;
-            else if (r2 == 5) weather = PlanetaryConditions.WI_TORNADO_F13;
-            else if (r2 == 6) weather = PlanetaryConditions.WI_TORNADO_F4;
+            else if (r2 == 5) wind = PlanetaryConditions.WI_TORNADO_F13; // tornadoes are classified as wind rather than weather.
+            else if (r2 == 6) wind = PlanetaryConditions.WI_TORNADO_F4;
         } else {
             if (r2 < 5) fog = PlanetaryConditions.FOG_LIGHT;
             else fog = PlanetaryConditions.FOG_HEAVY;


### PR DESCRIPTION
Some bullet proofing. Whenever we get ICE_STORM weather in a scenario, the PlanetaryConditions weather name resolver does not appreciate it, as it has an off by one error in it. 

Also, noticed that gales and tornadoes were resolving as downpour and light snow.