### PR TITLE
Fixed an issue where infantry were not properly counted for experienc…

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -277,8 +277,7 @@ class CampaignOpsReputation extends AbstractUnitRating {
 
         }
 
-        forceTotal = totalGround + totalAero + (totalInfantry / 28) +
-                     (totalBattleArmor / 5);
+        forceTotal = totalGround + totalAero + totalInfantry + totalBattleArmor;
         return forceTotal;
     }
 


### PR DESCRIPTION
…e rating.

Bug created when not paying close enough attention to what I am copying. Probably a rare bug for the most part, but one that needs fixing. This could cause situations where a Regular unit will appear as a Green unit by mistake due to incorrect calculations in the forceTotal.