### PR TITLE
Calculate DropShip rental costs based on untransported units only

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5943,12 +5943,6 @@ public class Campaign implements Serializable, ITechManager {
         // the FM:Mercs costs are per jump, which brings them a little closer
         // to the CO rules. I've left that as-is for now.
 
-        // A larger option is provided for mechs, because an Overlord is dramatically
-        // more efficient for units greater than company size. Even counting the extra
-        // docking collar costs, Gazelles and Buccaneers aren't tremendously less
-        // efficient than e.g. Triumphs and Mules, so those are left as-is for now
-        // (and are less likely to come up in the first place).
-
         // Roughly an Overlord
         int largeDropshipMechCapacity = 36;
         int largeMechDropshipASFCapacity = 6;
@@ -5966,10 +5960,19 @@ public class Campaign implements Serializable, ITechManager {
         int asfDropshipCargoCapacity = 90;
         long asfDropshipCost = (campaignOpsCosts ? 900000 : 80000);
 
+        // Roughly a Triumph
+        int largeDropshipVehicleCapacity = 50;
+        int largeVehicleDropshipCargoCapacity = 750;
+        long largeVehicleDropshipCost = (campaignOpsCosts ? 1750000 : 430000);
+
         // Roughly a Gazelle
         int averageDropshipVehicleCapacity = 15;
         int vehicleDropshipCargoCapacity = 65;
         long vehicleDropshipCost = (campaignOpsCosts ? 900000 : 40000);
+
+        // Roughly a Mule
+        int largeDropshipCargoCapacity = 8000;
+        long largeCargoDropshipCost = (campaignOpsCosts ? 750000 : 800000);
 
         // Roughly a Buccaneer
         int averageDropshipCargoCapacity = 2300;
@@ -5981,7 +5984,13 @@ public class Campaign implements Serializable, ITechManager {
 
         int asfCollars = 0;
         double leasedAverageASFDropships = 0;
+
+        int vehicleCollars = 0;
+        double leasedLargeVehicleDropships = 0;
         double leasedAverageVehicleDropships = 0;
+
+        int cargoCollars = 0;
+        double leasedLargeCargoDropships = 0;
         double leasedAverageCargoDropships = 0;
 
         int leasedASFCapacity = 0;
@@ -6025,8 +6034,8 @@ public class Campaign implements Serializable, ITechManager {
             }
 
             // Our Union-ish dropship can carry some ASFs and cargo.
-            leasedASFCapacity = (int) Math.floor(leasedAverageMechDropships * mechDropshipASFCapacity);
-            leasedCargoCapacity = (int) Math.floor(leasedAverageMechDropships * mechDropshipCargoCapacity);
+            leasedASFCapacity += (int) Math.floor(leasedAverageMechDropships * mechDropshipASFCapacity);
+            leasedCargoCapacity += (int) Math.floor(leasedAverageMechDropships * mechDropshipCargoCapacity);
         }
 
         // Leopard CVs
@@ -6036,12 +6045,15 @@ public class Campaign implements Serializable, ITechManager {
             if(noASF > 0) {
                 leasedAverageASFDropships = noASF / averageDropshipASFCapacity;
                 noASF -= leasedAverageASFDropships * averageDropshipASFCapacity;
+                asfCollars += leasedAverageASFDropships;
 
                 if (noASF > 0 && noASF < (averageDropshipASFCapacity / 2)) {
                     leasedAverageASFDropships += 0.5;
+                    asfCollars += 1;
                 }
                 else if (noASF > 0) {
                     leasedAverageASFDropships += 1;
+                    asfCollars += 1;
                 }
             }
 
@@ -6049,43 +6061,80 @@ public class Campaign implements Serializable, ITechManager {
             leasedCargoCapacity += (asfDropshipCargoCapacity * leasedAverageASFDropships);
         }
 
+        // Triumphs
+        if(noVehicles > averageDropshipVehicleCapacity) {
+            leasedLargeVehicleDropships = noVehicles / largeDropshipVehicleCapacity;
+            noVehicles -= leasedLargeVehicleDropships * largeDropshipVehicleCapacity;
+            vehicleCollars += leasedLargeVehicleDropships;
+
+            if(noVehicles > averageDropshipVehicleCapacity) {
+                leasedLargeVehicleDropships += 1;
+                noVehicles -= largeDropshipVehicleCapacity;
+                vehicleCollars += 1;
+            }
+
+            leasedCargoCapacity += leasedLargeVehicleDropships * largeVehicleDropshipCargoCapacity;
+        }
+
         // Gazelles
         if(noVehicles > 0) {
             leasedAverageVehicleDropships = (nohv + newNolv) / averageDropshipVehicleCapacity;
-
             noVehicles = (int)((nohv + newNolv) - leasedAverageVehicleDropships * averageDropshipVehicleCapacity);
+            vehicleCollars += leasedAverageVehicleDropships;
 
             // Gazelles are pretty minimal, so no half-measures.
             if(noVehicles > 0) {
                 leasedAverageVehicleDropships += 1;
+                noVehicles -= averageDropshipVehicleCapacity;
+                vehicleCollars += 1;
             }
 
             // Our Gazelle-ish dropship can carry some cargo.
             leasedCargoCapacity += (vehicleDropshipCargoCapacity * leasedAverageVehicleDropships);
         }
 
-        if(noCargo > leasedCargoCapacity) {
-            leasedAverageCargoDropships = noCargo / averageDropshipCargoCapacity;
+        // Do we have any leftover cargo?
+        noCargo -= leasedCargoCapacity;
 
-            noCargo -= leasedCargoCapacity * averageDropshipCargoCapacity;
+        // Mules
+        if(noCargo > averageDropshipCargoCapacity) {
+            leasedLargeCargoDropships = noCargo / largeDropshipCargoCapacity;
+            noCargo -= leasedLargeCargoDropships * largeDropshipCargoCapacity;
+            cargoCollars += leasedLargeCargoDropships;
+
+            if(noCargo > averageDropshipCargoCapacity) {
+                leasedLargeCargoDropships += 1;
+                noCargo -= largeDropshipCargoCapacity;
+                cargoCollars += 1;
+            }
+        }
+
+        // Buccaneers
+        if(noCargo > 0) {
+            leasedAverageCargoDropships = noCargo / averageDropshipCargoCapacity;
+            cargoCollars += leasedAverageCargoDropships;
+            noCargo -= leasedAverageCargoDropships * averageDropshipCargoCapacity;
 
             if(noCargo > 0 && noCargo < (averageDropshipCargoCapacity / 2)) {
                 leasedAverageCargoDropships += 0.5;
+                cargoCollars += 1;
             }
             else if(noCargo > 0) {
                 leasedAverageCargoDropships += 1;
+                cargoCollars += 1;
             }
-
-            // No need to update leased cargo capacity here, because we've already guaranteed we
-            // have enough cargo capacity.
         }
 
         dropshipCost = (long) (leasedAverageMechDropships * mechDropshipCost);
         dropshipCost += (long) (leasedLargeMechDropships * largeMechDropshipCost);
 
         dropshipCost += (long) (leasedAverageASFDropships * asfDropshipCost);
+
         dropshipCost += (long) (leasedAverageVehicleDropships * vehicleDropshipCost);
+        dropshipCost += (long) (leasedLargeVehicleDropships * largeVehicleDropshipCost);
+
         dropshipCost += (long) (leasedAverageCargoDropships * cargoDropshipCost);
+        dropshipCost += (long) (leasedLargeCargoDropships * largeCargoDropshipCost);
 
         // In Campaign Ops, DropShip costs are per month, so we need to find the
         // total cost for the transit and divide it among the number of jumps.
@@ -6094,7 +6143,7 @@ public class Campaign implements Serializable, ITechManager {
         }
 
         // Smaller/half-dropships are cheaper to rent, but still take one collar each
-        int collarsNeeded = mechCollars + (int) (Math.ceil(leasedAverageASFDropships) + Math.ceil(leasedAverageVehicleDropships) + Math.ceil(leasedAverageCargoDropships));
+        int collarsNeeded = mechCollars + asfCollars + vehicleCollars + cargoCollars;
 
         // add owned dropships
         collarsNeeded += nDropship;
@@ -6129,7 +6178,7 @@ public class Campaign implements Serializable, ITechManager {
 
             totalCost = totalCost + ownDropshipCost + ownJumpshipCost;
         }
-
+        
         return totalCost;
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5977,9 +5977,9 @@ public class Campaign implements Serializable, ITechManager {
         int vehicleDropshipCargoCapacity = 65;
         long vehicleDropshipCost = (campaignOpsCosts ? 900000 : 40000);
 
-        // Roughly a Monarch
-        int averageDropshipCargoCapacity = 1150;
-        long cargoDropshipCost = (campaignOpsCosts ? 700000 : 225000);
+        // Roughly a Buccaneer
+        int averageDropshipCargoCapacity = 2300;
+        long cargoDropshipCost = (campaignOpsCosts ? 550000 : 250000);
 
         double leasedMechDropships = 0;
         double leasedASFDropships = 0;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5914,10 +5914,10 @@ public class Campaign implements Serializable, ITechManager {
         // basing this on Field Manual Mercs, although I think the costs are
         // f'ed up
         long dropshipCost = 0;
-        dropshipCost += nMech * 10000;
-        dropshipCost += nAero * 15000;
-        dropshipCost += (nLVee+nHVee) * 3000;
-        dropshipCost += nBA * 250;
+        dropshipCost += noMech * 10000;
+        dropshipCost += newNoASF * 15000;
+        dropshipCost += (newNolv+nohv) * 3000;
+        dropshipCost += noBA * 250;
         dropshipCost += nMechInf * 100;
         dropshipCost += nMotorInf * 50;
         dropshipCost += nFootInf * 10;
@@ -5927,13 +5927,13 @@ public class Campaign implements Serializable, ITechManager {
         // some of the canonical designs
         int collarsNeeded = 0;
         // for mechs assume a union or smaller
-        collarsNeeded += (int) Math.ceil(nMech / 12.0);
+        collarsNeeded += (int) Math.ceil(noMech / 12.0);
         // for aeros, they may ride for free on the union, if not assume a
         // leopard cv
         collarsNeeded += (int) Math
-                .ceil(Math.max(0, nAero - collarsNeeded * 2) / 6.0);
+                .ceil(Math.max(0, newNoASF - collarsNeeded * 2) / 6.0);
         // for vees, assume a Triumph
-        collarsNeeded += (int) Math.ceil((nLVee+nHVee) / 53.0);
+        collarsNeeded += (int) Math.ceil(((newNolv+nohv)) / 53.0);
         // for now I am going to let infantry and BA tag along because of cargo
         // space rules
 

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -168,7 +168,7 @@ public class CurrentLocation implements Serializable {
 				if(campaign.getCampaignOptions().payForTransport()) {
 					double days = Math.round(jumpPath.getTotalTime(currentDate, campaign.getLocation().getTransitTime())*100.0)/100.0;
 					int roundedMonths = (int) Math.ceil(days / 30.0);
-					if(!campaign.getFinances().debit(campaign.calculateCostPerJump(true, false, jumpPath.getJumps(), roundedMonths), Transaction.C_TRANSPORT, "jump from " + currentPlanet.getName(currentDate) + " to " + jumpPath.get(1).getName(currentDate), campaign.getCalendar().getTime())) {
+					if(!campaign.getFinances().debit(campaign.calculateCostPerJump(true, campaign.getCampaignOptions().useEquipmentContractBase(), jumpPath.getJumps(), roundedMonths), Transaction.C_TRANSPORT, "jump from " + currentPlanet.getName(currentDate) + " to " + jumpPath.get(1).getName(currentDate), campaign.getCalendar().getTime())) {
 					    campaign.addReport("<font color='red'><b>You cannot afford to make the jump!</b></font>");
 					    return;
 					}

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -166,9 +166,7 @@ public class CurrentLocation implements Serializable {
 			if(isAtJumpPoint() && rechargeTime >= neededRechargeTime) {
 				//jump
 				if(campaign.getCampaignOptions().payForTransport()) {
-					double days = Math.round(jumpPath.getTotalTime(currentDate, campaign.getLocation().getTransitTime())*100.0)/100.0;
-					int roundedMonths = (int) Math.ceil(days / 30.0);
-					if(!campaign.getFinances().debit(campaign.calculateCostPerJump(true, campaign.getCampaignOptions().useEquipmentContractBase(), jumpPath.getJumps(), roundedMonths), Transaction.C_TRANSPORT, "jump from " + currentPlanet.getName(currentDate) + " to " + jumpPath.get(1).getName(currentDate), campaign.getCalendar().getTime())) {
+					if(!campaign.getFinances().debit(campaign.calculateCostPerJump(true, campaign.getCampaignOptions().useEquipmentContractBase()), Transaction.C_TRANSPORT, "jump from " + currentPlanet.getName(currentDate) + " to " + jumpPath.get(1).getName(currentDate), campaign.getCalendar().getTime())) {
 					    campaign.addReport("<font color='red'><b>You cannot afford to make the jump!</b></font>");
 					    return;
 					}

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -165,8 +165,10 @@ public class CurrentLocation implements Serializable {
 			}
 			if(isAtJumpPoint() && rechargeTime >= neededRechargeTime) {
 				//jump
-				if(campaign.getCampaignOptions().payForTransport()) {				    
-					if(!campaign.getFinances().debit(campaign.calculateCostPerJump(true), Transaction.C_TRANSPORT, "jump from " + currentPlanet.getName(currentDate) + " to " + jumpPath.get(1).getName(currentDate), campaign.getCalendar().getTime())) {
+				if(campaign.getCampaignOptions().payForTransport()) {
+					double days = Math.round(jumpPath.getTotalTime(currentDate, campaign.getLocation().getTransitTime())*100.0)/100.0;
+					int roundedMonths = (int) Math.ceil(days / 30.0);
+					if(!campaign.getFinances().debit(campaign.calculateCostPerJump(true, false, jumpPath.getJumps(), roundedMonths), Transaction.C_TRANSPORT, "jump from " + currentPlanet.getName(currentDate) + " to " + jumpPath.get(1).getName(currentDate), campaign.getCalendar().getTime())) {
 					    campaign.addReport("<font color='red'><b>You cannot afford to make the jump!</b></font>");
 					    return;
 					}

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -419,11 +419,10 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
         }
 		if(null != c.getPlanet(planetName) && c.getCampaignOptions().payForTransport()) {
 			JumpPath jumpPath = c.calculateJumpPath(c.getCurrentPlanet(), getPlanet());
-            int roundedMonths = (int) Math.ceil(getTravelDays(c) / 30.0);
 
 			boolean campaignOps = c.getCampaignOptions().useEquipmentContractBase();
-			transportAmount = (long)((transportComp/100.0) * 2 * c.calculateCostPerJump(campaignOps, campaignOps, jumpPath.getJumps(), roundedMonths) * jumpPath.getJumps());
-			profit -= 2 * c.calculateCostPerJump(campaignOps, campaignOps, jumpPath.getJumps(), roundedMonths) * jumpPath.getJumps();
+			transportAmount = (long)((transportComp/100.0) * 2 * c.calculateCostPerJump(campaignOps, campaignOps) * jumpPath.getJumps());
+			profit -= 2 * c.calculateCostPerJump(campaignOps, campaignOps) * jumpPath.getJumps();
 		}
 		return profit;
 	}
@@ -483,12 +482,11 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 		//calculate transportation costs
 		if(null != Planets.getInstance().getPlanetById(planetName)) {
             JumpPath jumpPath = c.calculateJumpPath(c.getCurrentPlanet(), getPlanet());
-            int roundedMonths = (int) Math.ceil(getTravelDays(c) / 30.0);
 
 			// FM:Mercs transport payments take into account owned transports and do not use CampaignOps dropship costs.
 			// CampaignOps doesn't care about owned transports and does use its own dropship costs.
 			boolean campaignOps = c.getCampaignOptions().useEquipmentContractBase();
-			transportAmount = (long)((transportComp/100.0) * 2 * c.calculateCostPerJump(campaignOps, campaignOps, jumpPath.getJumps(), roundedMonths) * jumpPath.getJumps());
+			transportAmount = (long)((transportComp/100.0) * 2 * c.calculateCostPerJump(campaignOps, campaignOps) * jumpPath.getJumps());
 		}
 
 		//calculate transit amount for CO

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -421,7 +421,6 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 			JumpPath jumpPath = c.calculateJumpPath(c.getCurrentPlanet(), getPlanet());
 
 			boolean campaignOps = c.getCampaignOptions().useEquipmentContractBase();
-			transportAmount = (long)((transportComp/100.0) * 2 * c.calculateCostPerJump(campaignOps, campaignOps) * jumpPath.getJumps());
 			profit -= 2 * c.calculateCostPerJump(campaignOps, campaignOps) * jumpPath.getJumps();
 		}
 		return profit;

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -266,9 +266,11 @@ public class JumpPathViewPanel extends javax.swing.JPanel {
             gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
             gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
             pnlStats.add(lblCost, gridBagConstraints);
-            
+
+            double days = Math.round(path.getTotalTime(currentDate, campaign.getLocation().getTransitTime())*100.0)/100.0;
+            int roundedMonths = (int) Math.ceil(days / 30.0);
             txtCost.setName("lblCost2"); // NOI18N
-            txtCost.setText(formatter.format(path.getJumps() * campaign.calculateCostPerJump(true)) + " C-bills");
+            txtCost.setText(formatter.format(path.getJumps() * campaign.calculateCostPerJump(true, false, path.getJumps(), roundedMonths)) + " C-bills");
             txtCost.setEditable(false);
             txtCost.setLineWrap(true);
             txtCost.setWrapStyleWord(true);

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -270,7 +270,7 @@ public class JumpPathViewPanel extends javax.swing.JPanel {
             double days = Math.round(path.getTotalTime(currentDate, campaign.getLocation().getTransitTime())*100.0)/100.0;
             int roundedMonths = (int) Math.ceil(days / 30.0);
             txtCost.setName("lblCost2"); // NOI18N
-            txtCost.setText(formatter.format(path.getJumps() * campaign.calculateCostPerJump(true, false, path.getJumps(), roundedMonths)) + " C-bills");
+            txtCost.setText(formatter.format(path.getJumps() * campaign.calculateCostPerJump(true, campaign.getCampaignOptions().useEquipmentContractBase(), path.getJumps(), roundedMonths)) + " C-bills");
             txtCost.setEditable(false);
             txtCost.setLineWrap(true);
             txtCost.setWrapStyleWord(true);

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -267,10 +267,8 @@ public class JumpPathViewPanel extends javax.swing.JPanel {
             gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
             pnlStats.add(lblCost, gridBagConstraints);
 
-            double days = Math.round(path.getTotalTime(currentDate, campaign.getLocation().getTransitTime())*100.0)/100.0;
-            int roundedMonths = (int) Math.ceil(days / 30.0);
             txtCost.setName("lblCost2"); // NOI18N
-            txtCost.setText(formatter.format(path.getJumps() * campaign.calculateCostPerJump(true, campaign.getCampaignOptions().useEquipmentContractBase(), path.getJumps(), roundedMonths)) + " C-bills");
+            txtCost.setText(formatter.format(path.getJumps() * campaign.calculateCostPerJump(true, campaign.getCampaignOptions().useEquipmentContractBase())) + " C-bills");
             txtCost.setEditable(false);
             txtCost.setLineWrap(true);
             txtCost.setWrapStyleWord(true);


### PR DESCRIPTION
This fixes a minor bug in the drop ship requirement calculations. Prior to this commit, the raw count of mechs, vehicles, and ASFs was used to determine DropShip requirements. This commit uses the count of untransported units, which is already calculated earlier in the method.

The attached saved game demonstrates the problem and verifies the solution. It contains a company of 12 mechs with a few attached ASFs, and has a Colossus and a JumpShip. The transport costs in the released dev snapshot are nonzero, despite the unit fitting entirely in its own transport assets. The transport costs in the version built with this commit are 0, as expected.

https://drive.google.com/file/d/0B4_Fe7AvNpDLTEdvSmpoelN5WTQ/view?usp=sharing