### PR TITLE
Issue #452: limit contract search by AtB search radius

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -368,14 +368,17 @@ public class ContractMarket implements Serializable {
 			}
 		}
 
+		int searchRadius = campaign.getCampaignOptions().getSearchRadius();
+		searchRadius += (int)(searchRadius * 0.10 * retries);
+
 		boolean isAttacker = (contract.getMissionType() == AtBContract.MT_PLANETARYASSAULT ||
 				contract.getMissionType() >= AtBContract.MT_PLANETARYASSAULT ||
 				(contract.getMissionType() == AtBContract.MT_RELIEFDUTY && Compute.d6() < 4) ||
 				contract.getEnemyCode().equals("REB"));
 		if (isAttacker) {
-			contract.setPlanetName(RandomFactionGenerator.getInstance().getMissionTarget(contract.getEmployerCode(), contract.getEnemyCode(), campaign.getDate()));
+			contract.setPlanetName(RandomFactionGenerator.getInstance().getMissionTarget(contract.getEmployerCode(), contract.getEnemyCode(), campaign.getDate(), campaign.getCurrentPlanet(), searchRadius));
 		} else {
-			contract.setPlanetName(RandomFactionGenerator.getInstance().getMissionTarget(contract.getEnemyCode(), contract.getEmployerCode(), campaign.getDate()));
+			contract.setPlanetName(RandomFactionGenerator.getInstance().getMissionTarget(contract.getEnemyCode(), contract.getEmployerCode(), campaign.getDate(), campaign.getCurrentPlanet(), searchRadius));
 		}
 		if (contract.getPlanetName() == null) {
 		    MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.WARNING,

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -369,7 +369,6 @@ public class ContractMarket implements Serializable {
 		}
 
 		int searchRadius = campaign.getCampaignOptions().getSearchRadius();
-		searchRadius += (int)(searchRadius * 0.10 * retries);
 
 		boolean isAttacker = (contract.getMissionType() == AtBContract.MT_PLANETARYASSAULT ||
 				contract.getMissionType() >= AtBContract.MT_PLANETARYASSAULT ||

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -686,15 +686,16 @@ public class RandomFactionGenerator implements Serializable {
 		return count;
 	}
 	
-	public String getMissionTarget(String attacker, String defender, Date date) {
-		ArrayList<Planet> planetList = getMissionTargetList(attacker, defender, date);
+	public String getMissionTarget(String attacker, String defender, Date date, Planet currentPlanet, int searchRadius) {
+		ArrayList<Planet> planetList = getMissionTargetList(attacker, defender, date, currentPlanet, searchRadius);
 		if (planetList.size() > 0) {
 			return Utilities.getRandomItem(planetList).getId();
 		}
 		return null;
 	}
 	
-	public ArrayList<Planet> getMissionTargetList(String attacker, String defender, Date date) {
+	public ArrayList<Planet> getMissionTargetList(String attacker, String defender, Date date, Planet currentPlanet, int searchRadius) {
+		boolean filterByDistance = (currentPlanet != null);
 		ArrayList<Planet> planetList = new ArrayList<Planet>();
 		int maxJumps = 3;
 		if (deepPeriphery.contains(attacker) || deepPeriphery.contains(defender)) {
@@ -734,7 +735,9 @@ public class RandomFactionGenerator implements Serializable {
 						if (f.getShortName().equals(defender) ||
 								defender.equals("PIR") ||
 								(f.getShortName().equals(attacker) && defender.equals("REB"))) {
-							planetList.add(planetKey);
+							if(filterByDistance && currentPlanet.getDistanceTo(planetKey) <= searchRadius) {
+								planetList.add(planetKey);
+							}
 						}
 					}
 				}

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -734,10 +734,9 @@ public class RandomFactionGenerator implements Serializable {
 					for (Faction f : planetKey.getFactionSet(Utilities.getDateTimeDay(date))) {
 						if (f.getShortName().equals(defender) ||
 								defender.equals("PIR") ||
-								(f.getShortName().equals(attacker) && defender.equals("REB"))) {
-							if(filterByDistance && currentPlanet.getDistanceTo(planetKey) <= searchRadius) {
-								planetList.add(planetKey);
-							}
+								(f.getShortName().equals(attacker) && defender.equals("REB")) &&
+								(filterByDistance && currentPlanet.getDistanceTo(planetKey) <= searchRadius)) {
+							planetList.add(planetKey);
 						}
 					}
 				}

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -479,8 +479,8 @@ public class NewAtBContractDialog extends NewContractDialog {
 				getCurrentEnemyCode().equals("REB") ||
 				getCurrentEnemyCode().equals("PIR")) {
 			for (Planet p : RandomFactionGenerator.getInstance().
-					getMissionTargetList(getCurrentEmployerCode(), getCurrentEnemyCode(),
-							campaign.getDate())) {
+					getMissionTargetList(getCurrentEmployerCode(), getCurrentEnemyCode(), campaign.getDate(), null, 0
+                    )) {
 				planets.add(p.getName(Utilities.getDateTimeDay(campaign.getCalendar())));
 			}
 		}
@@ -488,8 +488,8 @@ public class NewAtBContractDialog extends NewContractDialog {
 				contract.getMissionType() == AtBContract.MT_RELIEFDUTY) &&
 				!contract.getEnemyCode().equals("REB")) {
 			for (Planet p : RandomFactionGenerator.getInstance().
-					getMissionTargetList(getCurrentEnemyCode(), getCurrentEmployerCode(),
-							campaign.getDate())) {
+					getMissionTargetList(getCurrentEnemyCode(), getCurrentEmployerCode(), campaign.getDate(), null, 0
+                    )) {
 				planets.add(p.getName(Utilities.getDateTimeDay(campaign.getCalendar())));
 			}
 		}


### PR DESCRIPTION
These changes filter destination worlds for contracts based on
the search radius (in addition to the pre-existing filtering based
on employers with worlds in range). Some loosening of constraints
is included, adding 10% of the search radius per retry, in case
of difficult locations.

Tested by generating contracts in the near Periphery, Point Barrow in the middle of the Federated Suns, and near Terra. Doesn't seem to slow down contract generation.