### PR TITLE
Support - Peacetime Costs cleanup

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7509,6 +7509,9 @@ public class Campaign implements Serializable, ITechManager {
 
         long monthlyIncome = 0;
         long monthlyExpenses = 0;
+        long coSpareParts = 0;
+        long coFuel = 0;
+        long coAmmo = 0;
         long maintenance = 0;
         long salaries = 0;
         long overhead = 0;
@@ -7522,11 +7525,16 @@ public class Campaign implements Serializable, ITechManager {
         if (campaignOptions.payForOverhead()) {
             overhead = getOverheadExpenses();
         }
+        if (campaignOptions.usePeacetimeCost()) {
+            coSpareParts = getMonthlySpareParts();
+            coAmmo = getMonthlyAmmo();
+            coFuel = getMonthlyFuel();
+        }
         for (Contract contract : getActiveContracts()) {
             contracts += contract.getMonthlyPayOut();
         }
         monthlyIncome += contracts;
-        monthlyExpenses = maintenance + salaries + overhead;
+        monthlyExpenses = maintenance + salaries + overhead + coSpareParts + coAmmo + coFuel;
 
         long assets = cash + mech + vee + ba + infantry + largeCraft
                       + smallCraft + proto + getFinances().getTotalAssetValue();
@@ -7632,6 +7640,17 @@ public class Campaign implements Serializable, ITechManager {
         sb.append("    Overhead............. ")
           .append(String.format(formatted, DecimalFormat.getInstance()
                                                         .format(overhead))).append("\n");
+        if (campaignOptions.usePeacetimeCost()) {
+            sb.append("    Spare Parts.......... ")
+              .append(String.format(formatted, DecimalFormat.getInstance()
+                                                          .format(coSpareParts))).append("\n");
+            sb.append("    Training Munitions... ")
+              .append(String.format(formatted, DecimalFormat.getInstance()
+                                                          .format(coAmmo))).append("\n");
+            sb.append("    Fuel................. ")
+              .append(String.format(formatted, DecimalFormat.getInstance()
+                                                          .format(coFuel))).append("\n");
+        }
 
         return new String(sb);
     }

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -581,6 +581,10 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 				+transportAmount
 				+"</transportAmount>");
 		pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<transitAmount>"
+                +transitAmount
+                +"</transitAmount>");
+		pw1.println(MekHqXmlUtil.indentStr(indent+1)
 				+"<overheadAmount>"
 				+overheadAmount
 				+"</overheadAmount>");
@@ -665,6 +669,9 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 			else if (wn2.getNodeName().equalsIgnoreCase("transportAmount")) {
 				transportAmount = Long.parseLong(wn2.getTextContent().trim());
 			}
+			else if (wn2.getNodeName().equalsIgnoreCase("transitAmount")) {
+			    transitAmount = Long.parseLong(wn2.getTextContent().trim());
+            }
 			else if (wn2.getNodeName().equalsIgnoreCase("overheadAmount")) {
 				overheadAmount = Long.parseLong(wn2.getTextContent().trim());
 			}

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -24,6 +24,7 @@ package mekhq.campaign.unit;
 
 import java.io.PrintWriter;
 import java.math.BigInteger;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Enumeration;
@@ -3885,9 +3886,11 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     }
     
     public String displayMonthlyCost() {
-        String unitMonthlyCost = "<b>Spare Parts</b>: " + getSparePartsCost() + " C-bills<br>"
-                               + "<b>Ammunition</b>: " + getAmmoCost() + " C-bills<br>"
-                               + "<b>Fuel</b>: " + getFuelCost() + " C-bills<br>";
+        DecimalFormat numFormatter = new DecimalFormat();
+        
+        String unitMonthlyCost = "<b>Spare Parts</b>: " + numFormatter.format(getSparePartsCost()) + " C-bills<br>"
+                               + "<b>Ammunition</b>: " + numFormatter.format(getAmmoCost()) + " C-bills<br>"
+                               + "<b>Fuel</b>: " + numFormatter.format(getFuelCost()) + " C-bills<br>";
         return unitMonthlyCost;
     }
 


### PR DESCRIPTION
Fixed a bug where transit amounts were not being added to the contract amount when loading a save which resulted in the montly payout getting smaller.

Made a change to the supply cost dialog so the cost amounts would display with a comma, making them easier to read.