### PR TITLE
Fix infinite loops in personnel view panel log renderers

### DIFF
--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -158,7 +158,9 @@ public class PersonnelEventLogModel extends DataTableModel {
             lines = Math.max(lines, newLines);
 
             int height = fontHeight * lines + 4;
-            table.setRowHeight(row, height);
+            if(table.getRowHeight(row) < height) {
+                table.setRowHeight(row, height);
+            }
 
             setForeground(Color.BLACK);
             // tiger stripes

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -155,7 +155,9 @@ public class PersonnelKillLogModel extends DataTableModel {
             }
 
             int height = fontHeight * lines + 4;
-            table.setRowHeight(row, height);
+            if(table.getRowHeight(row) < height) {
+                table.setRowHeight(row, height);
+            }
 
             setForeground(Color.BLACK);
             // tiger stripes


### PR DESCRIPTION
Calling setRowHeight in getTableCellRendererComponent triggers a re-render, which calls getTableCellRendererComponent again. Check the current row height, and only set the row height if we're making the row taller.

(Making the row shorter is a case I can't ever see coming up, and a case the old code wouldn't have handled correctly either.)