### PR TITLE
Fix Unit Tests

### DIFF
--- a/MekHQ/build.xml
+++ b/MekHQ/build.xml
@@ -115,7 +115,7 @@
             <manifest>
                 <attribute name="Built-By" value="${user.name}"/>
                 <attribute name="Main-Class" value="${class.main}"/>
-                <attribute name="Class-Path" value="${classpath.manifest} ${megamek} ${megameklab}"/>
+                <attribute name="Class-Path" value=". ${classpath.manifest} ${megamek} ${megameklab}"/>
             </manifest>
             <fileset dir="${src}" includes="**/*.properties"/>
         </jar>
@@ -144,7 +144,7 @@
             <formatter type="xml" usefile="true"/>
             <batchtest fork="true" todir="${dir.build.teststaging}">
                 <fileset dir="${dir.build.test}">
-                    <include name="**/*Test.java"/>
+                    <include name="**/*Test.class"/>
                 </fileset>
             </batchtest>
         </junit>

--- a/MekHQ/packaging.xml
+++ b/MekHQ/packaging.xml
@@ -60,6 +60,25 @@
     <!-- This is the relative path to the 'data' directory -->
     <property name="dataclasspath" value="." />
 
+    <property name="megamek" value="MegaMek.jar"/>
+    <property name="megameklab" value="MegaMekLab.jar"/>
+
+    <!-- Runtime classpath to be added to the jar manifest's class-path. -->
+    <path id="classpath.runtime">
+        <fileset dir="${basedir}">
+            <include name="lib/*.jar"/>
+        </fileset>
+    </path>
+    <pathconvert property="classpath.manifest" pathsep=" ">
+        <path refid="classpath.runtime"/>
+        <mapper>
+            <chainedmapper>
+                <flattenmapper/>
+                <globmapper from="*.jar" to="lib/*.jar"/>
+            </chainedmapper>
+        </mapper>
+    </pathconvert>
+
     <condition property="isOsUnixLike">
         <os family="unix" />
     </condition>
@@ -209,8 +228,16 @@
                 </classpath>
             </javac>
 
-            <!-- jar -->
-            <jar basedir="${pkgbuilddir}" jarfile="${pkgdir}/${jarfile}" manifest="manifest.txt">
+        <echo message="Running unit tests."/>
+        <antcall target="tests-run"/>
+
+        <!-- jar -->
+        <jar basedir="${pkgbuilddir}" jarfile="${pkgdir}/${jarfile}">
+            <manifest>
+                <attribute name="Built-By" value="${user.name}"/>
+                <attribute name="Main-Class" value="${jarmainclass}"/>
+                <attribute name="Class-Path" value="${dataclasspath} ${classpath.manifest} ${megamek} ${megameklab}"/>
+            </manifest>
                 <fileset dir="${pkgdir}/${srcdir}" includes="**/*.properties"/>
             </jar>
 
@@ -278,16 +305,16 @@
             <javaproperty name="apple.awt.brushMetal" value="true" />
         </jarbundler>
         <jarbundler
-            dir="${osxdist}"
-            name="MekHQ"
-            mainclass="mekhq.MekHQ"
-            stubfile="packaging_utils/JavaApplicationStub"
-            icon="data/images/misc/mekhq.icns"
-            workingdirectory="$APP_PACKAGE/../"
-            useJavaXKey="true"
-            jvmversion="1.8+"
-            version="${version}"
-            vmoptions="-Xmx1024m">
+                dir="${osxdist}"
+                name="MekHQ"
+                mainclass="${jarmainclass}"
+                stubfile="packaging_utils/JavaApplicationStub"
+                icon="data/images/misc/mekhq.icns"
+                workingdirectory="$APP_PACKAGE/../"
+                useJavaXKey="true"
+                jvmversion="1.8+"
+                version="${version}"
+                vmoptions="-Xmx1024m">
             <jarfileset dir="${pkgdir}">
                 <include name="**/*.jar" />
                 <exclude name="${util}/" />
@@ -474,5 +501,69 @@
     <target name="nix-release" depends="pkgdir-build, nix-package, pkgdir-clean" description="Build the project from local source and package it as Unix" />
 
     <target name="src-release" depends="pkgdir-build, source-package, pkgdir-clean" description="Build the project from local source and package it as source-only" />
+
+    <property name="dir.build.teststaging" location="${builddir}/teststaging"/>
+    <property name="dir.build.testreport" location="${builddir}/testreport"/>
+    <property name="class.main" value="mekhq.MekHQ"/>
+    <property name="megamek" value="MegaMek.jar"/>
+    <property name="megameklab" value="MegaMekLab.jar"/>
+    <property name="dir.build.test" location="${builddir}/test"/>
+    <property name="dir.test.src" location="unittests"/>
+    <property name="libdir.test" value="lib-test"/>
+
+    <path id="classpath">
+        <fileset dir="${libdir}" includes="*.jar"/>
+    </path>
+    <path id="classpath.compile-unittest">
+        <path refid="classpath"/>
+        <pathelement location="${builddir}"/>
+        <fileset dir="${libdir.test}"/>
+        <fileset dir="${basedir}">
+            <include
+                    name="MegaMek.jar"
+            >
+            </include>
+            <include
+                    name="MegaMekLab.jar">
+            </include>
+        </fileset>
+    </path>
+    <path id="classpath.run-unittest">
+        <path refid="classpath.compile-unittest"/>
+        <pathelement location="${dir.build.test}"/>
+    </path>
+
+    <target name="tests-compile" unless="${skip.tests}">
+        <delete dir="${dir.build.test}"/>
+        <mkdir dir="${dir.build.test}"/>
+        <javac srcdir="${dir.test.src}" destdir="${dir.build.test}" encoding="UTF-8" includeantruntime="false"
+               debug="true">
+            <classpath refid="classpath.compile-unittest"/>
+        </javac>
+    </target>
+
+    <target depends="tests-compile" name="tests-run" unless="${skip.tests}">
+        <delete dir="${dir.build.teststaging}"/>
+        <delete dir="${dir.build.testreport}"/>
+        <mkdir dir="${dir.build.teststaging}"/>
+        <mkdir dir="${dir.build.testreport}"/>
+
+        <junit fork="true" maxmemory="256m" showoutput="true" printsummary="yes" forkmode="once" haltonfailure="true"
+               haltonerror="true" failureproperty="tests.failed">
+            <classpath refid="classpath.run-unittest"/>
+            <formatter type="xml" usefile="true"/>
+            <batchtest fork="true" todir="${dir.build.teststaging}">
+                <fileset dir="${dir.build.test}">
+                    <include name="**/*Test.class"/>
+                </fileset>
+            </batchtest>
+        </junit>
+
+        <junitreport todir="${dir.build.testreport}">
+            <fileset dir="${dir.build.teststaging}">
+                <include name="TEST-*.xml"/>
+            </fileset>
+        </junitreport>
+    </target>
 
 </project>

--- a/MekHQ/packaging_local.xml
+++ b/MekHQ/packaging_local.xml
@@ -53,6 +53,25 @@
 	<!-- This is the relative path to the 'data' directory -->
 	<property name="dataclasspath" value="." />
 
+	<property name="megamek" value="MegaMek.jar"/>
+	<property name="megameklab" value="MegaMekLab.jar"/>
+
+	<!-- Runtime classpath to be added to the jar manifest's class-path. -->
+	<path id="classpath.runtime">
+		<fileset dir="${basedir}">
+			<include name="lib/*.jar"/>
+		</fileset>
+	</path>
+	<pathconvert property="classpath.manifest" pathsep=" ">
+		<path refid="classpath.runtime"/>
+		<mapper>
+			<chainedmapper>
+				<flattenmapper/>
+				<globmapper from="*.jar" to="lib/*.jar"/>
+			</chainedmapper>
+		</mapper>
+	</pathconvert>
+
 	<condition property="isOsUnixLike">
 		<os family="unix" />
 	</condition>
@@ -204,8 +223,16 @@
 				</classpath>
 			</javac>
 
-			<!-- jar -->
-			<jar basedir="${localbuilddir}" jarfile="${localdir}/${jarfile}" manifest="manifest.txt">
+		<echo message="Running unit tests."/>
+		<antcall target="tests-run"/>
+
+		<!-- jar -->
+		<jar basedir="${localbuilddir}" jarfile="${localdir}/${jarfile}">
+			<manifest>
+				<attribute name="Built-By" value="${user.name}"/>
+				<attribute name="Main-Class" value="${jarmainclass}"/>
+				<attribute name="Class-Path" value="${dataclasspath} ${classpath.manifest} ${megamek} ${megameklab}"/>
+			</manifest>
 				<fileset dir="${localdir}/${srcdir}" includes="**/*.properties"/>
 			</jar>
 
@@ -272,16 +299,16 @@
             <javaproperty name="apple.awt.brushMetal" value="true" />
         </jarbundler>
         <jarbundler
-            dir="${osxdist}"
-            name="MekHQ"
-            mainclass="mekhq.MekHQ"
-            stubfile="packaging_utils/JavaApplicationStub"
-            icon="data/images/misc/mekhq.icns"
-            workingdirectory="$APP_PACKAGE/../"
-            useJavaXKey="true"
-            jvmversion="1.8+"
-            version="${version}"
-            vmoptions="-Xmx1024m">
+				dir="${osxdist}"
+				name="MekHQ"
+				mainclass="${jarmainclass}"
+				stubfile="packaging_utils/JavaApplicationStub"
+				icon="data/images/misc/mekhq.icns"
+				workingdirectory="$APP_PACKAGE/../"
+				useJavaXKey="true"
+				jvmversion="1.8+"
+				version="${version}"
+				vmoptions="-Xmx1024m">
             <jarfileset dir="${localdir}">
                 <include name="**/*.jar" />
                 <exclude name="${util}/" />
@@ -431,5 +458,69 @@
     <target name="nix-release" depends="localdev-build, nix-package, localdev-clean" description="Build the project from local source and package it as Unix" />
 
     <target name="src-release" depends="localdev-build, source-package, localdev-clean" description="Build the project from local source and package it as source-only" />
+
+	<property name="dir.build.teststaging" location="${builddir}/teststaging"/>
+	<property name="dir.build.testreport" location="${builddir}/testreport"/>
+	<property name="class.main" value="mekhq.MekHQ"/>
+	<property name="megamek" value="MegaMek.jar"/>
+	<property name="megameklab" value="MegaMekLab.jar"/>
+	<property name="dir.build.test" location="${builddir}/test"/>
+	<property name="dir.test.src" location="unittests"/>
+	<property name="libdir.test" value="lib-test"/>
+
+	<path id="classpath">
+		<fileset dir="${libdir}" includes="*.jar"/>
+	</path>
+	<path id="classpath.compile-unittest">
+		<path refid="classpath"/>
+		<pathelement location="${builddir}"/>
+		<fileset dir="${libdir.test}"/>
+		<fileset dir="${basedir}">
+			<include
+					name="MegaMek.jar"
+			>
+			</include>
+			<include
+					name="MegaMekLab.jar">
+			</include>
+		</fileset>
+	</path>
+	<path id="classpath.run-unittest">
+		<path refid="classpath.compile-unittest"/>
+		<pathelement location="${dir.build.test}"/>
+	</path>
+
+	<target name="tests-compile" unless="${skip.tests}">
+		<delete dir="${dir.build.test}"/>
+		<mkdir dir="${dir.build.test}"/>
+		<javac srcdir="${dir.test.src}" destdir="${dir.build.test}" encoding="UTF-8" includeantruntime="false"
+			   debug="true">
+			<classpath refid="classpath.compile-unittest"/>
+		</javac>
+	</target>
+
+	<target depends="tests-compile" name="tests-run" unless="${skip.tests}">
+		<delete dir="${dir.build.teststaging}"/>
+		<delete dir="${dir.build.testreport}"/>
+		<mkdir dir="${dir.build.teststaging}"/>
+		<mkdir dir="${dir.build.testreport}"/>
+
+		<junit fork="true" maxmemory="256m" showoutput="true" printsummary="yes" forkmode="once" haltonfailure="true"
+			   haltonerror="true" failureproperty="tests.failed">
+			<classpath refid="classpath.run-unittest"/>
+			<formatter type="xml" usefile="true"/>
+			<batchtest fork="true" todir="${dir.build.teststaging}">
+				<fileset dir="${dir.build.test}">
+					<include name="**/*Test.class"/>
+				</fileset>
+			</batchtest>
+		</junit>
+
+		<junitreport todir="${dir.build.testreport}">
+			<fileset dir="${dir.build.teststaging}">
+				<include name="TEST-*.xml"/>
+			</fileset>
+		</junitreport>
+	</target>
 
 </project>

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -262,6 +262,9 @@ class CampaignOpsReputation extends AbstractUnitRating {
             } else if ((u.getEntity().getEntityType() &
                         Entity.ETYPE_AERO) == Entity.ETYPE_AERO) {
                 totalAero++;
+            } else if ((u.getEntity().getEntityType() &
+                        Entity.ETYPE_DROPSHIP) == Entity.ETYPE_DROPSHIP) {
+                totalAero++;
             } else if (((u.getEntity().getEntityType() &
                          Entity.ETYPE_MECH) == Entity.ETYPE_MECH)
                        || ((u.getEntity().getEntityType() &
@@ -619,8 +622,7 @@ class CampaignOpsReputation extends AbstractUnitRating {
                 totalValue += 5;
             }
         }
-        if ((getDropshipCount() > 0) && (getDockingCollarCount() >=
-                                         getDropshipCount())) {
+        if ((getDropshipCount() > 0) && (getDockingCollarCount() >= getDropshipCount())) {
             totalValue += 5;
         }
 

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -28,13 +28,13 @@ import megamek.common.BipedMech;
 import megamek.common.Crew;
 import megamek.common.DockingCollar;
 import megamek.common.Dropship;
+import megamek.common.Entity;
 import megamek.common.Infantry;
 import megamek.common.InfantryBay;
 import megamek.common.Jumpship;
 import megamek.common.LightVehicleBay;
 import megamek.common.MechBay;
 import megamek.common.Tank;
-import megamek.common.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.mission.Mission;
@@ -238,6 +238,7 @@ public class CampaignOpsReputationTest {
         when(mockFighterTechSkillElite.getLevel()).thenReturn(5);
         when(mockVeeTechSkill.getLevel()).thenReturn(7);
 
+        when(mockThunderbolt1.getEntityType()).thenReturn(Entity.ETYPE_MECH);
         when(mockThunderboltUnit1.getEntity()).thenReturn(mockThunderbolt1);
         when(mockThunderbolt1Pilot.isAdmin()).thenReturn(false);
         when(mockThunderbolt1Pilot.getSkill(SkillType.S_GUN_MECH)).thenReturn(mockMechGunnery);
@@ -258,6 +259,7 @@ public class CampaignOpsReputationTest {
         personnelList.add(mockThunderbolt1Tech);
         astechs += 6;
 
+        when(mockThunderbolt2.getEntityType()).thenReturn(Entity.ETYPE_MECH);
         when(mockThunderboltUnit2.getEntity()).thenReturn(mockThunderbolt2);
         when(mockThunderbolt2Pilot.isAdmin()).thenReturn(false);
         when(mockThunderbolt2Pilot.getSkill(SkillType.S_GUN_MECH)).thenReturn(mockMechGunnery);
@@ -278,6 +280,7 @@ public class CampaignOpsReputationTest {
         personnelList.add(mockThunderbolt2Tech);
         astechs += 6;
 
+        when(mockGrasshopper1.getEntityType()).thenReturn(Entity.ETYPE_MECH);
         when(mockGrasshopperUnit1.getEntity()).thenReturn(mockGrasshopper1);
         when(mockGrasshopper1Pilot.isAdmin()).thenReturn(false);
         when(mockGrasshopper1Pilot.getSkill(SkillType.S_GUN_MECH)).thenReturn(mockMechGunnery);
@@ -298,6 +301,7 @@ public class CampaignOpsReputationTest {
         personnelList.add(mockGrasshopper1Tech);
         astechs += 6;
 
+        when(mockGrasshopper2.getEntityType()).thenReturn(Entity.ETYPE_MECH);
         when(mockGrasshopperUnit2.getEntity()).thenReturn(mockGrasshopper2);
         when(mockGrasshopper2Pilot.isAdmin()).thenReturn(false);
         when(mockGrasshopper2Pilot.getSkill(SkillType.S_GUN_MECH)).thenReturn(mockMechGunnery);
@@ -322,6 +326,7 @@ public class CampaignOpsReputationTest {
         personnelList.add(mockGrasshopper2Tech);
         astechs += 6;
 
+        when(mockBulldog1.getEntityType()).thenReturn(Entity.ETYPE_TANK);
         when(mockBulldogUnit1.getEntity()).thenReturn(mockBulldog1);
         when(mockBulldog1Driver.getSkill(SkillType.S_PILOT_GVEE)).thenReturn(mockTankPilot);
         when(mockBulldog1Driver.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
@@ -357,6 +362,7 @@ public class CampaignOpsReputationTest {
         when(mockBulldog1.getCrew()).thenReturn(mockBulldog1Crew);
         astechs += 6;
 
+        when(mockBulldog2.getEntityType()).thenReturn(Entity.ETYPE_TANK);
         when(mockBulldog2Driver.getSkill(SkillType.S_PILOT_GVEE)).thenReturn(mockTankPilot);
         when(mockBulldog2Driver.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
         when(mockBulldog2Gunner1.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
@@ -392,6 +398,7 @@ public class CampaignOpsReputationTest {
         when(mockBulldog2.getCrew()).thenReturn(mockBulldog2Crew);
         astechs += 6;
 
+        when(mockBulldog3.getEntityType()).thenReturn(Entity.ETYPE_TANK);
         when(mockBulldog3Driver.getSkill(SkillType.S_PILOT_GVEE)).thenReturn(mockTankPilot);
         when(mockBulldog3Driver.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
         when(mockBulldog3Gunner1.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
@@ -427,6 +434,7 @@ public class CampaignOpsReputationTest {
         when(mockBulldog3.getCrew()).thenReturn(mockBulldog3Crew);
         astechs += 6;
 
+        when(mockBulldog4.getEntityType()).thenReturn(Entity.ETYPE_TANK);
         when(mockBulldog4Driver.getSkill(SkillType.S_PILOT_GVEE)).thenReturn(mockTankPilot);
         when(mockBulldog4Driver.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
         when(mockBulldog4Gunner1.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
@@ -462,6 +470,7 @@ public class CampaignOpsReputationTest {
         when(mockBulldog4.getCrew()).thenReturn(mockBulldog4Crew);
         astechs += 6;
 
+        when(mockPackrat1.getEntityType()).thenReturn(Entity.ETYPE_TANK);
         when(mockPackrat1Driver.getSkill(SkillType.S_PILOT_GVEE)).thenReturn(mockTankPilot);
         when(mockPackrat1Driver.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
         when(mockPackrat1Gunner.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
@@ -487,6 +496,7 @@ public class CampaignOpsReputationTest {
         when(mockPackrat1.getCrew()).thenReturn(mockPackrat1Crew);
         astechs += 6;
 
+        when(mockPackrat2.getEntityType()).thenReturn(Entity.ETYPE_TANK);
         when(mockPackrat2Driver.getSkill(SkillType.S_PILOT_GVEE)).thenReturn(mockTankPilot);
         when(mockPackrat2Driver.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
         when(mockPackrat2Gunner.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
@@ -512,6 +522,7 @@ public class CampaignOpsReputationTest {
         when(mockPackrat2.getCrew()).thenReturn(mockPackrat2Crew);
         astechs += 6;
 
+        when(mockPackrat3.getEntityType()).thenReturn(Entity.ETYPE_TANK);
         when(mockPackrat3Driver.getSkill(SkillType.S_PILOT_GVEE)).thenReturn(mockTankPilot);
         when(mockPackrat3Driver.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
         when(mockPackrat3Gunner.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
@@ -537,6 +548,7 @@ public class CampaignOpsReputationTest {
         when(mockPackrat3.getCrew()).thenReturn(mockPackrat3Crew);
         astechs += 6;
 
+        when(mockPackrat4.getEntityType()).thenReturn(Entity.ETYPE_TANK);
         when(mockPackrat4Driver.getSkill(SkillType.S_PILOT_GVEE)).thenReturn(mockTankPilot);
         when(mockPackrat4Driver.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
         when(mockPackrat4Gunner.getSkill(SkillType.S_GUN_VEE)).thenReturn(mockTankGunnery);
@@ -562,6 +574,7 @@ public class CampaignOpsReputationTest {
         when(mockPackrat4.getCrew()).thenReturn(mockPackrat4Crew);
         astechs += 6;
 
+        when(mockLaserPlatoon.getEntityType()).thenReturn(Entity.ETYPE_INFANTRY);
         when(mockLaserPlatoon.getSquadSize()).thenReturn(7);
         when(mockLaserPlatoon.getSquadN()).thenReturn(4);
         when(mockLaserPlatoonUnit.getEntity()).thenReturn(mockLaserPlatoon);
@@ -580,6 +593,7 @@ public class CampaignOpsReputationTest {
         when(mockLaserPlatoon.getCrew()).thenReturn(mockLaserPlatoonCrew);
         personnelList.addAll(infantryPersonnel);
 
+        when(mockCorsair1.getEntityType()).thenReturn(Entity.ETYPE_AERO);
         when(mockCorsairUnit1.getEntity()).thenReturn(mockCorsair1);
         when(mockCorsair1Pilot.isAdmin()).thenReturn(false);
         when(mockCorsair1Pilot.getSkill(SkillType.S_GUN_AERO)).thenReturn(mockAeroGunnery);
@@ -600,6 +614,7 @@ public class CampaignOpsReputationTest {
         when(mockCorsair1.getCrew()).thenReturn(mockCorsair1Crew);
         astechs += 6;
 
+        when(mockCorsair2.getEntityType()).thenReturn(Entity.ETYPE_AERO);
         when(mockCorsairUnit2.getEntity()).thenReturn(mockCorsair2);
         when(mockCorsair2Pilot.isAdmin()).thenReturn(false);
         when(mockCorsair2Pilot.getSkill(SkillType.S_GUN_AERO)).thenReturn(mockAeroGunnery);
@@ -620,6 +635,7 @@ public class CampaignOpsReputationTest {
         when(mockCorsair2.getCrew()).thenReturn(mockCorsair2Crew);
         astechs += 6;
 
+        when(mockSeeker.getEntityType()).thenReturn(Entity.ETYPE_DROPSHIP);
         when(mockSeekerUnit.getEntity()).thenReturn(mockSeeker);
         Bay transportBay;
         Vector<Bay> bayList = new Vector<>();
@@ -654,6 +670,7 @@ public class CampaignOpsReputationTest {
         doReturn(mockDropGunnery.getLevel()).when(mockSeekerCrew).getGunnery();
         when(mockSeeker.getCrew()).thenReturn(mockSeekerCrew);
 
+        when(mockInvader.getEntityType()).thenReturn(Entity.ETYPE_JUMPSHIP);
         when(mockInvaderUnit.getEntity()).thenReturn(mockInvader);
         DockingCollar collar;
         Vector<DockingCollar> collarList = new Vector<>(4);
@@ -701,6 +718,11 @@ public class CampaignOpsReputationTest {
         unitList.add(mockCorsairUnit2);
         unitList.add(mockSeekerUnit);
         unitList.add(mockInvaderUnit);
+
+        for (Unit u : unitList) {
+            when(u.isPresent()).thenReturn(true);
+            when(u.hasPilot()).thenReturn(true);
+        }
 
         for (int i = 0; i < 10; i++) {
             Person admin = mock(Person.class);
@@ -847,7 +869,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testGetTransportValue() {
         spyReputation.initValues();
-        assertEquals(20, spyReputation.getTransportValue());
+        assertEquals(15, spyReputation.getTransportValue());
 
         // Test not having any dropships (though we still have a jumpship).
         doReturn(0).when(spyReputation).getDropshipCount();
@@ -870,7 +892,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testGetSupportValue() {
         spyReputation.initValues();
-        assertEquals(-5, spyReputation.getSupportValue());
+        assertEquals(-10, spyReputation.getSupportValue());
 
         // Test a brand new campaign.
         buildFreshCampaign();
@@ -892,7 +914,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testCalculateUnitRatingScore() {
         spyReputation.initValues();
-        assertEquals(38, spyReputation.calculateUnitRatingScore());
+        assertEquals(28, spyReputation.calculateUnitRatingScore());
 
         // Test a brand new campaign.
         buildFreshCampaign();
@@ -903,7 +925,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testGetReputationModifier() {
         spyReputation.initValues();
-        assertEquals(3, spyReputation.getModifier());
+        assertEquals(2, spyReputation.getModifier());
 
         // Test a brand new campaign.
         buildFreshCampaign();
@@ -927,7 +949,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testGetDetails() {
         String expectedDetails =
-                "Unit Reputation:    38\n" +
+                "Unit Reputation:    28\n" +
                 "    Method: Campaign Operations\n" +
                 "\n" +
                 "Experience:          10\n" +
@@ -945,7 +967,7 @@ public class CampaignOpsReputationTest {
                 "    Failed Missions:          0\n" +
                 "    Contract Breaches:        0\n" +
                 "\n" +
-                "Transportation:      20\n" +
+                "Transportation:      15\n" +
                 "    Mech Bays:                   4 needed /   4 available\n" +
                 "    Fighter Bays:                2 needed /   2 available\n" +
                 "    Small Craft Bays:            0 needed /   0 available\n" +
@@ -958,7 +980,7 @@ public class CampaignOpsReputationTest {
                 "    Has Jumpships?             Yes\n" +
                 "    Has Warships?               No\n" +
                 "\n" +
-                "Support:             -5\n" +
+                "Support:            -10\n" +
                 "    Tech Support:\n" +
                 "        Mech Techs:                   4 needed /    0 available\n" +
                 "            NOTE: Protomechs and mechs use same techs.\n" +
@@ -1080,7 +1102,7 @@ public class CampaignOpsReputationTest {
 
     @Test
     public void testGetTransportationDetails() {
-        String expected = "Transportation:      20\n" +
+        String expected = "Transportation:      15\n" +
                           "    Mech Bays:                   4 needed /   4 available\n" +
                           "    Fighter Bays:                2 needed /   2 available\n" +
                           "    Small Craft Bays:            0 needed /   0 available\n" +
@@ -1112,7 +1134,7 @@ public class CampaignOpsReputationTest {
         assertEquals(expected, spyReputation.getTransportationDetails());
 
         // Add excess heavy vehicle bays.
-        expected = "Transportation:      20\n" +
+        expected = "Transportation:      15\n" +
                    "    Mech Bays:                   4 needed /   4 available\n" +
                    "    Fighter Bays:                2 needed /   2 available\n" +
                    "    Small Craft Bays:            0 needed /   0 available\n" +


### PR DESCRIPTION
A while back, changes were made to calculations within CampaignOpsReputation but the unit tests for that class were not updated to match.  As a result, the unit tests fail.  This fixes that issue.  Also, I added code to ensure that unit tests are always run by the build and packaging scripts.