### PR TITLE
Faction.java redesign to fix issue with Eras.

### DIFF
--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -68,7 +68,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>TH</shortname>
 		<id>18</id>
 		<fullname>Terran Hegemony</fullname>
-		<startingPlanet>Terra,Terra,Terra, , , , , ,</startingPlanet>
+		<startingPlanet>Terra</startingPlanet>
 		<eraMods>-1,-1,-1,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,255,255</colorRGB>
@@ -79,7 +79,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<faction>
 		<shortname>AE</shortname>
 		<fullname>Amaris Empire</fullname>
-		<startingPlanet>Terra,Terra,Terra, , , , , ,</startingPlanet>
+		<startingPlanet>Terra</startingPlanet>
 		<eraMods>-1,-1,-1,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>142,74,123</colorRGB>
@@ -100,7 +100,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CC</shortname>
 		<id>1</id>
 		<fullname>Capellan Confederation</fullname>
-		<startingPlanet>Sian,Sian,Sian,Sian,Sian,Sian,Sian,Sian,Sian</startingPlanet>
+		<startingPlanet>Sian</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>0,156,85</colorRGB>
@@ -111,7 +111,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>DC</shortname>
 		<id>2</id>
 		<fullname>Draconis Combine</fullname>
-		<startingPlanet>New Samarkand,Luthien,Luthien,Luthien,Luthien,Luthien,Luthien,Luthien,Luthien</startingPlanet>
+		<startingPlanet>New Samarkand</startingPlanet>
+		<startingPlanet year='2619'>Luthien</startingPlanet>>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>DC</nameGenerator>
 		<colorRGB>234,45,46</colorRGB>
@@ -122,7 +123,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>FS</shortname>
 		<id>3</id>
 		<fullname>Federated Suns</fullname>
-		<startingPlanet>New Avalon,New Avalon,New Avalon,New Avalon,New Avalon,New Avalon,New Avalon,New Avalon,New Avalon</startingPlanet>
+		<startingPlanet>New Avalon</startingPlanet>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>FS</nameGenerator>
 		<colorRGB>248,212,44</colorRGB>
@@ -133,7 +134,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>FWL</shortname>
 		<id>4</id>
 		<fullname>Free Worlds League</fullname>
-		<startingPlanet>Atreus,Atreus,Atreus,Atreus,Atreus,Atreus,Atreus,Atreus,Atreus</startingPlanet>
+		<startingPlanet>Atreus</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>165,94,160</colorRGB>
@@ -144,7 +145,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>LA</shortname>
 		<id>5</id>
 		<fullname>Lyran Commonwealth</fullname>
-		<startingPlanet>Tharkad,Tharkad,Tharkad,Tharkad,Tharkad,Tharkad,Tharkad,Tharkad,Tharkad</startingPlanet>
+		<startingPlanet>Tharkad</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>LA</nameGenerator>
 		<colorRGB>0,124,186</colorRGB>
@@ -211,7 +212,6 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CTL</shortname>
 		<fullname>Chesterton Trade Federation</fullname>
-		<startingPlanet>,,,,,,,,</startingPlanet>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>184,134,22</colorRGB>
 		<tags>is</tags>
@@ -222,7 +222,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>ChP</shortname>
 		<fullname>Chisholm Protectorate</fullname>
-		<startingPlanet>Elgin (Chisholm 2878-),,,,,,,,</startingPlanet>
+		<startingPlanet>Elgin (Chisholm 2878-)</startingPlanet>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>224,104,32</colorRGB>
 		<tags>is</tags>
@@ -233,7 +233,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SSUP</shortname>
 		<fullname>Sarna Supremacy</fullname>
-		<startingPlanet>Sarna,Sarna,Sarna,Sarna,Sarna,Sarna,Sarna,Sarna,Sarna</startingPlanet>
+		<startingPlanet>Sarna</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>184,134,11</colorRGB>
@@ -289,7 +289,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>AC</shortname>
 		<fullname>Azami Caliphate</fullname>
-		<startingPlanet>Algedi,,,,,,,,</startingPlanet>
+		<startingPlanet>Algedi</startingPlanet>
 		<nameGenerator>DC</nameGenerator>
 		<colorRGB>255,80,93</colorRGB>
 		<tags>is</tags>
@@ -300,7 +300,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>PoR</shortname>
 		<fullname>Principality of Rasalhague</fullname>
-		<startingPlanet>Rasalhague,,,,,,,,</startingPlanet>
+		<startingPlanet>Rasalhague</startingPlanet>
 		<eraMods>0,0,0,0,0,0,2,1,0</eraMods>
 		<nameGenerator>FRR</nameGenerator>
 		<colorRGB>116,171,206</colorRGB>
@@ -323,7 +323,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
     <faction>
 		<shortname>ME</shortname>
 		<fullname>Muskegon Coalition</fullname>
-		<startingPlanet>Muskegon,,,,,,,,</startingPlanet>
+		<startingPlanet>Muskegon</startingPlanet>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>254,214,0</colorRGB>
 		<tags>is</tags>
@@ -334,7 +334,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>UHC</shortname>
 		<fullname>United Hindu Collective</fullname>
-		<startingPlanet>Basantapur,,,,,,,,</startingPlanet>
+		<startingPlanet>Basantapur</startingPlanet>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>FS</nameGenerator>
 		<colorRGB>171,148,118</colorRGB>
@@ -346,7 +346,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>MRep</shortname>
 		<fullname>Marik Republic</fullname>
-		<startingPlanet>Marik,,,,,,,,</startingPlanet>
+		<startingPlanet>Marik</startingPlanet>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>143,190,192</colorRGB>
 		<tags>is</tags>
@@ -357,7 +357,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>FoO</shortname>
 		<fullname>Federation of Oriente</fullname>
-		<startingPlanet>Oriente,,,,,,,,</startingPlanet>
+		<startingPlanet>Oriente</startingPlanet>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>163,112,120</colorRGB>
 		<tags>is</tags>
@@ -368,7 +368,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RP</shortname>
 		<fullname>Regulan Principality</fullname>
-		<startingPlanet>Regulas,,,,,,,,</startingPlanet>
+		<startingPlanet>Regulas</startingPlanet>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>255,51,51</colorRGB>
 		<tags>is</tags>
@@ -380,7 +380,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>SCon</shortname>
 		<fullname>Stewart Commonality</fullname>
 		<altNames>Stewart Confederation,Stewart Confederacy</altNames>
-		<startingPlanet>Stewart,,,,,,,,</startingPlanet>
+		<startingPlanet>Stewart</startingPlanet>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>76,0,153</colorRGB>
 		<tags>is</tags>
@@ -425,7 +425,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>RWR</shortname>
 		<id>19</id>
 		<fullname>Rim Worlds Republic</fullname>
-		<startingPlanet>Apollo,Apollo,Apollo,,,,,,,</startingPlanet>
+		<startingPlanet>Apollo</startingPlanet>
 		<eraMods>1,1,1,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>232,202,173</colorRGB>
@@ -436,7 +436,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>THW</shortname>
 		<fullname>Taurian Homeworlds</fullname>
-		<startingPlanet>Taurus,,,,,,,,</startingPlanet>
+		<startingPlanet>Taurus</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>179,62,38</colorRGB>
@@ -449,7 +449,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>TC</shortname>
 		<id>14</id>
 		<fullname>Taurian Concordat</fullname>
-		<startingPlanet>Taurus,Taurus,Taurus,Taurus,Taurus,Taurus,Taurus,Taurus,Taurus</startingPlanet>
+		<startingPlanet>Taurus</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,1,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>179,62,38</colorRGB>
@@ -460,7 +460,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>MOC</shortname>
 		<id>12</id>
 		<fullname>Magistracy of Canopus</fullname>
-		<startingPlanet>Canopus IV,Canopus IV,Canopus IV,Canopus IV,Canopus IV,Canopus IV,Canopus IV,Canopus IV,Canopus IV</startingPlanet>
+		<startingPlanet>Canopus IV</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,1,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>57,158,145</colorRGB>
@@ -471,7 +471,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>OA</shortname>
 		<id>13</id>
 		<fullname>Outworlds Alliance</fullname>
-		<startingPlanet>Alpheratz,Alpheratz,Alpheratz,Alpheratz,Alpheratz,Alpheratz,Alpheratz,Alpheratz,Alpheratz</startingPlanet>
+		<startingPlanet>Alpheratz</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,1,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>210,190,153</colorRGB>
@@ -497,7 +497,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>ARDC</shortname>
 		<id>17</id>
 		<fullname>Arc-Royal Defense Cordon</fullname>
-		<startingPlanet>Arc-Royal,Arc-Royal,Arc-Royal,Arc-Royal,Arc-Royal,Arc-Royal,Arc-Royal,Arc-Royal,Arc-Royal</startingPlanet>
+		<startingPlanet>Arc-Royal</startingPlanet>
 		<eraMods>0,0,0,1,2,3,2,0,0</eraMods>
 		<nameGenerator>LA</nameGenerator>
 		<colorRGB>218,165,32</colorRGB>
@@ -506,7 +506,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>AB</shortname>
 		<fullname>Azami Brotherhood</fullname>
-		<startingPlanet>Algedi,Algedi,Algedi,Algedi,Algedi,Algedi,Algedi,Algedi,Algedi</startingPlanet>
+		<startingPlanet>Algedi</startingPlanet>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>DC</nameGenerator>
 		<colorRGB>255,80,93</colorRGB>
@@ -525,7 +525,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CDP</shortname>
 		<fullname>Calderon Protectorate</fullname>
-		<startingPlanet>Erod's Escape,Erod's Escape,Erod's Escape,Erod's Escape,Erod's Escape,Erod's Escape,Erod's Escape,Erod's Escape,Erod's Escape,</startingPlanet>
+		<startingPlanet>Erod's Escape</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>0,128,128</colorRGB>
@@ -554,7 +554,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CIR</shortname>
 		<fullname>Circinus Federation</fullname>
-		<startingPlanet>Circinus,Circinus,Circinus,Circinus,Circinus,Circinus,Circinus,Circinus,Circinus</startingPlanet>
+		<startingPlanet>Circinus</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>198,36,58</colorRGB>
@@ -565,7 +565,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CBS</shortname>
 		<fullname>Clan Blood Spirit</fullname>
-		<startingPlanet>York (Clan),York (Clan),York (Clan),York (Clan),York (Clan),York (Clan),York (Clan),York (Clan),York (Clan)</startingPlanet>
+		<startingPlanet>York (Clan)</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>255,99,71</colorRGB>
@@ -586,7 +586,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CCC</shortname>
 		<fullname>Clan Cloud Cobra</fullname>
-		<startingPlanet>Homer,Homer,Homer,Homer,Homer,Homer,Homer,Homer,Homer</startingPlanet>
+		<startingPlanet>Homer</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>147,112,219</colorRGB>
@@ -596,7 +596,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CCO</shortname>
 		<fullname>Clan Coyote</fullname>
-		<startingPlanet>Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Babylon</startingPlanet>
+		<startingPlanet>Babylon</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>0,0,205</colorRGB>
@@ -606,7 +606,6 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SOC</shortname>
 		<fullname>The Society</fullname>
-		<startingPlanet>, , , , , , , ,</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>147,112,219</colorRGB>
@@ -627,7 +626,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CFM</shortname>
 		<fullname>Clan Fire Mandrill</fullname>
-		<startingPlanet>Shadow,Shadow,Shadow,Shadow,Shadow,Shadow,Shadow,Shadow,Shadow</startingPlanet>
+		<startingPlanet>Shadow</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>165,42,42</colorRGB>
@@ -651,7 +650,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CGS</shortname>
 		<fullname>Clan Goliath Scorpion</fullname>
-		<startingPlanet>Roche,Roche,Roche,Roche,Roche,Roche,Roche,Roche, </startingPlanet>
+		<startingPlanet>Roche</startingPlanet>
 		<altNamesByEra>, , , , , , , ,Escorpión Imperio</altNamesByEra>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
@@ -674,7 +673,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CIH</shortname>
 		<fullname>Clan Ice Hellion</fullname>
-		<startingPlanet>Hector,Hector,Hector,Hector,Hector,Hector,Hector,Hector,Hector</startingPlanet>
+		<startingPlanet>Hector</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>248,248,255</colorRGB>

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -17,15 +17,15 @@ Here is a description of what goes in each faction tag
 shortname - this is the abbreviation that is used to identify each faction in planets.xml and within
             MekHQ itself. This code must be unique.
 fullname  - the full display name for the faction.
-altNamesByYear - a comma-separated 9-item list that identifies alternate names for a given era. Use a single
-	       space between commas to indicate that the regular fullname should be used.
-altNames - A list of alternate names for a faction, also known as type of names,
+altNamesByYear - Identifies alternate names for a given year.
+					Format: <altNamesByYear year='XXXX'>Faction name</altNamesByYear>
+altNames - A list of alternate names for a faction, 'also known as' type of names,
 					not official designations
 startingPlanet - Identifies the starting planet if you begin a new campaign with this faction. 
 				 The name of the planet must be the name as it is recognized in MekHQ.
 				 If left out, then this defaults to Terra.
 changePlanet - Identifies the starting planet after the given year
-				 Format should be: <changePlanet year='XXXX'>Planet name</changePlanet>
+				 Format: <changePlanet year='XXXX'>Planet name</changePlanet>
 				 Years given in this first revision are best guesses
 eraMods - A comma-separated 9-item list of optional modifiers to repair/replacement rolls. as per
           Strat Ops. If left out, then this defaults to 0 for all eras.

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -117,7 +117,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<id>2</id>
 		<fullname>Draconis Combine</fullname>
 		<startingPlanet>New Samarkand</startingPlanet>
-		<changePlanet year='2619'>Luthien</startingPlanet>>
+		<changePlanet year='2619'>Luthien</changePlanet>>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>DC</nameGenerator>
 		<colorRGB>234,45,46</colorRGB>
@@ -1508,7 +1508,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>TD</shortname>
 		<fullname>Tortuga Dominions</fullname>
-		<startingPlanet>,Tortuga Prime</startingPlanet>
+		<startingPlanet>Tortuga Prime</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>34,139,34</colorRGB>

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -17,8 +17,10 @@ Here is a description of what goes in each faction tag
 shortname - this is the abbreviation that is used to identify each faction in planets.xml and within
             MekHQ itself. This code must be unique.
 fullname  - the full display name for the faction.
-altNamesByEra - a comma-separated 9-item list that identifies alternate names for a given era. Use a single
+altNamesByYear - a comma-separated 9-item list that identifies alternate names for a given era. Use a single
 	       space between commas to indicate that the regular fullname should be used.
+altNames - A list of alternate names for a faction, also known as type of names,
+					not official designations
 startingPlanet - Identifies the starting planet if you begin a new campaign with this faction. 
 				 The name of the planet must be the name as it is recognized in MekHQ.
 				 If left out, then this defaults to Terra.
@@ -154,7 +156,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>LA</nameGenerator>
 		<colorRGB>0,124,186</colorRGB>
-		<altNamesByEra>, , , , , , ,Lyran Alliance,Lyran Alliance</altNamesByEra>
+		<altNamesByYear year='3058'>Lyran Alliance</altNamesByYear>
+		<altNamesByYear year='3085'>Lyran Commonwealth</altNamesByYear>
 		<tags>is</tags>
 		<start>2340</start>
 		<end>3084</end>
@@ -480,7 +483,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<eraMods>1,1,1,1,2,3,2,1,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>210,190,153</colorRGB>
-		<altNamesByEra>, , , , , , , ,Raven Alliance</altNamesByEra>
+		<altNamesByYear year='3083'>Raven Alliance</altNamesByYear>
 		<tags>periphery</tags>
 		<start>2413</start>
 		<end>3083</end>
@@ -619,8 +622,9 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CDS</shortname>
 		<id>26</id>
-		<fullname>Clan Diamond Shark</fullname>
-		<altNamesByEra>, , ,Clan Sea Fox,Clan Sea Fox, , , , </altNamesByEra>
+		<fullname>Clan Sea Fox</fullname>
+		<altNamesByYear year='2984'>Clan Diamond Shark</altNamesByYear>
+		<altNamesByYear year='3100'>Clan Sea Fox</altNamesByYear>
 		<startingPlanet>Babylon</startingPlanet>
 		<changePlanet year='3065'>Twycross</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
@@ -649,7 +653,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>188,222,235</colorRGB>
-		<altNamesByEra>, , , , , , ,Ghost Bear Dominion,Ghost Bear Dominion</altNamesByEra>
+		<altNamesByYear year='3060'>Ghost Bear Dominion</altNamesByYear>
 		<tags>clan</tags>
 		<start>2807</start>
 		<end>3103</end>
@@ -658,7 +662,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CGS</shortname>
 		<fullname>Clan Goliath Scorpion</fullname>
 		<startingPlanet>Roche</startingPlanet>
-		<altNamesByEra>, , , , , , , ,Escorpión Imperio</altNamesByEra>
+		<altNamesByYear year='3080'>Escorpión Imperio</altNamesByYear>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>238,232,170</colorRGB>
@@ -745,7 +749,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>135,206,235</colorRGB>
-		<altNamesByEra>, , , , , , , ,Raven Alliance</altNamesByEra>
+		<altNamesByYear year='3083'>Raven Alliance</altNamesByYear>
 		<tags>clan</tags>
 		<start>2807</start>
 		<end>3083</end>
@@ -1704,7 +1708,11 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<fullname>Coreward Confederacy</fullname>
 		<startingPlanet>RWR Outpost #27</startingPlanet>
 		<eraMods>3,3,1,3,3,3,3,3,3</eraMods>
-		<altNamesByEra>Autocracy of New Virginia, Virginian Union, Rim Worlds Republic Outpost #27, , , , , ,</altNamesByEra>
+		<altNamesByYear year='2371'>Autocracy of New Virginia</altNamesByYear>
+		<altNamesByYear year='2400'>Virginian Union</altNamesByYear>
+		<altNamesByYear year='2700'>Rim Worlds Republic Outpost #27</altNamesByYear>
+		<altNamesByYear year='2798'>Virginian Union</altNamesByYear>
+		<altNamesByYear year='2816'>Coreward Confederacy</altNamesByYear>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,0,0</colorRGB>
 		<tags>periphery</tags>

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -3,6 +3,10 @@
 factions.xml
 1/19/2012
 Jay Lawson
+
+Modified Sept 2017
+Joshua Bartz (Bonepart)
+
 This file defines the factions used by MekHQ. Keep in mind that the faction shortnames are used by
 the planets.xml file, so if you remove a faction here, you need to remove all references to it in
 that file. Not all of the factions listed here are available to play by default. To add a faction as
@@ -15,11 +19,12 @@ shortname - this is the abbreviation that is used to identify each faction in pl
 fullname  - the full display name for the faction.
 altNamesByEra - a comma-separated 9-item list that identifies alternate names for a given era. Use a single
 	       space between commas to indicate that the regular fullname should be used.
-startingPlanet - A comma-separated 9-item list that identifies the starting planet if you
-			     begin a new campaign with this faction. The name of the planet must be the name
-			     as it is recognized in MekHQ. Each item corresponds to a different era as follows:
-			     Age of War, Reunification Wars, Star League, 1SW, 2SW, 3SW, 4SW, Clan Invasion, Jihad
-				 If left out, then this defaults to Terra for all eras.
+startingPlanet - Identifies the starting planet if you begin a new campaign with this faction. 
+				 The name of the planet must be the name as it is recognized in MekHQ.
+				 If left out, then this defaults to Terra.
+changePlanet - Identifies the starting planet after the given year
+				 Format should be: <changePlanet year='XXXX'>Planet name</changePlanet>
+				 Years given in this first revision are best guesses
 eraMods - A comma-separated 9-item list of optional modifiers to repair/replacement rolls. as per
           Strat Ops. If left out, then this defaults to 0 for all eras.
 nameGenerator - The name of the faction name generator that should be used for this faction. If
@@ -616,7 +621,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<id>26</id>
 		<fullname>Clan Diamond Shark</fullname>
 		<altNamesByEra>, , ,Clan Sea Fox,Clan Sea Fox, , , , </altNamesByEra>
-		<startingPlanet>Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Twycross</startingPlanet>
+		<startingPlanet>Babylon</startingPlanet>
+		<changePlanet year='3065'>Twycross</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>0,255,255</colorRGB>
@@ -638,7 +644,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CGB</shortname>
 		<id>23</id>
 		<fullname>Clan Ghost Bear</fullname>
-		<startingPlanet>Arcadia (Clan),Arcadia (Clan),Arcadia (Clan),Arcadia (Clan),Arcadia (Clan),Arcadia (Clan),Arcadia (Clan),Alshain,Alshain</startingPlanet>
+		<startingPlanet>Arcadia (Clan)</startingPlanet>
+		<changePlanet year='3060'>Alshain</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>188,222,235</colorRGB>
@@ -663,7 +670,9 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CHH</shortname>
 		<id>28</id>
 		<fullname>Clan Hell's Horses</fullname>
-		<startingPlanet>Niles (Clan),Niles (Clan),Niles (Clan),Niles (Clan),Niles (Clan),Niles (Clan),Niles (Clan),Csesztreg,Niles (Clan)</startingPlanet>
+		<!--Original data shows CHH back on Niles during the Jihad, but I am unable to find data for that -->
+		<startingPlanet>Niles (Clan)</startingPlanet>
+		<changePlanet year='3074'>Csesztreg</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>241,168,110</colorRGB>
@@ -685,7 +694,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CJF</shortname>
 		<id>22</id>
 		<fullname>Clan Jade Falcon</fullname>
-		<startingPlanet>Ironhold,Ironhold,Ironhold,Ironhold,Ironhold,Ironhold,Ironhold,Sudeten,Sudeten</startingPlanet>
+		<startingPlanet>Ironhold</startingPlanet>
+		<changePlanet year='3052'>Sudeten</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>172,208,115</colorRGB>
@@ -706,7 +716,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CNC</shortname>
 		<id>25</id>
 		<fullname>Clan Nova Cat</fullname>
-		<startingPlanet>Barcella,Barcella,Barcella,Barcella,Barcella,Barcella,Barcella,Irece,Irece</startingPlanet>
+		<startingPlanet>Barcella</startingPlanet>
+		<changePlanet year='3057'>Irece</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>245,255,250</colorRGB>
@@ -718,7 +729,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CSJ</shortname>
 		<id>24</id>
 		<fullname>Clan Smoke Jaguar</fullname>
-		<startingPlanet>Huntress,Huntress,Huntress,Huntress,Huntress,Huntress,Huntress,Luzerne, </startingPlanet>
+		<startingPlanet>Huntress</startingPlanet>
+		<changePlanet year='3052'>Luzerne</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>152,164,129</colorRGB>
@@ -784,7 +796,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CW</shortname>
 		<id>21</id>
 		<fullname>Clan Wolf</fullname>
-		<startingPlanet>Tranquil,Tranquil,Tranquil,Tranquil,Tranquil,Tranquil,Tranquil,Tamar,Tamar</startingPlanet>
+		<startingPlanet>Tranquil</startingPlanet>
+		<changePlanet year='3052'>Tamar</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>207,114,58</colorRGB>
@@ -805,7 +818,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CWIE</shortname>
 		<fullname>Clan Wolf-in-Exile</fullname>
-		<startingPlanet>Tranquil,Tranquil,Tranquil,Tranquil,Tranquil,Tranquil,Tranquil,Arc-Royal,Arc-Royal</startingPlanet>
+		<startingPlanet>Arc-Royal</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>160,82,45</colorRGB>
@@ -826,7 +839,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CS</shortname>
 		<id>8</id>
 		<fullname>ComStar</fullname>
-		<startingPlanet>Terra,Terra,Terra,Terra,Terra,Terra,Terra,Tukayyid,Tukayyid</startingPlanet>
+		<startingPlanet>Terra</startingPlanet>
+		<changePlanet year='3059'>Tukayyid</changePlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,250,240</colorRGB>
@@ -952,7 +966,8 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>FRR</shortname>
 		<id>10</id>
 		<fullname>Free Rasalhague Republic</fullname>
-		<startingPlanet>Rasalhague,Rasalhague,Rasalhague,Rasalhague,Rasalhague,Rasalhague,Rasalhague,Orestes,Orestes</startingPlanet>
+		<startingPlanet>Rasalhague</startingPlanet>
+		<changePlanet year='3052'>Orestes</changePlanet>
 		<eraMods>0,0,0,0,0,0,2,1,0</eraMods>
 		<nameGenerator>FRR</nameGenerator>
 		<colorRGB>116,171,206</colorRGB>
@@ -1124,7 +1139,10 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>MERC</shortname>
 		<id>0</id>
 		<fullname>Mercenary</fullname>
-		<startingPlanet>Galatea,Solaris,Galatea,Galatea,Galatea,Galatea,Outreach,Outreach,Outreach</startingPlanet>
+		<startingPlanet>Solaris</startingPlanet>
+		<changePlanet year='2789'>Galatea</changePlanet>
+		<changePlanet year='3052'>Outreach</changePlanet>
+		<changePlanet year='3067'>Galatea</changePlanet>
 		<eraMods>1,1,1,1,2,3,2,1,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>169,169,169</colorRGB>

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -112,7 +112,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<id>2</id>
 		<fullname>Draconis Combine</fullname>
 		<startingPlanet>New Samarkand</startingPlanet>
-		<startingPlanet year='2619'>Luthien</startingPlanet>>
+		<changePlanet year='2619'>Luthien</startingPlanet>>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>DC</nameGenerator>
 		<colorRGB>234,45,46</colorRGB>
@@ -617,7 +617,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<fullname>Clan Diamond Shark</fullname>
 		<altNamesByEra>, , ,Clan Sea Fox,Clan Sea Fox, , , , </altNamesByEra>
 		<startingPlanet>Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Babylon,Twycross</startingPlanet>
-				<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
+		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>0,255,255</colorRGB>
 		<tags>clan</tags>
@@ -729,7 +729,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CSR</shortname>
 		<fullname>Clan Snow Raven</fullname>
-		<startingPlanet>Circe,Circe,Circe,Circe,Circe,Circe,Circe,Circe,Circe</startingPlanet>
+		<startingPlanet>Circe</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>135,206,235</colorRGB>
@@ -741,7 +741,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CSA</shortname>
 		<fullname>Clan Star Adder</fullname>
-		<startingPlanet>Sheridan (Clan),Sheridan (Clan),Sheridan (Clan),Sheridan (Clan),Sheridan (Clan),Sheridan (Clan),Sheridan (Clan),Sheridan (Clan),Sheridan (Clan)</startingPlanet>
+		<startingPlanet>Sheridan (Clan)</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>218,165,32</colorRGB>
@@ -752,7 +752,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>CSV</shortname>
 		<id>27</id>
 		<fullname>Clan Steel Viper</fullname>
-		<startingPlanet>Homer,Homer,Homer,Homer,Homer,Homer,Homer,Homer,Homer</startingPlanet>
+		<startingPlanet>Homer</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>127,255,0</colorRGB>
@@ -763,7 +763,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CSL</shortname>
 		<fullname>Clan Stone Lion</fullname>
-		<startingPlanet>, , , , , , , ,Tokasha</startingPlanet>
+		<startingPlanet>Tokasha</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>241,168,110</colorRGB>
@@ -795,7 +795,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CWE</shortname>
 		<fullname>Wolf Empire</fullname>
-		<startingPlanet> , , , , , , , ,Gienah</startingPlanet>
+		<startingPlanet>Gienah</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>207,114,58</colorRGB>
@@ -836,7 +836,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>DA</shortname>
 		<fullname>Duchy of Andurien</fullname>
-		<startingPlanet>Andurien,Andurien,Andurien,Andurien,Andurien,Andurien,Andurien,Andurien,Andurien,</startingPlanet>
+		<startingPlanet>Andurien</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>148,148,255</colorRGB>
@@ -846,7 +846,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>DGM</shortname>
 		<fullname>Duchy of Graham-Marik</fullname>
-		<startingPlanet>Loyalty,Loyalty,Loyalty,Loyalty,Loyalty,Loyalty,Loyalty,Loyalty,Loyalty,</startingPlanet>
+		<startingPlanet>Loyalty</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>143,190,192</colorRGB>
@@ -857,7 +857,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>DO</shortname>
 		<fullname>Duchy of Oriente</fullname>
-		<startingPlanet>Oriente,Oriente,Oriente,Oriente,Oriente,Oriente,Oriente,Oriente,Oriente,</startingPlanet>
+		<startingPlanet>Oriente</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>163,112,120</colorRGB>
@@ -868,7 +868,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>DoO</shortname>
 		<fullname>Duchy of Orloff</fullname>
-		<startingPlanet>Vanra,Vanra,Vanra,Vanra,Vanra,Vanra,Vanra,Vanra,Vanra,</startingPlanet>
+		<startingPlanet>Vanra</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>164,94,126</colorRGB>
@@ -879,7 +879,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>DS</shortname>
 		<fullname>Duchy of Small</fullname>
-		<startingPlanet>Small World,Small World,Small World,Small World,Small World,Small World,Small World,Small World,Small World,</startingPlanet>
+		<startingPlanet>Small World</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>107,142,35</colorRGB>
@@ -890,7 +890,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>DTA</shortname>
 		<fullname>Duchy of Tamarind-Abbey</fullname>
-		<startingPlanet>Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,</startingPlanet>
+		<startingPlanet>Tamarind</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>99,94,165</colorRGB>
@@ -901,7 +901,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<faction>
 		<shortname>DT</shortname>
 		<fullname>Duchy of Tamarind</fullname>
-		<startingPlanet>Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,Tamarind,</startingPlanet>
+		<startingPlanet>Tamarind</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>158,60,147</colorRGB>
@@ -912,7 +912,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>EF</shortname>
 		<fullname>Elysian Fields</fullname>
-		<startingPlanet>Nyserta,Nyserta,Nyserta,Nyserta,Nyserta,Nyserta,Nyserta,Nyserta,Nyserta,</startingPlanet>
+		<startingPlanet>Nyserta</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,0,255</colorRGB>
@@ -921,7 +921,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CEI</shortname>
 		<fullname>Escorpion Imperio</fullname>
-		<startingPlanet>Granda,Granda,Granda,Granda,Granda,Granda,Granda,Granda,Granda,</startingPlanet>
+		<startingPlanet>Granda</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>238,232,170</colorRGB>
@@ -932,7 +932,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>FC</shortname>
 		<id>6</id>
 		<fullname>Federated Commonwealth</fullname>
-		<startingPlanet>New Avalon,New Avalon,New Avalon,New Avalon,New Avalon,New Avalon,New Avalon,New Avalon,New Avalon</startingPlanet>
+		<startingPlanet>New Avalon</startingPlanet>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>248,212,44</colorRGB>
@@ -941,7 +941,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>FVC</shortname>
 		<fullname>Filtvelt Coalition</fullname>
-		<startingPlanet>Filtvelt,Filtvelt,Filtvelt,Filtvelt,Filtvelt,Filtvelt,Filtvelt,Filtvelt,Filtvelt,</startingPlanet>
+		<startingPlanet>Filtvelt</startingPlanet>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>FS</nameGenerator>
 		<colorRGB>255,228,181</colorRGB>
@@ -963,7 +963,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>FWLR</shortname>
 		<fullname>Free Worlds League Rebels</fullname>
-		<startingPlanet>New Delos,New Delos,New Delos,New Delos,New Delos,New Delos,New Delos,New Delos,New Delos</startingPlanet>
+		<startingPlanet>New Delos</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>68,212,228</colorRGB>
@@ -972,7 +972,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>FR</shortname>
 		<fullname>Fronc Reaches</fullname>
-		<startingPlanet>Fronc,Fronc,Fronc,Fronc,Fronc,Fronc,Fronc,Fronc,Fronc,</startingPlanet>
+		<startingPlanet>Fronc</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>128,169,127</colorRGB>
@@ -982,7 +982,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>GV</shortname>
 		<fullname>Greater Valkyrate</fullname>
-		<startingPlanet>Gotterdammerung,Gotterdammerung,Gotterdammerung,Gotterdammerung,Gotterdammerung,Gotterdammerung,Gotterdammerung,Gotterdammerung,Gotterdammerung,</startingPlanet>
+		<startingPlanet>Gotterdammerung</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,105,180</colorRGB>
@@ -993,7 +993,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>HL</shortname>
 		<fullname>Hanseatic League</fullname>
-		<startingPlanet>,,,,Bremen,Bremen,Bremen,Bremen,Bremen</startingPlanet>
+		<startingPlanet>Bremen</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>219,112,147</colorRGB>
@@ -1003,7 +1003,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>IP</shortname>
 		<fullname>Illyrian Palatinate</fullname>
-		<startingPlanet>Illyria,Illyria,Illyria,Illyria,Illyria,Illyria,Illyria,Illyria,Illyria</startingPlanet>
+		<startingPlanet>Illyria</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>0,255,255</colorRGB>
@@ -1032,7 +1032,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>JF</shortname>
 		<fullname>Jarnfolk</fullname>
-		<startingPlanet>Trondheim,Trondheim,Trondheim,Trondheim,Trondheim,Trondheim,Trondheim,Trondheim,Trondheim</startingPlanet>
+		<startingPlanet>Trondheim</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>FRR</nameGenerator>
 		<colorRGB>153,50,204</colorRGB>
@@ -1069,7 +1069,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>LL</shortname>
 		<fullname>Lothian League</fullname>
-		<startingPlanet>,,Lothario,Lothario,Lothario,Lothario,Lothario,,</startingPlanet>
+		<startingPlanet>Lothario</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,140,0</colorRGB>
@@ -1079,7 +1079,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>MC</shortname>
 		<fullname>Malagrotta Cooperative</fullname>
-		<startingPlanet>,,,,,,,Malagrotta,Malagrotta</startingPlanet>
+		<startingPlanet>Malagrotta</startingPlanet>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>FS</nameGenerator>
 		<colorRGB>218,112,214</colorRGB>
@@ -1091,7 +1091,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>MH</shortname>
 		<id>15</id>
 		<fullname>Marian Hegemony</fullname>
-		<startingPlanet>Alphard (Periphery),Alphard (Periphery),Alphard (Periphery),Alphard (Periphery),Alphard (Periphery),Alphard (Periphery),Alphard (Periphery),Alphard (Periphery),Alphard (Periphery)</startingPlanet>
+		<startingPlanet>Alphard (Periphery)</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>236,136,65</colorRGB>
@@ -1101,7 +1101,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>MCM</shortname>
 		<fullname>Marik Commonwealth</fullname>
-		<startingPlanet>,,,,,,,Marik,Marik</startingPlanet>
+		<startingPlanet>Marik</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>165,94,160</colorRGB>
@@ -1112,7 +1112,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>MSC</shortname>
 		<fullname>Marik-Stewart Commonwealth</fullname>
-		<startingPlanet>,,,,,,,Marik,Marik</startingPlanet>
+		<startingPlanet>Marik</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>117,65,113</colorRGB>
@@ -1133,7 +1133,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>MV</shortname>
 		<fullname>Morgraine's Valkyrate</fullname>
-		<startingPlanet>,,,,,Apollo,Apollo,,</startingPlanet>
+		<startingPlanet>Apollo</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,105,180</colorRGB>
@@ -1144,7 +1144,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>BoS</shortname>
 		<fullname>Barony of Strang</fullname>
-		<startingPlanet>,,,,,Von Strang's World,Von Strang's World,Von Strang's World,Von Strang's World</startingPlanet>
+		<startingPlanet>Von Strang's World</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>165,94,160</colorRGB>
@@ -1153,7 +1153,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>MA</shortname>
 		<fullname>Mosiro Archipelago</fullname>
-		<startingPlanet>,,,,,,,Mosiro,Mosiro</startingPlanet>
+		<startingPlanet>Mosiro</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>165,94,160</colorRGB>
@@ -1164,7 +1164,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>NCR</shortname>
 		<fullname>New Colony Region</fullname>
-		<startingPlanet>,,,,,,Fronc,Fronc,Fronc</startingPlanet>
+		<startingPlanet>Fronc</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,1,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>32,178,170</colorRGB>
@@ -1175,7 +1175,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>NC</shortname>
 		<fullname>Nueva Castile</fullname>
-		<startingPlanet>Asturias,Asturias,Asturias,Asturias,Asturias,Asturias,Asturias,Asturias,Asturias</startingPlanet>
+		<startingPlanet>Asturias</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>0,255,0</colorRGB>
@@ -1186,7 +1186,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>OC</shortname>
 		<fullname>Oberon Confederation</fullname>
-		<startingPlanet>,,,,Oberon VI,Oberon VI,,,</startingPlanet>
+		<startingPlanet>Oberon VI</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>50,205,50</colorRGB>
@@ -1197,7 +1197,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>NOC</shortname>
 		<fullname>New Oberon Confederation</fullname>
-		<startingPlanet>,,,,,,,,Oberon VI</startingPlanet>
+		<startingPlanet>Oberon VI</startingPlanet>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>231,178,50</colorRGB>
 		<tags>periphery</tags>
@@ -1206,7 +1206,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>OZP</shortname>
 		<fullname>Ohrenson-Zion Province</fullname>
-		<startingPlanet>,,,,,,,Ohrenson,Ohrenson</startingPlanet>
+		<startingPlanet>Ohrenson</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>160,165,94</colorRGB>
@@ -1217,7 +1217,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>OP</shortname>
 		<fullname>Oriente Protectorate</fullname>
-		<startingPlanet>,,,,,,,Oriente,Oriente</startingPlanet>
+		<startingPlanet>Oriente</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>163,112,120</colorRGB>
@@ -1228,7 +1228,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>PG</shortname>
 		<fullname>Principality of Gibson</fullname>
-		<startingPlanet>,,,,,,,Gibson,Gibson</startingPlanet>
+		<startingPlanet>Gibson</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>250,250,250</colorRGB>
@@ -1238,7 +1238,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>PR</shortname>
 		<fullname>Principality of Regulus</fullname>
-		<startingPlanet>,,,,,,,Regulas,Regulas</startingPlanet>
+		<startingPlanet>Regulas</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>192,143,189</colorRGB>
@@ -1249,7 +1249,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RD</shortname>
 		<fullname>Rasalhague Dominion</fullname>
-		<startingPlanet>,,,,,,,Rasalhague,Rasalhague</startingPlanet>
+		<startingPlanet>Rasalhague</startingPlanet>
 		<eraMods>0,0,0,0,0,0,2,1,0</eraMods>
 		<nameGenerator>FRR</nameGenerator>
 		<colorRGB>188,222,235</colorRGB>
@@ -1259,7 +1259,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RA</shortname>
 		<fullname>Raven Alliance</fullname>
-		<startingPlanet>,,,,,,,Alpheratz,Alpheratz</startingPlanet>
+		<startingPlanet>Alpheratz</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,1,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>25,120,110</colorRGB>
@@ -1269,7 +1269,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RF</shortname>
 		<fullname>Regulan Fiefs</fullname>
-		<startingPlanet>,,,,,,,Regulas,Regulas</startingPlanet>
+		<startingPlanet>Regulas</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>255,51,51</colorRGB>
@@ -1279,7 +1279,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RFS</shortname>
 		<fullname>Regulan Free States</fullname>
-		<startingPlanet>,,,,,,,Regulas,Regulas</startingPlanet>
+		<startingPlanet>Regulas</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>165,94,160</colorRGB>
@@ -1291,7 +1291,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>ROS</shortname>
 		<id>7</id>
 		<fullname>Republic of the Sphere</fullname>
-		<startingPlanet>,,,,,,,,Terra</startingPlanet>
+		<startingPlanet>Terra</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>207,119,57</colorRGB>
@@ -1302,7 +1302,6 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>Stone</shortname>
 		<fullname>Stone's Coalition</fullname>
 		<altNames>Coalition Forces</altNames>
-		<startingPlanet>, , , , , , , , </startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>207,119,57</colorRGB>
@@ -1321,7 +1320,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RIM</shortname>
 		<fullname>Rim Collection</fullname>
-		<startingPlanet>Gillfillan’s Gold,Gillfillan’s Gold,Gillfillan’s Gold,Gillfillan’s Gold,Gillfillan’s Gold,Gillfillan’s Gold,Gillfillan’s Gold,Gillfillan’s Gold,Gillfillan’s Gold</startingPlanet>
+		<startingPlanet>Gillfillan’s Gold</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>95,158,160</colorRGB>
@@ -1331,7 +1330,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RCM</shortname>
 		<fullname>Rim Commonality</fullname>
-		<startingPlanet>,,,,,,,Lesnovo,Lesnovo</startingPlanet>
+		<startingPlanet>Lesnovo</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>95,158,160</colorRGB>
@@ -1342,7 +1341,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RT</shortname>
 		<fullname>Rim Territories</fullname>
-		<startingPlanet>,,,,,,,Pain,Pain</startingPlanet>
+		<startingPlanet>Pain</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>175,238,238</colorRGB>
@@ -1352,7 +1351,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>ST</shortname>
 		<fullname>Saiph Triumvirate</fullname>
-		<startingPlanet>,,,,,,Saiph,Saiph,Saiph</startingPlanet>
+		<startingPlanet>Saiph</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>128,128,0</colorRGB>
@@ -1363,7 +1362,6 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SP</shortname>
 		<fullname>Sarna Protectorate</fullname>
-		<startingPlanet>,,,,,,,,</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>184,134,11</colorRGB>
@@ -1380,7 +1378,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SHC</shortname>
 		<fullname>Silver Hawk Coalition</fullname>
-		<startingPlanet>,,,,,,Amity,,</startingPlanet>
+		<startingPlanet>Amity</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>255,0,127</colorRGB>
@@ -1391,7 +1389,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>SIC</shortname>
 		<id>11</id>
 		<fullname>St. Ives Compact</fullname>
-		<startingPlanet>St. Ives,St. Ives,St. Ives,St. Ives,St. Ives,St. Ives,St. Ives,St. Ives,St. Ives</startingPlanet>
+		<startingPlanet>St. Ives</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>188,223,186</colorRGB>
@@ -1402,7 +1400,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SL</shortname>
 		<fullname>Star League</fullname>
-		<startingPlanet>Terra,Terra,Terra, , , , , ,</startingPlanet>
+		<startingPlanet>Terra</startingPlanet>
 		<eraMods>-1,-1,-1,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>176,196,222</colorRGB>
@@ -1411,7 +1409,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SLIE</shortname>
 		<fullname>Star League-in-Exile</fullname>
-		<startingPlanet>,,Strana Mechty,Strana Mechty,,,,,</startingPlanet>
+		<startingPlanet>Strana Mechty</startingPlanet>
 		<eraMods>-1,-1,-1,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>176,196,222</colorRGB>
@@ -1422,7 +1420,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SC</shortname>
 		<fullname>Stewart Commonality</fullname>
-		<startingPlanet> , , , , , , ,Stewart,Stewart</startingPlanet>
+		<startingPlanet>Stewart</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>76,0,153</colorRGB>
@@ -1431,7 +1429,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SKC</shortname>
 		<fullname>Styk Commonality</fullname>
-		<startingPlanet>,,,,,,Styk,,</startingPlanet>
+		<startingPlanet>Styk</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>0,139,139</colorRGB>
@@ -1442,7 +1440,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>SKP</shortname>
 		<fullname>Styk Protectorate</fullname>
-		<startingPlanet>,,,,,,,Styk,Styk</startingPlanet>
+		<startingPlanet>Styk</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>0,139,139</colorRGB>
@@ -1451,7 +1449,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>TCC</shortname>
 		<fullname>Terracap Confederation</fullname>
-		<startingPlanet>,,,,,,Terra Firma,Terra Firma,Terra Firma</startingPlanet>
+		<startingPlanet>Terra Firma</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>233,150,122</colorRGB>
@@ -1462,7 +1460,6 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>TB</shortname>
 		<fullname>The Barrens</fullname>
-		<startingPlanet>,,,,,,,,</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,255,224</colorRGB>
@@ -1472,7 +1469,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>TP</shortname>
 		<fullname>The Protectorate</fullname>
-		<startingPlanet>,,,,,,,New Delos,New Delos</startingPlanet>
+		<startingPlanet>New Delos</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>255,51,51</colorRGB>
@@ -1482,7 +1479,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>TFR</shortname>
 		<fullname>Tikonov Free Republic</fullname>
-		<startingPlanet>Tikonov,Tikonov,Tikonov,Tikonov,Tikonov,Tikonov,Tikonov,Tikonov,Tikonov</startingPlanet>
+		<startingPlanet>Tikonov</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>255,160,122</colorRGB>
@@ -1493,7 +1490,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>TD</shortname>
 		<fullname>Tortuga Dominions</fullname>
-		<startingPlanet>,Tortuga Prime,Tortuga Prime,Tortuga Prime,Tortuga Prime,Tortuga Prime,Tortuga Prime,Tortuga Prime,Tortuga Prime</startingPlanet>
+		<startingPlanet>,Tortuga Prime</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>34,139,34</colorRGB>
@@ -1511,7 +1508,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>WOB</shortname>
 		<id>9</id>
 		<fullname>Word of Blake</fullname>
-		<startingPlanet>, , , , , , ,Terra,Terra</startingPlanet>
+		<startingPlanet>Terra</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,1,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>205,192,176</colorRGB>
@@ -1521,7 +1518,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CLAN</shortname>
 		<fullname>All Clans</fullname>
-		<startingPlanet> , ,Strana Mechty,Strana Mechty,Strana Mechty,Strana Mechty,Strana Mechty,Strana Mechty,Strana Mechty</startingPlanet>
+		<startingPlanet>Strana Mechty</startingPlanet>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>139,69,19</colorRGB>
 		<tags>clan</tags>
@@ -1530,21 +1527,20 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>NIOPS</shortname>
 		<fullname>Niops Association</fullname>
-		<startingPlanet> ,Niops VII,Niops VII,Niops VII,Niops VII,Niops VII,Niops VII,Niops VII,Niops VII</startingPlanet>
+		<startingPlanet>Niops VII</startingPlanet>
 		<colorRGB>205,173,0</colorRGB>
 		<tags>periphery,minor</tags>
 	</faction>
 	<faction>
 		<shortname>NONE</shortname>
 		<fullname>Unexplored</fullname>
-		<startingPlanet> , , , , , , , , </startingPlanet>
 		<colorRGB>0,0,0</colorRGB>
 		<tags>periphery,abandoned,inactive,chaos</tags>
 	</faction>
 	<faction>
 		<shortname>FOR</shortname>
 		<fullname>Fiefdom Randis</fullname>
-		<startingPlanet> , , , , ,Randis IV,Randis IV,Randis IV,Randis IV</startingPlanet>
+		<startingPlanet>Randis IV</startingPlanet>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>30,144,255</colorRGB>
 		<tags>periphery</tags>
@@ -1552,7 +1548,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>MM</shortname>
 		<fullname>Mica Majority</fullname>
-		<startingPlanet>Mica II,Mica II,Mica II,Mica II,Mica II,Mica II,Mica II,Mica II,Mica II</startingPlanet>
+		<startingPlanet>Mica II</startingPlanet>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>240,230,140</colorRGB>
 		<tags>periphery</tags>
@@ -1561,7 +1557,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<shortname>SA</shortname>
 		<fullname>Senatorial Alliance</fullname>
 		<altNames>Senate Alliance</altNames>
-		<startingPlanet>, , , , , , , ,Augustine</startingPlanet>
+		<startingPlanet>Augustine</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,102,153</colorRGB>
@@ -1572,7 +1568,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>AA</shortname>
 		<fullname>Augustine Alliance</fullname>
-		<startingPlanet>, , , , , , , ,Augustine</startingPlanet>
+		<startingPlanet>Augustine</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>255,102,153</colorRGB>
@@ -1581,7 +1577,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>TTU</shortname>
 		<fullname>Tall Trees Union</fullname>
-		<startingPlanet>, , , , , , , ,Tall Trees</startingPlanet>
+		<startingPlanet>Tall Trees</startingPlanet>
 		<eraMods>1,0,0,1,2,3,2,1,0</eraMods>
 		<nameGenerator>CC</nameGenerator>
 		<colorRGB>153,153,51</colorRGB>
@@ -1590,7 +1586,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>ShA</shortname>
 		<fullname>Shiloh Alliance</fullname>
-		<startingPlanet>, , , , , , , ,Shiloh</startingPlanet>
+		<startingPlanet>Shiloh</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>97,26,92</colorRGB>
@@ -1599,7 +1595,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CvW</shortname>
 		<fullname>Covenant Worlds</fullname>
-		<startingPlanet>, , , , , , , ,Bordon</startingPlanet>
+		<startingPlanet>Bordon</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>102,51,51</colorRGB>
@@ -1608,7 +1604,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>PC</shortname>
 		<fullname>Protectorate Coalition</fullname>
-		<startingPlanet>, , , , , , , ,Rochelle</startingPlanet>
+		<startingPlanet>Rochelle</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>51,51,102</colorRGB>
@@ -1617,7 +1613,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>MiC</shortname>
 		<fullname>Milton Combine</fullname>
-		<startingPlanet>, , , , , , , ,Milton</startingPlanet>
+		<startingPlanet>Milton</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>FWL</nameGenerator>
 		<colorRGB>255,0,51</colorRGB>
@@ -1626,7 +1622,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CP</shortname>
 		<fullname>Clan Protectorate</fullname>
-		<startingPlanet>, , , , , , , ,Marik</startingPlanet>
+		<startingPlanet>Marik</startingPlanet>
 		<eraMods>0,0,0,1,2,3,1,1,0</eraMods>
 		<nameGenerator>Clan</nameGenerator>
 		<colorRGB>153,255,51</colorRGB>
@@ -1635,7 +1631,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RR</shortname>
 		<fullname>Republic Remnant</fullname>
-		<startingPlanet>, , , , , , , ,Callison</startingPlanet>
+		<startingPlanet>Callison</startingPlanet>
 		<eraMods>0,0,0,0,0,0,0,0,0</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>128,40,0</colorRGB>
@@ -1653,7 +1649,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>UC</shortname>
 		<fullname>Umayyad Caliphate</fullname>
-		<startingPlanet>,Granada,Granada,Granada,Granada,Granada,Granada,Granada, </startingPlanet>
+		<startingPlanet>Granada</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>0,255,0</colorRGB>
@@ -1669,7 +1665,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>RON</shortname>
 		<fullname>Ronin</fullname>
-		<startingPlanet>, , , , , ,Predlitz, , </startingPlanet>
+		<startingPlanet>Predlitz</startingPlanet>
 		<eraMods>0,0,0,1,2,2,1,0,0</eraMods>
 		<nameGenerator>DC</nameGenerator>
 		<colorRGB>234,45,46</colorRGB>
@@ -1678,7 +1674,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>AXP</shortname>
 		<fullname>Axumite Providence</fullname>
-		<startingPlanet>,Thala,Thala,Thala,Thala,Thala,Thala,Thala,Thala</startingPlanet>
+		<startingPlanet>Thala</startingPlanet>
 		<eraMods>1,1,1,1,2,3,2,2,1</eraMods>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>153,50,204</colorRGB>
@@ -1688,7 +1684,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>CCon</shortname>
 		<fullname>Coreward Confederacy</fullname>
-		<startingPlanet>, RWR Outpost #27,RWR Outpost #27,RWR Outpost #27,RWR Outpost #27,RWR Outpost #27,RWR Outpost #27,RWR Outpost #27,RWR Outpost #27</startingPlanet>
+		<startingPlanet>RWR Outpost #27</startingPlanet>
 		<eraMods>3,3,1,3,3,3,3,3,3</eraMods>
 		<altNamesByEra>Autocracy of New Virginia, Virginian Union, Rim Worlds Republic Outpost #27, , , , , ,</altNamesByEra>
 		<nameGenerator>General</nameGenerator>
@@ -1698,7 +1694,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
 		<shortname>GDL</shortname>
 		<fullname>Galatean Defense League</fullname>
-		<startingPlanet>, , , , , , , ,Galatea</startingPlanet>
+		<startingPlanet>Galatea</startingPlanet>
 		<nameGenerator>General</nameGenerator>
 		<colorRGB>102,255,255</colorRGB>
 		<tags>is</tags>
@@ -1706,7 +1702,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 	<faction>
       <shortname>GL</shortname>
       <fullname>Galatean League</fullname>
-      <startingPlanet>, , , , , , , ,Galatea</startingPlanet>
+      <startingPlanet>Galatea</startingPlanet>
       <nameGenerator>General</nameGenerator>
       <colorRGB>102,255,255</colorRGB>
 		<tags>is</tags>
@@ -1722,7 +1718,7 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
    <faction>
       <shortname>NDC</shortname>
       <fullname>New Delphi Compact</fullname>
-      <startingPlanet> , , , New Delphi,New Delphi,New Delphi,New Delphi,New Delphi,New Delphi</startingPlanet>
+      <startingPlanet>New Delphi</startingPlanet>
       <nameGenerator>General</nameGenerator>
       <colorRGB>127,151,139</colorRGB>
 		<tags>periphery</tags>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6024,7 +6024,7 @@ public class Campaign implements Serializable, ITechManager {
         target.append(partWork.getAllMods(tech));
 
         if (getCampaignOptions().useEraMods()) {
-            target.addModifier(getFaction().getEraMod(getEra()), "era");
+            target.addModifier(getFaction().getEraMod(calendar.get(Calendar.YEAR)), "era");
         }
 
         boolean isOvertime = false;
@@ -6091,7 +6091,7 @@ public class Campaign implements Serializable, ITechManager {
         target.append(partWork.getAllModsForMaintenance());
 
         if (getCampaignOptions().useEraMods()) {
-            target.addModifier(getFaction().getEraMod(getEra()), "era");
+            target.addModifier(getFaction().getEraMod(calendar.get(Calendar.YEAR)), "era");
         }
 
         if (null != partWork.getUnit() && null != tech) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -428,6 +428,10 @@ public class Campaign implements Serializable, ITechManager {
     public int getEra() {
         return Era.getEra(calendar.get(Calendar.YEAR));
     }
+    
+    public int getYear() {
+        return calendar.get(Calendar.YEAR);
+    }
 
     public String getTitle() {
         return getName() + " (" + getFactionName() + ")" + " - "
@@ -6818,7 +6822,7 @@ public class Campaign implements Serializable, ITechManager {
 
     public void setStartingPlanet() {
     	Map<String, Planet> planetList = Planets.getInstance().getPlanets();
-        Planet startingPlanet = planetList.get(getFaction().getStartingPlanet(getEra()));
+        Planet startingPlanet = planetList.get(getFaction().getStartingPlanet(getYear()));
 
         if (startingPlanet == null) {
         	startingPlanet = planetList.get(JOptionPane.showInputDialog("This faction does not have a starting planet for this era. Please choose a planet."));

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -360,11 +360,11 @@ public class Campaign implements Serializable, ITechManager {
         partsStore = new PartsStore(this);
         gameOptions = new GameOptions();
         gameOptions.initialize();
-        gameOptions.getOption("year").setValue(calendar.get(Calendar.YEAR));
+        gameOptions.getOption("year").setValue(getGameYear());
         game.setOptions(gameOptions);
         customs = new ArrayList<String>();
         shoppingList = new ShoppingList();
-        news = new News(calendar.get(Calendar.YEAR), id.getLeastSignificantBits());
+        news = new News(getGameYear(), id.getLeastSignificantBits());
         personnelMarket = new PersonnelMarket();
         contractMarket = new ContractMarket();
         unitMarket = new UnitMarket();
@@ -422,15 +422,11 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public String getEraName() {
-        return Era.getEraNameFromYear(calendar.get(Calendar.YEAR));
+        return Era.getEraNameFromYear(getGameYear());
     }
 
     public int getEra() {
-        return Era.getEra(calendar.get(Calendar.YEAR));
-    }
-    
-    public int getYear() {
-        return calendar.get(Calendar.YEAR);
+        return Era.getEra(getGameYear());
     }
 
     public String getTitle() {
@@ -538,7 +534,7 @@ public class Campaign implements Serializable, ITechManager {
     		rm.setIgnoreRatEra(campaignOptions.canIgnoreRatEra());
     		unitGenerator = rm;    			
 		} else {
-			RATGeneratorConnector rgc = new RATGeneratorConnector(calendar.get(Calendar.YEAR));
+			RATGeneratorConnector rgc = new RATGeneratorConnector(getGameYear());
 			unitGenerator = rgc;
 		}    	
     }
@@ -2116,7 +2112,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public void reloadNews() {
-        news.loadNewsFor(calendar.get(Calendar.YEAR), id.getLeastSignificantBits());
+        news.loadNewsFor(getGameYear(), id.getLeastSignificantBits());
     }
 
     public int getDeploymentDeficit(AtBContract contract) {
@@ -2153,8 +2149,8 @@ public class Campaign implements Serializable, ITechManager {
         }
 
         // Ensure that the MegaMek year GameOption matches the campaign year
-        if (gameOptions.intOption("year") != calendar.get(Calendar.YEAR)) {
-            gameOptions.getOption("year").setValue(calendar.get(Calendar.YEAR));
+        if (gameOptions.intOption("year") != getGameYear()) {
+            gameOptions.getOption("year").setValue(getGameYear());
         }
 
         //read the news
@@ -3059,7 +3055,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public String getFactionName() {
-        return getFaction().getFullName(getYear());
+        return getFaction().getFullName(getGameYear());
     }
 
     public void setFactionCode(String i) {
@@ -5595,7 +5591,7 @@ public class Campaign implements Serializable, ITechManager {
     				break;
     			}
     			person.setBloodname(Bloodname.randomBloodname(factionCode, phenotype,
-    						calendar.get(Calendar.YEAR)).getName());
+    						getGameYear()).getName());
     		}
         }
         MekHQ.triggerEvent(new PersonChangedEvent(person));
@@ -6028,7 +6024,7 @@ public class Campaign implements Serializable, ITechManager {
         target.append(partWork.getAllMods(tech));
 
         if (getCampaignOptions().useEraMods()) {
-            target.addModifier(getFaction().getEraMod(calendar.get(Calendar.YEAR)), "era");
+            target.addModifier(getFaction().getEraMod(getGameYear()), "era");
         }
 
         boolean isOvertime = false;
@@ -6095,7 +6091,7 @@ public class Campaign implements Serializable, ITechManager {
         target.append(partWork.getAllModsForMaintenance());
 
         if (getCampaignOptions().useEraMods()) {
-            target.addModifier(getFaction().getEraMod(calendar.get(Calendar.YEAR)), "era");
+            target.addModifier(getFaction().getEraMod(getGameYear()), "era");
         }
 
         if (null != partWork.getUnit() && null != tech) {
@@ -6822,7 +6818,7 @@ public class Campaign implements Serializable, ITechManager {
 
     public void setStartingPlanet() {
     	Map<String, Planet> planetList = Planets.getInstance().getPlanets();
-        Planet startingPlanet = planetList.get(getFaction().getStartingPlanet(getYear()));
+        Planet startingPlanet = planetList.get(getFaction().getStartingPlanet(getGameYear()));
 
         if (startingPlanet == null) {
         	startingPlanet = planetList.get(JOptionPane.showInputDialog("This faction does not have a starting planet for this era. Please choose a planet."));
@@ -8730,7 +8726,7 @@ public class Campaign implements Serializable, ITechManager {
     @Override
     public int getTechIntroYear() {
         if (campaignOptions.limitByYear()) {
-            return calendar.get(Calendar.YEAR);
+            return getGameYear();
         } else {
             return Integer.MAX_VALUE;
         }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3059,7 +3059,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public String getFactionName() {
-        return getFaction().getFullName(getEra());
+        return getFaction().getFullName(getYear());
     }
 
     public void setFactionCode(String i) {

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -238,7 +238,7 @@ public class ContractMarket implements Serializable {
 			 */
 			for (Faction f : campaign.getCurrentPlanet().getFactionSet(currentDate)) {
 				try {
-					if (f.getStartingPlanet(campaign.getYear()).equals(campaign.getCurrentPlanet().getId())
+					if (f.getStartingPlanet(campaign.getGameYear()).equals(campaign.getCurrentPlanet().getId())
 							&& RandomFactionGenerator.getInstance().getEmployerSet().contains(f.getShortName())) {
 						AtBContract c = generateAtBContract(campaign, f.getShortName(), unitRatingMod);
 						if (c != null) {
@@ -338,7 +338,7 @@ public class ContractMarket implements Serializable {
         		employer = RandomFactionGenerator.getInstance().getEmployer();
         	}
         }
-		contract.setEmployerCode(employer, campaign.getYear());
+		contract.setEmployerCode(employer, campaign.getGameYear());
 		contract.setMissionType(findAtBMissionType(unitRatingMod,
 				RandomFactionGenerator.getInstance().isISMajorPower(contract.getEmployerCode())));
 
@@ -431,7 +431,7 @@ public class ContractMarket implements Serializable {
 	protected AtBContract generateAtBSubcontract(Campaign campaign,
 			AtBContract parent, int unitRatingMod) {
 		AtBContract contract = new AtBContract("New Subcontract");
-		contract.setEmployerCode(parent.getEmployerCode(), campaign.getYear());
+		contract.setEmployerCode(parent.getEmployerCode(), campaign.getGameYear());
 		contract.setMissionType(findAtBMissionType(unitRatingMod,
 				RandomFactionGenerator.getInstance().isISMajorPower(contract.getEmployerCode())));
 
@@ -519,7 +519,7 @@ public class ContractMarket implements Serializable {
 			return;
 		}
 		AtBContract followup = new AtBContract("Followup Contract");
-		followup.setEmployerCode(contract.getEmployerCode(), campaign.getYear());
+		followup.setEmployerCode(contract.getEmployerCode(), campaign.getGameYear());
 		followup.setEnemyCode(contract.getEnemyCode());
 		followup.setPlanetName(contract.getPlanetName());
 		switch (contract.getMissionType()) {

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -338,7 +338,7 @@ public class ContractMarket implements Serializable {
         		employer = RandomFactionGenerator.getInstance().getEmployer();
         	}
         }
-		contract.setEmployerCode(employer, campaign.getEra());
+		contract.setEmployerCode(employer, campaign.getYear());
 		contract.setMissionType(findAtBMissionType(unitRatingMod,
 				RandomFactionGenerator.getInstance().isISMajorPower(contract.getEmployerCode())));
 
@@ -431,7 +431,7 @@ public class ContractMarket implements Serializable {
 	protected AtBContract generateAtBSubcontract(Campaign campaign,
 			AtBContract parent, int unitRatingMod) {
 		AtBContract contract = new AtBContract("New Subcontract");
-		contract.setEmployerCode(parent.getEmployerCode(), campaign.getEra());
+		contract.setEmployerCode(parent.getEmployerCode(), campaign.getYear());
 		contract.setMissionType(findAtBMissionType(unitRatingMod,
 				RandomFactionGenerator.getInstance().isISMajorPower(contract.getEmployerCode())));
 
@@ -519,7 +519,7 @@ public class ContractMarket implements Serializable {
 			return;
 		}
 		AtBContract followup = new AtBContract("Followup Contract");
-		followup.setEmployerCode(contract.getEmployerCode(), campaign.getEra());
+		followup.setEmployerCode(contract.getEmployerCode(), campaign.getYear());
 		followup.setEnemyCode(contract.getEnemyCode());
 		followup.setPlanetName(contract.getPlanetName());
 		switch (contract.getMissionType()) {

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -238,7 +238,7 @@ public class ContractMarket implements Serializable {
 			 */
 			for (Faction f : campaign.getCurrentPlanet().getFactionSet(currentDate)) {
 				try {
-					if (f.getStartingPlanet(campaign.getEra()).equals(campaign.getCurrentPlanet().getId())
+					if (f.getStartingPlanet(campaign.getYear()).equals(campaign.getCurrentPlanet().getId())
 							&& RandomFactionGenerator.getInstance().getEmployerSet().contains(f.getShortName())) {
 						AtBContract c = generateAtBContract(campaign, f.getShortName(), unitRatingMod);
 						if (c != null) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -218,8 +218,8 @@ public class AtBContract extends Contract implements Serializable {
         	setOverheadComp(OH_NONE);
         }
         
-        allyBotName = getEmployerName(campaign.getYear());
-        enemyBotName = getEnemyName(campaign.getYear());
+        allyBotName = getEmployerName(campaign.getGameYear());
+        enemyBotName = getEnemyName(campaign.getGameYear());
 	}
 	
 	public void calculateLength(boolean variable) {
@@ -1490,7 +1490,7 @@ public class AtBContract extends Contract implements Serializable {
 				missionType = MT_PLANETARYASSAULT;
 			}
 		}
-		Faction f = Faction.getFactionFromFullNameAndYear(c.getEmployer(), campaign.getYear());
+		Faction f = Faction.getFactionFromFullNameAndYear(c.getEmployer(), campaign.getGameYear());
 		if (null == f) {
 			employerCode = "IND";
 		} else {
@@ -1506,8 +1506,8 @@ public class AtBContract extends Contract implements Serializable {
 		
 		requiredLances = Math.max(getEffectiveNumUnits(campaign) / 6, 1);
 		calculatePartsAvailabilityLevel(campaign);
-        allyBotName = getEmployerName(campaign.getYear());
-        enemyBotName = getEnemyName(campaign.getYear());
+        allyBotName = getEmployerName(campaign.getGameYear());
+        enemyBotName = getEnemyName(campaign.getGameYear());
 	}
 
 	public static AtBContract getContractExtension(AtBContract c, int length, Campaign campaign) {
@@ -1536,7 +1536,7 @@ public class AtBContract extends Contract implements Serializable {
 		retVal.setMRBCFee(c.payMRBCFee());
 		
 		retVal.setMissionType(c.getMissionType());
-		retVal.setEmployerCode(c.getEmployerCode(), campaign.getYear());
+		retVal.setEmployerCode(c.getEmployerCode(), campaign.getGameYear());
 		retVal.setEnemyCode(c.getEnemyCode());
 		retVal.requiredLances = c.getRequiredLances();
 		retVal.calculatePartsAvailabilityLevel(campaign);

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -218,8 +218,8 @@ public class AtBContract extends Contract implements Serializable {
         	setOverheadComp(OH_NONE);
         }
         
-        allyBotName = getEmployerName(campaign.getEra());
-        enemyBotName = getEnemyName(campaign.getEra());
+        allyBotName = getEmployerName(campaign.getYear());
+        enemyBotName = getEnemyName(campaign.getYear());
 	}
 	
 	public void calculateLength(boolean variable) {
@@ -1233,25 +1233,25 @@ public class AtBContract extends Contract implements Serializable {
 		return employerCode;
 	}
 	
-	public void setEmployerCode(String code, int era) {
+	public void setEmployerCode(String code, int year) {
 		employerCode = code;
-		setEmployer(getEmployerName(era));
+		setEmployer(getEmployerName(year));
 	}
 	
-	public String getEmployerName(int era) {
+	public String getEmployerName(int year) {
 		if (mercSubcontract) {
 			return "Mercenary (" +
-					Faction.getFaction(employerCode).getFullName(era) + ")";
+					Faction.getFaction(employerCode).getFullName(year) + ")";
 		}
-		return Faction.getFaction(employerCode).getFullName(era);
+		return Faction.getFaction(employerCode).getFullName(year);
 	}
 	
 	public String getEnemyCode() {
 		return enemyCode;
 	}
 		
-	public String getEnemyName(int era) {
-		return Faction.getFaction(enemyCode).getFullName(era);
+	public String getEnemyName(int year) {
+		return Faction.getFaction(enemyCode).getFullName(year);
 	}
 
 	public void setEnemyCode(String enemyCode) {
@@ -1490,7 +1490,7 @@ public class AtBContract extends Contract implements Serializable {
 				missionType = MT_PLANETARYASSAULT;
 			}
 		}
-		Faction f = Faction.getFactionFromFullNameAndEra(c.getEmployer(), campaign.getEra());
+		Faction f = Faction.getFactionFromFullNameAndYear(c.getEmployer(), campaign.getYear());
 		if (null == f) {
 			employerCode = "IND";
 		} else {
@@ -1506,8 +1506,8 @@ public class AtBContract extends Contract implements Serializable {
 		
 		requiredLances = Math.max(getEffectiveNumUnits(campaign) / 6, 1);
 		calculatePartsAvailabilityLevel(campaign);
-        allyBotName = getEmployerName(campaign.getEra());
-        enemyBotName = getEnemyName(campaign.getEra());
+        allyBotName = getEmployerName(campaign.getYear());
+        enemyBotName = getEnemyName(campaign.getYear());
 	}
 
 	public static AtBContract getContractExtension(AtBContract c, int length, Campaign campaign) {
@@ -1536,7 +1536,7 @@ public class AtBContract extends Contract implements Serializable {
 		retVal.setMRBCFee(c.payMRBCFee());
 		
 		retVal.setMissionType(c.getMissionType());
-		retVal.setEmployerCode(c.getEmployerCode(), campaign.getEra());
+		retVal.setEmployerCode(c.getEmployerCode(), campaign.getYear());
 		retVal.setEnemyCode(c.getEnemyCode());
 		retVal.requiredLances = c.getRequiredLances();
 		retVal.calculatePartsAvailabilityLevel(campaign);

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -86,9 +86,9 @@ public class Faction {
         fullname = fname;
         nameGenerator = "General";
         color = Color.LIGHT_GRAY;
-        startingPlanet = new String[]{"Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra"};
-        altNamesByEra = new String[]{"","","","","","","","",""};
-        eraMods = new int[]{0,0,0,0,0,0,0,0,0};
+        startingPlanet = new String[]{"Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra"};
+        altNamesByEra = new String[]{"","","","","","","","","","",""};
+        eraMods = new int[]{0,0,0,0,0,0,0,0,0,0,0};
         tags = EnumSet.noneOf(Faction.Tag.class);
         start = 0;
         end = 9999;

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -88,7 +88,7 @@ public class Faction {
         color = Color.LIGHT_GRAY;
         startingPlanet = new String[]{"Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra"};
         altNamesByEra = new String[]{"","","","","","","","","","",""};
-        eraMods = new int[]{0,0,0,0,0,0,0,0,0,0,0};
+        eraMods = new int[]{0,0,0,0,0,0,0,0,0};
         tags = EnumSet.noneOf(Faction.Tag.class);
         start = 0;
         end = 9999;
@@ -135,11 +135,43 @@ public class Faction {
         return "Terra";
     }
 
-    public int getEraMod(int era) {
-        if(eraMods.length > era) {
-            return eraMods[era];
+    public int getEraMod(int year) {
+        if(year < 2570) {
+            //Era: Age of War
+            return eraMods[0];
+        } 
+        else if(year < 2598) {
+            //Era: RW
+            return eraMods[1];
         }
-        return 0;
+        else if(year < 2785) {
+            //Era: Star League
+            return eraMods[2];
+        } 
+        else if(year < 2828) {
+            //Era: 1st SW
+            return eraMods[3];
+        }
+        else if(year < 2864) {
+            //Era: 2nd SW
+            return eraMods[4];
+        }
+        else if(year < 3028) {
+            //Era: 3rd SW
+            return eraMods[5];
+        }
+        else if(year < 3050) {
+            //Era: 4th SW
+            return eraMods[6];
+        }
+        else if(year < 3067) {
+            //Era: Clan Invasion
+            return eraMods[7];
+        }
+        else {
+            //Era: Jihad
+            return eraMods[8];
+        }
     }
 
     public int getTechMod(Part part, Campaign campaign) {
@@ -307,7 +339,7 @@ public class Faction {
             MekHQ.getLogger().log(Faction.class, METHOD_NAME, LogLevel.WARNING,
                     retVal.fullname + " faction did not have a long enough altNamesByEra vector"); //$NON-NLS-1$
         }
-        if(retVal.eraMods.length < Era.E_NUM) {
+        if(retVal.eraMods.length < 9) {
             MekHQ.getLogger().log(Faction.class, METHOD_NAME, LogLevel.WARNING,
                     retVal.fullname + " faction did not have a long enough eraMods vector"); //$NON-NLS-1$
         }

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -326,19 +326,20 @@ public class Faction {
                 if (retVal.changePlanet == null) {
                     retVal.changePlanet = new ArrayList<factionChange>();
                 }
-                factionChange pChange = retVal.new factionChange(Integer.parseInt(wn2.getAttributes().getNamedItem("year").getTextContent()),
+                factionChange pChange = retVal.getChangeObject(Integer.parseInt(wn2.getAttributes().getNamedItem("year").getTextContent()),
                         wn2.getTextContent());
                 retVal.changePlanet.add(pChange);
             } else if (wn2.getNodeName().equalsIgnoreCase("altNamesByYear")) {
                 if (retVal.changeName == null) {
                     retVal.changeName = new ArrayList<factionChange>();
                 }
-                factionChange nChange = retVal.new factionChange(Integer.parseInt(wn2.getAttributes().getNamedItem("year").getTextContent()),
+                factionChange nChange = retVal.getChangeObject(Integer.parseInt(wn2.getAttributes().getNamedItem("year").getTextContent()),
                         wn2.getTextContent());
                 retVal.changeName.add(nChange);
             } else if (wn2.getNodeName().equalsIgnoreCase("altNames")) {
                 retVal.altNames = wn2.getTextContent().split(",", 0);
             } else if (wn2.getNodeName().equalsIgnoreCase("eraMods")) {
+                retVal.eraMods = new int[] {0,0,0,0,0,0,0,0,0};
                 String[] values = wn2.getTextContent().split(",", -2);
                 for(int i = 0; i < values.length; i++) {
                     retVal.eraMods[i] = Integer.parseInt(values[i]);
@@ -363,7 +364,7 @@ public class Faction {
             }
         }
 
-        if(retVal.eraMods.length < 9) {
+        if(retVal.eraMods != null && retVal.eraMods.length < 9) {
             MekHQ.getLogger().log(Faction.class, METHOD_NAME, LogLevel.WARNING,
                     retVal.fullname + " faction did not have a long enough eraMods vector"); //$NON-NLS-1$
         }
@@ -445,16 +446,20 @@ public class Faction {
     }
 
     /** @return Sorted list of faction names as one string */
-    public static String getFactionNames(Collection<Faction> factions, int era) {
+    public static String getFactionNames(Collection<Faction> factions, int year) {
         if( null == factions ) {
             return "-"; //$NON-NLS-1$
         }
         List<String> factionNames = new ArrayList<>(factions.size());
         for(Faction f : factions) {
-            factionNames.add(f.getFullName(era));
+            factionNames.add(f.getFullName(year));
         }
         Collections.sort(factionNames);
         return Utilities.combineString(factionNames, "/"); //$NON-NLS-1$
+    }
+    
+    private factionChange getChangeObject(int year, String name) {
+        return new factionChange(year, name);
     }
 
     public static enum Tag {
@@ -486,7 +491,7 @@ public class Faction {
         int year;
         String name;
         
-        public factionChange(int year, String name) {
+        factionChange(int year, String name) {
             this.year = year;
             this.name = name;
         }

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -86,8 +86,10 @@ public class Faction {
         fullname = fname;
         nameGenerator = "General";
         color = Color.LIGHT_GRAY;
-        startingPlanet = new String[]{"Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra","Terra"};
-        altNamesByEra = new String[]{"","","","","","","","","","",""};
+        startingPlanet = new String[Era.E_NUM];
+        altNamesByEra = new String[Era.E_NUM];
+        Arrays.fill(startingPlanet, "Terra");
+        Arrays.fill(altNamesByEra, "");
         eraMods = new int[]{0,0,0,0,0,0,0,0,0};
         tags = EnumSet.noneOf(Faction.Tag.class);
         start = 0;

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -628,8 +628,7 @@ public class Planet implements Serializable {
     }
 
     public String getFactionDesc(DateTime when) {
-        int era = Era.getEra(when.getYear());
-        return Faction.getFactionNames(getFactionSet(when), era);
+        return Faction.getFactionNames(getFactionSet(when), when.getYear());
     }
 
     // Stellar event data, to be moved

--- a/MekHQ/src/mekhq/gui/FactionComboBox.java
+++ b/MekHQ/src/mekhq/gui/FactionComboBox.java
@@ -75,11 +75,11 @@ public class FactionComboBox extends JComboBox<Map.Entry<String, String>> {
 		});
 	}
 	
-	public void addFactionEntries(Collection<String> list, int era) {
+	public void addFactionEntries(Collection<String> list, int year) {
 		HashMap<String, String> map = new HashMap<String, String>();
 		HashSet<String> collisions = new HashSet<String>();
 		for (String key : list) {
-			String fullName = Faction.getFaction(key).getFullName(era);
+			String fullName = Faction.getFaction(key).getFullName(year);
 			if (map.containsValue(fullName)) {
 				collisions.add(fullName);
 			}

--- a/MekHQ/src/mekhq/gui/dialog/BloodnameDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BloodnameDialog.java
@@ -18,7 +18,6 @@ import javax.swing.JLabel;
 import javax.swing.JTextArea;
 
 import mekhq.campaign.personnel.Bloodname;
-import mekhq.campaign.universe.Era;
 import mekhq.campaign.universe.Faction;
 
 /**
@@ -171,7 +170,7 @@ public class BloodnameDialog extends JDialog {
 								cbPhenotype.getSelectedIndex(),
 								(Integer)cbEra.getSelectedItem());
 				lblName.setText(n.getName() + " (" + n.getFounder() + ")");
-				lblOrigClan.setText(Faction.getFaction(n.getOrigClan()).getFullName(Era.getEra((Integer)cbEra.getSelectedItem())));
+				lblOrigClan.setText(Faction.getFaction(n.getOrigClan()).getFullName((Integer)cbEra.getSelectedItem()));
 				lblPhenotype.setText(Bloodname.phenotypeNames[n.getPhenotype()]);
 			}
 		});

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -107,7 +107,6 @@ import mekhq.campaign.personnel.Ranks;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.rating.UnitRatingMethod;
-import mekhq.campaign.universe.Era;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.RATManager;
 import mekhq.gui.SpecialAbilityPanel;
@@ -679,9 +678,9 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
         factionModel = new SortedComboBoxModel<String>();
         for (String sname : Faction.choosableFactionCodes) {
-            factionModel.addElement(Faction.getFaction(sname).getFullName(Era.getEra(date.get(Calendar.YEAR))));
+            factionModel.addElement(Faction.getFaction(sname).getFullName(date.get(Calendar.YEAR)));
         }
-        factionModel.setSelectedItem(campaign.getFaction().getFullName(Era.getEra(date.get(Calendar.YEAR))));
+        factionModel.setSelectedItem(campaign.getFaction().getFullName(date.get(Calendar.YEAR)));
         comboFaction.setModel(factionModel);
         comboFaction.setMinimumSize(new java.awt.Dimension(400, 30));
         comboFaction.setName("comboFaction"); // NOI18N
@@ -4596,9 +4595,9 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
             btnDate.setText(getDateAsString());
             factionModel = new SortedComboBoxModel<String>();
             for (String sname : Faction.choosableFactionCodes) {
-                factionModel.addElement(Faction.getFaction(sname).getFullName(Era.getEra(date.get(Calendar.YEAR))));
+                factionModel.addElement(Faction.getFaction(sname).getFullName(date.get(Calendar.YEAR)));
             }
-            factionModel.setSelectedItem(campaign.getFaction().getFullName(Era.getEra(date.get(Calendar.YEAR))));
+            factionModel.setSelectedItem(campaign.getFaction().getFullName(date.get(Calendar.YEAR)));
             comboFaction.setModel(factionModel);
         }
     }//GEN-LAST:event_btnDateActionPerformed

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -4082,7 +4082,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
     }
 
     private void switchFaction() {
-        String factionCode = Faction.getFactionFromFullNameAndEra(String.valueOf(comboFaction.getSelectedItem()), Era.getEra(date.get(Calendar.YEAR)))
+        String factionCode = Faction.getFactionFromFullNameAndYear(String.valueOf(comboFaction.getSelectedItem()), date.get(Calendar.YEAR))
                                     .getNameGenerator();
         boolean found = false;
         for (Iterator<String> i = campaign.getRNG().getFactions(); i.hasNext(); ) {
@@ -4265,8 +4265,8 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         if (gameOpts.intOption("year") != campaignYear) {
             gameOpts.getOption("year").setValue(campaignYear);
         }
-        campaign.setFactionCode(Faction.getFactionFromFullNameAndEra
-        		(String.valueOf(comboFaction.getSelectedItem()), Era.getEra(date.get(Calendar.YEAR))).getShortName());
+        campaign.setFactionCode(Faction.getFactionFromFullNameAndYear
+        		(String.valueOf(comboFaction.getSelectedItem()), date.get(Calendar.YEAR)).getShortName());
         if (null != comboFactionNames.getSelectedItem()) {
             campaign.getRNG().setChosenFaction((String) comboFactionNames.getSelectedItem());
         }

--- a/MekHQ/src/mekhq/gui/dialog/ChooseFactionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseFactionsDialog.java
@@ -24,7 +24,6 @@ import javax.swing.JScrollPane;
 import org.joda.time.DateTime;
 
 import megamek.common.util.EncodeControl;
-import mekhq.campaign.universe.Era;
 import mekhq.campaign.universe.Faction;
 
 public class ChooseFactionsDialog extends JDialog {
@@ -76,7 +75,7 @@ public class ChooseFactionsDialog extends JDialog {
                     boolean cellHasFocus) {
                 DefaultListCellRenderer result = (DefaultListCellRenderer) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if(value instanceof Faction) {
-                    result.setText(((Faction)value).getFullName(Era.getEra(date.getYear())));
+                    result.setText(((Faction)value).getFullName(date.getYear()));
                 }
                 return result;
             }
@@ -132,9 +131,8 @@ public class ChooseFactionsDialog extends JDialog {
         private List<String> names;
         
         public FactionListModel(DateTime date) {
-            int era = Era.getEra(date.getYear());
             for(Faction faction : Faction.getFactions()) {
-                factionMap.put(faction.getFullName(era), faction);
+                factionMap.put(faction.getFullName(date.getYear()), faction);
             }
             names = new ArrayList<>(factionMap.navigableKeySet());
         }

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -287,8 +287,8 @@ public class ContractMarketDialog extends JDialog {
 			c.calculateContract(campaign);
 			Vector<String> row = new Vector<String>();
 			if (c instanceof AtBContract) {
-				row.add(((AtBContract)c).getEmployerName(campaign.getEra()));
-				row.add(((AtBContract)c).getEnemyName(campaign.getEra()));
+				row.add(((AtBContract)c).getEmployerName(campaign.getYear()));
+				row.add(((AtBContract)c).getEnemyName(campaign.getYear()));
 				if (((AtBContract)c).isSubcontract()) {
 					row.add(((AtBContract)c).getMissionTypeName() + " (Subcontract)");
 				} else {
@@ -341,7 +341,7 @@ public class ContractMarketDialog extends JDialog {
         gbc.fill = GridBagConstraints.NONE;
         panelRetainer.add(lblCurrentRetainer, gbc);
         if (null != campaign.getRetainerEmployerCode()) {
-        	lblRetainerEmployer.setText(Faction.getFaction(campaign.getRetainerEmployerCode()).getFullName(campaign.getEra()));
+        	lblRetainerEmployer.setText(Faction.getFaction(campaign.getRetainerEmployerCode()).getFullName(campaign.getYear()));
         }
         gbc.gridx = 1;
         gbc.gridy = 0;
@@ -372,7 +372,7 @@ public class ContractMarketDialog extends JDialog {
         gbc.gridx = 0;
         gbc.gridy = 2;
         panelRetainer.add(lblRetainerAvailable, gbc);
-        cbRetainerEmployer.addFactionEntries(possibleRetainerContracts, campaign.getEra());
+        cbRetainerEmployer.addFactionEntries(possibleRetainerContracts, campaign.getYear());
         gbc.gridx = 1;
         gbc.gridy = 2;
         panelRetainer.add(cbRetainerEmployer, gbc);
@@ -390,7 +390,7 @@ public class ContractMarketDialog extends JDialog {
 		        lblCurrentRetainer.setVisible(true);
 		        lblRetainerEmployer.setVisible(true);
 		        btnEndRetainer.setVisible(true);
-	        	lblRetainerEmployer.setText(Faction.getFaction(campaign.getRetainerEmployerCode()).getFullName(campaign.getEra()));
+	        	lblRetainerEmployer.setText(Faction.getFaction(campaign.getRetainerEmployerCode()).getFullName(campaign.getYear()));
 		        //Remove the selected faction and add the previous one, if any
 		        countSuccessfulContracts();
 		        lblRetainerAvailable.setVisible(possibleRetainerContracts.size() > 0);
@@ -422,8 +422,8 @@ public class ContractMarketDialog extends JDialog {
 
         		c.calculateContract(campaign);
         		Vector<String> row = new Vector<String>();
-        		row.add(((AtBContract)c).getEmployerName(campaign.getEra()));
-        		row.add(((AtBContract)c).getEnemyName(campaign.getEra()));
+        		row.add(((AtBContract)c).getEmployerName(campaign.getYear()));
+        		row.add(((AtBContract)c).getEnemyName(campaign.getYear()));
         		row.add(((AtBContract)c).getMissionTypeName());
 
         		((DefaultTableModel)tblContracts.getModel()).addRow(row);

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -287,8 +287,8 @@ public class ContractMarketDialog extends JDialog {
 			c.calculateContract(campaign);
 			Vector<String> row = new Vector<String>();
 			if (c instanceof AtBContract) {
-				row.add(((AtBContract)c).getEmployerName(campaign.getYear()));
-				row.add(((AtBContract)c).getEnemyName(campaign.getYear()));
+				row.add(((AtBContract)c).getEmployerName(campaign.getGameYear()));
+				row.add(((AtBContract)c).getEnemyName(campaign.getGameYear()));
 				if (((AtBContract)c).isSubcontract()) {
 					row.add(((AtBContract)c).getMissionTypeName() + " (Subcontract)");
 				} else {
@@ -341,7 +341,7 @@ public class ContractMarketDialog extends JDialog {
         gbc.fill = GridBagConstraints.NONE;
         panelRetainer.add(lblCurrentRetainer, gbc);
         if (null != campaign.getRetainerEmployerCode()) {
-        	lblRetainerEmployer.setText(Faction.getFaction(campaign.getRetainerEmployerCode()).getFullName(campaign.getYear()));
+        	lblRetainerEmployer.setText(Faction.getFaction(campaign.getRetainerEmployerCode()).getFullName(campaign.getGameYear()));
         }
         gbc.gridx = 1;
         gbc.gridy = 0;
@@ -372,7 +372,7 @@ public class ContractMarketDialog extends JDialog {
         gbc.gridx = 0;
         gbc.gridy = 2;
         panelRetainer.add(lblRetainerAvailable, gbc);
-        cbRetainerEmployer.addFactionEntries(possibleRetainerContracts, campaign.getYear());
+        cbRetainerEmployer.addFactionEntries(possibleRetainerContracts, campaign.getGameYear());
         gbc.gridx = 1;
         gbc.gridy = 2;
         panelRetainer.add(cbRetainerEmployer, gbc);
@@ -390,7 +390,7 @@ public class ContractMarketDialog extends JDialog {
 		        lblCurrentRetainer.setVisible(true);
 		        lblRetainerEmployer.setVisible(true);
 		        btnEndRetainer.setVisible(true);
-	        	lblRetainerEmployer.setText(Faction.getFaction(campaign.getRetainerEmployerCode()).getFullName(campaign.getYear()));
+	        	lblRetainerEmployer.setText(Faction.getFaction(campaign.getRetainerEmployerCode()).getFullName(campaign.getGameYear()));
 		        //Remove the selected faction and add the previous one, if any
 		        countSuccessfulContracts();
 		        lblRetainerAvailable.setVisible(possibleRetainerContracts.size() > 0);
@@ -422,8 +422,8 @@ public class ContractMarketDialog extends JDialog {
 
         		c.calculateContract(campaign);
         		Vector<String> row = new Vector<String>();
-        		row.add(((AtBContract)c).getEmployerName(campaign.getYear()));
-        		row.add(((AtBContract)c).getEnemyName(campaign.getYear()));
+        		row.add(((AtBContract)c).getEmployerName(campaign.getGameYear()));
+        		row.add(((AtBContract)c).getEnemyName(campaign.getGameYear()));
         		row.add(((AtBContract)c).getMissionTypeName());
 
         		((DefaultTableModel)tblContracts.getModel()).addRow(row);

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -156,10 +156,10 @@ public class CustomizeAtBContractDialog extends JDialog {
 		txtName = new JTextField();
         JLabel lblName = new JLabel();
         cbEmployer = new FactionComboBox();
-        cbEmployer.addFactionEntries(currentFactions, campaign.getYear());
+        cbEmployer.addFactionEntries(currentFactions, campaign.getGameYear());
         JLabel lblEmployer = new JLabel();
 		cbEnemy = new FactionComboBox();
-        cbEnemy.addFactionEntries(currentFactions, campaign.getYear());
+        cbEnemy.addFactionEntries(currentFactions, campaign.getGameYear());
         JLabel lblEnemy = new JLabel();
     	chkShowAllFactions = new JCheckBox();
     	cbMissionType = new JComboBox<String>(AtBContract.missionTypeNames);
@@ -579,7 +579,7 @@ public class CustomizeAtBContractDialog extends JDialog {
     
     private void btnOKActionPerformed(ActionEvent evt) {//GEN-FIRST:event_btnHireActionPerformed
     	contract.setName(txtName.getText());
-    	contract.setEmployerCode(cbEmployer.getSelectedItemKey(), campaign.getYear());
+    	contract.setEmployerCode(cbEmployer.getSelectedItemKey(), campaign.getGameYear());
     	contract.setEnemyCode(cbEnemy.getSelectedItemKey());
     	contract.setMissionType(cbMissionType.getSelectedIndex());
     	contract.setAllySkill(cbAllySkill.getSelectedIndex());
@@ -609,11 +609,11 @@ public class CustomizeAtBContractDialog extends JDialog {
     	cbEmployer.removeAllItems();
     	cbEnemy.removeAllItems();
     	if (allFactions) {
-    		cbEmployer.addFactionEntries(Faction.getFactionList(),	campaign.getYear());
-    		cbEnemy.addFactionEntries(Faction.getFactionList(),	campaign.getYear());
+    		cbEmployer.addFactionEntries(Faction.getFactionList(),	campaign.getGameYear());
+    		cbEnemy.addFactionEntries(Faction.getFactionList(),	campaign.getGameYear());
     	} else {
-    		cbEmployer.addFactionEntries(currentFactions, campaign.getYear());
-    		cbEnemy.addFactionEntries(currentFactions, campaign.getYear());
+    		cbEmployer.addFactionEntries(currentFactions, campaign.getGameYear());
+    		cbEnemy.addFactionEntries(currentFactions, campaign.getGameYear());
     	}
     }
     

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -156,10 +156,10 @@ public class CustomizeAtBContractDialog extends JDialog {
 		txtName = new JTextField();
         JLabel lblName = new JLabel();
         cbEmployer = new FactionComboBox();
-        cbEmployer.addFactionEntries(currentFactions, campaign.getEra());
+        cbEmployer.addFactionEntries(currentFactions, campaign.getYear());
         JLabel lblEmployer = new JLabel();
 		cbEnemy = new FactionComboBox();
-        cbEnemy.addFactionEntries(currentFactions, campaign.getEra());
+        cbEnemy.addFactionEntries(currentFactions, campaign.getYear());
         JLabel lblEnemy = new JLabel();
     	chkShowAllFactions = new JCheckBox();
     	cbMissionType = new JComboBox<String>(AtBContract.missionTypeNames);
@@ -579,7 +579,7 @@ public class CustomizeAtBContractDialog extends JDialog {
     
     private void btnOKActionPerformed(ActionEvent evt) {//GEN-FIRST:event_btnHireActionPerformed
     	contract.setName(txtName.getText());
-    	contract.setEmployerCode(cbEmployer.getSelectedItemKey(), campaign.getEra());
+    	contract.setEmployerCode(cbEmployer.getSelectedItemKey(), campaign.getYear());
     	contract.setEnemyCode(cbEnemy.getSelectedItemKey());
     	contract.setMissionType(cbMissionType.getSelectedIndex());
     	contract.setAllySkill(cbAllySkill.getSelectedIndex());
@@ -609,11 +609,11 @@ public class CustomizeAtBContractDialog extends JDialog {
     	cbEmployer.removeAllItems();
     	cbEnemy.removeAllItems();
     	if (allFactions) {
-    		cbEmployer.addFactionEntries(Faction.getFactionList(),	campaign.getEra());
-    		cbEnemy.addFactionEntries(Faction.getFactionList(),	campaign.getEra());
+    		cbEmployer.addFactionEntries(Faction.getFactionList(),	campaign.getYear());
+    		cbEnemy.addFactionEntries(Faction.getFactionList(),	campaign.getYear());
     	} else {
-    		cbEmployer.addFactionEntries(currentFactions, campaign.getEra());
-    		cbEnemy.addFactionEntries(currentFactions, campaign.getEra());
+    		cbEmployer.addFactionEntries(currentFactions, campaign.getYear());
+    		cbEnemy.addFactionEntries(currentFactions, campaign.getYear());
     	}
     }
     

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -110,11 +110,11 @@ public class GMToolsDialog extends JDialog implements ActionListener {
         
         Collection<String> factionIds = Faction.getFactionList();
         List<FactionChoice> factionChoices = new ArrayList<>(factionIds.size());
-        int era = gui.getCampaign().getEra();
+        int year = gui.getCampaign().getYear();
         StringBuilder sb = new StringBuilder();
         for(String factionId : factionIds) {
             sb.setLength(0);
-            sb.append(Faction.getFaction(factionId).getFullName(era)).append(" [").append(factionId).append("]");
+            sb.append(Faction.getFaction(factionId).getFullName(year)).append(" [").append(factionId).append("]");
             factionChoices.add(new FactionChoice(factionId, sb.toString()));
         }
         Collections.sort(factionChoices, new Comparator<FactionChoice>() {

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -12,7 +12,6 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -110,7 +109,7 @@ public class GMToolsDialog extends JDialog implements ActionListener {
         
         Collection<String> factionIds = Faction.getFactionList();
         List<FactionChoice> factionChoices = new ArrayList<>(factionIds.size());
-        int year = gui.getCampaign().getYear();
+        int year = gui.getCampaign().getGameYear();
         StringBuilder sb = new StringBuilder();
         for(String factionId : factionIds) {
             sb.setLength(0);
@@ -134,9 +133,9 @@ public class GMToolsDialog extends JDialog implements ActionListener {
             
         });
         factionPicker = new JComboBox<FactionChoice>(factionChoices.toArray(new FactionChoice[factionChoices.size()]));
-        System.out.println(gui.getCampaign().getCalendar().get(Calendar.YEAR));
+        System.out.println(gui.getCampaign().getGameYear());
         yearPicker = new JTextField(5);
-        yearPicker.setText(String.valueOf(gui.getCampaign().getCalendar().get(Calendar.YEAR)));
+        yearPicker.setText(String.valueOf(gui.getCampaign().getGameYear()));
         qualityPicker = new JComboBox<String>(qualityNames);
         unitTypePicker = new JComboBox<String>();
         for (int ut = 0; ut < UnitType.SIZE; ut++) {

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -102,7 +102,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         updatePlanets();
 
         if (getCurrentEmployerCode() != null) {
-        	((AtBContract)contract).setEmployerCode(getCurrentEmployerCode(), campaign.getYear());
+        	((AtBContract)contract).setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
         }
         if (getCurrentEnemyCode() != null) {
         	((AtBContract)contract).setEnemyCode(getCurrentEnemyCode());
@@ -124,7 +124,7 @@ public class NewAtBContractDialog extends NewContractDialog {
 		txtName = new javax.swing.JTextField();
         JLabel lblName = new JLabel();
         cbEmployer = new FactionComboBox();
-        cbEmployer.addFactionEntries(employerSet, campaign.getYear());
+        cbEmployer.addFactionEntries(employerSet, campaign.getGameYear());
         JLabel lblEmployer = new JLabel();
 		cbEnemy = new FactionComboBox();
         JLabel lblEnemy = new JLabel();
@@ -436,7 +436,7 @@ public class NewAtBContractDialog extends NewContractDialog {
 			return;
 		}
 		cbEnemy.addFactionEntries(RandomFactionGenerator.getInstance().
-				getEnemyList(getCurrentEmployerCode()), campaign.getYear());
+				getEnemyList(getCurrentEmployerCode()), campaign.getGameYear());
 		cbEnemy.setSelectedItemByKey(((AtBContract)contract).getEnemyCode());
 	}
 	
@@ -446,13 +446,13 @@ public class NewAtBContractDialog extends NewContractDialog {
 		if (show) {
 			cbEmployer.removeAllItems();
 			cbEnemy.removeAllItems();
-			cbEmployer.addFactionEntries(currentFactions, campaign.getYear());
-			cbEnemy.addFactionEntries(currentFactions, campaign.getYear());
+			cbEmployer.addFactionEntries(currentFactions, campaign.getGameYear());
+			cbEnemy.addFactionEntries(currentFactions, campaign.getGameYear());
 			cbEmployer.setSelectedItemByKey(((AtBContract)contract).getEmployerCode());
 			cbEnemy.setSelectedItemByKey(((AtBContract)contract).getEnemyCode());
 		} else {
 			cbEmployer.removeAllItems();
-			cbEmployer.addFactionEntries(employerSet, campaign.getYear());
+			cbEmployer.addFactionEntries(employerSet, campaign.getGameYear());
 			cbEmployer.setSelectedItemByKey(((AtBContract)contract).getEmployerCode());
 			updateEnemies();
 		}
@@ -521,7 +521,7 @@ public class NewAtBContractDialog extends NewContractDialog {
 		} else {
 			contract.setPlanetName((String)cbPlanets.getSelectedItem());
 		}
-    	contract.setEmployerCode(getCurrentEmployerCode(), campaign.getYear());
+    	contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
     	contract.setMissionType(cbMissionType.getSelectedIndex());
     	contract.setDesc(txtDesc.getText());
     	contract.setCommandRights(choiceCommand.getSelectedIndex());
@@ -531,8 +531,8 @@ public class NewAtBContractDialog extends NewContractDialog {
     	contract.setAllyQuality(cbAllyQuality.getSelectedIndex());
     	contract.setEnemySkill(cbEnemySkill.getSelectedIndex());
     	contract.setEnemyQuality(cbEnemyQuality.getSelectedIndex());
-    	contract.setAllyBotName(contract.getEmployerName(campaign.getYear()));
-    	contract.setEnemyBotName(contract.getEnemyName(campaign.getYear()));
+    	contract.setAllyBotName(contract.getEmployerName(campaign.getGameYear()));
+    	contract.setEnemyBotName(contract.getEnemyName(campaign.getGameYear()));
     	contract.setSharesPct((Integer)spnShares.getValue());
     	
     	contract.calculatePartsAvailabilityLevel(campaign);
@@ -553,7 +553,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         } else if (source.equals(cbEmployer)) {
         	System.out.println("Setting employer code to " + getCurrentEmployerCode());
         	long time = System.currentTimeMillis();
-    		contract.setEmployerCode(getCurrentEmployerCode(), campaign.getYear());
+    		contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
     		System.out.println("to set employer code: " + (System.currentTimeMillis() - time));
         	time = System.currentTimeMillis();
     		updateEnemies();

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -102,7 +102,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         updatePlanets();
 
         if (getCurrentEmployerCode() != null) {
-        	((AtBContract)contract).setEmployerCode(getCurrentEmployerCode(), campaign.getEra());
+        	((AtBContract)contract).setEmployerCode(getCurrentEmployerCode(), campaign.getYear());
         }
         if (getCurrentEnemyCode() != null) {
         	((AtBContract)contract).setEnemyCode(getCurrentEnemyCode());
@@ -124,7 +124,7 @@ public class NewAtBContractDialog extends NewContractDialog {
 		txtName = new javax.swing.JTextField();
         JLabel lblName = new JLabel();
         cbEmployer = new FactionComboBox();
-        cbEmployer.addFactionEntries(employerSet, campaign.getEra());
+        cbEmployer.addFactionEntries(employerSet, campaign.getYear());
         JLabel lblEmployer = new JLabel();
 		cbEnemy = new FactionComboBox();
         JLabel lblEnemy = new JLabel();
@@ -436,7 +436,7 @@ public class NewAtBContractDialog extends NewContractDialog {
 			return;
 		}
 		cbEnemy.addFactionEntries(RandomFactionGenerator.getInstance().
-				getEnemyList(getCurrentEmployerCode()), campaign.getEra());
+				getEnemyList(getCurrentEmployerCode()), campaign.getYear());
 		cbEnemy.setSelectedItemByKey(((AtBContract)contract).getEnemyCode());
 	}
 	
@@ -446,13 +446,13 @@ public class NewAtBContractDialog extends NewContractDialog {
 		if (show) {
 			cbEmployer.removeAllItems();
 			cbEnemy.removeAllItems();
-			cbEmployer.addFactionEntries(currentFactions, campaign.getEra());
-			cbEnemy.addFactionEntries(currentFactions, campaign.getEra());
+			cbEmployer.addFactionEntries(currentFactions, campaign.getYear());
+			cbEnemy.addFactionEntries(currentFactions, campaign.getYear());
 			cbEmployer.setSelectedItemByKey(((AtBContract)contract).getEmployerCode());
 			cbEnemy.setSelectedItemByKey(((AtBContract)contract).getEnemyCode());
 		} else {
 			cbEmployer.removeAllItems();
-			cbEmployer.addFactionEntries(employerSet, campaign.getEra());
+			cbEmployer.addFactionEntries(employerSet, campaign.getYear());
 			cbEmployer.setSelectedItemByKey(((AtBContract)contract).getEmployerCode());
 			updateEnemies();
 		}
@@ -521,7 +521,7 @@ public class NewAtBContractDialog extends NewContractDialog {
 		} else {
 			contract.setPlanetName((String)cbPlanets.getSelectedItem());
 		}
-    	contract.setEmployerCode(getCurrentEmployerCode(), campaign.getEra());
+    	contract.setEmployerCode(getCurrentEmployerCode(), campaign.getYear());
     	contract.setMissionType(cbMissionType.getSelectedIndex());
     	contract.setDesc(txtDesc.getText());
     	contract.setCommandRights(choiceCommand.getSelectedIndex());
@@ -531,8 +531,8 @@ public class NewAtBContractDialog extends NewContractDialog {
     	contract.setAllyQuality(cbAllyQuality.getSelectedIndex());
     	contract.setEnemySkill(cbEnemySkill.getSelectedIndex());
     	contract.setEnemyQuality(cbEnemyQuality.getSelectedIndex());
-    	contract.setAllyBotName(contract.getEmployerName(campaign.getEra()));
-    	contract.setEnemyBotName(contract.getEnemyName(campaign.getEra()));
+    	contract.setAllyBotName(contract.getEmployerName(campaign.getYear()));
+    	contract.setEnemyBotName(contract.getEnemyName(campaign.getYear()));
     	contract.setSharesPct((Integer)spnShares.getValue());
     	
     	contract.calculatePartsAvailabilityLevel(campaign);
@@ -553,7 +553,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         } else if (source.equals(cbEmployer)) {
         	System.out.println("Setting employer code to " + getCurrentEmployerCode());
         	long time = System.currentTimeMillis();
-    		contract.setEmployerCode(getCurrentEmployerCode(), campaign.getEra());
+    		contract.setEmployerCode(getCurrentEmployerCode(), campaign.getYear());
     		System.out.println("to set employer code: " + (System.currentTimeMillis() - time));
         	time = System.currentTimeMillis();
     		updateEnemies();

--- a/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
@@ -47,7 +47,6 @@ import mekhq.Utilities;
 import mekhq.adapter.SocioIndustrialDataAdapter;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.Climate;
-import mekhq.campaign.universe.Era;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.LifeForm;
 import mekhq.campaign.universe.Planet;
@@ -849,7 +848,7 @@ public class NewPlanetaryEventDialog extends JDialog {
                 factionSet.add(Faction.getFaction(f));
             }
         }
-        factionsButton.setText(Faction.getFactionNames(factionSet, Era.getEra(date.getYear())));
+        factionsButton.setText(Faction.getFactionNames(factionSet, date.getYear()));
         lifeFormField.setSelectedItem(new LifeFormChoice((null != event) ? event.lifeForm : null));
         climateField.setSelectedItem(new ClimateChoice((null != event) ? event.climate : null));
         if((null == event) || (null == event.percentWater)) {

--- a/MekHQ/src/mekhq/gui/view/AtBContractViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBContractViewPanel.java
@@ -212,7 +212,7 @@ public class AtBContractViewPanel extends JPanel {
         pnlStats.add(lblEmployer, gridBagConstraints);
         
         txtEmployer.setName("txtEmployer"); // NOI18N
-        txtEmployer.setText(contract.getEmployerName(campaign.getEra()));
+        txtEmployer.setText(contract.getEmployerName(campaign.getYear()));
         txtEmployer.setEditable(false);
         txtEmployer.setLineWrap(true);
         txtEmployer.setWrapStyleWord(true);
@@ -235,7 +235,7 @@ public class AtBContractViewPanel extends JPanel {
         pnlStats.add(lblEnemy, gridBagConstraints);
         
         txtEnemy.setName("txtEnemy"); // NOI18N
-        txtEnemy.setText(contract.getEnemyName(campaign.getEra()));
+        txtEnemy.setText(contract.getEnemyName(campaign.getYear()));
         txtEnemy.setEditable(false);
         txtEnemy.setLineWrap(true);
         txtEnemy.setWrapStyleWord(true);

--- a/MekHQ/src/mekhq/gui/view/AtBContractViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBContractViewPanel.java
@@ -212,7 +212,7 @@ public class AtBContractViewPanel extends JPanel {
         pnlStats.add(lblEmployer, gridBagConstraints);
         
         txtEmployer.setName("txtEmployer"); // NOI18N
-        txtEmployer.setText(contract.getEmployerName(campaign.getYear()));
+        txtEmployer.setText(contract.getEmployerName(campaign.getGameYear()));
         txtEmployer.setEditable(false);
         txtEmployer.setLineWrap(true);
         txtEmployer.setWrapStyleWord(true);
@@ -235,7 +235,7 @@ public class AtBContractViewPanel extends JPanel {
         pnlStats.add(lblEnemy, gridBagConstraints);
         
         txtEnemy.setName("txtEnemy"); // NOI18N
-        txtEnemy.setText(contract.getEnemyName(campaign.getYear()));
+        txtEnemy.setText(contract.getEnemyName(campaign.getGameYear()));
         txtEnemy.setEditable(false);
         txtEnemy.setLineWrap(true);
         txtEnemy.setWrapStyleWord(true);

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -264,7 +264,7 @@ public class ContractSummaryPanel extends JPanel {
 			mainPanel.add(lblEnemy, gridBagConstraints);
 
 			txtEnemy.setName("txtEnemy"); // NOI18N
-			txtEnemy.setText(((AtBContract)contract).getEnemyName(campaign.getEra()));
+			txtEnemy.setText(((AtBContract)contract).getEnemyName(campaign.getYear()));
 			txtEnemy.setEditable(false);
 			txtEnemy.setLineWrap(true);
 			txtEnemy.setWrapStyleWord(true);

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -264,7 +264,7 @@ public class ContractSummaryPanel extends JPanel {
 			mainPanel.add(lblEnemy, gridBagConstraints);
 
 			txtEnemy.setName("txtEnemy"); // NOI18N
-			txtEnemy.setText(((AtBContract)contract).getEnemyName(campaign.getYear()));
+			txtEnemy.setText(((AtBContract)contract).getEnemyName(campaign.getGameYear()));
 			txtEnemy.setEditable(false);
 			txtEnemy.setLineWrap(true);
 			txtEnemy.setWrapStyleWord(true);


### PR DESCRIPTION
This fixes the errors and problems caused by the recent Era.java change.

startingPlanet
altNamesByEra
eraMods

all moved away from depending on Era.java. First two now based on campaign year instead of Era. I updated the factions.xml data as well.