### PR TITLE
Fix two tech team-related bugs in Campaign Ops reputation calculations

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -323,6 +323,8 @@ public class CampaignOpsReputation extends AbstractUnitRating {
 
     private void updatePersonnelCounts() {
         setNonAdminPersonnelCount(0);
+        technicians = 0;
+
         List<Person> personnelList =
                 new ArrayList<>(getCampaign().getPersonnel());
         for (Person p : personnelList) {
@@ -908,7 +910,7 @@ public class CampaignOpsReputation extends AbstractUnitRating {
                                               getBaTechTeams()));
         out.append("\n").append(String.format(TEMPLATE_CAT, "Astechs:",
                                               technicians * 6,
-                                              getCampaign().getAstechPool()));
+                                              getCampaign().getNumberAstechs()));
         out.append("\n").append(String.format("    %-" + (CATEGORY_LENGTH + 4) +
                                               "s %4d needed / %4d available",
                                               "Admin Support:",

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -988,7 +988,7 @@ public class CampaignOpsReputationTest {
                 "        Mechanics:                    8 needed /    0 available\n" +
                 "            NOTE: Vehicles and Infantry use the same mechanics.\n" +
                 "        BA Techs:                     0 needed /    0 available\n" +
-                "        Astechs:                    168 needed /   84 available\n" +
+                "        Astechs:                     84 needed /   84 available\n" +
                 "    Admin Support:                   20 needed /   10 available\n" +
                 "    Large Craft Crew:\n" +
                 "        All fully crewed.\n" +
@@ -1043,7 +1043,7 @@ public class CampaignOpsReputationTest {
                 "        Mechanics:                    0 needed /    0 available\n" +
                 "            NOTE: Vehicles and Infantry use the same mechanics.\n" +
                 "        BA Techs:                     0 needed /    0 available\n" +
-                "        Astechs:                    168 needed /    0 available\n" +
+                "        Astechs:                      0 needed /    0 available\n" +
                 "    Admin Support:                    0 needed /    0 available\n" +
                 "    Large Craft Crew:\n" +
                 "        All fully crewed.\n" +


### PR DESCRIPTION
1. The technicians count was never reset. updatePersonnelCounts()
adds to that variable, and is called when advancing the day and
(possibly) when making other changes, so the number of astechs
required would increase every day.
2. In getSupportDetails(), the code used getAstechPool() (which
only gets the number of temp astechs) instead of getNumberAstechs()
(which takes into account personnel with the role 'astech').
(Only the display was wrong; the calculation used to actually
determine the rating was correct.)