### PR TITLE
Change Campaign.clearGameData(Entity) to fix Bomb unmounting

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6920,13 +6920,14 @@ public class Campaign implements Serializable, ITechManager {
             m.setCoolingFlawActive(false);
         } else if (entity instanceof Aero) {
             Aero a = (Aero) entity;
+            //This should return an int[] filled with 0's
             int[] bombChoices = a.getBombChoices();
             for (Mounted m : a.getBombs()) {
                 if (!(m.getType() instanceof BombType)) {
                     continue;
                 }
-                if(m.getBaseShotsLeft() == 0) {
-                    bombChoices[BombType.getBombTypeFromInternalName(m.getType().getInternalName())] -= 1;
+                if(m.getBaseShotsLeft() == 1) {
+                    bombChoices[BombType.getBombTypeFromInternalName(m.getType().getInternalName())] += 1;
                 }
             }
             a.setBombChoices(bombChoices);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6920,18 +6920,21 @@ public class Campaign implements Serializable, ITechManager {
             m.setCoolingFlawActive(false);
         } else if (entity instanceof Aero) {
             Aero a = (Aero) entity;
-            //This should return an int[] filled with 0's
-            int[] bombChoices = a.getBombChoices();
-            for (Mounted m : a.getBombs()) {
-                if (!(m.getType() instanceof BombType)) {
-                    continue;
+            List<Mounted> mountedBombs = a.getBombs();
+            if (mountedBombs.size() > 0) {
+                //This should return an int[] filled with 0's
+                int[] bombChoices = a.getBombChoices();
+                for (Mounted m : mountedBombs) {
+                    if (!(m.getType() instanceof BombType)) {
+                        continue;
+                    }
+                    if(m.getBaseShotsLeft() == 1) {
+                        bombChoices[BombType.getBombTypeFromInternalName(m.getType().getInternalName())] += 1;
+                    }
                 }
-                if(m.getBaseShotsLeft() == 1) {
-                    bombChoices[BombType.getBombTypeFromInternalName(m.getType().getInternalName())] += 1;
-                }
+                a.setBombChoices(bombChoices);
+                a.clearBombs();
             }
-            a.setBombChoices(bombChoices);
-            a.clearBombs();
             if(a.isSpheroid()) {
                 entity.setMovementMode(EntityMovementMode.SPHEROID);
             } else {

--- a/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
@@ -35,6 +35,7 @@ import javax.swing.JScrollPane;
 
 import megamek.client.ui.swing.BombChoicePanel;
 import megamek.common.BombType;
+import megamek.common.EquipmentType;
 import megamek.common.IBomber;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.AmmoStorage;
@@ -133,11 +134,19 @@ public class BombsDialog extends JDialog implements ActionListener {
             }
             
             for (int type = 0; type < BombType.B_NUM; type++) {
-                if(newLoadout[type] != 0 && bombCatalog[type] > 0) {
-                    AmmoStorage storedBombs = (AmmoStorage) campaign.getPart(bombCatalog[type]);
-                    storedBombs.changeShots(newLoadout[type]);
-                    if(storedBombs.getShots() == 0) {
-                        campaign.removePart(storedBombs);
+                if (newLoadout[type] != 0) {
+                    //IF there are bombs of this TYPE in the warehouse
+                    if (bombCatalog[type] > 0) {
+                        AmmoStorage storedBombs = (AmmoStorage) campaign.getPart(bombCatalog[type]);
+                        storedBombs.changeShots(newLoadout[type]);
+                        if(storedBombs.getShots() == 0) {
+                            campaign.removePart(storedBombs);
+                        }
+                    //No bombs of this type in warehouse, add bombs
+                    //In this case newLoadout should always be greater than 0, but check to be sure
+                    } else if (bombCatalog[type] == 0 && newLoadout[type] > 0) {
+                        AmmoStorage excessBombs = new AmmoStorage(0, EquipmentType.get(BombType.getBombInternalName(type)), newLoadout[type], campaign);
+                        campaign.addPart(excessBombs, 0);
                     }
                 }
             }


### PR DESCRIPTION
Was previously expecting Aero.bombChoices to keep total bombs loaded on
ASF, bombChoices is now set to 0, corrected bomb unmounting code for
that.

This is the fix for https://github.com/MegaMek/mekhq/issues/488