### PR TITLE
Issue #495: tech roles determine multi-skilled tech team type

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -653,16 +653,16 @@ public class CampaignOpsReputation extends AbstractUnitRating {
                 break;
             }
 
-            if (tech.getSkill(SkillType.S_TECH_MECH) != null) {
+            if (tech.getPrimaryRole() == Person.T_MECH_TECH && tech.getSkill(SkillType.S_TECH_MECH) != null) {
                 setMechTechTeams(getMechTechTeams() + 1);
                 astechTeams--;
-            } else if (tech.getSkill(SkillType.S_TECH_AERO) != null) {
+            } else if (tech.getPrimaryRole() == Person.T_AERO_TECH && tech.getSkill(SkillType.S_TECH_AERO) != null) {
                 setAeroTechTeams(getAeroTechTeams() + 1);
                 astechTeams--;
-            } else if (tech.getSkill(SkillType.S_TECH_MECHANIC) != null) {
+            } else if (tech.getPrimaryRole() == Person.T_MECHANIC && tech.getSkill(SkillType.S_TECH_MECHANIC) != null) {
                 setMechanicTeams(getMechanicTeams() + 1);
                 astechTeams--;
-            } else if (tech.getSkill(SkillType.S_TECH_BA) != null) {
+            } else if (tech.getPrimaryRole() == Person.T_BA_TECH && tech.getSkill(SkillType.S_TECH_BA) != null) {
                 setBaTechTeams(getBaTechTeams() + 1);
                 astechTeams--;
             } else {

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -653,16 +653,16 @@ public class CampaignOpsReputation extends AbstractUnitRating {
                 break;
             }
 
-            if (tech.getPrimaryRole() == Person.T_MECH_TECH && tech.getSkill(SkillType.S_TECH_MECH) != null) {
+            if ((tech.getPrimaryRole() == Person.T_MECH_TECH || tech.getSecondaryRole() == Person.T_MECH_TECH) && tech.getSkill(SkillType.S_TECH_MECH) != null) {
                 setMechTechTeams(getMechTechTeams() + 1);
                 astechTeams--;
-            } else if (tech.getPrimaryRole() == Person.T_AERO_TECH && tech.getSkill(SkillType.S_TECH_AERO) != null) {
+            } else if ((tech.getPrimaryRole() == Person.T_AERO_TECH || tech.getSecondaryRole() == Person.T_AERO_TECH)  && tech.getSkill(SkillType.S_TECH_AERO) != null) {
                 setAeroTechTeams(getAeroTechTeams() + 1);
                 astechTeams--;
-            } else if (tech.getPrimaryRole() == Person.T_MECHANIC && tech.getSkill(SkillType.S_TECH_MECHANIC) != null) {
+            } else if ((tech.getPrimaryRole() == Person.T_MECHANIC || tech.getSecondaryRole() == Person.T_MECHANIC)  && tech.getSkill(SkillType.S_TECH_MECHANIC) != null) {
                 setMechanicTeams(getMechanicTeams() + 1);
                 astechTeams--;
-            } else if (tech.getPrimaryRole() == Person.T_BA_TECH && tech.getSkill(SkillType.S_TECH_BA) != null) {
+            } else if ((tech.getPrimaryRole() == Person.T_BA_TECH || tech.getSecondaryRole() == Person.T_BA_TECH)  && tech.getSkill(SkillType.S_TECH_BA) != null) {
                 setBaTechTeams(getBaTechTeams() + 1);
                 astechTeams--;
             } else {


### PR DESCRIPTION
i.e., if you have someone with Tech/Mech and Tech/Aero skills, the CamOps reputation method will use their selected role to decide what kind of tech team they have. They still have to have some ranks in the skill to count as a tech of a given type.