### PR TITLE
Fix backwards conditional in common-ancestor marriage check (issue #503)

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1129,7 +1129,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
 		return (
 				!this.equals(p)
 				&& (getAncestorsID() == null
-				|| campaign.getAncestors(getAncestorsID()).checkMutualAncestors(campaign.getAncestors(p.getAncestorsID())))
+				|| !campaign.getAncestors(getAncestorsID()).checkMutualAncestors(campaign.getAncestors(p.getAncestorsID())))
 				&& p.getSpouseID() == null
 				&& getGender() != p.getGender()
 				&& p.getAge(campaign.getCalendar()) > 13


### PR DESCRIPTION
Previously: only characters with common ancestors could marry.
Now: only characters without common ancestors can marry.