### PR TITLE
Fix for Issue #507

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2893,7 +2893,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         //and set it to true when we start up through MHQ
         entity.getCrew().setPiloting(Math.min(Math.max(piloting, 0), 8), 0);
         entity.getCrew().setGunnery(Math.min(Math.max(gunnery, 0), 7), 0);
-        entity.getCrew().setArtillery(Math.min(Math.max(artillery, 7), 8), 0);
+        entity.getCrew().setArtillery(Math.min(Math.max(artillery, 0), 8), 0);
         entity.getCrew().setSize(nCrew);
         entity.getCrew().setMissing(false, 0);
     }
@@ -2943,7 +2943,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         crew.setGunnery(Math.min(Math.max(gunneryMech, 0), 7));
         crew.setPilotingAero(Math.min(Math.max(pilotingAero, 0), 8));
         crew.setGunneryAero(Math.min(Math.max(gunneryAero, 0), 7));
-        entity.getCrew().setArtillery(Math.min(Math.max(artillery, 7), 8), 0);
+        entity.getCrew().setArtillery(Math.min(Math.max(artillery, 0), 8), 0);
         entity.getCrew().setSize(1);
         entity.getCrew().setMissing(false, 0);
     }


### PR DESCRIPTION
Fixes an issue where artillery gunners would show up in MegaMek with an Artillery Skill of 7 at best, even if their actual Artillery skill in MekHQ was better. 

TN modifier remains 7+ for indirect artillery fire, but should no longer be stuck at 14+ base TN when you have a gunner with rank 6 Artillery skill. 