### PR TITLE
Expand discrete portraits feature

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7157,6 +7157,9 @@ public class Campaign implements Serializable, ITechManager {
         if (searchCat_Role.startsWith("Admin/")) {
             searchCat_Role = "Admin/";
         }
+        if (searchCat_Role.endsWith("Tech")) {
+        	searchCat_Role = "Mechanic/";
+        }
         
         while (categories.hasNext()) {
             String category = categories.next();

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7211,7 +7211,7 @@ public class Campaign implements Serializable, ITechManager {
 
         possiblePortraits = getPossibleRandomPortraits(portraits, existingPortraits, searchCat_Gender + searchCat_Role);
 
-        if (possiblePortraits.isEmpty()) {
+        if (possiblePortraits.isEmpty() && !searchCat_RoleGroup.isEmpty()) {
             possiblePortraits = getPossibleRandomPortraits(portraits, existingPortraits, searchCat_Gender + searchCat_RoleGroup);
         }
         if (possiblePortraits.isEmpty()) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7146,7 +7146,10 @@ public class Campaign implements Serializable, ITechManager {
         }
         ArrayList<String> possiblePortraits = new ArrayList<String>();
         Iterator<String> categories = portraits.getCategoryNames();
-        
+
+        // Will search for portraits in the /gender/primaryrole folder first,
+        // and if none are found then /gender/rolegroup, then /gender/combat or
+        // /gender/support, then in /gender.
         String searchCat_Gender = "";
         if (p.getGender() == Person.G_FEMALE) {
             searchCat_Gender += "Female/";
@@ -7154,13 +7157,27 @@ public class Campaign implements Serializable, ITechManager {
             searchCat_Gender += "Male/";
         }
         String searchCat_Role = Person.getRoleDesc(p.getPrimaryRole(), false) + "/";
+        String searchCat_RoleGroup = "";
+        String searchCat_CombatSupport = "";
         if (searchCat_Role.startsWith("Admin/")) {
-            searchCat_Role = "Admin/";
+            searchCat_RoleGroup = "Admin/";
         }
-        if (searchCat_Role.endsWith("Tech")) {
-        	searchCat_Role = "Mechanic/";
+        if (searchCat_Role.endsWith("Tech/") || searchCat_Role.equals("Mechanic/")) {
+            searchCat_RoleGroup = "Tech/";
         }
-        
+        if (searchCat_Role.equals("Medic/") || searchCat_Role.equals("Doctor/")) {
+            searchCat_RoleGroup = "Medical/";
+        }
+        if (searchCat_Role.startsWith("Vessel") || searchCat_Role.equals("Hyperspace Navigator/")) {
+            searchCat_RoleGroup = "Vessel Crew/";
+        }
+
+        if (p.isSupport()) {
+            searchCat_CombatSupport = "Support/";
+        } else {
+            searchCat_CombatSupport = "Combat/";
+        }
+
         while (categories.hasNext()) {
             String category = categories.next();
             if (category.endsWith(searchCat_Gender + searchCat_Role)) {
@@ -7172,6 +7189,41 @@ public class Campaign implements Serializable, ITechManager {
                         continue;
                     }
                     possiblePortraits.add(location);
+                }
+            }
+        }
+
+        if (possiblePortraits.isEmpty()) {
+            categories = portraits.getCategoryNames();
+            while (categories.hasNext()) {
+                String category = categories.next();
+                if (category.endsWith(searchCat_Gender + searchCat_RoleGroup)) {
+                    Iterator<String> names = portraits.getItemNames(category);
+                    while (names.hasNext()) {
+                        String name = names.next();
+                        String location = category + ":" + name;
+                        if (existingPortraits.contains(location)) {
+                            continue;
+                        }
+                        possiblePortraits.add(location);
+                    }
+                }
+            }
+        }
+        if (possiblePortraits.isEmpty()) {
+            categories = portraits.getCategoryNames();
+            while (categories.hasNext()) {
+                String category = categories.next();
+                if (category.endsWith(searchCat_Gender + searchCat_CombatSupport)) {
+                    Iterator<String> names = portraits.getItemNames(category);
+                    while (names.hasNext()) {
+                        String name = names.next();
+                        String location = category + ":" + name;
+                        if (existingPortraits.contains(location)) {
+                            continue;
+                        }
+                        possiblePortraits.add(location);
+                    }
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7178,16 +7178,28 @@ public class Campaign implements Serializable, ITechManager {
         String searchCat_Role = Person.getRoleDesc(p.getPrimaryRole(), false) + "/";
         String searchCat_RoleGroup = "";
         String searchCat_CombatSupport = "";
-        if (searchCat_Role.startsWith("Admin/")) {
+//        if (searchCat_Role.startsWith("Admin/")) {
+        if (p.getPrimaryRole() == Person.T_ADMIN_COM
+                || p.getPrimaryRole() == Person.T_ADMIN_HR
+                || p.getPrimaryRole() == Person.T_ADMIN_LOG
+                || p.getPrimaryRole() == Person.T_ADMIN_TRA) {
             searchCat_RoleGroup = "Admin/";
         }
-        if (searchCat_Role.endsWith("Tech/") || searchCat_Role.equals("Mechanic/")) {
+        //if (searchCat_Role.endsWith("Tech/") || searchCat_Role.equals("Mechanic/")) {
+        if (p.getPrimaryRole() == Person.T_MECHANIC
+                || p.getPrimaryRole() == Person.T_AERO_TECH
+                || p.getPrimaryRole() == Person.T_MECH_TECH
+                || p.getPrimaryRole() == Person.T_BA_TECH) {
             searchCat_RoleGroup = "Tech/";
         }
-        if (searchCat_Role.equals("Medic/") || searchCat_Role.equals("Doctor/")) {
+        if (p.getPrimaryRole() == Person.T_MEDIC
+                || p.getPrimaryRole() == Person.T_DOCTOR) {
             searchCat_RoleGroup = "Medical/";
         }
-        if (searchCat_Role.startsWith("Vessel") || searchCat_Role.equals("Hyperspace Navigator/")) {
+        if (p.getPrimaryRole() == Person.T_SPACE_CREW
+                || p.getPrimaryRole() == Person.T_SPACE_GUNNER
+                || p.getPrimaryRole() == Person.T_SPACE_PILOT
+                || p.getPrimaryRole() == Person.T_NAVIGATOR) {
             searchCat_RoleGroup = "Vessel Crew/";
         }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7126,6 +7126,25 @@ public class Campaign implements Serializable, ITechManager {
         p.addLogEntry(entry);
     }
 
+    public ArrayList<String> getPossibleRandomPortraits (DirectoryItems portraits, ArrayList<String> existingPortraits, String subDir ) {
+        ArrayList<String> possiblePortraits = new ArrayList<String>();
+        Iterator<String> categories = portraits.getCategoryNames();
+        while (categories.hasNext()) {
+            String category = categories.next();
+            if (category.endsWith(subDir)) {
+                Iterator<String> names = portraits.getItemNames(category);
+                while (names.hasNext()) {
+                    String name = names.next();
+                    String location = category + ":" + name;
+                    if (existingPortraits.contains(location)) {
+                        continue;
+                    }
+                    possiblePortraits.add(location);
+                }
+            }
+        }
+        return possiblePortraits;
+    }
     public void assignRandomPortraitFor(Person p) {
         // first create a list of existing portait strings, so we can check for
         // duplicates
@@ -7178,71 +7197,16 @@ public class Campaign implements Serializable, ITechManager {
             searchCat_CombatSupport = "Combat/";
         }
 
-        while (categories.hasNext()) {
-            String category = categories.next();
-            if (category.endsWith(searchCat_Gender + searchCat_Role)) {
-                Iterator<String> names = portraits.getItemNames(category);
-                while (names.hasNext()) {
-                    String name = names.next();
-                    String location = category + ":" + name;
-                    if (existingPortraits.contains(location)) {
-                        continue;
-                    }
-                    possiblePortraits.add(location);
-                }
-            }
-        }
+        possiblePortraits = getPossibleRandomPortraits(portraits, existingPortraits, searchCat_Gender + searchCat_Role);
 
         if (possiblePortraits.isEmpty()) {
-            categories = portraits.getCategoryNames();
-            while (categories.hasNext()) {
-                String category = categories.next();
-                if (category.endsWith(searchCat_Gender + searchCat_RoleGroup)) {
-                    Iterator<String> names = portraits.getItemNames(category);
-                    while (names.hasNext()) {
-                        String name = names.next();
-                        String location = category + ":" + name;
-                        if (existingPortraits.contains(location)) {
-                            continue;
-                        }
-                        possiblePortraits.add(location);
-                    }
-                }
-            }
+            possiblePortraits = getPossibleRandomPortraits(portraits, existingPortraits, searchCat_Gender + searchCat_RoleGroup);
         }
         if (possiblePortraits.isEmpty()) {
-            categories = portraits.getCategoryNames();
-            while (categories.hasNext()) {
-                String category = categories.next();
-                if (category.endsWith(searchCat_Gender + searchCat_CombatSupport)) {
-                    Iterator<String> names = portraits.getItemNames(category);
-                    while (names.hasNext()) {
-                        String name = names.next();
-                        String location = category + ":" + name;
-                        if (existingPortraits.contains(location)) {
-                            continue;
-                        }
-                        possiblePortraits.add(location);
-                    }
-                }
-            }
+            possiblePortraits = getPossibleRandomPortraits(portraits, existingPortraits, searchCat_Gender + searchCat_CombatSupport);
         }
         if (possiblePortraits.isEmpty()) {
-            categories = portraits.getCategoryNames();
-            while (categories.hasNext()) {
-                String category = categories.next();
-                if (category.endsWith(searchCat_Gender)) {
-                    Iterator<String> names = portraits.getItemNames(category);
-                    while (names.hasNext()) {
-                        String name = names.next();
-                        String location = category + ":" + name;
-                        if (existingPortraits.contains(location)) {
-                            continue;
-                        }
-                        possiblePortraits.add(location);
-                    }
-                }
-            }
+            possiblePortraits = getPossibleRandomPortraits(portraits, existingPortraits, searchCat_Gender);
         }
         if (!possiblePortraits.isEmpty()) {
             String chosenPortrait = possiblePortraits.get(Compute

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7178,14 +7178,12 @@ public class Campaign implements Serializable, ITechManager {
         String searchCat_Role = Person.getRoleDesc(p.getPrimaryRole(), false) + "/";
         String searchCat_RoleGroup = "";
         String searchCat_CombatSupport = "";
-//        if (searchCat_Role.startsWith("Admin/")) {
         if (p.getPrimaryRole() == Person.T_ADMIN_COM
                 || p.getPrimaryRole() == Person.T_ADMIN_HR
                 || p.getPrimaryRole() == Person.T_ADMIN_LOG
                 || p.getPrimaryRole() == Person.T_ADMIN_TRA) {
             searchCat_RoleGroup = "Admin/";
         }
-        //if (searchCat_Role.endsWith("Tech/") || searchCat_Role.equals("Mechanic/")) {
         if (p.getPrimaryRole() == Person.T_MECHANIC
                 || p.getPrimaryRole() == Person.T_AERO_TECH
                 || p.getPrimaryRole() == Person.T_MECH_TECH

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7126,7 +7126,7 @@ public class Campaign implements Serializable, ITechManager {
         p.addLogEntry(entry);
     }
 
-    public ArrayList<String> getPossibleRandomPortraits (DirectoryItems portraits, ArrayList<String> existingPortraits, String subDir ) {
+    private ArrayList<String> getPossibleRandomPortraits (DirectoryItems portraits, ArrayList<String> existingPortraits, String subDir ) {
         ArrayList<String> possiblePortraits = new ArrayList<String>();
         Iterator<String> categories = portraits.getCategoryNames();
         while (categories.hasNext()) {
@@ -7221,8 +7221,7 @@ public class Campaign implements Serializable, ITechManager {
             possiblePortraits = getPossibleRandomPortraits(portraits, existingPortraits, searchCat_Gender);
         }
         if (!possiblePortraits.isEmpty()) {
-            String chosenPortrait = possiblePortraits.get(Compute
-                                                                  .randomInt(possiblePortraits.size()));
+            String chosenPortrait = possiblePortraits.get(Compute.randomInt(possiblePortraits.size()));
             String[] temp = chosenPortrait.split(":");
             if (temp.length != 2) {
                 return;

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -816,7 +816,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                 break;
             case CMD_RANDOM_PORTRAIT:
                 for (Person person: people) {
-                    if (!person.getPortraitFileName().equals(Crew.PORTRAIT_NONE)) {
+                    if (person.getPortraitFileName().equals(Crew.PORTRAIT_NONE)) {
                         gui.getCampaign().assignRandomPortraitFor(person);
                         gui.getCampaign().personUpdated(person);
                         MekHQ.triggerEvent(new PersonChangedEvent(person));


### PR DESCRIPTION
As per #280, expanding on PR#481 this adds a layered fallback approach to random portraits: first look into a folder matching the person's primary role, then if no valid unused pictures exist check the "group" folder (Admin/, Tech/, etc.), then Combat/ or Support/, and then just the gendered folders.