### PR TITLE
Implements #526: option to auto-randomize portrait on job change

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -225,6 +225,7 @@ public class CampaignOptions implements Serializable {
 
     //random portraits related
     private boolean[] usePortraitForType;
+    private boolean assignPortraitOnRoleChange;
 
     //Against the Bot related
     private boolean useAtB;
@@ -348,6 +349,7 @@ public class CampaignOptions implements Serializable {
             usePortraitForType[i] = false;
         }
         usePortraitForType[Person.T_MECHWARRIOR] = true;
+        assignPortraitOnRoleChange = false;
         idleXP = 0;
         targetIdleXP = 10;
         monthsIdleXP = 2;
@@ -1089,6 +1091,14 @@ public class CampaignOptions implements Serializable {
             return;
         }
         usePortraitForType[type] = b;
+    }
+
+    public boolean getAssignPortraitOnRoleChange() {
+        return assignPortraitOnRoleChange;
+    }
+
+    public void setAssignPortraitOnRoleChange(boolean b) {
+        assignPortraitOnRoleChange = b;
     }
 
     public int getIdleXP() {
@@ -2152,6 +2162,7 @@ public class CampaignOptions implements Serializable {
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "contractMarketReportRefresh", contractMarketReportRefresh);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "unitMarketReportRefresh", unitMarketReportRefresh);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "startGameDelay", startGameDelay);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "assignPortraitOnRoleChange", assignPortraitOnRoleChange);
 
         //Mass Repair/Salvage Options
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairUseExtraTime", massRepairUseExtraTime);
@@ -2467,6 +2478,8 @@ public class CampaignOptions implements Serializable {
                         retVal.usePortraitForType[i] = Boolean.parseBoolean(values[i].trim());
                     }
                 }
+            } else if (wn2.getNodeName().equalsIgnoreCase("assignPortraitOnRoleChange")) {
+                retVal.assignPortraitOnRoleChange = Boolean.parseBoolean(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("destroyByMargin")) {
                 retVal.destroyByMargin = Boolean.parseBoolean(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("destroyMargin")) {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -231,6 +231,11 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                 for (Person person : people) {
                     person.setPrimaryRole(role);
                     gui.getCampaign().personUpdated(person);
+                    if (gui.getCampaign().getCampaignOptions().usePortraitForType(role)
+                            && gui.getCampaign().getCampaignOptions().getAssignPortraitOnRoleChange()
+                            && person.getPortraitFileName().equals(Crew.PORTRAIT_NONE)) {
+                        gui.getCampaign().assignRandomPortraitFor(person);
+                    }
                 }
                 break;
             case CMD_SECONDARY_ROLE:

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -201,6 +201,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
     private JCheckBox usePeacetimeCostBox;
     private JCheckBox useExtendedPartsModifierBox;
     private JCheckBox showPeacetimeCostBox;
+    private JCheckBox chkAssignPortraitOnRoleChange;
 
     private JTextField[] txtSalaryBase;
     private JSpinner[] spnSalaryXp;
@@ -488,6 +489,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         usePeacetimeCostBox.setSelected(options.usePeacetimeCost());
         useExtendedPartsModifierBox.setSelected(options.useExtendedPartsModifier());
         showPeacetimeCostBox.setSelected(options.showPeacetimeCost());
+        chkAssignPortraitOnRoleChange.setSelected(options.getAssignPortraitOnRoleChange());
 
         useDamageMargin.setSelected(options.isDestroyByMargin());
         useQualityMaintenance.setSelected(options.useQualityMaintenance());
@@ -586,6 +588,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         usePeacetimeCostBox = new JCheckBox();
         useExtendedPartsModifierBox = new JCheckBox();
         showPeacetimeCostBox = new JCheckBox();
+        chkAssignPortraitOnRoleChange = new JCheckBox();
         sellUnitsBox = new JCheckBox();
         sellPartsBox = new JCheckBox();
         useQuirksBox = new JCheckBox();
@@ -3029,7 +3032,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
         panRandomPortrait.add(panUsePortrait, BorderLayout.CENTER);
         JTextArea txtPortraitInst = new JTextArea(resourceMap.getString("txtPortraitInst.text"));
-        txtPortraitInst.setPreferredSize(new Dimension(728, 50));
+        txtPortraitInst.setPreferredSize(new Dimension(728, 60));
         txtPortraitInst.setEditable(false);
         txtPortraitInst.setLineWrap(true);
         txtPortraitInst.setWrapStyleWord(true);
@@ -3048,6 +3051,16 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         gridBagConstraints.insets = new Insets(10, 0, 0, 0);
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         panNameGen.add(panRandomPortrait, gridBagConstraints);
+
+        chkAssignPortraitOnRoleChange.setText(resourceMap.getString("chkAssignPortraitOnRoleChange.text"));
+        chkAssignPortraitOnRoleChange.setToolTipText(resourceMap.getString("chkAssignPortraitOnRoleChange.toolTipText"));
+        chkAssignPortraitOnRoleChange.setName("chkAssignPortraitOnRoleChange");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 4;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        panNameGen.add(chkAssignPortraitOnRoleChange, gridBagConstraints);
+        // assignPortraitOnRoleChange
 
         tabOptions.addTab(resourceMap.getString("panNameGen.TabConstraints.tabTitle"), panNameGen); // NOI18N
 
@@ -4384,6 +4397,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         options.setUsePeacetimeCost(usePeacetimeCostBox.isSelected());
         options.setUseExtendedPartsModifier(useExtendedPartsModifierBox.isSelected());
         options.setShowPeacetimeCost(showPeacetimeCostBox.isSelected());
+        options.setAssignPortraitOnRoleChange(chkAssignPortraitOnRoleChange.isSelected());
 
         options.setEquipmentContractBase(btnContractEquipment.isSelected());
         options.setEquipmentContractPercent((Double) spnEquipPercent.getModel().getValue());

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -2947,6 +2947,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
         tabOptions.addTab(resourceMap.getString("panRank.TabConstraints.tabTitle"), panRank); // NOI18N
 
+        // Name and Portraits tab controls below
         panNameGen.setName("panNameGen"); // NOI18N
         panNameGen.setLayout(new java.awt.GridBagLayout());
 
@@ -2962,7 +2963,8 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 0;
+        int gridy = 0;
+        gridBagConstraints.gridy = gridy;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
@@ -2973,7 +2975,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         lblFactionNames.setName("lblFactionNames"); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridy = ++gridy;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         panNameGen.add(lblFactionNames, gridBagConstraints);
 
@@ -2990,7 +2992,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         comboFactionNames.setEnabled(!useFactionForNamesBox.isSelected());
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridy = gridy;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         panNameGen.add(comboFactionNames, gridBagConstraints);
 
@@ -2998,7 +3000,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         lblGender.setName("lblGender"); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridy = ++gridy;
         gridBagConstraints.insets = new Insets(10, 0, 0, 0);
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         panNameGen.add(lblGender, gridBagConstraints);
@@ -3011,7 +3013,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         sldGender.setValue(campaign.getRNG().getPercentFemale());
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridy = gridy;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new Insets(10, 0, 0, 0);
         panNameGen.add(sldGender, gridBagConstraints);
@@ -3045,7 +3047,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridy = ++gridy;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         gridBagConstraints.insets = new Insets(10, 0, 0, 0);
@@ -3057,7 +3059,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         chkAssignPortraitOnRoleChange.setName("chkAssignPortraitOnRoleChange");
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 4;
+        gridBagConstraints.gridy = ++gridy;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         panNameGen.add(chkAssignPortraitOnRoleChange, gridBagConstraints);
         // assignPortraitOnRoleChange

--- a/MekHQ/src/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/src/mekhq/resources/CampaignOptionsDialog.properties
@@ -293,3 +293,5 @@ chkContractMarketReportRefresh.text=Display a report when contract market refres
 chkUnitMarketReportRefresh.text=Display a report when unit market refreshes
 chkCapturePrisoners.text=Capture Prisoners in Scenarios
 chkCapturePrisoners.toolTipText=If checked, you will have the opportunity to capture prisoners when resolving scenarios
+chkAssignPortraitOnRoleChange.text=Automatically assign portrait on role change
+chkAssignPortraitOnRoleChange.toolTipText=With this enabled, a person without a portrait will automatically gain a random portrait when their primary role is switched to one of those selected below


### PR DESCRIPTION
When the new option is enabled in the Name and Portraits tab, any personnel with no current portrait whose primary role is changed to one that is selected for random portraits in the same options will automatically gain a random portrait. Discussed with scJazz and this solve #526.