### PR TITLE
Unit rating fixup

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1176,6 +1176,10 @@ public class Campaign implements Serializable, ITechManager {
         return personnel;
     }
 
+    /**
+     * Provides a filtered list of personnel including only active Persons.
+     * @return ArrayList<Person>
+     */
     public ArrayList<Person> getActivePersonnel() {
         ArrayList<Person> activePersonnel = new ArrayList<Person>();
         for (Person p : getPersonnel()) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1176,6 +1176,14 @@ public class Campaign implements Serializable, ITechManager {
         return personnel;
     }
 
+    public ArrayList<Person> getActivePersonnel() {
+        ArrayList<Person> activePersonnel = new ArrayList<Person>();
+        for (Person p : getPersonnel()) {
+            if (p.isActive()) {activePersonnel.add(p);}
+        }
+        return activePersonnel;
+    }
+
     public ArrayList<Ancestors> getAncestors() {
         return ancestors;
     }

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -328,13 +328,15 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         List<Person> personnelList =
                 new ArrayList<>(getCampaign().getPersonnel());
         for (Person p : personnelList) {
-            if (p.isAdmin() || p.isDoctor()) {
-                continue;
+            if (p.isActive()) {
+                if (p.isAdmin() || p.isDoctor()) {
+                    continue;
+                }
+                if (p.isTech()) {
+                    technicians++;
+                }
+                setNonAdminPersonnelCount(getNonAdminPersonnelCount() + 1);
             }
-            if (p.isTech()) {
-                technicians++;
-            }
-            setNonAdminPersonnelCount(getNonAdminPersonnelCount() + 1);
         }
         setNonAdminPersonnelCount(getNonAdminPersonnelCount() +
                                   getCampaign().getAstechPool());

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -326,17 +326,15 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         technicians = 0;
 
         List<Person> personnelList =
-                new ArrayList<>(getCampaign().getPersonnel());
+                new ArrayList<>(getCampaign().getActivePersonnel());
         for (Person p : personnelList) {
-            if (p.isActive()) {
-                if (p.isAdmin() || p.isDoctor()) {
-                    continue;
-                }
-                if (p.isTech()) {
-                    technicians++;
-                }
-                setNonAdminPersonnelCount(getNonAdminPersonnelCount() + 1);
+            if (p.isAdmin() || p.isDoctor()) {
+                continue;
             }
+            if (p.isTech()) {
+                technicians++;
+            }
+            setNonAdminPersonnelCount(getNonAdminPersonnelCount() + 1);
         }
         setNonAdminPersonnelCount(getNonAdminPersonnelCount() +
                                   getCampaign().getAstechPool());

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -321,7 +321,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         int numSquads = new BigDecimal(activePersonnel.size())
                 .divide(new BigDecimal(7), 0,
                         RoundingMode.DOWN).intValue();
-        int leftOver = getCampaign().getPersonnel().size() - (numSquads * 7);
+        int leftOver = activePersonnel.size() - (numSquads * 7);
 
         medSupportNeeded = (numSquads * 4) +
                            (3 + (new BigDecimal(leftOver).divide(
@@ -346,7 +346,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
                 (p.getSecondaryRole() == Person.T_ADMIN_LOG)) {
                 continue;
             }
-            personnelCount++;
+            if (p.isActive()) { personnelCount++; }
         }
         int totalSupport = personnelCount + getTechSupportNeeded() +
                            dropJumpShipSupportNeeded;

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -146,15 +146,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         final String METHOD_NAME = "updateAvailableSupport()";
 
         getLogger().methodCalled(getClass(), METHOD_NAME);
-        for (Person p : getCampaign().getPersonnel()) {
-            getLogger().log(getClass(), METHOD_NAME, LogLevel.DEBUG,
-                            "Checking " + p.getName());
-            if (!p.isActive()) {
-                getLogger().log(getClass(), METHOD_NAME, LogLevel.DEBUG,
-                                "Person, " + p.getName() +
-                                ", is not active.");
-                continue;
-            }
+        for (Person p : getCampaign().getActivePersonnel()) {
             if (p.isTech()) {
                 updateTechSupportHours(p);
             } else if (p.isDoctor()) {
@@ -315,13 +307,10 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
     //   3 + (4/5) = 3 + 0.8 = 3.8 = 4 hours.
     //   total = 16 hours.
     private void calcMedicalSupportHoursNeeded() {
-        ArrayList<Person> activePersonnel = new ArrayList<>();
-        // Only count active personnel. Dead or absent people don't need medical support. >.>
-        for (Person p : getCampaign().getPersonnel()) { if (p.isActive()) { activePersonnel.add(p); } }
-        int numSquads = new BigDecimal(activePersonnel.size())
+        int numSquads = new BigDecimal(getCampaign().getActivePersonnel().size())
                 .divide(new BigDecimal(7), 0,
                         RoundingMode.DOWN).intValue();
-        int leftOver = activePersonnel.size() - (numSquads * 7);
+        int leftOver = getCampaign().getActivePersonnel().size() - (numSquads * 7);
 
         medSupportNeeded = (numSquads * 4) +
                            (3 + (new BigDecimal(leftOver).divide(
@@ -335,7 +324,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
 
     private void calcAdminSupportHoursNeeded() {
         int personnelCount = 0;
-        for (Person p : getCampaign().getPersonnel()) {
+        for (Person p : getCampaign().getActivePersonnel()) {
             if ((p.getPrimaryRole() == Person.T_ADMIN_TRA) ||
                 (p.getPrimaryRole() == Person.T_ADMIN_COM) ||
                 (p.getPrimaryRole() == Person.T_ADMIN_LOG) ||
@@ -346,7 +335,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
                 (p.getSecondaryRole() == Person.T_ADMIN_LOG)) {
                 continue;
             }
-            if (p.isActive()) { personnelCount++; }
+            personnelCount++;
         }
         int totalSupport = personnelCount + getTechSupportNeeded() +
                            dropJumpShipSupportNeeded;

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -22,6 +22,7 @@ package mekhq.campaign.rating;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.Map;
 
 import megamek.common.Aero;
@@ -314,7 +315,10 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
     //   3 + (4/5) = 3 + 0.8 = 3.8 = 4 hours.
     //   total = 16 hours.
     private void calcMedicalSupportHoursNeeded() {
-        int numSquads = new BigDecimal(getCampaign().getPersonnel().size())
+        ArrayList<Person> activePersonnel = new ArrayList<>();
+        // Only count active personnel. Dead or absent people don't need medical support. >.>
+        for (Person p : getCampaign().getPersonnel()) { if (p.isActive()) { activePersonnel.add(p); } }
+        int numSquads = new BigDecimal(activePersonnel.size())
                 .divide(new BigDecimal(7), 0,
                         RoundingMode.DOWN).intValue();
         int leftOver = getCampaign().getPersonnel().size() - (numSquads * 7);

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -307,10 +307,11 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
     //   3 + (4/5) = 3 + 0.8 = 3.8 = 4 hours.
     //   total = 16 hours.
     private void calcMedicalSupportHoursNeeded() {
-        int numSquads = new BigDecimal(getCampaign().getActivePersonnel().size())
+        int activePersonnelCount = getCampaign().getActivePersonnel().size();
+        int numSquads = new BigDecimal(activePersonnelCount)
                 .divide(new BigDecimal(7), 0,
                         RoundingMode.DOWN).intValue();
-        int leftOver = getCampaign().getActivePersonnel().size() - (numSquads * 7);
+        int leftOver = activePersonnelCount - (numSquads * 7);
 
         medSupportNeeded = (numSquads * 4) +
                            (3 + (new BigDecimal(leftOver).divide(

--- a/MekHQ/src/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/src/mekhq/resources/CampaignGUI.properties
@@ -189,8 +189,8 @@ customizeMenu.removeIndividualCamo.text=Remove individual camo
 # For Overview Panel
 scrollOverviewParts.TabConstraints.tabTitle=Parts In Use
 scrollOverviewParts.TabConstraints.toolTipText=Detailed breakdown of all parts in use by all of your assets
-scrollOverviewDragoonsRating.TabConstraints.tabTitle=Dragoons Rating
-scrollOverviewDragoonsRating.TabConstraints.toolTipText=Detailed breakdown of the Dragoons Rating if your unit is a Mercenary group
+scrollOverviewDragoonsRating.TabConstraints.tabTitle=Unit Rating
+scrollOverviewDragoonsRating.TabConstraints.toolTipText=Detailed breakdown of the Unit Rating if your unit is a Mercenary group
 scrollOverviewHangar.TabConstraints.tabTitle=Hangar Breakdown
 scrollOverviewHangar.TabConstraints.toolTipText=Detailed breakdown of all your Hangar assets
 scrollOverviewPersonnel.TabConstraints.tabTitle=Personnel Breakdown

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -70,6 +70,7 @@ public class CampaignOpsReputationTest {
     private Campaign mockCampaign = mock(Campaign.class);
     private ArrayList<Unit> unitList = new ArrayList<>();
     private ArrayList<Person> personnelList = new ArrayList<>();
+    private ArrayList<Person> activePersonnelList = new ArrayList<>();
     private ArrayList<Mission> missionList = new ArrayList<>();
 
     // Mothballed units.
@@ -204,6 +205,7 @@ public class CampaignOpsReputationTest {
         mockCampaign = mock(Campaign.class);
         unitList = new ArrayList<>();
         personnelList = new ArrayList<>();
+        activePersonnelList = new ArrayList<>();
         missionList = new ArrayList<>();
         infantryPersonnel = new HashSet<>(28);
         seekerCrew = new HashSet<>(20);
@@ -731,11 +733,15 @@ public class CampaignOpsReputationTest {
             regularAdmins.add(admin);
         }
         personnelList.addAll(regularAdmins);
+        for (Person p : personnelList) {
+            if (p.isActive()) { activePersonnelList.add(p); }
+        }
 
         when(mockFinances.isInDebt()).thenReturn(false);
 
         doReturn(unitList).when(mockCampaign).getCopyOfUnits();
         doReturn(personnelList).when(mockCampaign).getPersonnel();
+        doReturn(activePersonnelList).when(mockCampaign).getActivePersonnel();
         doReturn(astechs).when(mockCampaign).getAstechPool();
         doCallRealMethod().when(mockCampaign).getNumberAstechs();
         doCallRealMethod().when(mockCampaign).getNumberPrimaryAstechs();
@@ -817,6 +823,7 @@ public class CampaignOpsReputationTest {
     private void buildFreshCampaign() {
         doReturn(new ArrayList<Unit>(0)).when(mockCampaign).getCopyOfUnits();
         doReturn(new ArrayList<Person>(0)).when(mockCampaign).getPersonnel();
+        doReturn(new ArrayList<Person>(0)).when(mockCampaign).getActivePersonnel();
         doReturn(new ArrayList<Person>(0)).when(mockCampaign).getAdmins();
         doReturn(new ArrayList<Person>(0)).when(mockCampaign).getTechs();
         doReturn(new ArrayList<Person>(0)).when(mockCampaign).getDoctors();

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -761,14 +761,14 @@ public class CampaignOpsReputationTest {
         assertEquals(8, spyReputation.getVeeCount());
         assertEquals(0, spyReputation.getBattleArmorCount());
         assertEquals(28, spyReputation.getInfantryCount());
-        assertEquals(200, spyReputation.getNonAdminPersonnelCount());
+        assertEquals(98, spyReputation.getNonAdminPersonnelCount());
         assertEquals(1, spyReputation.getDropshipCount());
         BigDecimalAssert.assertEquals(expectedTotalSkill, spyReputation.getTotalSkillLevels(), 2);
         assertEquals(4, spyReputation.getMechTechTeamsNeeded());
         assertEquals(2, spyReputation.getAeroTechTeamsNeeded());
         assertEquals(8, spyReputation.getMechanicTeamsNeeded());
         assertEquals(0, spyReputation.getBattleArmorTechTeamsNeeded());
-        assertEquals(20, spyReputation.getAdminsNeeded());
+        assertEquals(10, spyReputation.getAdminsNeeded());
         assertEquals(expectedAverageSkill, spyReputation.calcAverageExperience());
         assertEquals(10, spyReputation.getExperienceValue());
 
@@ -782,14 +782,14 @@ public class CampaignOpsReputationTest {
         assertEquals(8, spyReputation.getVeeCount());
         assertEquals(0, spyReputation.getBattleArmorCount());
         assertEquals(28, spyReputation.getInfantryCount());
-        assertEquals(200, spyReputation.getNonAdminPersonnelCount());
+        assertEquals(98, spyReputation.getNonAdminPersonnelCount());
         assertEquals(1, spyReputation.getDropshipCount());
         BigDecimalAssert.assertEquals(expectedTotalSkill, spyReputation.getTotalSkillLevels(), 2);
         assertEquals(4, spyReputation.getMechTechTeamsNeeded());
         assertEquals(2, spyReputation.getAeroTechTeamsNeeded());
         assertEquals(8, spyReputation.getMechanicTeamsNeeded());
         assertEquals(0, spyReputation.getBattleArmorTechTeamsNeeded());
-        assertEquals(20, spyReputation.getAdminsNeeded());
+        assertEquals(10, spyReputation.getAdminsNeeded());
         assertEquals(expectedAverageSkill, spyReputation.calcAverageExperience());
         assertEquals(10, spyReputation.getExperienceValue());
 
@@ -892,7 +892,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testGetSupportValue() {
         spyReputation.initValues();
-        assertEquals(-10, spyReputation.getSupportValue());
+        assertEquals(-5, spyReputation.getSupportValue());
 
         // Test a brand new campaign.
         buildFreshCampaign();
@@ -914,7 +914,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testCalculateUnitRatingScore() {
         spyReputation.initValues();
-        assertEquals(28, spyReputation.calculateUnitRatingScore());
+        assertEquals(33, spyReputation.calculateUnitRatingScore());
 
         // Test a brand new campaign.
         buildFreshCampaign();
@@ -925,7 +925,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testGetReputationModifier() {
         spyReputation.initValues();
-        assertEquals(2, spyReputation.getModifier());
+        assertEquals(3, spyReputation.getModifier());
 
         // Test a brand new campaign.
         buildFreshCampaign();
@@ -949,7 +949,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testGetDetails() {
         String expectedDetails =
-                "Unit Reputation:    28\n" +
+                "Unit Reputation:    33\n" +
                 "    Method: Campaign Operations\n" +
                 "\n" +
                 "Experience:          10\n" +
@@ -980,7 +980,7 @@ public class CampaignOpsReputationTest {
                 "    Has Jumpships?             Yes\n" +
                 "    Has Warships?               No\n" +
                 "\n" +
-                "Support:            -10\n" +
+                "Support:             -5\n" +
                 "    Tech Support:\n" +
                 "        Mech Techs:                   4 needed /    0 available\n" +
                 "            NOTE: Protomechs and mechs use same techs.\n" +
@@ -989,7 +989,7 @@ public class CampaignOpsReputationTest {
                 "            NOTE: Vehicles and Infantry use the same mechanics.\n" +
                 "        BA Techs:                     0 needed /    0 available\n" +
                 "        Astechs:                     84 needed /   84 available\n" +
-                "    Admin Support:                   20 needed /   10 available\n" +
+                "    Admin Support:                   10 needed /   10 available\n" +
                 "    Large Craft Crew:\n" +
                 "        All fully crewed.\n" +
                 "\n" +

--- a/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
@@ -47,6 +47,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
@@ -61,7 +62,8 @@ public class FieldManualMercRevDragoonsRatingTest {
 
     private Campaign mockCampaign = mock(Campaign.class);
 
-    private ArrayList<Person> mockPersonnnelList = new ArrayList<>();
+    private ArrayList<Person> mockPersonnelList = new ArrayList<>();
+    private ArrayList<Person> mockActivePersonnelList = new ArrayList<>();
 
     private Person mockDoctor = mock(Person.class);
     private Person mockTech = mock(Person.class);
@@ -100,10 +102,13 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockMedicSkill.getExperienceLevel()).thenReturn(SkillType.EXP_REGULAR);
         when(mockAstechSkill.getExperienceLevel()).thenReturn(SkillType.EXP_REGULAR);
 
-        mockPersonnnelList.add(mockDoctor);
-        mockPersonnnelList.add(mockTech);
+        mockPersonnelList.add(mockDoctor);
+        mockPersonnelList.add(mockTech);
+        mockActivePersonnelList.add(mockDoctor);
+        mockActivePersonnelList.add(mockTech);
 
-        when(mockCampaign.getPersonnel()).thenReturn(mockPersonnnelList);
+        when(mockCampaign.getPersonnel()).thenReturn(mockPersonnelList);
+        when(mockCampaign.getActivePersonnel()).thenReturn(mockActivePersonnelList);
         when(mockCampaign.getNumberMedics()).thenCallRealMethod();
         when(mockCampaign.getNumberAstechs()).thenCallRealMethod();
         when(mockCampaign.getNumberPrimaryAstechs()).thenCallRealMethod();
@@ -125,7 +130,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(TechConstants.T_INTRO_BOXSET).when(mockWaspE).getTechLevel();
         doReturn(20.0).when(mockWaspE).getWeight();
         Person waspPilot = mock(Person.class);
-        mockPersonnnelList.add(waspPilot);
+        mockPersonnelList.add(waspPilot);
         doReturn(waspPilot).when(mockWasp).getCommander();
         Crew waspCrew = mock(Crew.class);
         doReturn(4).when(waspCrew).getGunnery();
@@ -139,7 +144,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(20.0).when(mockStingerE).getWeight();
         doReturn(mockStingerE).when(mockStinger).getEntity();
         Person stingerPilot = mock(Person.class);
-        mockPersonnnelList.add(stingerPilot);
+        mockPersonnelList.add(stingerPilot);
         doReturn(stingerPilot).when(mockStinger).getCommander();
         Crew stingerCrew = mock(Crew.class);
         doReturn(4).when(stingerCrew).getGunnery();
@@ -156,7 +161,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(65.0).when(mockThunderboltE).getWeight();
         doReturn(mockThunderboltE).when(mockThunderbolt).getEntity();
         Person thunderboltPilot = mock(Person.class);
-        mockPersonnnelList.add(thunderboltPilot);
+        mockPersonnelList.add(thunderboltPilot);
         doReturn(thunderboltPilot).when(mockThunderbolt).getCommander();
         Crew thunderboltCrew = mock(Crew.class);
         doReturn(thunderboltCrew).when(mockThunderboltE).getCrew();
@@ -170,7 +175,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(TechConstants.T_INTRO_BOXSET).when(mockShrekE).getTechLevel();
         doReturn(mockShrekE).when(mockShrek).getEntity();
         Person shrekCommander = mock(Person.class);
-        mockPersonnnelList.add(shrekCommander);
+        mockPersonnelList.add(shrekCommander);
         doReturn(shrekCommander).when(mockShrek).getCommander();
         Crew shrekCrew = mock(Crew.class);
         doReturn(shrekCrew).when(mockShrekE).getCrew();
@@ -184,7 +189,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(TechConstants.T_INTRO_BOXSET).when(mockShrek2E).getTechLevel();
         doReturn(mockShrek2E).when(mockShrek2).getEntity();
         Person shrek2Commander = mock(Person.class);
-        mockPersonnnelList.add(shrek2Commander);
+        mockPersonnelList.add(shrek2Commander);
         doReturn(shrek2Commander).when(mockShrek2).getCommander();
         Crew shrek2Crew = mock(Crew.class);
         doReturn(shrek2Crew).when(mockShrek2E).getCrew();
@@ -198,7 +203,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(TechConstants.T_IS_TW_NON_BOX).when(mockHarasserE).getTechLevel();
         doReturn(mockHarasserE).when(mockHarasser).getEntity();
         Person harasserCommander = mock(Person.class);
-        mockPersonnnelList.add(harasserCommander);
+        mockPersonnelList.add(harasserCommander);
         doReturn(harasserCommander).when(mockHarasser).getCommander();
         Crew harasserCrew = mock(Crew.class);
         doReturn(harasserCrew).when(mockHarasserE).getCrew();
@@ -212,7 +217,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(TechConstants.T_IS_TW_NON_BOX).when(mockHarasser2E).getTechLevel();
         doReturn(mockHarasser2E).when(mockHarasser2).getEntity();
         Person harasser2Commander = mock(Person.class);
-        mockPersonnnelList.add(harasser2Commander);
+        mockPersonnelList.add(harasser2Commander);
         doReturn(harasser2Commander).when(mockHarasser2).getCommander();
         Crew harasser2Crew = mock(Crew.class);
         doReturn(harasser2Crew).when(mockHarasser2E).getCrew();
@@ -226,7 +231,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(50.0).when(mockLightingE).getWeight();
         doReturn(mockLightingE).when(mockLightning).getEntity();
         Person lightningPilot = mock(Person.class);
-        mockPersonnnelList.add(lightningPilot);
+        mockPersonnelList.add(lightningPilot);
         doReturn(lightningPilot).when(mockLightning).getCommander();
         Crew lightningCrew = mock(Crew.class);
         doReturn(lightningCrew).when(mockLightingE).getCrew();
@@ -240,7 +245,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(50.0).when(mockLighting2E).getWeight();
         doReturn(mockLighting2E).when(mockLightning2).getEntity();
         Person lightning2Pilot = mock(Person.class);
-        mockPersonnnelList.add(lightning2Pilot);
+        mockPersonnelList.add(lightning2Pilot);
         doReturn(lightning2Pilot).when(mockLightning2).getCommander();
         Crew lightning2Crew = mock(Crew.class);
         doReturn(lightning2Crew).when(mockLighting2E).getCrew();
@@ -254,7 +259,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(3600.0).when(mockUnionE).getWeight();
         doReturn(mockUnionE).when(mockUnion).getEntity();
         Person unionCommander = mock(Person.class);
-        mockPersonnnelList.add(unionCommander);
+        mockPersonnelList.add(unionCommander);
         doReturn(unionCommander).when(mockUnion).getCommander();
         Crew unionCrew = mock(Crew.class);
         doReturn(unionCrew).when(mockUnionE).getCrew();
@@ -272,7 +277,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(152000.0).when(mockInvaderE).getWeight();
         doReturn(mockInvaderE).when(mockInvader).getEntity();
         Person invaderCommander = mock(Person.class);
-        mockPersonnnelList.add(invaderCommander);
+        mockPersonnelList.add(invaderCommander);
         doReturn(invaderCommander).when(mockInvader).getCommander();
         Crew invaderCrew = mock(Crew.class);
         doReturn(invaderCrew).when(mockInvaderE).getCrew();
@@ -323,7 +328,8 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockMechwarrior.isDeployed()).thenReturn(false);
         when(mockMechwarrior.getSkill(eq(SkillType.S_DOCTOR))).thenReturn(mockDoctorSkillGreen);
         when(mockMechwarrior.hasSkill(eq(SkillType.S_DOCTOR))).thenReturn(true);
-        mockPersonnnelList.add(mockMechwarrior);
+        mockPersonnelList.add(mockMechwarrior);
+        mockActivePersonnelList.add(mockMechwarrior);
         expectedHours += 15;
         testFieldManuMercRevDragoonsRating.updateAvailableSupport();
         assertEquals(expectedHours, testFieldManuMercRevDragoonsRating.getMedicalSupportAvailable());
@@ -337,7 +343,8 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockMedic.isDeployed()).thenReturn(false);
         when(mockMedic.getSkill(eq(SkillType.S_MEDTECH))).thenReturn(mockMedicSkill);
         when(mockMedic.hasSkill(eq(SkillType.S_MEDTECH))).thenReturn(true);
-        mockPersonnnelList.add(mockMedic);
+        mockPersonnelList.add(mockMedic);
+        mockActivePersonnelList.add(mockMedic);
         expectedHours += 20;
         testFieldManuMercRevDragoonsRating.updateAvailableSupport();
         assertEquals(expectedHours, testFieldManuMercRevDragoonsRating.getMedicalSupportAvailable());
@@ -369,7 +376,8 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockMechwarrior.isDeployed()).thenReturn(false);
         when(mockMechwarrior.getSkill(eq(SkillType.S_TECH_MECH))).thenReturn(mockMechTechSkillRegular);
         when(mockMechwarrior.hasSkill(eq(SkillType.S_TECH_MECH))).thenReturn(true);
-        mockPersonnnelList.add(mockMechwarrior);
+        mockPersonnelList.add(mockMechwarrior);
+        mockActivePersonnelList.add(mockMechwarrior);
         expectedHours += 20;
         testFieldManuMercRevDragoonsRating.updateAvailableSupport();
         assertEquals(expectedHours, testFieldManuMercRevDragoonsRating.getTechSupportHours());
@@ -384,7 +392,8 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockAstech.isDeployed()).thenReturn(false);
         when(mockAstech.getSkill(eq(SkillType.S_ASTECH))).thenReturn(mockAstechSkill);
         when(mockAstech.hasSkill(eq(SkillType.S_ASTECH))).thenReturn(true);
-        mockPersonnnelList.add(mockAstech);
+        mockPersonnelList.add(mockAstech);
+        mockActivePersonnelList.add(mockAstech);
         expectedHours += 20;
         testFieldManuMercRevDragoonsRating.updateAvailableSupport();
         assertEquals(expectedHours, testFieldManuMercRevDragoonsRating.getTechSupportHours());
@@ -419,6 +428,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockCampaign.getFlaggedCommander()).thenReturn(null);
         doReturn(commandList).when(testRating).getCommanderList();
         when(expectedCommander.isActive()).thenReturn(false);
+        mockActivePersonnelList.remove(expectedCommander);
         when(leftennant.getExperienceLevel(anyBoolean())).thenReturn(SkillType.EXP_VETERAN);
         when(leftennant.isActive()).thenReturn(true);
         when(leftennant2.getExperienceLevel(anyBoolean())).thenReturn(SkillType.EXP_REGULAR);


### PR DESCRIPTION
Fix for #510, making Dragoons Rating medical support requirement count only active personnel. 

Also makes CamOps reputation admin support requirement count only active personnel.

Also renames the "Dragoons Rating" panel in the Overview tab to "Unit Rating" for consistency, as requested in #519. 