### PR TITLE
getPersonnel() usage cleanup pass

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1176,6 +1176,10 @@ public class Campaign implements Serializable, ITechManager {
         return personnel;
     }
 
+    /**
+     * Provides a filtered list of personnel including only active Persons.
+     * @return ArrayList<Person>
+     */
     public ArrayList<Person> getActivePersonnel() {
         ArrayList<Person> activePersonnel = new ArrayList<Person>();
         for (Person p : getPersonnel()) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1176,6 +1176,14 @@ public class Campaign implements Serializable, ITechManager {
         return personnel;
     }
 
+    public ArrayList<Person> getActivePersonnel() {
+        ArrayList<Person> activePersonnel = new ArrayList<Person>();
+        for (Person p : getPersonnel()) {
+            if (p.isActive()) {activePersonnel.add(p);}
+        }
+        return activePersonnel;
+    }
+
     public ArrayList<Ancestors> getAncestors() {
         return ancestors;
     }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1634,7 +1634,8 @@ public class Campaign implements Serializable, ITechManager {
         int patients = 0;
         for (Person person : getPersonnel()) {
             if (null != person.getDoctorId()
-                && person.getDoctorId().equals(doctor.getId())) {
+                    && person.getDoctorId().equals(doctor.getId())
+                    && person.isActive()) {
                 patients++;
             }
         }

--- a/MekHQ/src/mekhq/campaign/handler/XPHandler.java
+++ b/MekHQ/src/mekhq/campaign/handler/XPHandler.java
@@ -49,7 +49,7 @@ public class XPHandler {
             return;
         }
         for (Person person : campaign.getPersonnel()) {
-            if (person.isAdminPrimary()) {
+            if (person.isAdminPrimary() && person.isActive()) {
                 if(adminXPPeriod > 1) {
                     Integer weeksLeft = person.getExtraData().get(NEXT_ADMIN_XP_DELAY);
                     if(null == weeksLeft) {

--- a/MekHQ/src/mekhq/campaign/handler/XPHandler.java
+++ b/MekHQ/src/mekhq/campaign/handler/XPHandler.java
@@ -48,8 +48,8 @@ public class XPHandler {
         if((adminXP <= 0) || (campaign.getCalendar().get(Calendar.DAY_OF_WEEK) != Calendar.MONDAY)) {
             return;
         }
-        for (Person person : campaign.getPersonnel()) {
-            if (person.isAdminPrimary() && person.isActive()) {
+        for (Person person : campaign.getAdmins()) {
+            if (person.isAdminPrimary()) {
                 if(adminXPPeriod > 1) {
                     Integer weeksLeft = person.getExtraData().get(NEXT_ADMIN_XP_DELAY);
                     if(null == weeksLeft) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3646,7 +3646,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     }
 
     public int getNumShares(boolean sharesForAll) {
-    	if (isPrisoner() || isBondsman()) {
+    	if (isPrisoner() || isBondsman() || !isActive()) {
     		return 0;
     	}
     	if (!sharesForAll && primaryRole != T_MECHWARRIOR &&

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -116,7 +116,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
 		}
 		int totalShares = 0;
 		for (Person p : campaign.getPersonnel()) {
-			totalShares += p.getNumShares(campaign.getCampaignOptions().getSharesForAll());
+			if (p.isActive()) { totalShares += p.getNumShares(campaign.getCampaignOptions().getSharesForAll()); }
 		}
 		return netWorth / totalShares;
 	}

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -115,8 +115,8 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
             MekHQ.getLogger().log(RetirementDefectionTracker.class, METHOD_NAME, e);
 		}
 		int totalShares = 0;
-		for (Person p : campaign.getPersonnel()) {
-			if (p.isActive()) { totalShares += p.getNumShares(campaign.getCampaignOptions().getSharesForAll()); }
+		for (Person p : campaign.getActivePersonnel()) {
+			totalShares += p.getNumShares(campaign.getCampaignOptions().getSharesForAll());
 		}
 		return netWorth / totalShares;
 	}

--- a/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
@@ -300,7 +300,7 @@ public class NewContractDialog extends javax.swing.JDialog {
         cboNegotiator.setName("cboNegotiator");
         // Add negotiators
         for (Person p : campaign.getPersonnel()) {
-            if (p.hasSkill(SkillType.S_NEG)) {
+            if (p.hasSkill(SkillType.S_NEG) && p.isActive()) {
                 cboNegotiator.addItem(p);
             }
         }

--- a/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
@@ -299,8 +299,8 @@ public class NewContractDialog extends javax.swing.JDialog {
 
         cboNegotiator.setName("cboNegotiator");
         // Add negotiators
-        for (Person p : campaign.getPersonnel()) {
-            if (p.hasSkill(SkillType.S_NEG) && p.isActive()) {
+        for (Person p : campaign.getActivePersonnel()) {
+            if (p.hasSkill(SkillType.S_NEG)) {
                 cboNegotiator.addItem(p);
             }
         }


### PR DESCRIPTION
This goes over a few places where Campaign.getPersonnel() was used and the calling method implicitly assumed it was querying active personnel. I've added checks to make sure those places are only counting active persons.