### PR TITLE
Fixed issue with campaign options dialog numbering.

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -1585,12 +1585,12 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
         chkUseTransfers = new JCheckBox("Log Saver - Use Reassign instead of Remove/Assign"); // NOI18N
         chkUseTransfers.setSelected(options.useTransfers());
-        gridBagConstraints.gridy++;
+        gridBagConstraints.gridy = 22;
         panPersonnel.add(chkUseTransfers, gridBagConstraints);
 
         chkUseTimeInService = new JCheckBox("Track Time In Service"); // NOI18N
         chkUseTimeInService.setSelected(options.getUseTimeInService());
-        gridBagConstraints.gridy = 22;
+        gridBagConstraints.gridy = 23;
         panPersonnel.add(chkUseTimeInService, gridBagConstraints);
 
         JPanel panSalary = new JPanel(new GridBagLayout());


### PR DESCRIPTION
This affected options in the personnel tab that would keep the Time in Service option from showing up. The issue was caused by another PR being merged around the same time that also dealt with the numbering in the section fixed.