### PR TITLE
Fix issue misusing edge rerolls on automatic success tasks

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2128,7 +2128,7 @@ public class Campaign implements Serializable, ITechManager {
             if ((getCampaignOptions().isDestroyByMargin()
                         && getCampaignOptions().getDestroyMargin() <= (target.getValue() - roll))
                     || (!getCampaignOptions().isDestroyByMargin() && (tech.getExperienceLevel(false) == SkillType.EXP_ELITE //if an elite, primary tech and destroy by margin is NOT on
-                            || tech.getPrimaryRole() == 12)) //For vessel crews
+                            || tech.getPrimaryRole() == Person.T_SPACE_CREW)) //For vessel crews
                         && roll < target.getValue()) {
                 tech.setEdge(tech.getEdge() - 1);
                 if (tech.isRightTechTypeFor(partWork)) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2123,11 +2123,12 @@ public class Campaign implements Serializable, ITechManager {
         //if we fail and would break a part, here's a chance to use Edge for a reroll...
         if (getCampaignOptions().useSupportEdge() 
                 && tech.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_BREAK_PART)
-                && tech.getEdge() > 0) {
+                && tech.getEdge() > 0
+                && target.getValue() != TargetRoll.AUTOMATIC_SUCCESS) {
             if ((getCampaignOptions().isDestroyByMargin()
                         && getCampaignOptions().getDestroyMargin() <= (target.getValue() - roll))
-                    || (tech.getExperienceLevel(false) == SkillType.EXP_ELITE //if an elite, primary tech
-                            || tech.getPrimaryRole() == 12) //For vessel crews
+                    || (!getCampaignOptions().isDestroyByMargin() && (tech.getExperienceLevel(false) == SkillType.EXP_ELITE //if an elite, primary tech and destroy by margin is NOT on
+                            || tech.getPrimaryRole() == 12)) //For vessel crews
                         && roll < target.getValue()) {
                 tech.setEdge(tech.getEdge() - 1);
                 if (tech.isRightTechTypeFor(partWork)) {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1906,7 +1906,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                     menu = new JMenu(resourceMap.getString("setEdgeTriggers.text")); //$NON-NLS-1$
                     //Start of role-specific Edge reroll options
                     //Mechwarriors
-                    if (person.getPrimaryRole() == 1) {
+                    if (person.getPrimaryRole() == Person.T_MECHWARRIOR) {
                         cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerHeadHits.text")); //$NON-NLS-1$
                         cbMenuItem.setSelected(person.getOptions()
                                 .booleanOption(OPT_EDGE_HEADHIT));
@@ -1939,7 +1939,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                         cbMenuItem.addActionListener(this);
                         menu.add(cbMenuItem);
                     //Doctors    
-                    } else if (person.getPrimaryRole() == 20 && gui.getCampaign().getCampaignOptions().useSupportEdge()) {
+                    } else if (person.getPrimaryRole() == Person.T_DOCTOR && gui.getCampaign().getCampaignOptions().useSupportEdge()) {
                         cbMenuItem = new JCheckBoxMenuItem(
                                 resourceMap.getString("edgeTriggerHealCheck.text")); //$NON-NLS-1$
                         cbMenuItem.setSelected(person.getOptions()
@@ -1948,11 +1948,11 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                         cbMenuItem.addActionListener(this);
                         menu.add(cbMenuItem);
                     //Techs
-                    } else if ((person.getPrimaryRole() == 12
-                                || person.getPrimaryRole() == 15
-                                || person.getPrimaryRole() == 16
-                                || person.getPrimaryRole() == 17
-                                || person.getPrimaryRole() == 18)
+                    } else if ((person.getPrimaryRole() == Person.T_SPACE_CREW
+                                || person.getPrimaryRole() == Person.T_MECH_TECH
+                                || person.getPrimaryRole() == Person.T_MECHANIC
+                                || person.getPrimaryRole() == Person.T_AERO_TECH
+                                || person.getPrimaryRole() == Person.T_BA_TECH)
                                 && gui.getCampaign().getCampaignOptions().useSupportEdge()) {
                         cbMenuItem = new JCheckBoxMenuItem(
                                 resourceMap.getString("edgeTriggerBreakPart.text")); //$NON-NLS-1$
@@ -1969,10 +1969,10 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                         cbMenuItem.addActionListener(this);
                         menu.add(cbMenuItem);
                     //Admins
-                    } else if ((person.getPrimaryRole() == 22
-                            || person.getPrimaryRole() == 23
-                            || person.getPrimaryRole() == 24
-                            || person.getPrimaryRole() == 25) 
+                    } else if ((person.getPrimaryRole() == Person.T_ADMIN_COM
+                            || person.getPrimaryRole() == Person.T_ADMIN_LOG
+                            || person.getPrimaryRole() == Person.T_ADMIN_TRA
+                            || person.getPrimaryRole() == Person.T_ADMIN_HR) 
                             && gui.getCampaign().getCampaignOptions().useSupportEdge()) {
                         cbMenuItem = new JCheckBoxMenuItem(
                                 resourceMap.getString("edgeTriggerAcquireCheck.text")); //$NON-NLS-1$


### PR DESCRIPTION
Fixes a couple of extra support edge issues I noticed in playtesting - Elite techs were consuming edge on auto-success tasks like loading ammo and tasks with a smaller MoF than the set break part value. 