### PR TITLE
Fix for issue #592

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4243,7 +4243,7 @@ public class Campaign implements Serializable, ITechManager {
         for (int x = 0; x < retVal.units.size(); x++) {
             Unit unit = retVal.units.get(x);
             // just in case parts are missing (i.e. because they weren't tracked
-            // in previous versions)
+            // in previous versions)            
             unit.initializeParts(true);
             unit.runDiagnostic(false);
             if (!unit.isRepairable()) {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2267,6 +2267,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                         bayPartsToAdd.get(bay.getBayNumber()).add(cubicle);
                         addPart(cubicle);
                         partsToAdd.add(cubicle);
+                        cubicles.add(cubicle);
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -754,7 +754,7 @@ public class Planet implements Serializable {
     private static Set<Faction> getFactionsFrom(Collection<String> codes) {
         Set<Faction> factions = new HashSet<Faction>(codes.size());
         for(String code : codes) {
-            factions.add(Faction.getFaction(code));
+            factions.add(Faction.getFaction(code.toUpperCase()));
         }
         return factions;
     }

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -492,6 +492,12 @@ public class RandomFactionGenerator implements Serializable {
 		}
 		for (Planet planetKey : Planets.getInstance().getNearbyPlanets(p, distance)) {
 			for (Faction f2 : planetKey.getFactionSet(Utilities.getDateTimeDay(lastUpdate))) {
+			    if(f2 == null) {
+			        MekHQ.getLogger().log(this.getClass(), "RandomFactionGenerator.UpdateBorders", 
+			                LogLevel.ERROR, "Invalid faction code in planets.xml: " + f2);
+			        continue;
+			    }
+			    
 				String eName = f2.getShortName();
 				if (eName.equals("ABN") ||
 						eName.equals("UND") ||


### PR DESCRIPTION
Fixed out of memory bug due to adding endless cubicles when loading game with infantry transport capable dropship.

The actual error was a problem loading a faction whose name was specified in lower case for some reason.
  