### PR TITLE
Custom spa

### DIFF
--- a/MekHQ/data/universe/customspa.xml
+++ b/MekHQ/data/universe/customspa.xml
@@ -12,11 +12,14 @@
     <!ENTITY    CHOICE      "4">
 ]>
 
+     
 <options>
+<!-- Examples customs of custom abilities. See docs/custom_spa.txt for
+     more information
+
     <option name="tetris_master">
         <group>&L3;</group>
         <type>&CHOICE;</type>
-        <default>false</default>
     </option>
     
     <option name="edge_paper_cut">
@@ -28,4 +31,6 @@
         <group>&AUGMENTATION;</group>
         <type>&BOOLEAN;</type>
     </option>
+-->
+
 </options>

--- a/MekHQ/data/universe/customspa.xml
+++ b/MekHQ/data/universe/customspa.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE doc [
+    <!ENTITY    L3              "lvl3Advantages">
+    <!ENTITY    EDGE            "edgeAdvantages">
+    <!ENTITY    AUGMENTATION    "MDAdvantages">
+
+    <!ENTITY    BOOLEAN     "0">
+    <!ENTITY    STRING      "3">
+]>
+
+<options>
+    <option name="envelope_pusher">
+        <group>&L3;</group>
+        <type>&BOOLEAN;</type>
+        <default>false</default>
+    </option>
+    
+    <option name="edge_paper_cut">
+        <group>&EDGE;</group>
+        <type>&BOOLEAN;</type>
+        <default>false</default>
+    </option>
+    
+    <option name="md_prosthetic_blowtorch">
+        <group>&AUGMENTATION;</group>
+        <type>&BOOLEAN;</type>
+        <default>false</default>
+    </option>
+</options>

--- a/MekHQ/data/universe/customspa.xml
+++ b/MekHQ/data/universe/customspa.xml
@@ -6,25 +6,26 @@
     <!ENTITY    AUGMENTATION    "MDAdvantages">
 
     <!ENTITY    BOOLEAN     "0">
+    <!ENTITY    INT         "1">
+    <!ENTITY    FLOAT       "2">
     <!ENTITY    STRING      "3">
+    <!ENTITY    CHOICE      "4">
 ]>
 
 <options>
-    <option name="envelope_pusher">
+    <option name="tetris_master">
         <group>&L3;</group>
-        <type>&BOOLEAN;</type>
+        <type>&CHOICE;</type>
         <default>false</default>
     </option>
     
     <option name="edge_paper_cut">
         <group>&EDGE;</group>
         <type>&BOOLEAN;</type>
-        <default>false</default>
     </option>
     
     <option name="md_prosthetic_blowtorch">
         <group>&AUGMENTATION;</group>
         <type>&BOOLEAN;</type>
-        <default>false</default>
     </option>
 </options>

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -332,7 +332,8 @@
 		<desc>Failed acquisition check will be rerolled with edge.</desc>
 	</edgeTrigger>
 
-<!-- customs -->
+<!-- Example entries corresponding to the examples in customspa.xml
+     See docs/custom_spa.txt
 	
 	<ability>
 		<lookupName>tetris_master</lookupName>
@@ -364,6 +365,7 @@
             <skill>Tech/Vessel</skill>
         </skillPrereq>
 	</implant>
+-->
 	
 </abilities>
 

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -335,14 +335,15 @@
 <!-- customs -->
 	
 	<ability>
-		<lookupName>envelope_pusher</lookupName>
-		<displayName>Envelope Pusher</displayName>
+		<lookupName>tetris_master</lookupName>
+		<displayName>Tetris Master</displayName>
 		<xpCost>4</xpCost>
 		<weight>2</weight>
         <skillPrereq>
-            <skill>Hyperspace Navigation</skill>
+            <skill>Administration</skill>
         </skillPrereq>
-        <desc>Increase the maximum range of a hyperspace jump</desc>
+        <desc>Increase the capacity of a cargo or transport bay.</desc>
+        <choiceValues>None::Cargo::Mech::Vehicle::Fighter::Infantry</choiceValues>
 	</ability>
 	
 	<edgeTrigger>

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -308,6 +308,17 @@
     	</skillPrereq>
 	</ability>
 	
+	<ability>
+		<lookupName>envelope_pusher</lookupName>
+		<displayName>Envelope Pusher</displayName>
+		<xpCost>4</xpCost>
+		<weight>2</weight>
+        <skillPrereq>
+            <skill>Hyperspace Navigation</skill>
+        </skillPrereq>
+        <desc>Increase the maximum range of a hyperspace jump</desc>
+	</ability>
+	
 	<edgeTrigger>
 		<lookupName>edge_when_heal_crit_fail</lookupName>
 		<displayName>Use Edge for doctor critical failure.</displayName>
@@ -331,7 +342,14 @@
 		<displayName>Use Edge for acquisition failure.</displayName>
 		<desc>Failed acquisition check will be rerolled with edge.</desc>
 	</edgeTrigger>
+
+<!-- customs -->
 	
+	<edgeTrigger>
+	    <lookupName>edge_paper_cut</lookupName>
+	    <displayName>Use Edge to avoid paper cut.</displayName>
+	    <desc>A paper cut injury check will be rerolled with edge.</desc>
+	</edgeTrigger>
 </abilities>
 
 <!--  

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -308,17 +308,6 @@
     	</skillPrereq>
 	</ability>
 	
-	<ability>
-		<lookupName>envelope_pusher</lookupName>
-		<displayName>Envelope Pusher</displayName>
-		<xpCost>4</xpCost>
-		<weight>2</weight>
-        <skillPrereq>
-            <skill>Hyperspace Navigation</skill>
-        </skillPrereq>
-        <desc>Increase the maximum range of a hyperspace jump</desc>
-	</ability>
-	
 	<edgeTrigger>
 		<lookupName>edge_when_heal_crit_fail</lookupName>
 		<displayName>Use Edge for doctor critical failure.</displayName>
@@ -345,11 +334,36 @@
 
 <!-- customs -->
 	
+	<ability>
+		<lookupName>envelope_pusher</lookupName>
+		<displayName>Envelope Pusher</displayName>
+		<xpCost>4</xpCost>
+		<weight>2</weight>
+        <skillPrereq>
+            <skill>Hyperspace Navigation</skill>
+        </skillPrereq>
+        <desc>Increase the maximum range of a hyperspace jump</desc>
+	</ability>
+	
 	<edgeTrigger>
 	    <lookupName>edge_paper_cut</lookupName>
 	    <displayName>Use Edge to avoid paper cut.</displayName>
 	    <desc>A paper cut injury check will be rerolled with edge.</desc>
 	</edgeTrigger>
+	
+	<implant>
+	    <lookupName>md_prosthetic_blowtorch</lookupName>
+	    <displayName>Prosthetic Blowtorch</displayName>
+	    <desc>Reduce repair times by 10%</desc>
+        <skillPrereq>
+            <skill>Tech/Mech</skill>
+            <skill>Tech/Mechanic</skill>
+            <skill>Tech/Aero</skill>
+            <skill>Tech/BA</skill>
+            <skill>Tech/Vessel</skill>
+        </skillPrereq>
+	</implant>
+	
 </abilities>
 
 <!--  

--- a/MekHQ/docs/custom_spa.txt
+++ b/MekHQ/docs/custom_spa.txt
@@ -1,0 +1,34 @@
+Custom SPAs
+
+MekHQ supports unofficial extensions to the SPA (special pilot abilities) system used in MegaMek.
+This allows support personnel to spend XP to gain special abilities used in their duties (though in
+this context SPA should probably mean "special personnel abilities) as well allowing them to set
+triggers to spend edge points to reroll critical failed skill checks in critical situations. At the
+time of writing, the only custom SPA is Clan tech knowledge, which allows Inner Sphere techs to work
+on Clan equipment without penalty. There are also edge triggers for part breaking parts during repair
+for techs, failed healing checks for doctors, and failed acquisition rolls for administrators (or whichever
+role acquires parts in the campaign).
+
+There is also a means for players to add their own custom SPAs, edge triggers, and implants. At the time
+of writing there are no actual in-game effects of custom SPAs, and they are provided for book-keeping
+purposes. MekHQ can manage the bookkeeping of spending XP and tracking which personnel have acquired
+the special ability, but it is up the player to manage the effects. There are plans to add plugin module
+support to MekHQ at some point in the future, and plugins can be designed to apply the effects of the SPA.
+Note that without a plugin system edge triggers have no practical purpose and were included with the
+eventual availability of plugins in mind.
+
+To add an SPA, edge trigger, or implant, an entry must be made in the data/universe/customspa.xml file.
+The distributed file has a comment section showing one example of each type. The minimum required for the
+entry to work is a unique value for the name attribute. Xml entities are provided for all legal values
+of the group and type nodes. The group should be set to &L3; for spas, &EDGE; for edge triggers, or
+&AUGMENTATION; for implants. If the group is not set it defaults to &L3;. In most cases the type should be
+set to &BOOLEAN:, which is the default and indicates an spa that is either set or not. The second most common
+is &CHOICE;, which is for an SPA that can be set to one of a list of available values. The actual values will
+be provided in the next step.
+
+Adding to customspa.xml will add the option to the hard-coded options, but just as with the hard-coded options
+it still needs an entry in defaultspa.xml to provide XP costs, display name, and description used
+by MekHQ. This is done as for any other SPA, or HQ-specific edge triggers and implants. The one addition
+is that custom SPAs of type CHOICE should list all the possible settings in a <choiceValues> node using
+two colons as a separator between values. The defaultspa.xml has a comment section showing the entries
+corresponding to the examples in customspa.xml at the end.

--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -34,6 +34,7 @@ v0.43.7-git
 + Issue #591: Special Abilities can be selected multiple times
 + Issue #577: MRMS does not always use BTH settings
 + Fixed unofficial Clan tech knowledge SPA.
++ Custom SPAs for tracking purposes (see docs/custom_spa.txt).
 
 v0.43.6 (2017-12-22 10:00 UTC)
 + Bug: ClassCastException when loading campaign from earlier versions with large craft with missing ammo bin.

--- a/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
+++ b/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
@@ -124,7 +124,6 @@ public class CustomOption {
         
         try {
             retVal = new CustomOption(key);
-            String defaultText = null;
             NodeList nl = wn.getChildNodes();
 
             for (int x = 0; x < nl.getLength(); x++) {
@@ -133,40 +132,23 @@ public class CustomOption {
                     retVal.group = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("type")) {
                     retVal.type = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("default")) {
-                    defaultText = wn2.getTextContent();
                 }
             }
 
             switch (retVal.type) {
                 case IOption.BOOLEAN:
-                    if (null != defaultText) {
-                        retVal.defaultVal = Boolean.valueOf(defaultText);
-                    } else {
-                        retVal.defaultVal = Boolean.FALSE;
-                    }
+                    retVal.defaultVal = Boolean.FALSE;
                     break;
                 case IOption.INTEGER:
-                    if (null != defaultText) {
-                        retVal.defaultVal = Integer.valueOf(defaultText);
-                    } else {
-                        retVal.defaultVal = new Integer(0);
-                    }
+                    retVal.defaultVal = new Integer(0);
                     break;
                 case IOption.FLOAT:
-                    if (null != defaultText) {
-                        retVal.defaultVal = Float.valueOf(defaultText);
-                    } else {
-                        retVal.defaultVal = new Float(0.0f);
-                    }
+                    retVal.defaultVal = new Float(0.0f);
                     break;
                 case IOption.STRING:
+                case IOption.CHOICE:
                 default:
-                    if (null != defaultText) {
-                        retVal.defaultVal = defaultText;
-                    } else {
-                        retVal.defaultVal = "";
-                    }
+                    retVal.defaultVal = "";
                     break;
             }
         } catch (Exception ex) {

--- a/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
+++ b/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
@@ -1,0 +1,182 @@
+/**
+ * 
+ */
+package mekhq.campaign.personnel;
+
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import megamek.common.logging.LogLevel;
+import megamek.common.options.IOption;
+import megamek.common.options.PilotOptions;
+import mekhq.MekHQ;
+
+/**
+ * Parses custom SPA file and passes data to the PersonnelOption constructor so the custom
+ * abilities are included.
+ * 
+ * @author Neoancient
+ *
+ */
+public class CustomOption {
+    
+    private String name;
+    private String group;
+    private int type;
+    private Object defaultVal;
+    
+    private CustomOption(String key) {
+        this.name = key;
+        group = PilotOptions.LVL3_ADVANTAGES;
+        type = IOption.BOOLEAN;
+        defaultVal = Boolean.FALSE;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public String getGroup() {
+        return group;
+    }
+    
+    public int getType() {
+        return type;
+    }
+    
+    public Object getDefault() {
+        return defaultVal;
+    }
+    
+    public static List<CustomOption> getCustomAbilities() {
+        final String METHOD_NAME = "getCustomAbilities()"; //$NON-NLS-1$
+        List<CustomOption> retVal = new ArrayList<>();
+
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        Document xmlDoc = null;
+
+
+        try {
+            FileInputStream fis = new FileInputStream("data/universe/customspa.xml");
+            // Using factory get an instance of document builder
+            DocumentBuilder db = dbf.newDocumentBuilder();
+
+            // Parse using builder to get DOM representation of the XML file
+            xmlDoc = db.parse(fis);
+        } catch (Exception ex) {
+            MekHQ.getLogger().log(CustomOption.class, METHOD_NAME, ex);
+        }
+
+        Element spaEle = xmlDoc.getDocumentElement();
+        NodeList nl = spaEle.getChildNodes();
+
+        // Get rid of empty text nodes and adjacent text nodes...
+        // Stupid weird parsing of XML.  At least this cleans it up.
+        spaEle.normalize();
+
+        // Okay, lets iterate through the children, eh?
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn = nl.item(x);
+
+            if (wn.getParentNode() != spaEle)
+                continue;
+
+            int xc = wn.getNodeType();
+
+            if (xc == Node.ELEMENT_NODE) {
+                // This is what we really care about.
+                // All the meat of our document is in this node type, at this
+                // level.
+                // Okay, so what element is it?
+                String xn = wn.getNodeName();
+
+                if (xn.equalsIgnoreCase("option")) {
+                    CustomOption option = CustomOption.generateInstanceFromXML(wn);
+                    if (null != option) {
+                        retVal.add(option);
+                    }
+                }
+            }
+        }
+        return retVal;
+    }
+
+    public static CustomOption generateInstanceFromXML(Node wn) {
+        final String METHOD_NAME = "generateInstanceFromXML(Node)"; //$NON-NLS-1$
+
+        CustomOption retVal = null;
+
+        String key = wn.getAttributes().getNamedItem("name").getTextContent();
+        if (null == key) {
+            MekHQ.getLogger().log(CustomOption.class, METHOD_NAME, LogLevel.ERROR,
+                    "Custom ability does not have a 'name' attribute.");
+            return null;
+        }
+        
+        try {
+            retVal = new CustomOption(key);
+            String defaultText = null;
+            NodeList nl = wn.getChildNodes();
+
+            for (int x = 0; x < nl.getLength(); x++) {
+                Node wn2 = nl.item(x);
+                if (wn2.getNodeName().equalsIgnoreCase("group")) {
+                    retVal.group = wn2.getTextContent();
+                } else if (wn2.getNodeName().equalsIgnoreCase("type")) {
+                    retVal.type = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("default")) {
+                    defaultText = wn2.getTextContent();
+                }
+            }
+
+            switch (retVal.type) {
+                case IOption.BOOLEAN:
+                    if (null != defaultText) {
+                        retVal.defaultVal = Boolean.valueOf(defaultText);
+                    } else {
+                        retVal.defaultVal = Boolean.FALSE;
+                    }
+                    break;
+                case IOption.INTEGER:
+                    if (null != defaultText) {
+                        retVal.defaultVal = Integer.valueOf(defaultText);
+                    } else {
+                        retVal.defaultVal = new Integer(0);
+                    }
+                    break;
+                case IOption.FLOAT:
+                    if (null != defaultText) {
+                        retVal.defaultVal = Float.valueOf(defaultText);
+                    } else {
+                        retVal.defaultVal = new Float(0.0f);
+                    }
+                    break;
+                case IOption.STRING:
+                default:
+                    if (null != defaultText) {
+                        retVal.defaultVal = defaultText;
+                    } else {
+                        retVal.defaultVal = "";
+                    }
+                    break;
+            }
+        } catch (Exception ex) {
+            MekHQ.getLogger().log(CustomOption.class, METHOD_NAME, LogLevel.ERROR,
+                    "Error parsing custom ability " + retVal.name);
+        }
+        
+        return retVal;
+    }
+
+    
+
+}

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -70,7 +70,7 @@ public class PersonnelOptions extends PilotOptions {
             // This really shouldn't happen.
             MekHQ.getLogger().log(PersonnelOptions.class, METHOD_NAME,
                     LogLevel.WARNING, "Could not find L3Advantage group"); //$NON-NLS-1$
-            edge = addGroup("adv", PilotOptions.LVL3_ADVANTAGES); // $NON-NLS-1$
+            l3a = addGroup("adv", PilotOptions.LVL3_ADVANTAGES); // $NON-NLS-1$
         }
         if (null == edge) {
             // This really shouldn't happen.
@@ -83,7 +83,7 @@ public class PersonnelOptions extends PilotOptions {
             // This really shouldn't happen.
             MekHQ.getLogger().log(PersonnelOptions.class, METHOD_NAME,
                     LogLevel.WARNING, "Could not find augmentation (MD) group"); //$NON-NLS-1$
-            edge = addGroup("md", PilotOptions.MD_ADVANTAGES); // $NON-NLS-1$
+            md = addGroup("md", PilotOptions.MD_ADVANTAGES); // $NON-NLS-1$
         }
         
         // Add MekHQ-specific options
@@ -99,7 +99,7 @@ public class PersonnelOptions extends PilotOptions {
             if (option.getGroup().equals(PilotOptions.LVL3_ADVANTAGES)) {
                 addOption(l3a, option.getName(), option.getType(), option.getDefault());
             } else if (option.getGroup().equals(PilotOptions.EDGE_ADVANTAGES)) {
-                addOption(l3a, option.getName(), option.getType(), option.getDefault());
+                addOption(edge, option.getName(), option.getType(), option.getDefault());
             } else if (option.getGroup().equals(PilotOptions.MD_ADVANTAGES)) {
                 addOption(md, option.getName(), option.getType(), option.getDefault());
             }
@@ -180,6 +180,8 @@ public class PersonnelOptions extends PilotOptions {
         public String getDisplayableName() {
             if (null != SpecialAbility.getAbility(name)) {
                 return SpecialAbility.getAbility(name).getDisplayName();
+            } else if (null != SpecialAbility.getDefaultAbility(name)) {
+                return SpecialAbility.getDefaultAbility(name).getDisplayName();
             } else if (null != SpecialAbility.getEdgeTrigger(name)) {
                 return SpecialAbility.getEdgeTrigger(name).getDisplayName();
             } else if (null != mmOptions.getOption(name)){
@@ -206,6 +208,8 @@ public class PersonnelOptions extends PilotOptions {
         public String getDescription() {
             if (null != SpecialAbility.getAbility(name)) {
                 return SpecialAbility.getAbility(name).getDescription();
+            } else if (null != SpecialAbility.getDefaultAbility(name)) {
+                return SpecialAbility.getDefaultAbility(name).getDescription();
             } else if (null != SpecialAbility.getEdgeTrigger(name)) {
                 return SpecialAbility.getEdgeTrigger(name).getDescription();
             } else if (null != mmOptions.getOption(name)){

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -178,12 +178,9 @@ public class PersonnelOptions extends PilotOptions {
 
         @Override
         public String getDisplayableName() {
-            if (null != SpecialAbility.getAbility(name)) {
-                return SpecialAbility.getAbility(name).getDisplayName();
-            } else if (null != SpecialAbility.getDefaultAbility(name)) {
-                return SpecialAbility.getDefaultAbility(name).getDisplayName();
-            } else if (null != SpecialAbility.getEdgeTrigger(name)) {
-                return SpecialAbility.getEdgeTrigger(name).getDisplayName();
+            SpecialAbility spa = SpecialAbility.getOption(name);
+            if (null != spa) {
+                return spa.getDisplayName();
             } else if (null != mmOptions.getOption(name)){
                 return mmOptions.getOption(name).getDisplayableName();
             } else {
@@ -193,10 +190,9 @@ public class PersonnelOptions extends PilotOptions {
 
         @Override
         public String getDisplayableNameWithValue() {
-            if (null != SpecialAbility.getAbility(name)) {
-                return SpecialAbility.getAbility(name).getDisplayName();
-            } else if (null != SpecialAbility.getEdgeTrigger(name)) {
-                return SpecialAbility.getEdgeTrigger(name).getDisplayName();
+            SpecialAbility spa = SpecialAbility.getOption(name);
+            if (null != spa) {
+                return spa.getDisplayName();
             } else if (null != mmOptions.getOption(name)){
                 return mmOptions.getOption(name).getDisplayableName();
             } else {
@@ -206,12 +202,9 @@ public class PersonnelOptions extends PilotOptions {
 
         @Override
         public String getDescription() {
-            if (null != SpecialAbility.getAbility(name)) {
-                return SpecialAbility.getAbility(name).getDescription();
-            } else if (null != SpecialAbility.getDefaultAbility(name)) {
-                return SpecialAbility.getDefaultAbility(name).getDescription();
-            } else if (null != SpecialAbility.getEdgeTrigger(name)) {
-                return SpecialAbility.getEdgeTrigger(name).getDescription();
+            SpecialAbility spa = SpecialAbility.getOption(name);
+            if (null != spa) {
+                return spa.getDescription();
             } else if (null != mmOptions.getOption(name)){
                 return mmOptions.getOption(name).getDescription();
             } else {

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -15,6 +15,7 @@ package mekhq.campaign.personnel;
 
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.List;
 
 import megamek.common.logging.LogLevel;
 import megamek.common.options.AbstractOptionsInfo;
@@ -53,12 +54,15 @@ public class PersonnelOptions extends PilotOptions {
 
         IBasicOptionGroup l3a = null;
         IBasicOptionGroup edge = null;
+        IBasicOptionGroup md = null;
         for (Enumeration<IBasicOptionGroup> e = getOptionsInfoImp().getGroups(); e.hasMoreElements(); ) {
             final IBasicOptionGroup group = e.nextElement();
             if ((null == l3a) && group.getKey().equals(PilotOptions.LVL3_ADVANTAGES)) {
                 l3a = group;
             } else if ((null== edge) && group.getKey().equals(PilotOptions.EDGE_ADVANTAGES)) {
                 edge = group;
+            } else if ((null== md) && group.getKey().equals(PilotOptions.MD_ADVANTAGES)) {
+                md = group;
             }
         }
         
@@ -75,6 +79,12 @@ public class PersonnelOptions extends PilotOptions {
             edge = addGroup("edge", PilotOptions.EDGE_ADVANTAGES); // $NON-NLS-1$
             addOption(edge, OptionsConstants.EDGE, 0);
         }
+        if (null == md) {
+            // This really shouldn't happen.
+            MekHQ.getLogger().log(PersonnelOptions.class, METHOD_NAME,
+                    LogLevel.WARNING, "Could not find augmentation (MD) group"); //$NON-NLS-1$
+            edge = addGroup("md", PilotOptions.MD_ADVANTAGES); // $NON-NLS-1$
+        }
         
         // Add MekHQ-specific options
         addOption(l3a, TECH_CLAN_TECH_KNOWLEDGE, false);
@@ -83,6 +93,17 @@ public class PersonnelOptions extends PilotOptions {
         addOption(edge, EDGE_REPAIR_BREAK_PART, false);
         addOption(edge, EDGE_REPAIR_FAILED_REFIT, false);
         addOption(edge, EDGE_ADMIN_ACQUIRE_FAIL, false);
+        
+        List<CustomOption> customs = CustomOption.getCustomAbilities();
+        for (CustomOption option : customs) {
+            if (option.getGroup().equals(PilotOptions.LVL3_ADVANTAGES)) {
+                addOption(l3a, option.getName(), option.getType(), option.getDefault());
+            } else if (option.getGroup().equals(PilotOptions.EDGE_ADVANTAGES)) {
+                addOption(l3a, option.getName(), option.getType(), option.getDefault());
+            } else if (option.getGroup().equals(PilotOptions.MD_ADVANTAGES)) {
+                addOption(md, option.getName(), option.getType(), option.getDefault());
+            }
+        }
     }
 
     /* 

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -71,6 +71,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
     private static Hashtable<String, SpecialAbility> specialAbilities;
     private static Hashtable<String, SpecialAbility> defaultSpecialAbilities;
     private static Hashtable<String, SpecialAbility> edgeTriggers;
+    private static Hashtable<String, SpecialAbility> implants;
 
     private String displayName;
     private String lookupName;
@@ -347,6 +348,8 @@ public class SpecialAbility implements MekHqXmlSerializable {
         
         if (wn.getNodeName().equalsIgnoreCase("edgetrigger")) {
             edgeTriggers.put(retVal.lookupName, retVal);
+        } else if (wn.getNodeName().equalsIgnoreCase("implant")) {
+            implants.put(retVal.lookupName,  retVal);
         } else {
             specialAbilities.put(retVal.lookupName, retVal);
         }
@@ -418,6 +421,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
         final String METHOD_NAME = "initializeSPA()"; //$NON-NLS-1$
         specialAbilities = new Hashtable<>();
         edgeTriggers = new Hashtable<>();
+        implants = new Hashtable<>();
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
@@ -460,7 +464,8 @@ public class SpecialAbility implements MekHqXmlSerializable {
                 String xn = wn.getNodeName();
 
                 if (xn.equalsIgnoreCase("ability")
-                        || xn.equalsIgnoreCase("edgeTrigger")) {
+                        || xn.equalsIgnoreCase("edgeTrigger")
+                        || xn.equalsIgnoreCase("implant")) {
                     SpecialAbility.generateInstanceFromXML(wn, options, null);
                 }
             }
@@ -494,9 +499,35 @@ public class SpecialAbility implements MekHqXmlSerializable {
     public static Hashtable<String, SpecialAbility> getAllEdgeTriggers() {
         return edgeTriggers;
     }
+    
+    public static SpecialAbility getImplant(String name) {
+        return implants.get(name);
+    }
+    
+    public static Hashtable<String, SpecialAbility> getAllImplants() {
+        return implants;
+    }
 
     public static void replaceSpecialAbilities(Hashtable<String, SpecialAbility> spas) {
     	specialAbilities = spas;
+    }
+    
+    public static SpecialAbility getOption(String name) {
+        SpecialAbility retVal = specialAbilities.get(name);
+        if (null != retVal) {
+            return retVal;
+        }
+        if (null != defaultSpecialAbilities) {
+            retVal = defaultSpecialAbilities.get(name);
+            if (null != retVal) {
+                return retVal;
+            }
+        }
+        retVal = edgeTriggers.get(name);
+        if (null != retVal) {
+            return retVal;
+        }
+        return implants.get(name);
     }
 
     public static String chooseWeaponSpecialization(int type, boolean isClan, int techLvl, int year) {

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -477,7 +477,10 @@ public class SpecialAbility implements MekHqXmlSerializable {
     }
 
     public static SpecialAbility getDefaultAbility(String name) {
-        return defaultSpecialAbilities.get(name);
+        if (null != defaultSpecialAbilities) {
+            return defaultSpecialAbilities.get(name);
+        }
+        return null;
     }
 
     public static Hashtable<String, SpecialAbility> getAllDefaultSpecialAbilities() {

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -94,6 +94,9 @@ public class SpecialAbility implements MekHqXmlSerializable {
     //(typically this is a lower value ability on the same chain (e.g. Cluster Hitter removed when you get Cluster Master)
     private Vector<String> removeAbilities;
     
+    // For custom SPAs of type CHOICE the legal values need to be provided.
+    private Vector<String> choiceValues;
+    
     public SpecialAbility() {
         this("unknown");
     }
@@ -109,6 +112,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
         prereqAbilities = new Vector<String>();
         invalidAbilities = new Vector<String>();
         removeAbilities = new Vector<String>();
+        choiceValues = new Vector<>();
         prereqSkills = new Vector<SkillPrereq>();
         prereqMisc = new HashMap<>();
         xpCost = 1;
@@ -125,6 +129,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
     	clone.prereqAbilities = (Vector<String>)this.prereqAbilities.clone();
     	clone.invalidAbilities = (Vector<String>)this.invalidAbilities.clone();
     	clone.removeAbilities = (Vector<String>)this.removeAbilities.clone();
+    	clone.choiceValues = (Vector<String>)this.choiceValues.clone();
     	clone.prereqSkills = (Vector<SkillPrereq>)this.prereqSkills.clone();
     	clone.prereqMisc = new HashMap<>(this.prereqMisc);
     	return clone;
@@ -222,6 +227,14 @@ public class SpecialAbility implements MekHqXmlSerializable {
     public void setRemovedAbilities(Vector<String> remove) {
     	removeAbilities = remove;
     }
+    
+    public Vector<String> getChoiceValues() {
+        return choiceValues;
+    }
+    
+    public void setChoiceValues(Vector<String> values) {
+        choiceValues = values;
+    }
 
     public void clearPrereqSkills() {
         prereqSkills = new Vector<SkillPrereq>();
@@ -266,6 +279,10 @@ public class SpecialAbility implements MekHqXmlSerializable {
                 +"<removeAbilities>"
                 +Utilities.combineString(removeAbilities, "::")
                 +"</removeAbilities>");
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<choiceValues>"
+                +Utilities.combineString(choiceValues, "::")
+                +"</choiceValues>");
         for(SkillPrereq skillpre : prereqSkills) {
             skillpre.writeToXml(pw1, indent+1);
         }
@@ -307,6 +324,8 @@ public class SpecialAbility implements MekHqXmlSerializable {
                     retVal.invalidAbilities = Utilities.splitString(wn2.getTextContent(), "::");
                 } else if (wn2.getNodeName().equalsIgnoreCase("removeAbilities")) {
                     retVal.removeAbilities = Utilities.splitString(wn2.getTextContent(), "::");
+                } else if (wn2.getNodeName().equalsIgnoreCase("choiceValues")) {
+                    retVal.choiceValues = Utilities.splitString(wn2.getTextContent(), "::");
                 } else if (wn2.getNodeName().equalsIgnoreCase("skillPrereq")) {
                     SkillPrereq skill = SkillPrereq.generateInstanceFromXML(wn2);
                     if(!skill.isEmpty()) {
@@ -384,6 +403,8 @@ public class SpecialAbility implements MekHqXmlSerializable {
                     retVal.invalidAbilities = Utilities.splitString(wn2.getTextContent(), "::");
                 } else if (wn2.getNodeName().equalsIgnoreCase("removeAbilities")) {
                     retVal.removeAbilities = Utilities.splitString(wn2.getTextContent(), "::");
+                } else if (wn2.getNodeName().equalsIgnoreCase("choiceValues")) {
+                    retVal.choiceValues = Utilities.splitString(wn2.getTextContent(), "::");
                 } else if (wn2.getNodeName().equalsIgnoreCase("skillPrereq")) {
                     SkillPrereq skill = SkillPrereq.generateInstanceFromXML(wn2);
                     if(!skill.isEmpty()) {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -42,12 +42,15 @@ import megamek.common.EquipmentType;
 import megamek.common.WeaponType;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
+import megamek.common.options.Option;
+import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
 import megamek.common.util.EncodeControl;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.unit.Unit;
 
 /**
@@ -872,7 +875,7 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
         DialogOptionComponent optionComp = new DialogOptionComponent(this,
                 option, editable);
 
-        if ("weapon_specialist".equals(option.getName())) { //$NON-NLS-1$
+        if (OptionsConstants.GUNNERY_WEAPON_SPECIALIST.equals(option.getName())) { //$NON-NLS-1$
             optionComp.addValue("None"); //$NON-NLS-1$
             //holy crap, do we really need to add every weapon?
             for (Enumeration<EquipmentType> i = EquipmentType.getAllTypes(); i.hasMoreElements();) {
@@ -882,32 +885,34 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
                 }
             }
             optionComp.setSelected(option.stringValue());
-        }
-        
-        if ("specialist".equals(option.getName())) { //$NON-NLS-1$
+        } else if (OptionsConstants.GUNNERY_SPECIALIST.equals(option.getName())) { //$NON-NLS-1$
             optionComp.addValue(Crew.SPECIAL_NONE);
             optionComp.addValue(Crew.SPECIAL_ENERGY);
             optionComp.addValue(Crew.SPECIAL_BALLISTIC);
             optionComp.addValue(Crew.SPECIAL_MISSILE);
             optionComp.setSelected(option.stringValue());
-        }
-
-        if ("range_master".equals(option.getName())) { //$NON-NLS-1$
+        } else if (OptionsConstants.GUNNERY_RANGE_MASTER.equals(option.getName())) { //$NON-NLS-1$
             optionComp.addValue(Crew.RANGEMASTER_NONE);
             optionComp.addValue(Crew.RANGEMASTER_MEDIUM);
             optionComp.addValue(Crew.RANGEMASTER_LONG);
             optionComp.addValue(Crew.RANGEMASTER_EXTREME);
             optionComp.addValue(Crew.RANGEMASTER_LOS);
             optionComp.setSelected(option.stringValue());
-        }
-
-        if ("human_tro".equals(option.getName())) { //$NON-NLS-1$
+        } else if (OptionsConstants.MISC_HUMAN_TRO.equals(option.getName())) { //$NON-NLS-1$
             optionComp.addValue(Crew.HUMANTRO_NONE);
             optionComp.addValue(Crew.HUMANTRO_MECH);
             optionComp.addValue(Crew.HUMANTRO_AERO);
             optionComp.addValue(Crew.HUMANTRO_VEE);
             optionComp.addValue(Crew.HUMANTRO_BA);
             optionComp.setSelected(option.stringValue());
+        } else if (option.getType() == Option.CHOICE) {
+            SpecialAbility spa = SpecialAbility.getOption(option.getName());
+            if (null != spa) {
+                for (String val : spa.getChoiceValues()) {
+                    optionComp.addValue(val);
+                }
+                optionComp.setSelected(option.stringValue());
+            }
         }
 
         gridbag.setConstraints(optionComp, c);


### PR DESCRIPTION
Allows user to add spas/edge triggers/implants to the hard-coded ones through a data/universe/customspa.xml file that provides initialization data. The custom options use the existing PersonnelOption framework that is built on top of the MM PilotOption framework. Until such time as we have plugin modules, these have no game effect other than providing a way for users to manage XP expenditures and track which personnel have which ability.