### PR TITLE
Removed Lyran End Date

### DIFF
--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -160,7 +160,6 @@ tags - a comma-separated list of tags. Currently recognised tags: "is", "periphe
 		<altNamesByYear year='3085'>Lyran Commonwealth</altNamesByYear>
 		<tags>is</tags>
 		<start>2340</start>
-		<end>3084</end>
 	</faction>
 	<!-- Star League Era factions -->
 	<faction>


### PR DESCRIPTION
Was brought up on Slack.  The LC exists into the present (3145) so removed the <end> field causing the faction to disappear during the Dark Ages.