### PR TITLE
honor user's press of 'cancel' button during Load Save Game dialog

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -356,6 +356,10 @@ public class MekHQ implements GameListener {
     public void joinGame(Scenario scenario, ArrayList<Unit> meks) {
 		LaunchGameDialog lgd = new LaunchGameDialog(campaigngui.getFrame(), false, campaign);
 		lgd.setVisible(true);
+		
+		if(lgd.cancelled) {
+		    return;
+		}
 
     	try {
     		client = new Client(lgd.playerName, lgd.serverAddr, lgd.port);
@@ -377,6 +381,11 @@ public class MekHQ implements GameListener {
     	LaunchGameDialog lgd = new LaunchGameDialog(campaigngui.getFrame(), true, campaign);
 		lgd.setVisible(true);
 
+		if(lgd.cancelled) {
+		    stopHost();
+		    return;
+		}
+		
     	try {
             myServer = new Server("", lgd.port);
             if (loadSavegame) {
@@ -387,7 +396,7 @@ public class MekHQ implements GameListener {
                     myServer.loadGame(new File(f.getDirectory(), f.getFile()));
                 } else {
                     stopHost();
-                    throw new FileNotFoundException();
+                    return; // exceptions as flow control? no thanks.
                 }
             }
     	} catch (FileNotFoundException ex) {

--- a/MekHQ/src/mekhq/gui/dialog/LaunchGameDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LaunchGameDialog.java
@@ -28,6 +28,7 @@ public class LaunchGameDialog extends JDialog implements ActionListener {
     public String playerName;
     public String serverAddr;
     public int port;
+    public boolean cancelled;
     private JLabel yourNameL;
     private JLabel serverAddrL;
     private JLabel portL;
@@ -137,6 +138,8 @@ public class LaunchGameDialog extends JDialog implements ActionListener {
             } catch (NumberFormatException ex) {
                 System.err.println(ex.getMessage());
             }
+        } else {
+            cancelled = true;
         }
         setVisible(false);
 	}


### PR DESCRIPTION
When hitting 'load saved game' in the briefing screen, if the user clicks 'cancel', it brings up the file dialog anyway. 

Then, if the user hits cancel, it tries to start up megamek anyway, then used an exception for flow control. This set of changes optimizes the behavior somewhat.