### PR TITLE
Fix ClassCastException when acquiring refit parts.

### DIFF
--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -1,6 +1,7 @@
 VERSION HISTORY:
 ----------------
 v0.43.9-git
++ Issue #647: Exception Causing UI Issues while Unit is Being Refit
 
 v0.43.8-RC2 (2018-02-11 22:40 UTC)
 + Issue #626: News events with year but no specific date should now fire with better distribution

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -995,7 +995,10 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 		for(Part part : shoppingList) {
 			if(part instanceof IAcquisitionWork) {
 			    //check to see if we found a replacement
-			    Part replacement = ((MissingPart)part).findReplacement(true);
+			    Part replacement = part;
+			    if (part instanceof MissingPart) {
+			        replacement = ((MissingPart)part).findReplacement(true);
+			    }
 			    if(null != replacement) {
 			        if(replacement.getQuantity() > 1) {
 			            Part actualReplacement = replacement.clone();


### PR DESCRIPTION
Some changes that fix long-standing issues with ammo bins in refits
involve including AmmoStorage parts in the shopping list. Previously the
shopping list was only instances of MissingPart and acquireParts()
method had an unchecked cast based on that assumption.

Fixes #647: Exception Causing UI Issues while Unit is Being Refit