### PR TITLE
Adjusted unit rating calculation and infantry counts

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
@@ -84,7 +84,6 @@ public abstract class AbstractUnitRating implements IUnitRating {
     private int battleArmorCount = 0;
     private int numberBaSquads = 0;
     private int infantryCount = 0;
-    private int mechanizedInfantryCount = 0;
     private int infantryUnitCount = 0;
     private int smallCraftCount = 0;
     private int dropshipCount = 0;
@@ -436,7 +435,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
         setBattleArmorCount(0);
         setNumberBaSquads(0);
         setInfantryCount(0);
-        setMechInfantryCount(0);
+        setInfantryUnitCount(0);
         setDropshipCount(0);
         setJumpshipCount(0);
         setWarshipCount(0);
@@ -574,6 +573,10 @@ public abstract class AbstractUnitRating implements IUnitRating {
         mechCount++;
     }
     
+    private void setInfantryUnitCount(int count) {
+        infantryUnitCount = count;
+    }
+    
     private void incrementInfantryUnitCount() {
         infantryUnitCount++;
     }
@@ -680,28 +683,12 @@ public abstract class AbstractUnitRating implements IUnitRating {
 
     /**
      * Calculate the number of infantry "platoons" present in the company, based on the numbers
-     * of various infantry. This is used for the purposes of stuffing people into infantry bays,
-     * where infantry of most kinds can be fit at 28 per bay, except mechanized infnatry, which 
-     * can only be fit at 7 per bay.
+     * of various infantry present. Per CamOps, the simplification is that an infantry cube can
+     * house 28 infantry.
      * @return Number of infantry "platoons" in the company.
      */
     int calcInfantryPlatoons() {
-        int infantryPlatoonCount = (int) Math.ceil((double) getInfantryCount() / 28);
-        int mechInfantryPlatoonCount = (int) Math.ceil((double) getMechInfantryCount() / 7);
-        
-        return infantryPlatoonCount + mechInfantryPlatoonCount;
-    }
-
-    int getMechInfantryCount() {
-        return mechanizedInfantryCount;
-    }
-    
-    void setMechInfantryCount(int count) {
-        mechanizedInfantryCount = count;
-    }
-    
-    private void incrementMechInfantryCount(int amount) {
-        mechanizedInfantryCount += amount;
+        return (int) Math.ceil((double) getInfantryCount() / 28);
     }
     
     int getDropshipCount() {
@@ -943,16 +930,8 @@ public abstract class AbstractUnitRating implements IUnitRating {
             case UnitType.INFANTRY:
                 Infantry i = (Infantry) e;
                 
-                // mechanized infantry takes up more space in infantry bays than
-                // standard infantry, so we have to count them up separately.
-                if(i.isMechanized()) {
-                    incrementMechInfantryCount(i.getSquadSize() * i.getSquadN());
-                } else {
-                    incrementInfantryCount(i.getSquadSize() * i.getSquadN());
-                }
-                
+                incrementInfantryCount(i.getSquadSize() * i.getSquadN());
                 incrementInfantryUnitCount();
-                
                 break;
         }
     }

--- a/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
@@ -1,5 +1,5 @@
 /*
- * AbstractMrbcRating.java
+ * AbstractUnitRating.java
  *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  *
@@ -84,6 +84,8 @@ public abstract class AbstractUnitRating implements IUnitRating {
     private int battleArmorCount = 0;
     private int numberBaSquads = 0;
     private int infantryCount = 0;
+    private int mechanizedInfantryCount = 0;
+    private int infantryUnitCount = 0;
     private int smallCraftCount = 0;
     private int dropshipCount = 0;
     private int warshipCount = 0;
@@ -434,6 +436,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
         setBattleArmorCount(0);
         setNumberBaSquads(0);
         setInfantryCount(0);
+        setMechInfantryCount(0);
         setDropshipCount(0);
         setJumpshipCount(0);
         setWarshipCount(0);
@@ -570,6 +573,14 @@ public abstract class AbstractUnitRating implements IUnitRating {
     private void incrementMechCount() {
         mechCount++;
     }
+    
+    private void incrementInfantryUnitCount() {
+        infantryUnitCount++;
+    }
+    
+    public int getInfantryUnitCount() {
+        return infantryUnitCount;
+    }
 
     int getProtoCount() {
         return protoCount;
@@ -667,10 +678,32 @@ public abstract class AbstractUnitRating implements IUnitRating {
         infantryCount += amount;
     }
 
+    /**
+     * Calculate the number of infantry "platoons" present in the company, based on the numbers
+     * of various infantry. This is used for the purposes of stuffing people into infantry bays,
+     * where infantry of most kinds can be fit at 28 per bay, except mechanized infnatry, which 
+     * can only be fit at 7 per bay.
+     * @return Number of infantry "platoons" in the company.
+     */
     int calcInfantryPlatoons() {
-        return (int) Math.ceil(getInfantryCount() / 28);
+        int infantryPlatoonCount = (int) Math.ceil((double) getInfantryCount() / 28);
+        int mechInfantryPlatoonCount = (int) Math.ceil((double) getMechInfantryCount() / 7);
+        
+        return infantryPlatoonCount + mechInfantryPlatoonCount;
     }
 
+    int getMechInfantryCount() {
+        return mechanizedInfantryCount;
+    }
+    
+    void setMechInfantryCount(int count) {
+        mechanizedInfantryCount = count;
+    }
+    
+    private void incrementMechInfantryCount(int amount) {
+        mechanizedInfantryCount += amount;
+    }
+    
     int getDropshipCount() {
         return dropshipCount;
     }
@@ -909,7 +942,17 @@ public abstract class AbstractUnitRating implements IUnitRating {
                 break;
             case UnitType.INFANTRY:
                 Infantry i = (Infantry) e;
-                incrementInfantryCount(i.getSquadSize() * i.getSquadN());
+                
+                // mechanized infantry takes up more space in infantry bays than
+                // standard infantry, so we have to count them up separately.
+                if(i.isMechanized()) {
+                    incrementMechInfantryCount(i.getSquadSize() * i.getSquadN());
+                } else {
+                    incrementInfantryCount(i.getSquadSize() * i.getSquadN());
+                }
+                
+                incrementInfantryUnitCount();
+                
                 break;
         }
     }

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -998,7 +998,7 @@ public class CampaignOpsReputation extends AbstractUnitRating {
      */
     private class TransportCapacityIndicators {
         private boolean sufficientCapacity = true;
-        private boolean excessCapacity = true;
+        private boolean excessCapacity = false;
         private boolean doubleCapacity = true;
         
         public boolean hasSufficientCapacity() {
@@ -1025,12 +1025,21 @@ public class CampaignOpsReputation extends AbstractUnitRating {
                 return;
             }
             
-            // if any unit type is under capacity, the whole thing falls through and we count as being under capacity
-            // because god forbid units share unused bay space
-                        
-            sufficientCapacity &= (bayCount >= unitCount); // we have enough capacity if there are as many or more bays than units
-            excessCapacity &= (bayCount > unitCount);   // we have excess capacity if there are more bays than units
-            doubleCapacity &= (bayCount > (unitCount * 2)); // we have double capacity if there are more than twice as many bays as units
+            // examples: 
+            //  1 infantry platoon, 1 bay = sufficient capacity
+            //  1 infantry platoon, 1 tank, 1 infantry bay, 1 tank bay = excess capacity
+            //  1 infantry platoon, 1 tank, 2 infantry bay, 1 tank bay = double capacity
+            //  1 infantry platoon, no infantry bays, 1 tank, 1 tank bay = insufficient capacity
+            
+            // we have enough capacity if there are as many or more bays than units
+            sufficientCapacity &= (bayCount >= unitCount); 
+            
+            // we have excess capacity if there are more bays than units for at least one unit type AND 
+            // we have sufficient capacity for everything else
+            excessCapacity |= (bayCount > unitCount) && sufficientCapacity;
+            
+            // we have double capacity if there are more than twice as many bays as units for every unit type
+            doubleCapacity &= (bayCount > (unitCount * 2)); 
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -1,5 +1,5 @@
 /*
- * DefaultMrbcRating.java
+ * CampaignOpsRating.java
  *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  *
@@ -165,13 +165,16 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         if (null == crew) {
             return;
         }
+        
         int gunnery = crew.getGunnery();
         int antiMek = infantry.getAntiMekSkill();
-        if (antiMek == 0) {
+        if (antiMek == 0 || antiMek == 8) {
             antiMek = gunnery + 1;
         }
+        
         BigDecimal skillLevel = BigDecimal.valueOf(gunnery)
-                                          .add(BigDecimal.valueOf(antiMek));
+                                    .add(BigDecimal.valueOf(antiMek));
+
         incrementSkillRatingCounts(getExperienceLevelName(skillLevel));
         setTotalSkillLevels(getTotalSkillLevels(false).add(skillLevel));
     }
@@ -229,8 +232,8 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         totalCombatUnits += getFighterCount();
         totalCombatUnits += getProtoCount();
         totalCombatUnits += getVeeCount();
-        totalCombatUnits += (getBattleArmorCount() / 5);
-        totalCombatUnits += (getInfantryCount() / 28);
+        totalCombatUnits += getNumberBaSquads();
+        totalCombatUnits += getInfantryUnitCount();
         totalCombatUnits += getDropshipCount();
         totalCombatUnits += getSmallCraftCount();
         return totalCombatUnits;
@@ -569,14 +572,14 @@ public class CampaignOpsReputation extends AbstractUnitRating {
             fullCapacity = false;
             doubleExcessCapacity = false;
         }
-        if (getInfantryBayCount() < getInfantryCount() / 28) {
+        if (getInfantryBayCount() == calcInfantryPlatoons()) {
             excessCapacity = false;
             doubleExcessCapacity = false;
-        } else if (getInfantryBayCount() < getInfantryCount() / 28) {
+        } else if (getInfantryBayCount() < calcInfantryPlatoons()) {
             fullCapacity = false;
             excessCapacity = false;
             doubleExcessCapacity = false;
-        } else if (getInfantryBayCount() < getInfantryCount() / 14) {
+        } else if (getInfantryBayCount() < calcInfantryPlatoons() / 2) {
             fullCapacity = false;
             doubleExcessCapacity = false;
         }
@@ -868,7 +871,7 @@ public class CampaignOpsReputation extends AbstractUnitRating {
                                           getBattleArmorCount() / 5,
                                           getBaBayCount()) +
                      "\n" + String.format(TEMPLATE, "Infantry Bays:",
-                                          getInfantryCount() / 28,
+                                          calcInfantryPlatoons(),
                                           getInfantryBayCount()) +
                      "\n" + String.format(TEMPLATE, "Docking Collars:",
                                           getDropshipCount(),

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -1,5 +1,5 @@
 /*
- * FieldManualMercRevMrbcRating.java
+ * FieldManualMercRevDragoonsRating.java
  *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  *


### PR DESCRIPTION
Two sets of changes:

One spurred by issue #639, on line 171 in CampaignOpsReputation.java. This emulates the behavior of the dragoons rating code, which, if no anti-mek skill is present, assumes an anti-mek skill of "small arms + 1".

The rest is because the average skill level wasn't computing correctly due to always dividing the number of infantry by 28, even though infantry units may have man counts of not 28. That also led me to mess around with transport capacity-related code.