### PR TITLE
Fix for #688: Cannot slot Endo Steel crits.

### DIFF
--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -828,7 +828,7 @@ public class MekLabTab extends CampaignGuiTab {
 
         @Override
         public void refreshSummary() {
-            structureTab.refresh();
+            structureTab.refreshSummary();
         }
 
         @Override


### PR DESCRIPTION
Pretty straighforward.

The call to refreshSummary() is supposed to refresh just the weight/slot
breakdown view on the structure tab, but it was calling refresh()
instead. This was causing a listener to get added a second time, so when
the listener was removed to refresh data without updating the Entity it
was updating anyway. This was causing any critical slots to assigned to
internal structure to be unallocated.

I double-checked the panels for the other unit types, and `MekPanel` was the only one with the typo.