### PR TITLE
Fix for #668: Empty heat sink/double heat sink omnipods not available for Purchase Parts

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -197,12 +197,16 @@ public class PartsStore implements Serializable {
 					parts.add(new AmmoStorage(0, et, ((AmmoType)et).getShots(), c));
 				}
 			} else if(et instanceof MiscType && (((MiscType)et).hasFlag(MiscType.F_HEAT_SINK) || ((MiscType)et).hasFlag(MiscType.F_DOUBLE_HEAT_SINK))) {
-            	parts.add(new HeatSink(0, et, -1, false, c));
+            	Part p = new HeatSink(0, et, -1, false, c);
+            	parts.add(p);
+                parts.add(new OmniPod(p, c));
             	parts.add(new HeatSink(0, et, -1, true, c));
 			} else if(et instanceof MiscType && ((MiscType)et).hasFlag(MiscType.F_JUMP_JET)) {
 				//need to do it by rating and unit tonnage
 				for(int ton = 10; ton <= 100; ton += 5) {
-                    parts.add(new JumpJet(ton, et, -1, false, c));
+				    Part p = new JumpJet(ton, et, -1, false, c);
+                    parts.add(p);
+                    parts.add(new OmniPod(p, c));
                     parts.add(new JumpJet(ton, et, -1, true, c));
 				}
 			} else if ((et instanceof MiscType && ((MiscType)et).hasFlag(MiscType.F_TANK_EQUIPMENT) && ((MiscType)et).hasFlag(MiscType.F_CHASSIS_MODIFICATION))
@@ -227,6 +231,7 @@ public class PartsStore implements Serializable {
                             MASC sp = new MASC(0, et, -1 , c, rating, false);
                             sp.setEquipTonnage(eton);
                             parts.add(sp);
+                            parts.add(new OmniPod(sp, c));
                             sp = new MASC(0, et, -1 , c, rating, true);
                             sp.setEquipTonnage(eton);
 							parts.add(sp);
@@ -239,7 +244,9 @@ public class PartsStore implements Serializable {
 							if(rating < ton || (rating % ton) != 0) {
 								continue;
 							}
-                            parts.add(new MASC(ton, et, -1, c, rating, false));
+							Part p = new MASC(ton, et, -1, c, rating, false);
+                            parts.add(p);
+                            parts.add(new OmniPod(p, c));
                             parts.add(new MASC(ton, et, -1, c, rating, true));
 						}
 					}
@@ -255,6 +262,7 @@ public class PartsStore implements Serializable {
 						    epart = new EquipmentPart(0, et, -1, true, c);
 	                        epart.setEquipTonnage(ton);
 	                        parts.add(epart);
+	                        parts.add(new OmniPod(epart, c));
 						}
 						//TODO: still need to deal with talons (unit tonnage) and masc (engine rating)
 					}

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -75,7 +75,12 @@ public class OmniPod extends Part {
 
     @Override
     public String getDetails() {
-        return partType.getName();
+        String details = partType.getDetails().replaceAll("\\d+ hit\\(s\\)(,\\s)?", "");
+        if (details.length() > 0) {
+            return partType.getName() + " (" + details + ")";
+        } else {
+            return partType.getName();
+        }
     }
     
     @Override

--- a/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
@@ -335,7 +335,9 @@ public class PartsStoreDialog extends javax.swing.JDialog {
         	public boolean include(Entry<? extends PartsTableModel, ? extends Integer> entry) {
         		PartsTableModel partsModel = entry.getModel();
         		Part part = partsModel.getPartAt(entry.getIdentifier());
-        		if(txtFilter.getText().length() > 0 && !part.getName().toLowerCase().contains(txtFilter.getText().toLowerCase())) {
+        		if ((txtFilter.getText().length() > 0)
+        		        && !part.getName().toLowerCase().contains(txtFilter.getText().toLowerCase())
+        		        && !part.getDetails().toLowerCase().contains(txtFilter.getText().toLowerCase())) {
                     return false;
                 }
     			if(part.getTechBase() == Part.T_CLAN && !campaign.getCampaignOptions().allowClanPurchases()) {


### PR DESCRIPTION
Pods were only being added in the general case scenario and not where they required special handling (heat sinks, jump jets, MASC/supercharger, variable weight).

In addition to adding the missing empty pods to the store I changed the filter in the dialog to match either the name or the details so you can actually find the pod you want. I also had the parts store exclude any equipment without the appropriate MiscType or WeaponType flag for mech, vee, or asf equipment.