### PR TITLE
Fix for #704: NPE when bringing up the refit dialog

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -72,6 +72,7 @@ import megamek.common.Crew;
 import megamek.common.CriticalSlot;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
+import megamek.common.ITechnology;
 import megamek.common.Infantry;
 import megamek.common.Jumpship;
 import megamek.common.LandAirMech;
@@ -382,6 +383,7 @@ public class Utilities {
 	}
 
 	public static ArrayList<String> getAllVariants(Entity en, Campaign campaign) {
+	    final String METHOD_NAME = "getAllVariants(Entity, Campaign)"; // $NON-NLS-1$
 	    CampaignOptions options = campaign.getCampaignOptions();
 		ArrayList<String> variants = new ArrayList<String>();
 		for(MechSummary summary : MechSummaryCache.getInstance().getAllMechs()) {
@@ -397,7 +399,14 @@ public class Utilities {
 				continue;
 			}
             // If the unit doesn't meet the tech filter criteria we continue
-			if (!campaign.isLegal(UnitTechProgression.getProgression(summary, campaign.getTechFaction(), true))) {
+			ITechnology techProg = UnitTechProgression.getProgression(summary, campaign.getTechFaction(), true);
+			if (null == techProg) {
+			    // This should never happen unless there was an exception thrown when calculating the progression.
+			    // In such a case we will log it and take the least restrictive action, which is to let it through.
+			    MekHQ.getLogger().log(Utilities.class, METHOD_NAME, LogLevel.WARNING,
+			            "Could not determine tech progression for " + summary.getName() // $NON-NLS-1$
+			            + ", including among available refits."); // $NON-NLS-1$
+			} else if (!campaign.isLegal(techProg)) {
 			    continue;
 			}
 			// Otherwise, we can offer it for selection

--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
@@ -113,6 +113,9 @@ public class UnitTechProgression {
         }
         try {
             Map<MechSummary,ITechnology> map = task.get();
+            if (!map.containsKey(ms)) {
+                map.put(ms, calcTechProgression(ms, techFaction));
+            }
             return map.get(ms);
         } catch (InterruptedException e) {
             task.cancel(true);
@@ -121,6 +124,23 @@ public class UnitTechProgression {
                     "getProgression(MechSummary,int,boolean)", e);
         }
         return null;
+    }
+    
+    private static ITechnology calcTechProgression(MechSummary ms, int techFaction) {
+        final String METHOD_NAME = "calcTechProgression(MechSummary, int)"; // $NON-NLS-1$
+        try {
+            Entity en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
+            if (null == en) {
+                MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR,
+                        "Entity was null: " + ms.getName());
+            }
+            return en.factionTechLevel(techFaction);
+        } catch (EntityLoadingException ex) {
+            MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR,
+                    "Exception loading entity " + ms.getName());
+            MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, ex);
+            return null;
+        }
     }
     
     /**
@@ -137,22 +157,9 @@ public class UnitTechProgression {
         // Load all the Entities in the MechSummaryCache and calculate the tech level for the given faction.
         @Override
         public Map<MechSummary, ITechnology> call() throws Exception {
-            final String METHOD_NAME = "call()"; // $NON-NLS-1$
             Map<MechSummary,ITechnology> map = new HashMap<MechSummary,ITechnology>();
             for (MechSummary ms : MechSummaryCache.getInstance().getAllMechs()) {
-                try {
-                    Entity en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
-                    if (null == en) {
-                        MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR,
-                                "Entity was null: " + ms.getName());
-                    }
-                    CompositeTechLevel tech = en.factionTechLevel(techFaction);
-                    map.put(ms,  tech);
-                } catch (EntityLoadingException ex) {
-                    MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR,
-                            "Exception loading entity " + ms.getName());
-                    MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, ex);
-                }
+                map.put(ms, calcTechProgression(ms, techFaction));
             }
             return map;
         }


### PR DESCRIPTION
Because of new options available with IO tech advancement rules (in particular, faction-specific dates), MHQ creates a unit tech progression cache when loaded. When a new unit is created in the MekLab, it doesn't get added to the cache, so a request for the unit's tech advancement stats returns null.

With this fix MekHQ will check whether a unit is in the cache when a request is made, and if not will do the calculation and add to the cache. The only reason it should return null is if there is an exception thrown while calculating tech progression, which is logged at the time the calculation is made, but I also added a check where the refit code finds all variants that will allow the refit to proceed but log a warning message there as well.