### PR TITLE
improved communication regarding gm-generate contract failure

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -411,6 +411,12 @@ public class ContractMarketDialog extends JDialog {
         btnGenerate.addActionListener(new java.awt.event.ActionListener() {
         	public void actionPerformed(java.awt.event.ActionEvent evt) {
         		AtBContract c = contractMarket.addAtBContract(campaign);
+        		
+        		if(c == null) {
+        		    campaign.addReport(resourceMap.getString("report.UnabletoGMContract"));
+        		    return;
+        		}
+        		
         		c.initContractDetails(campaign);
         		c.calculatePartsAvailabilityLevel(campaign);
         		c.setSharesPct(campaign.getCampaignOptions().getUseShareSystem()?

--- a/MekHQ/src/mekhq/resources/ContractMarketDialog.properties
+++ b/MekHQ/src/mekhq/resources/ContractMarketDialog.properties
@@ -43,3 +43,6 @@ lblTotalAmountPlus1.text=Net Amount:
 lblAdvanceMoney1.text=Advance Money:
 lblMonthlyAmount1.text=Monthly Amount:
 lblProfit1.text=Estimated Total Profit:
+
+# reports
+report.UnabletoGMContract=Unable to GM-generate contract from the current location. Increase contract search radius or travel to a border world for better odds of success.


### PR DESCRIPTION
Improved communication when the GM - Generate Contract button fails. Now, instead of throwing a NPE, it'll record a message to the daily log.