### PR TITLE
minor adjustment to dragoons rating

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -106,7 +106,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
                                 " is mothballed.  Skipping.");
                 continue;
             }
-
+            
             updateUnitCounts(u);
             BigDecimal value = getUnitValue(u);
             getLogger().log(getClass(), METHOD_NAME, LogLevel.DEBUG,
@@ -428,7 +428,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         final String METHOD_NAME = "updateSkillLevel(Unit, BigDecimal)";
 
         //Make sure this is a combat unit.
-        if ((null == u.getEntity()) || (null == u.getEntity().getCrew())) {
+        if ((null == u.getEntity()) || (u.getCrew().size() == 0)) {
             return;
         }
 

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -106,7 +106,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
                                 " is mothballed.  Skipping.");
                 continue;
             }
-            
+
             updateUnitCounts(u);
             BigDecimal value = getUnitValue(u);
             getLogger().log(getClass(), METHOD_NAME, LogLevel.DEBUG,


### PR DESCRIPTION
Dragoons rating counted unmanned units for the purposes of "average skill" calculations. getCrew() never returns null, but can return a 0-length list, so the code was adjusted to account for that.