### PR TITLE
Fixes issue #600 and #621 by adding faction handling to person/crew creation

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -601,8 +601,8 @@ public class Utilities {
 
 		return false;
     }
-
-	public static Map<CrewType, Collection<Person>> genRandomCrewWithCombinedSkill(Campaign c, Unit u) {
+	
+	public static Map<CrewType, Collection<Person>> genRandomCrewWithCombinedSkill(Campaign c, Unit u, String factionCode) {
 	    Objects.requireNonNull(c);
 	    Objects.requireNonNull(u);
 	    Objects.requireNonNull(u.getEntity(), "Unit needs to have a valid Entity attached");
@@ -634,35 +634,35 @@ public class Utilities {
 		if (u.usesSoloPilot()) {
 			Person p = null;
 			if (u.getEntity() instanceof LandAirMech) {
-                p = c.newPerson(Person.T_MECHWARRIOR);
+                p = c.newPerson(Person.T_MECHWARRIOR, factionCode);
                 p.addSkill(SkillType.S_PILOT_MECH, SkillType.getType(SkillType.S_PILOT_MECH).getTarget() - oldCrew.getPiloting(), 0);
                 p.addSkill(SkillType.S_GUN_MECH, SkillType.getType(SkillType.S_GUN_MECH).getTarget() - oldCrew.getGunnery(), 0);
                 p.addSkill(SkillType.S_PILOT_AERO, SkillType.getType(SkillType.S_PILOT_AERO).getTarget() - oldCrew.getPiloting(), 0);
                 p.addSkill(SkillType.S_GUN_AERO, SkillType.getType(SkillType.S_GUN_AERO).getTarget() - oldCrew.getGunnery(), 0);
                 p.setSecondaryRole(Person.T_AERO_PILOT);
 			} else if (u.getEntity() instanceof Mech) {
-    			p = c.newPerson(Person.T_MECHWARRIOR);
+    			p = c.newPerson(Person.T_MECHWARRIOR, factionCode);
     			p.addSkill(SkillType.S_PILOT_MECH, SkillType.getType(SkillType.S_PILOT_MECH).getTarget() - oldCrew.getPiloting(), 0);
     			p.addSkill(SkillType.S_GUN_MECH, SkillType.getType(SkillType.S_GUN_MECH).getTarget() - oldCrew.getGunnery(), 0);
     		} else if (u.getEntity() instanceof Aero) {
-    			p = c.newPerson(Person.T_AERO_PILOT);
+    			p = c.newPerson(Person.T_AERO_PILOT, factionCode);
     			p.addSkill(SkillType.S_PILOT_AERO, SkillType.getType(SkillType.S_PILOT_AERO).getTarget() - oldCrew.getPiloting(), 0);
     			p.addSkill(SkillType.S_GUN_AERO, SkillType.getType(SkillType.S_GUN_AERO).getTarget() - oldCrew.getGunnery(), 0);
     		} else if (u.getEntity() instanceof ConvFighter) {
-    			p = c.newPerson(Person.T_CONV_PILOT);
+    			p = c.newPerson(Person.T_CONV_PILOT, factionCode);
     			p.addSkill(SkillType.S_PILOT_JET, SkillType.getType(SkillType.S_PILOT_JET).getTarget() - oldCrew.getPiloting(), 0);
     			p.addSkill(SkillType.S_GUN_JET, SkillType.getType(SkillType.S_GUN_JET).getTarget() - oldCrew.getPiloting(), 0);
     		} else if (u.getEntity() instanceof Protomech) {
-    			p = c.newPerson(Person.T_PROTO_PILOT);
+    			p = c.newPerson(Person.T_PROTO_PILOT, factionCode);
     			//p.addSkill(SkillType.S_PILOT_PROTO, SkillType.getType(SkillType.S_PILOT_PROTO).getTarget() - oldCrew.getPiloting(), 0);
     			p.addSkill(SkillType.S_GUN_PROTO, SkillType.getType(SkillType.S_GUN_PROTO).getTarget() - oldCrew.getGunnery(), 0);
     		} else if (u.getEntity() instanceof VTOL) {
-    			p = c.newPerson(Person.T_VTOL_PILOT);
+    			p = c.newPerson(Person.T_VTOL_PILOT, factionCode);
     			p.addSkill(SkillType.S_PILOT_VTOL, SkillType.getType(SkillType.S_PILOT_VTOL).getTarget() - oldCrew.getPiloting(), 0);
     			p.addSkill(SkillType.S_GUN_VEE, SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(), 0);
     		} else {
     			//assume tanker if we got here
-    			p = c.newPerson(Person.T_GVEE_DRIVER);
+    			p = c.newPerson(Person.T_GVEE_DRIVER, factionCode);
     			p.addSkill(SkillType.S_PILOT_GVEE, SkillType.getType(SkillType.S_PILOT_GVEE).getTarget() - oldCrew.getPiloting(), 0);
     			p.addSkill(SkillType.S_GUN_VEE, SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(), 0);
     		}
@@ -674,11 +674,11 @@ public class Utilities {
 		    for (int slot = 0; slot < oldCrew.getSlotCount(); slot++) {
 		        Person p = null;
 	            if(u.getEntity() instanceof Mech) {
-	                p = c.newPerson(Person.T_MECHWARRIOR);
+	                p = c.newPerson(Person.T_MECHWARRIOR, factionCode);
 	                p.addSkill(SkillType.S_PILOT_MECH, SkillType.getType(SkillType.S_PILOT_MECH).getTarget() - oldCrew.getPiloting(slot), 0);
 	                p.addSkill(SkillType.S_GUN_MECH, SkillType.getType(SkillType.S_GUN_MECH).getTarget() - oldCrew.getGunnery(slot), 0);
 	            } else if(u.getEntity() instanceof Aero) {
-	                p = c.newPerson(Person.T_AERO_PILOT);
+	                p = c.newPerson(Person.T_AERO_PILOT, factionCode);
 	                p.addSkill(SkillType.S_PILOT_AERO, SkillType.getType(SkillType.S_PILOT_AERO).getTarget() - oldCrew.getPiloting(slot), 0);
 	                p.addSkill(SkillType.S_GUN_AERO, SkillType.getType(SkillType.S_GUN_AERO).getTarget() - oldCrew.getGunnery(slot), 0);
 	            }
@@ -705,31 +705,31 @@ public class Utilities {
 			while(drivers.size() < driversNeeded) {
 	    		Person p = null;
 	    		if(u.getEntity() instanceof SmallCraft || u.getEntity() instanceof Jumpship) {
-	    			p = c.newPerson(Person.T_SPACE_PILOT);
+	    			p = c.newPerson(Person.T_SPACE_PILOT, factionCode);
 	    			p.addSkill(SkillType.S_PILOT_SPACE, randomSkillFromTarget(SkillType.getType(SkillType.S_PILOT_SPACE).getTarget() - oldCrew.getPiloting()), 0);
 	    			totalPiloting += p.getSkill(SkillType.S_PILOT_SPACE).getFinalSkillValue();
 	    		}
 	    		else if(u.getEntity() instanceof BattleArmor) {
-	    			p = c.newPerson(Person.T_BA);
+	    			p = c.newPerson(Person.T_BA, factionCode);
 	    			p.addSkill(SkillType.S_GUN_BA, randomSkillFromTarget(SkillType.getType(SkillType.S_GUN_BA).getTarget() - oldCrew.getGunnery()), 0);
 	    			totalGunnery += p.getSkill(SkillType.S_GUN_BA).getFinalSkillValue();
 	    		}
 	    		else if(u.getEntity() instanceof Infantry) {
-	    			p = c.newPerson(Person.T_INFANTRY);
+	    			p = c.newPerson(Person.T_INFANTRY, factionCode);
 	    			p.addSkill(SkillType.S_SMALL_ARMS, randomSkillFromTarget(SkillType.getType(SkillType.S_SMALL_ARMS).getTarget() - oldCrew.getGunnery()), 0);
 	    			totalGunnery += p.getSkill(SkillType.S_SMALL_ARMS).getFinalSkillValue();
 	    		}
 	    		else if(u.getEntity() instanceof VTOL) {
-	    			p = c.newPerson(Person.T_VTOL_PILOT);
+	    			p = c.newPerson(Person.T_VTOL_PILOT, factionCode);
 	    			p.addSkill(SkillType.S_PILOT_VTOL, SkillType.getType(SkillType.S_PILOT_VTOL).getTarget() - oldCrew.getPiloting(), 0);
 	    			p.addSkill(SkillType.S_GUN_VEE, SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(), 0);
                 } else if (u.getEntity() instanceof Mech) {
-                    p = c.newPerson(Person.T_MECHWARRIOR);
+                    p = c.newPerson(Person.T_MECHWARRIOR, factionCode);
                     p.addSkill(SkillType.S_PILOT_MECH, SkillType.getType(SkillType.S_PILOT_MECH).getTarget() - oldCrew.getPiloting(), 0);
                     p.addSkill(SkillType.S_GUN_MECH, SkillType.getType(SkillType.S_GUN_MECH).getTarget() - oldCrew.getGunnery(), 0);
 	    		} else {
 	    			//assume tanker if we got here
-	    			p = c.newPerson(Person.T_GVEE_DRIVER);
+	    			p = c.newPerson(Person.T_GVEE_DRIVER, factionCode);
 	    			p.addSkill(SkillType.S_PILOT_GVEE, SkillType.getType(SkillType.S_PILOT_GVEE).getTarget() - oldCrew.getPiloting(), 0);
 	    			p.addSkill(SkillType.S_GUN_VEE, SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(), 0);
 	    		}
@@ -779,17 +779,17 @@ public class Utilities {
 		    	while(gunners.size() < u.getTotalGunnerNeeds()) {
 		    		Person p = null;
 		    		if (u.getEntity() instanceof SmallCraft || u.getEntity() instanceof Jumpship) {
-		    			p = c.newPerson(Person.T_SPACE_GUNNER);
+		    			p = c.newPerson(Person.T_SPACE_GUNNER, factionCode);
 		    			p.addSkill(SkillType.S_GUN_SPACE, randomSkillFromTarget(SkillType.getType(SkillType.S_GUN_SPACE).getTarget() - oldCrew.getGunnery()), 0);
 		    			totalGunnery += p.getSkill(SkillType.S_GUN_SPACE).getFinalSkillValue();
 	                } else if (u.getEntity() instanceof Mech) {
-	                    p = c.newPerson(Person.T_MECHWARRIOR);
+	                    p = c.newPerson(Person.T_MECHWARRIOR, factionCode);
 	                    p.addSkill(SkillType.S_PILOT_MECH, SkillType.getType(SkillType.S_PILOT_MECH).getTarget() - oldCrew.getPiloting(), 0);
 	                    p.addSkill(SkillType.S_GUN_MECH, SkillType.getType(SkillType.S_GUN_MECH).getTarget() - oldCrew.getGunnery(), 0);
 	                    totalGunnery += p.getSkill(SkillType.S_GUN_MECH).getFinalSkillValue();
 		    		} else {
 		    			//assume tanker if we got here
-		    			p = c.newPerson(Person.T_VEE_GUNNER);
+		    			p = c.newPerson(Person.T_VEE_GUNNER, factionCode);
 		    			p.addSkill(SkillType.S_GUN_VEE, randomSkillFromTarget(SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery()), 0);
 		    			totalGunnery += p.getSkill(SkillType.S_GUN_VEE).getFinalSkillValue();
 		    		}
@@ -826,7 +826,7 @@ public class Utilities {
 		//Multi-slot crews already have the names set. Single-slot multi-crew units need to assign the commander's name.
 		boolean nameset = oldCrew.getSlotCount() > 1;
 		while(vesselCrew.size() < u.getTotalCrewNeeds()) {
-    		Person p = c.newPerson(Person.T_SPACE_CREW);
+    		Person p = c.newPerson(Person.T_SPACE_CREW, factionCode);
     		if (!nameset) {
     		    p.setName(commanderName);
     		    nameset = true;
@@ -835,12 +835,12 @@ public class Utilities {
     	}
 
     	if(u.canTakeNavigator()) {
-    		Person p = c.newPerson(Person.T_NAVIGATOR);
+    		Person p = c.newPerson(Person.T_NAVIGATOR, factionCode);
     		navigator = p;
     	}
     	
     	if (u.canTakeTechOfficer()) {
-    	    Person p = c.newPerson(Person.T_VEE_GUNNER);
+    	    Person p = c.newPerson(Person.T_VEE_GUNNER, factionCode);
     	    consoleCmdr = p;
     	}
     	

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1029,7 +1029,7 @@ public class Campaign implements Serializable, ITechManager {
         unit.setDaysToArrival(days);
 
         if (allowNewPilots) {
-            Map<CrewType, Collection<Person>> newCrew = Utilities.genRandomCrewWithCombinedSkill(this, unit);
+            Map<CrewType, Collection<Person>> newCrew = Utilities.genRandomCrewWithCombinedSkill(this, unit, getFactionCode());
             newCrew.forEach((type, personnel) -> personnel.forEach(p -> type.addMethod.accept(unit, p)));
         }
         unit.resetPilotAndEntity();
@@ -5312,10 +5312,18 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public Person newPerson(int type) {
+        return newPerson(type, Person.T_NONE, getFactionCode());
+    }
+
+    public Person newPerson(int type, int secondary) {
+        return newPerson(type, secondary, getFactionCode());
+    }
+    
+    public Person newPerson(int type, String factionCode) {
         if (type == Person.T_LAM_PILOT) {
-            return newPerson(Person.T_MECHWARRIOR, Person.T_AERO_PILOT);
+            return newPerson(Person.T_MECHWARRIOR, Person.T_AERO_PILOT, factionCode);
         }
-        return newPerson(type, Person.T_NONE);
+        return newPerson(type, Person.T_NONE, factionCode);
     }
 
     /**
@@ -5326,9 +5334,9 @@ public class Campaign implements Serializable, ITechManager {
      * @param secondary A secondary role; used for LAM pilots to generate MW + Aero pilot
      * @return
      */
-    public Person newPerson(int type, int secondary) {
+    public Person newPerson(int type, int secondary, String factionCode) {
         boolean isFemale = getRNG().isFemale();
-        Person person = new Person(this);
+        Person person = new Person(this, factionCode);
         if (isFemale) {
             person.setGender(Person.G_FEMALE);
         }

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -78,6 +78,7 @@ import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Faction;
 
 /**
  * This object will be the main workhorse for the scenario
@@ -680,6 +681,15 @@ public class ResolveScenarioTracker {
      *                  in order to be processed, a unit must be in the salvageStatus hashtable.
      */
     private void processPrisonerCapture(List<TestUnit> unitsToProcess) {
+
+        Mission currentMission = campaign.getMission(scenario.getMissionId());
+        String enemyCode;
+        if (currentMission instanceof AtBContract) {
+            enemyCode = ((AtBContract) currentMission).getEnemyCode();
+        } else {
+            enemyCode = "IND";
+        }
+
         for(Unit u : unitsToProcess) {
             if (null == u) {
                 continue; // Shouldn't happen... but well... ya know
@@ -713,7 +723,7 @@ public class ResolveScenarioTracker {
                 continue;
             }
             //shuffling the crew ensures that casualties are randomly assigned in multi-crew units
-            List<Person> crew = Utilities.genRandomCrewWithCombinedSkill(campaign, u).values().stream().flatMap(c -> c.stream()).collect(Collectors.toList());
+            List<Person> crew = Utilities.genRandomCrewWithCombinedSkill(campaign, u, enemyCode).values().stream().flatMap(c -> c.stream()).collect(Collectors.toList());
             crew = shuffleCrew(crew);
 
             //For vees we may need to know the commander or driver, which aren't assigned for TestUnit.

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -84,6 +84,7 @@ import mekhq.campaign.mod.am.InjuryUtil;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
+import mekhq.campaign.universe.Faction;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -338,7 +339,15 @@ public class Person implements Serializable, MekHqXmlSerializable {
         this("Biff the Understudy", c);
     }
 
+    public Person(Campaign c, String factionCode) {
+        this("Biff the Understudy", c, factionCode);
+    }
+    
     public Person(String name, Campaign c) {
+        this(name, c, c.getFactionCode());
+    }
+    
+    public Person(String name, Campaign c, String factionCode) {
         this.name = name;
         callsign = "";
         portraitCategory = Crew.ROOT_PORTRAIT;
@@ -374,7 +383,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         techUnitIds = new ArrayList<UUID>();
         salary = -1;
         phenotype = PHENOTYPE_NONE;
-        clan = campaign.getFaction() != null && campaign.getFaction().isClan();
+        clan = Faction.getFaction(factionCode).isClan();
         bloodname = "";
         primaryDesignator = DESIG_NONE;
         secondaryDesignator = DESIG_NONE;


### PR DESCRIPTION
This should fix #600 and #621 by adding faction handling (which only deals with the clan flag at the moment as far as I can tell).  ResolveScenarioTracker's processPrisonerCapture now determines the enemy's faction and passes that to genRandomCrewWithCombinedSkill.  Added faction handling to Person's constructor as well as Campaign's newPerson.  I left the original functions in place but have them call the new faction handling version with the player's faction as that was the previous behavior.