### PR TITLE
Fix for issue #731

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -680,6 +680,12 @@ public class Campaign implements Serializable, ITechManager {
         shipSearchExpiration = null;
     }
 
+    /**
+     * Process retirements for retired personnel, if any.
+     * @param totalPayout The total retirement payout.
+     * @param unitAssignments List of unit assignments.
+     * @return False if there were payments AND they were unable to be processed, true otherwise.
+     */
     public boolean applyRetirement(long totalPayout, HashMap<UUID, UUID> unitAssignments) {
         if (totalPayout > 0) {
             if (null != getRetirementDefectionTracker().getRetirees()) {
@@ -722,10 +728,12 @@ public class Campaign implements Serializable, ITechManager {
                     return true;
                 } else {
                     addReport("<font color='red'>You cannot afford to make the final payments.</font>");
+                    return false;
                 }
             }
         }
-        return false;
+        
+        return true;
     }
 
     public News getNews() {
@@ -7630,7 +7638,6 @@ public class Campaign implements Serializable, ITechManager {
                         + contract.getName());
             }
         }
-        MekHQ.triggerEvent(new MissionCompletedEvent(mission));
     }
 
     public int calculatePartTransitTime(int mos) {

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -433,7 +433,13 @@ public final class BriefingTab extends CampaignGuiTab {
                             }
                         }
                     }
+                    
+                    if(mission.getStatus() != Mission.S_ACTIVE) {
+                        MekHQ.triggerEvent(new MissionCompletedEvent(mission));
+                    }
                 }
+                
+                
                 if (!mission.isActive()) {
                     if (getCampaign().getCampaignOptions().getUseAtB() && mission instanceof AtBContract) {
                         ((AtBContract) mission).checkForFollowup(getCampaign());


### PR DESCRIPTION
Changed the "applyRetirement" method to return false only if a) there actually are payments to process and b) they were unabled to be processed.

Also, changed the MissionComplete event to fire only after all the retirement rigmarole is done and the mission is actually complete.