### PR TITLE
Fix for endless loop causing issue #748

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -781,6 +781,15 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 		}
         return new AmmoStorage(1,type,shots,campaign);
     }
+	
+	/**
+	 * Get an "IAcquisitionWork" with a specific number of shots.
+	 * @param shots The number of shots to get.
+	 * @return IAcquisitionWork object.
+	 */
+	public IAcquisitionWork getAcquisitionWork(int shots) {
+	    return new AmmoStorage(1, type, shots, campaign);
+	}
 
 	@Override
 	public boolean needsMaintenance() {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -781,15 +781,6 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 		}
         return new AmmoStorage(1,type,shots,campaign);
     }
-	
-	/**
-	 * Get an "IAcquisitionWork" with a specific number of shots.
-	 * @param shots The number of shots to get.
-	 * @return IAcquisitionWork object.
-	 */
-	public IAcquisitionWork getAcquisitionWork(int shots) {
-	    return new AmmoStorage(1, type, shots, campaign);
-	}
 
 	@Override
 	public boolean needsMaintenance() {

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -510,6 +510,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                             part.setTeamId(null);
                             part.cancelReservation();
                             part.remove(false);
+                            needsCheck = true;
                         } else {
                             if(part.needsFixing()) {
                                 needsCheck = true;
@@ -531,10 +532,9 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                             // we magically find the ammo we need, then load the bin
                             // we only want to get the amount of ammo the bin actually needs                            
                             if(ammoBin.getShotsNeeded() > 0) {
-                                ammoBin.getAcquisitionWork(ammoBin.getShotsNeeded()).find(0);
-                            }                            
-                            
-                            ammoBin.loadBin();
+                                ammoBin.setShotsNeeded(0);
+                                ammoBin.updateConditionFromPart();
+                            }
                         }
                         
                     }

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -496,11 +496,12 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
         } else if(command.equalsIgnoreCase("RESTORE_UNIT")) {
             for (Unit unit : units) {
                 unit.setSalvage(false);
-                Collection<Part> partsToFix = new HashSet<>(unit.getParts());
+                
                 boolean needsCheck = true;
                 while(unit.isAvailable() && needsCheck) {
                     needsCheck = false;
-                    for(Part part : partsToFix) {
+                    for(int x = 0; x < unit.getParts().size(); x++) {
+                        Part part = unit.getParts().get(x);
                         if(part instanceof Armor) {
                             final Armor armor = (Armor) part;
                             armor.setAmount(armor.getTotalAmount());
@@ -509,13 +510,14 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                             ammoBin.setShotsNeeded(0);
                         }
                         if(part instanceof MissingPart) {
-                            // MissingPart has no easy way to just tell it "replace me with a workig one" either ...
+                            // MissingPart has no easy way to just tell it "replace me with a working one" either ...
+                            part.getCampaign().addPart(((MissingPart) part).getNewPart(), 0);
+                            part.fix();
                             part.resetTimeSpent();
                             part.resetOvertime();
                             part.setTeamId(null);
                             part.cancelReservation();
                             part.remove(false);
-                            needsCheck = true;
                         } else {
                             if(part.needsFixing()) {
                                 needsCheck = true;
@@ -542,10 +544,6 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                             }
                         }
                     }
-                    // Check for more parts to fix (because the list above is not
-                    // sorted usefully)
-                    unit.initializeParts(true);
-                    partsToFix = new HashSet<>(unit.getParts());
                 }
                 MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -38,6 +38,7 @@ import mekhq.Utilities;
 import mekhq.campaign.event.RepairStatusChangedEvent;
 import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.finances.Transaction;
+import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.Part;
@@ -507,10 +508,13 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                             armor.setAmount(armor.getTotalAmount());
                         } else if(part instanceof AmmoBin) {
                             final AmmoBin ammoBin = (AmmoBin) part;
-                            ammoBin.setShotsNeeded(0);
+                            // we magically find the ammo we need, then load the bin
+                            ammoBin.getAcquisitionWork().find(0);
+                            ammoBin.loadBin();
                         }
+                        
                         if(part instanceof MissingPart) {
-                            // MissingPart has no easy way to just tell it "replace me with a working one" either ...
+                            // We magically acquire a replacement part, then fix the missing one.
                             part.getCampaign().addPart(((MissingPart) part).getNewPart(), 0);
                             part.fix();
                             part.resetTimeSpent();

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -500,21 +500,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                     needsCheck = false;
                     for(int x = 0; x < unit.getParts().size(); x++) {
                         Part part = unit.getParts().get(x);
-                        if(part instanceof Armor) {
-                            final Armor armor = (Armor) part;
-                            armor.setAmount(armor.getTotalAmount());
-                        } else if(part instanceof AmmoBin) {
-                            final AmmoBin ammoBin = (AmmoBin) part;
-                            
-                            // we magically find the ammo we need, then load the bin
-                            // we only want to get the amount of ammo the bin actually needs                            
-                            if(ammoBin.getShotsNeeded() > 0) {
-                                ammoBin.getAcquisitionWork(ammoBin.getShotsNeeded()).find(0);
-                            }                            
-                            
-                            ammoBin.loadBin();
-                        }
-                        
+                                                
                         if(part instanceof MissingPart) {
                             // We magically acquire a replacement part, then fix the missing one.
                             part.getCampaign().addPart(((MissingPart) part).getNewPart(), 0);
@@ -534,7 +520,25 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                             part.setTeamId(null);
                             part.cancelReservation();
                         }
+                        
+                        // replace damaged armor and reload ammo bins after fixing their respective locations
+                        if(part instanceof Armor) {
+                            final Armor armor = (Armor) part;
+                            armor.setAmount(armor.getTotalAmount());
+                        } else if(part instanceof AmmoBin) {
+                            final AmmoBin ammoBin = (AmmoBin) part;
+                            
+                            // we magically find the ammo we need, then load the bin
+                            // we only want to get the amount of ammo the bin actually needs                            
+                            if(ammoBin.getShotsNeeded() > 0) {
+                                ammoBin.getAcquisitionWork(ammoBin.getShotsNeeded()).find(0);
+                            }                            
+                            
+                            ammoBin.loadBin();
+                        }
+                        
                     }
+                    
                     // TODO: Make this less painful. We just want to fix hips and shoulders.
                     Entity entity = unit.getEntity();
                     if(entity instanceof Mech) {

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -7,8 +7,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.text.NumberFormat;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.UUID;
 import java.util.Vector;
 
@@ -38,7 +36,6 @@ import mekhq.Utilities;
 import mekhq.campaign.event.RepairStatusChangedEvent;
 import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.finances.Transaction;
-import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.Part;
@@ -508,8 +505,13 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                             armor.setAmount(armor.getTotalAmount());
                         } else if(part instanceof AmmoBin) {
                             final AmmoBin ammoBin = (AmmoBin) part;
+                            
                             // we magically find the ammo we need, then load the bin
-                            ammoBin.getAcquisitionWork().find(0);
+                            // we only want to get the amount of ammo the bin actually needs                            
+                            if(ammoBin.getShotsNeeded() > 0) {
+                                ammoBin.getAcquisitionWork(ammoBin.getShotsNeeded()).find(0);
+                            }                            
+                            
                             ammoBin.loadBin();
                         }
                         


### PR DESCRIPTION
This was an amazing example of an endless loop that didn't eventually run out of memory.

Basically, the loop was:
a) Not actually replacing the missing parts.
b) Re-initializing the parts list from somewhere so that the missing part would pop back up even if it was replaced. 

Changed it to actually replace the missing part. Also fixed an issue where "restore unit" wouldn't actually reload ammo bins.