### PR TITLE
Added arbitrary contract score modifier

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -148,6 +148,7 @@ public class AtBContract extends Contract implements Serializable {
 	
 	protected int playerMinorBreaches;
 	protected int employerMinorBreaches;
+	protected int contractScoreArbitraryModifier;
 	
 	protected int moraleMod = 0;
 	protected int numBonusParts;
@@ -598,7 +599,12 @@ public class AtBContract extends Contract implements Serializable {
 		if (earlySuccess) {
 			score += 4;
 		}
+		score += contractScoreArbitraryModifier;
 		return score;
+	}
+
+	public int getContractScoreArbitraryModifier() {
+		return contractScoreArbitraryModifier;
 	}
 	
 	public void doBonusRoll(Campaign c) {
@@ -1417,6 +1423,10 @@ public class AtBContract extends Contract implements Serializable {
 	
 	public void addEmployerMinorBreaches(int num) {
 		employerMinorBreaches += num;
+	}
+
+	public void setContractScoreArbitraryModifier(int newModifier) {
+		contractScoreArbitraryModifier = newModifier;
 	}
 	
 	public int getNumBonusParts() {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -99,6 +99,7 @@ public class CustomizeAtBContractDialog extends JDialog {
 	protected JComboBox<String> cbEnemyQuality;
 	protected JSpinner spnRequiredLances;
 	protected JComboBox<String> cbEnemyMorale;
+	protected JSpinner spnContractScoreArbitraryModifier;
 	protected JTextField txtAllyBotName;
 	protected JTextField txtEnemyBotName;
 	protected JButton btnAllyCamo;
@@ -192,6 +193,10 @@ public class CustomizeAtBContractDialog extends JDialog {
     	spnRequiredLances = new JSpinner(new SpinnerNumberModel(contract.getRequiredLances(), 1,
     			null, 1));
     	JLabel lblEnemyMorale = new JLabel();
+        spnContractScoreArbitraryModifier = new JSpinner(
+                new SpinnerNumberModel(contract.getContractScoreArbitraryModifier(),
+                        null,null,1));
+        JLabel lblContractScoreArbitraryModifier = new JLabel();
     	cbEnemyMorale = new JComboBox<String>(AtBContract.moraleLevelNames);
    	
     	int y = 0;
@@ -373,7 +378,7 @@ public class CustomizeAtBContractDialog extends JDialog {
         gbc.gridwidth = 1;
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         leftPanel.add(lblEnemyMorale, gbc);
-        
+
         cbEnemyMorale.setSelectedIndex(contract.getMoraleLevel());
         gbc.gridx = 1;
         gbc.gridy = y++;
@@ -382,6 +387,22 @@ public class CustomizeAtBContractDialog extends JDialog {
         gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         leftPanel.add(cbEnemyMorale, gbc);
+
+        lblContractScoreArbitraryModifier.setText(resourceMap.getString("lblContractScoreArbitraryModifier.text")); // NOI18N
+        lblContractScoreArbitraryModifier.setName("lblContractScoreArbitraryModifier"); // NOI18N
+        gbc.gridx = 0;
+        gbc.gridy = y;
+        gbc.gridwidth = 1;
+        gbc.insets = new java.awt.Insets(5, 5, 5, 5);
+        leftPanel.add(lblContractScoreArbitraryModifier, gbc);
+
+        gbc.gridx = 1;
+        gbc.gridy = y++;
+        gbc.gridwidth = 1;
+        gbc.weightx = 1.0;
+        gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gbc.insets = new java.awt.Insets(5, 5, 5, 5);
+        leftPanel.add(spnContractScoreArbitraryModifier, gbc);
 
         txtDesc.setText(contract.getDescription());
         txtDesc.setName("txtDesc");
@@ -593,6 +614,7 @@ public class CustomizeAtBContractDialog extends JDialog {
     	contract.setEnemyQuality(cbEnemyQuality.getSelectedIndex());
     	contract.setRequiredLances((Integer)spnRequiredLances.getValue());
     	contract.setMoraleLevel(cbEnemyMorale.getSelectedIndex());
+    	contract.setContractScoreArbitraryModifier((Integer)spnContractScoreArbitraryModifier.getValue());
     	contract.setAllyBotName(txtAllyBotName.getText());
     	contract.setEnemyBotName(txtEnemyBotName.getText());
     	contract.setAllyCamoCategory(allyCamoCategory);

--- a/MekHQ/src/mekhq/resources/NewContractDialog.properties
+++ b/MekHQ/src/mekhq/resources/NewContractDialog.properties
@@ -46,4 +46,5 @@ lblAllyCamo.text=Ally Camo
 lblEnemyCamo.text=Enemy Camo
 lblRequiredLances.text=Required Lances:
 lblEnemyMorale.text=Enemy Morale:
+lblContractScoreArbitraryModifier.text=Contract Score Modifier:
 lblShares.text=Percent for Shares:


### PR DESCRIPTION
Adds a simple spinner found in the "Edit Mission" dialog for the player to set a custom, arbitrary contract score modifier, mostly as a "crutch" to handle conditions not currently covered by MekHQ for now. 

Looks like this, in a new GM-created Contract that started at the usual contract score of 1: 
![image](https://user-images.githubusercontent.com/360217/41584071-4eb7d87c-7374-11e8-83f3-c9b51782e833.png)

