### PR TITLE
Fix for salvaging dropship ammo

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -237,6 +237,11 @@ public class LargeCraftAmmoBin extends AmmoBin {
     }
     
     @Override
+    public boolean isSalvaging() {
+        return super.isSalvaging() && (getCurrentShots() > 0);
+    }
+    
+    @Override
     public void remove(boolean salvage) {
         // The bin represents capacity rather than an actual part, and cannot be
         // removed or damaged.

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -237,6 +237,13 @@ public class LargeCraftAmmoBin extends AmmoBin {
     }
     
     @Override
+    public void remove(boolean salvage) {
+        // The bin represents capacity rather than an actual part, and cannot be
+        // removed or damaged.
+        unload();
+    }
+
+    @Override
     public MissingPart getMissingPart() {
         return null;
     }


### PR DESCRIPTION
While test the restore unit fix last week I discovered that attempting to salvage ammo on a dropship throws an NPE due to the inherited behavior that removes it and replace it with the corresponding MissingPart. Large Craft bays are not actually parts but rather ways to track capacity and have no corresponding MissingPart. I fixed it by overriding the replace method so that it simply unloads the ammo, and also ensured that ammo bins only show up in the task list for salvaging if they have ammo in them.