### PR TITLE
allow purchasing and adding of parts en-masse, addresses issue: #121

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
@@ -248,46 +248,73 @@ public class PartsStoreDialog extends javax.swing.JDialog {
 			btnAdd = new JButton(resourceMap.getString("btnAdd.text"));
 			btnAdd.addActionListener(new java.awt.event.ActionListener() {
 	            public void actionPerformed(java.awt.event.ActionEvent evt) {
-	                addPart(false, false);
+	            	if (partsTable.getSelectedRowCount() > 0) {
+	            		int selectedRow[] = partsTable.getSelectedRows();
+	            		for (int i : selectedRow) {
+	            			addPart(false, i, 1);
+	            		}
+	            	}
 	            }
 	        });
 			btnAdd.setEnabled(campaign.isGM());
 			btnBuyBulk = new JButton(resourceMap.getString("btnBuyBulk.text"));
 			btnBuyBulk.addActionListener(new java.awt.event.ActionListener() {
 	            public void actionPerformed(java.awt.event.ActionEvent evt) {
-	            	addPart(true, true);
-	                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_TARGET);
-	                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_TRANSIT);
-	                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_SUPPLY);
-	                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_QUEUE);
+	            	if (partsTable.getSelectedRowCount() > 0) {
+	            		int quantity = 1;
+            			PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(campaignGUI.getFrame(), true, "How Many?", quantity, 1, CampaignGUI.MAX_QUANTITY_SPINNER);
+            			pcd.setVisible(true);
+            			quantity = pcd.getValue();
+
+	            		int selectedRow[] = partsTable.getSelectedRows();
+	            		for (int i : selectedRow) {
+			            	addPart(true, false, i, quantity);
+			                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_TARGET);
+			                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_TRANSIT);
+			                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_SUPPLY);
+			                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_QUEUE);
+	            		}
+	            	}
 	            }
 	        });
 			btnBuy = new JButton(resourceMap.getString("btnBuy.text"));
 			btnBuy.addActionListener(new java.awt.event.ActionListener() {
 	            public void actionPerformed(java.awt.event.ActionEvent evt) {
-	                addPart(true, false);
-	                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_TARGET);
-	                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_TRANSIT);
-	                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_SUPPLY);
-	                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_QUEUE);            }
+	            	if (partsTable.getSelectedRowCount() > 0) {
+	            		int selectedRow[] = partsTable.getSelectedRows();
+	            		for (int i : selectedRow) {
+			                addPart(true, i, 1);
+			                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_TARGET);
+			                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_TRANSIT);
+			                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_SUPPLY);
+			                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_QUEUE);            }
+	            		}
+	            	}
 	        });
 			btnUseBonusPart = new JButton();
 			if (campaign.getCampaignOptions().getUseAtB()) {
-				int numBonusParts = campaign.totalBonusParts();
-				btnUseBonusPart.setText("Use Bonus Part (" + numBonusParts + ")");
+				btnUseBonusPart.setText(resourceMap.getString("useBonusPart.text") + " (" + campaign.totalBonusParts() + ")");
 				btnUseBonusPart.addActionListener(new java.awt.event.ActionListener() {
 		            public void actionPerformed(java.awt.event.ActionEvent evt) {
-		                addPart(true, false, true);
-		                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_TARGET);
-		                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_TRANSIT);
-		                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_SUPPLY);
-		                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(partsTable.getSelectedRow()), PartsTableModel.COL_QUEUE);
-		            	int numBonusParts = campaign.totalBonusParts();
-						btnUseBonusPart.setText("Use Bonus Part (" + numBonusParts + ")");
-		            	btnUseBonusPart.setVisible(numBonusParts > 0);
+		            	if (partsTable.getSelectedRowCount() > 0) {
+		            		int selectedRow[] = partsTable.getSelectedRows();
+		            		for (int i : selectedRow) {
+				                if (campaign.totalBonusParts() > 0)
+				                	campaign.addReport(resourceMap.getString("bonusPartLog.text") + " " + partsModel.getPartAt(partsTable.convertRowIndexToModel(i)).getPartName());
+
+				                addPart(true, campaign.totalBonusParts() > 0, i, 1);
+				                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_TARGET);
+				                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_TRANSIT);
+				                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_SUPPLY);
+				                partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i), PartsTableModel.COL_QUEUE);
+
+								btnUseBonusPart.setText(resourceMap.getString("useBonusPart.text") + " (" + campaign.totalBonusParts() + ")");
+				            	btnUseBonusPart.setVisible(campaign.totalBonusParts() > 0);
+		            		}
+		            	}
 	                }
 		        });
-				btnUseBonusPart.setVisible(numBonusParts > 0);
+				btnUseBonusPart.setVisible(campaign.totalBonusParts() > 0);
 			}
 			btnClose = new JButton(resourceMap.getString("btnClose.text"));
 			btnClose.addActionListener(new java.awt.event.ActionListener() {
@@ -304,7 +331,7 @@ public class PartsStoreDialog extends javax.swing.JDialog {
 			panButtons.add(btnAdd, new GridBagConstraints());
 			panButtons.add(btnClose, new GridBagConstraints());
 		} else {
-            //if we arent adding the unit to the campaign, then different buttons
+            //if we aren't adding the unit to the campaign, then different buttons
             btnAdd = new JButton("Add");
 			btnAdd.addActionListener(new java.awt.event.ActionListener() {
 	            public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -399,25 +426,15 @@ public class PartsStoreDialog extends javax.swing.JDialog {
     }
 
 
-    private void addPart(boolean purchase, boolean bulk) {
-    	addPart(purchase, bulk, false);
+    private void addPart(boolean purchase, int row, int quantity) {
+    	addPart(purchase, false, row, quantity);
     }
 
-    private void addPart(boolean purchase, boolean bulk, boolean bonus) {
-        final String METHOD_NAME = "addPart(boolean,boolean,boolean)"; //$NON-NLS-1$
+    private void addPart(boolean purchase, boolean bonus, int row, int quantity) {
+        final String METHOD_NAME = "addPart(boolean,boolean,int,int)"; //$NON-NLS-1$
         
-    	int row = partsTable.getSelectedRow();
-		if(row < 0) {
-			return;
-		}
-		Part selectedPart = partsModel.getPartAt(partsTable.convertRowIndexToModel(row));
-		int quantity = 1;
-		if(bulk) {
-			PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(campaignGUI.getFrame(), true, "How Many " + selectedPart.getName(), quantity, 1, CampaignGUI.MAX_QUANTITY_SPINNER);
-			pcd.setVisible(true);
-			quantity = pcd.getValue();
-		}
-
+        Part selectedPart = partsModel.getPartAt(partsTable.convertRowIndexToModel(row));
+        
 		if(bonus) {
 			String report = selectedPart.getAcquisitionWork().find(0);
 			if (report.endsWith("0 days.")) {

--- a/MekHQ/src/mekhq/resources/PartsStoreDialog.properties
+++ b/MekHQ/src/mekhq/resources/PartsStoreDialog.properties
@@ -5,3 +5,5 @@ btnAdd.text=Add (GM)
 btnClose.text=Close
 lblPartsChoice.text=Type:
 lblFilter.text=Filter:
+bonusPartLog.text=Bonus part used to acquire 1x
+useBonusPart.text=Use Bonus Part


### PR DESCRIPTION
Use CTRL + CLICK to select multiple rows.

If someone could double-check the logic, especially all of those booleans that would be great.  I had to refactor a bit for the bulk case.  I believe it should all work for purchasing (single and bulk) as well as adding (GM mode).  I didn't test the bonus and left that as-is single selection since it has to decrement the bonus amount.  I also don't have a campaign to test that condition.