### PR TITLE
Fix #384: Negotiation re-rolls now getting person by order of negotiation skill

### DIFF
--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -121,13 +121,13 @@ public class ContractSummaryPanel extends JPanel {
 		this.campaign = campaign;
 		this.allowRerolls = allowRerolls;
 		if (allowRerolls) {
-			Person admin = campaign.findBestInRole(Person.T_ADMIN_COM, SkillType.S_ADMIN, SkillType.S_NEG);
+			Person admin = campaign.findBestInRole(Person.T_ADMIN_COM, SkillType.S_NEG, SkillType.S_ADMIN);
 			cmdRerolls = (admin == null || admin.getSkill(SkillType.S_NEG) == null)?
 					0 : admin.getSkill(SkillType.S_NEG).getLevel();
-			admin = campaign.findBestInRole(Person.T_ADMIN_LOG, SkillType.S_ADMIN, SkillType.S_NEG);
+			admin = campaign.findBestInRole(Person.T_ADMIN_LOG, SkillType.S_NEG, SkillType.S_ADMIN);
 			logRerolls = (admin == null || admin.getSkill(SkillType.S_NEG) == null)?
 					0 : admin.getSkill(SkillType.S_NEG).getLevel();
-			admin = campaign.findBestInRole(Person.T_ADMIN_TRA, SkillType.S_ADMIN, SkillType.S_NEG);
+			admin = campaign.findBestInRole(Person.T_ADMIN_TRA, SkillType.S_NEG, SkillType.S_ADMIN);
 			tranRerolls = (admin == null || admin.getSkill(SkillType.S_NEG) == null)?
 					0 : admin.getSkill(SkillType.S_NEG).getLevel();
 		}


### PR DESCRIPTION
Quick simple fix to #384 - now it searches for the person with the highest negotation skill, using admin as tie-break.