### PR TITLE
show tips/suggestions on loading screen and under Help menu

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -85,6 +85,7 @@ import mekhq.gui.StartUpGUI;
 import mekhq.gui.dialog.LaunchGameDialog;
 import mekhq.gui.dialog.ResolveScenarioWizardDialog;
 import mekhq.gui.dialog.RetirementDefectionDialog;
+import mekhq.gui.dialog.TipsDialog;
 
 /**
  * The main class of the application.
@@ -252,21 +253,26 @@ public class MekHQ implements GameListener {
     public static void main(String[] args) {
     	System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name","MekHQ");
+        System.setProperty("showLoadingTips", "true");
         //redirect output to log file
         redirectOutput();
         MekHQ.getInstance().startup();
     }
 
     protected static Properties setDefaultPreferences() {
-    	Properties defaults = new Properties();
-    	defaults.setProperty("laf", UIManager.getSystemLookAndFeelClassName());
-    	return defaults;
+        Properties defaults = new Properties();
+        defaults.setProperty("laf", UIManager.getSystemLookAndFeelClassName());
+        defaults.setProperty("showLoadingTips", "true");
+        return defaults;
     }
 
     protected void readPreferences() {
-    	preferences = new Properties(setDefaultPreferences());
+        preferences = new Properties(setDefaultPreferences());
         try {
             preferences.load(new FileInputStream(PROPERTIES_FILE));
+            if (preferences.getProperty("showLoadingTips").equalsIgnoreCase("true") || preferences.getProperty("showLoadingTips").equalsIgnoreCase("false")) {
+                TipsDialog.showTips = Boolean.valueOf(preferences.getProperty("showLoadingTips"));
+            }
             MekHQ.logMessage("loading mekhq properties from " + PROPERTIES_FILE);
         } catch (FileNotFoundException e) {
             MekHQ.logMessage("No mekhq properties file found. Reverting to defaults.");
@@ -276,15 +282,15 @@ public class MekHQ implements GameListener {
     }
 
     protected void savePreferences() {
-    	preferences.setProperty("laf", UIManager.getLookAndFeel().getClass().getName());
-    	try {
-			preferences.store(new FileOutputStream(PROPERTIES_FILE), "MekHQ Preferences");
-		} catch (FileNotFoundException e) {
-			MekHQ.logMessage("could not save preferences to " + PROPERTIES_FILE);
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+        preferences.setProperty("laf", UIManager.getLookAndFeel().getClass().getName());
+        preferences.setProperty("showLoadingTips", Boolean.toString(TipsDialog.showTips).toLowerCase());
+        try {
+            preferences.store(new FileOutputStream(PROPERTIES_FILE), "MekHQ Preferences");
+        } catch (FileNotFoundException e) {
+            MekHQ.logMessage("could not save preferences to " + PROPERTIES_FILE);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
     
     private void showInfo() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -154,6 +154,7 @@ import mekhq.gui.dialog.RefitNameDialog;
 import mekhq.gui.dialog.ReportDialog;
 import mekhq.gui.dialog.RetirementDefectionDialog;
 import mekhq.gui.dialog.ShipSearchDialog;
+import mekhq.gui.dialog.TipsDialog;
 import mekhq.gui.dialog.UnitCostReportDialog;
 import mekhq.gui.dialog.UnitMarketDialog;
 import mekhq.gui.dialog.UnitSelectorDialog;
@@ -230,6 +231,12 @@ public class CampaignGUI extends JPanel {
         MekHQAboutBox aboutBox = new MekHQAboutBox(getFrame());
         aboutBox.setLocationRelativeTo(getFrame());
         aboutBox.setVisible(true);
+    }
+
+    public void showTipsDialog() {
+        TipsDialog tipsDialog = new TipsDialog(getFrame());
+        tipsDialog.setLocationRelativeTo(getFrame());
+        tipsDialog.setVisible(true);
     }
 
     private void showHistoricalDailyReportDialog() {
@@ -1160,6 +1167,17 @@ public class CampaignGUI extends JPanel {
             }
         });
         menuHelp.add(menuAboutItem);
+
+        JMenuItem menuTipsItem = new JMenuItem("tipsMenuItem"); // NOI18N
+        menuTipsItem.setText(resourceMap.getString("tipsMenu.text"));
+        menuTipsItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                showTipsDialog();
+            }
+        });
+        menuHelp.add(menuTipsItem);
+
         menuBar.add(menuHelp);
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -20,6 +20,8 @@
 package mekhq.gui.dialog;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Font;
 import java.awt.Image;
 import java.awt.MediaTracker;
 import java.beans.PropertyChangeEvent;
@@ -37,7 +39,9 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JProgressBar;
+import javax.swing.SwingConstants;
 import javax.swing.SwingWorker;
+import javax.swing.border.EmptyBorder;
 
 import megamek.client.RandomNameGenerator;
 import megamek.common.MechSummaryCache;
@@ -76,7 +80,7 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
         this.frame = frame;
         this.app = app;
         this.fileCampaign = f;
-        
+
         resourceMap = ResourceBundle.getBundle("mekhq.resources.DataLoadingDialog", new EncodeControl()); //$NON-NLS-1$
 
         setUndecorated(true);
@@ -102,6 +106,20 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
         // make splash image panel
         ImageIcon icon = new ImageIcon(imgSplash);
         JLabel splash = new JLabel(icon);
+        splash.setLayout(new BorderLayout());
+        
+        if (TipsDialog.showTips) {
+            JLabel tipLabel = new JLabel(TipsDialog.getRandomTip(), SwingConstants.RIGHT);
+            tipLabel.setFont(new Font("Arial", Font.BOLD, 24));
+            tipLabel.setForeground(Color.WHITE);
+            tipLabel.setVerticalAlignment(JLabel.BOTTOM);
+            tipLabel.setOpaque(true);
+            tipLabel.setBackground(new Color(0, 0, 0, 120)); // last value is the transparency, 0-255
+            tipLabel.setBorder(new EmptyBorder(12,12,12,12)); // add spacing
+
+            splash.add(tipLabel, BorderLayout.SOUTH);
+        }
+        
         getContentPane().setLayout(new BorderLayout());
         getContentPane().add(splash, BorderLayout.CENTER);
         getContentPane().add(progressBar, BorderLayout.PAGE_END);

--- a/MekHQ/src/mekhq/gui/dialog/TipsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/TipsDialog.java
@@ -1,0 +1,303 @@
+/*
+ * TipsDialog.java
+ *
+ * Copyright (c) 2018
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import megamek.common.util.EncodeControl;
+
+
+
+public class TipsDialog extends JDialog {
+
+    private static final long serialVersionUID = 8517524238015359837L;
+
+    private ResourceBundle resourceMap;
+    private static ResourceBundle tipsSuggestions = ResourceBundle.getBundle("mekhq.resources.TipsAndSuggestions", new EncodeControl()); //$NON-NLS-1$
+    private static Set<String> keySet = tipsSuggestions.keySet();
+    // we can't access sets by index, thus the conversion to a list
+    private static ArrayList<String> keyList = new ArrayList<String>(keySet);
+    private static int selectedCategoryIndex;
+
+    private JCheckBox tipsCheckbox;
+    private JLabel categoryLbl;
+    private JComboBox<String> categoryDropdown;
+    private JButton previousBtn;
+    private JButton nextBtn;
+    private JLabel tipLbl;
+    private JLabel numericPositionLbl;
+    private JButton closeBtn;
+
+    public static boolean showTips = true;
+
+    public TipsDialog (Frame owner) {
+        super(owner, true);
+        this.setPreferredSize(new Dimension(650,500));
+        this.setMinimumSize(new Dimension(650,500));
+        initComponents();
+
+        setLocationRelativeTo(owner);
+    }
+
+    private void initComponents() {
+        resourceMap = ResourceBundle.getBundle("mekhq.resources.TipsDialog", new EncodeControl()); //$NON-NLS-1$
+
+        setTitle(resourceMap.getString("title.text"));
+
+        getContentPane().setLayout(new GridBagLayout());
+
+        tipsCheckbox = new JCheckBox(resourceMap.getString("showTipsStartup.text"));
+        tipsCheckbox.setSelected(showTips);
+        tipsCheckbox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                if (e.getStateChange() == ItemEvent.SELECTED) {
+                    showTips = true;
+                } else {
+                    showTips = false;
+                }
+            }
+        });
+
+        GridBagConstraints gridBag = new GridBagConstraints();
+        gridBag.fill = GridBagConstraints.HORIZONTAL;
+        gridBag.anchor = GridBagConstraints.NORTHWEST;
+        gridBag.gridx = 0;
+        gridBag.gridy = 0;
+        gridBag.gridwidth = 3;
+        gridBag.insets = new Insets(15,15,15,15); //add some spacing for readability
+        getContentPane().add(tipsCheckbox, gridBag);
+
+        JPanel categoryPanel = new JPanel();
+        categoryLbl = new JLabel(resourceMap.getString("category.text"));
+        categoryPanel.add(categoryLbl);
+
+        categoryDropdown = new JComboBox<String>(getAllPossibleCategories().toArray(new String[getAllPossibleCategories().size()]));
+        categoryDropdown.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                if (e.getStateChange() == ItemEvent.SELECTED) {
+                    String key = getRandomTipKeyInCategory(categoryDropdown.getSelectedItem().toString());
+                    refreshUI(key);
+                }
+            }
+        });
+        categoryPanel.add(categoryDropdown);
+
+        gridBag = new GridBagConstraints();
+        gridBag.gridx = 0;
+        gridBag.gridy = 1;
+        gridBag.weighty = 0.2;
+        gridBag.anchor = GridBagConstraints.SOUTH;
+        gridBag.gridwidth = 3;
+        getContentPane().add(categoryPanel, gridBag);
+
+        previousBtn = new JButton("<-");
+        previousBtn.setFont(new Font("Arial", Font.PLAIN, 18));
+        previousBtn.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                btnClick(false);
+            }
+        });
+        gridBag = new GridBagConstraints();
+        gridBag.gridx = 0;
+        gridBag.gridy = 2;
+        gridBag.weightx = 0.1;
+        getContentPane().add(previousBtn, gridBag);
+
+        String key = getRandomTipKey();
+
+        tipLbl = new JLabel();
+        tipLbl.setFont(new Font("Arial", Font.PLAIN, 14));
+        gridBag = new GridBagConstraints();
+        gridBag.fill = GridBagConstraints.BOTH;
+        gridBag.gridx = 1;
+        gridBag.gridy = 2;
+        gridBag.weightx = 0.8;
+        gridBag.weighty = 0.6;
+        gridBag.insets = new Insets(15,15,15,15); //add some spacing for readability
+        getContentPane().add(tipLbl, gridBag);
+
+        nextBtn = new JButton("->");
+        nextBtn.setFont(new Font("Arial", Font.PLAIN, 18));
+        nextBtn.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                btnClick(true);
+            }
+        });
+        gridBag = new GridBagConstraints();
+        gridBag.gridx = 2;
+        gridBag.gridy = 2;
+        gridBag.weightx = 0.1;
+        getContentPane().add(nextBtn, gridBag);
+
+        numericPositionLbl = new JLabel();
+        gridBag = new GridBagConstraints();
+        gridBag.gridx = 1;
+        gridBag.gridy = 3;
+        gridBag.weighty = 0.2;
+        gridBag.anchor = GridBagConstraints.NORTH;
+        getContentPane().add(numericPositionLbl, gridBag);
+
+        closeBtn = new JButton(resourceMap.getString("closeBtn.text"));
+        closeBtn.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                setVisible(false);
+            }
+        });
+        gridBag = new GridBagConstraints();
+        gridBag.gridx = 0;
+        gridBag.gridy = 4;
+        gridBag.fill = GridBagConstraints.HORIZONTAL;
+        gridBag.anchor = GridBagConstraints.PAGE_END;
+        gridBag.gridwidth = 3;
+        getContentPane().add(closeBtn, gridBag);
+
+        categoryDropdown.setSelectedItem(getCategory(key));
+        refreshUI(key);
+    }
+
+    public static String getRandomTip() {
+        // pick a random tip/suggestion
+        String key = getRandomTipKey();
+        return getTipString(key);
+    }
+
+    private static String getTipString(String key) {
+        // JLabels will auto resize the text across multiple lines by adding <html></html> tags
+        String tip = "";
+        if (key.toLowerCase().contains("atb")) {
+            tip = "<html>(AtB): "+tipsSuggestions.getString(key)+"</html>";
+        } else {
+            tip = "<html>"+tipsSuggestions.getString(key)+"</html>";
+        }
+        return tip;
+    }
+
+    private void btnClick(boolean forward) {
+        String key = getKeyByCategoryIndex(selectedCategoryIndex, categoryDropdown.getSelectedItem().toString());
+        if (getNumber(key) == 1 && !forward) {
+            selectedCategoryIndex = getTotalNumberCategories(key);
+        } else if (getNumber(key) == getTotalNumberCategories(key) && forward) {
+            selectedCategoryIndex = 1;
+        } else if (forward) {
+            selectedCategoryIndex = getNumber(key) + 1;
+        } else if (!forward) {
+            selectedCategoryIndex = getNumber(key) - 1;
+        }
+        key = getKeyByCategoryIndex(selectedCategoryIndex, getCategory(key));
+        refreshUI(key);
+    }
+
+    private static String getRandomTipKey() {
+        Random r = new Random();
+        selectedCategoryIndex = r.nextInt(keyList.size());
+        return keyList.get(selectedCategoryIndex);
+    }
+
+    private static String getKeyByCategoryIndex(int categoryIndex, String category) {
+        for (String key : keyList) {
+            if (getNumber(key) == categoryIndex && category.equals(getCategory(key))) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    private static String getCategory(String key) {
+        Pattern r = Pattern.compile("(?:tips\\.)(.*?)(?:\\.)");
+        Matcher m = r.matcher(key);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    private static int getNumber(String key) {
+        Pattern r = Pattern.compile("(?:\\.)(\\d+)(?:\\.text)$");
+        Matcher m = r.matcher(key);
+        if (m.find()) {
+            return Integer.parseInt(m.group(1));
+        }
+        return 0;
+    }
+
+    private static int getTotalNumberCategories(String key) {
+        String category = getCategory(key);
+        int count = 0;
+        for (String tip : keyList) {
+            if (category.equals(getCategory(tip))) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static String getRandomTipKeyInCategory(String category) {
+        String key = getRandomTipKey();
+        while (!getCategory(key).equals(category)) {
+            key = getRandomTipKey();
+        }
+        return key;
+    }
+
+    private static ArrayList<String> getAllPossibleCategories() {
+        ArrayList<String> categories = new ArrayList<String>();
+        for (String tipKey : keyList) {
+            if (!categories.contains(getCategory(tipKey))) {
+                categories.add(getCategory(tipKey));
+            }
+        }
+        return categories;
+    }
+
+    private void refreshUI(String key) {
+        int position = getNumber(key);
+        int total = getTotalNumberCategories(key);
+        numericPositionLbl.setText(Integer.toString(position) + " / " + Integer.toString(total)); //$NON-NLS-1$
+        tipLbl.setText(getTipString(key));
+        selectedCategoryIndex = position;
+    }
+}
+

--- a/MekHQ/src/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/src/mekhq/resources/CampaignGUI.properties
@@ -60,6 +60,7 @@ panMap.TabConstraints.tabTitle=Interstellar Map
 panBriefing.TabConstraints.tabTitle=Briefing Room
 panMekLab.TabConstraints.tabTitle=Mek Lab
 jLabel2.text=Nothing Implemented Yet!
+tipsMenu.text=Tips and Suggestions
 btnAssignDoc.text=Assign
 btnUnassignDoc.text=Unassign
 menuMarket.text=Marketplace

--- a/MekHQ/src/mekhq/resources/TipsAndSuggestions.properties
+++ b/MekHQ/src/mekhq/resources/TipsAndSuggestions.properties
@@ -1,0 +1,41 @@
+# Tips are displayed on the loading screen.
+# Tips are grouped into common themes or categories and by AtB or non-AtB tips:
+# For non-AtB: 		tips.<theme>.<number>.text
+# For AtB: 			tips.<theme>.atb.<number>.text
+# Try to keep the string length reasonable to two sentences or less.  Remember, on the loading
+# screen users will only have a few seconds to read this string.
+
+
+# Finance category/theme
+tips.finance.1.text=Personnel are paid a salary on a monthly basis based on their job.
+
+# Contract category/theme
+tips.contract.atb.1.text=Some contracts will pay for your travel via the "transport terms" percentage.
+
+# Combat category/theme
+tips.combat.1.text=Mechs generally have weaker armor in the back.
+
+# Personnel category/theme
+tips.personnel.1.text=Medics clogging up your personnel table?  Hire temporary medics via Marketplace -> Medic Pool.
+tips.personnel.2.text=Astechs clogging up your personnel table?  Hire temporary astechs via Marketplace -> Astech Pool.
+
+# Parts category/theme
+
+# Repairs category/theme
+
+# Travel category/theme
+
+# Hanger category/theme
+
+# Infirmary category/theme
+
+# GM category/theme
+tips.gm.1.text=GM mode gives you full editing ability.  Click the "GM Mode" button in the top right.
+
+# Campaign category/theme
+tips.campaign.1.text=Play against the AI/computer with the Against the Bot (AtB) option in the Campaign Options.
+
+# Community category/theme
+tips.community.1.text=Visit the MegaMek website: https://megamek.org
+tips.community.2.text=Found a bug?  Submit an issue: https://github.com/MegaMek/mekhq/issues
+tips.community.3.text=Chat, find a game, and talk with the devs on Slack: http://megamek.org:3000/

--- a/MekHQ/src/mekhq/resources/TipsDialog.properties
+++ b/MekHQ/src/mekhq/resources/TipsDialog.properties
@@ -1,0 +1,4 @@
+title.text=Tips and Suggestions
+showTipsStartup.text=Show Tips on Startup Loading Screen
+category.text=Category
+closeBtn.text=Close


### PR DESCRIPTION
This uses the `MekHQ\mmconf\mekhq.properties` file to allow uers to enable/disable showing tips on the loading screen.  It's related to this Megamek issue: https://github.com/MegaMek/megamek/issues/816.  While this initial work primarily puts the framework in, it would be possible to extend this to have the tips be displayed in-context.  All tips are stored as a resource for future translations.  The naming of the resources follows a particular format to encode information about the category and other information for future in-context work.  The loading screen tips are enabled by default.