### PR TITLE
Fix for #796: LAM Pilot shows as Support in Personnel Breakdown

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8607,7 +8607,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public String getCombatPersonnelDetails() {
-        int[] countPersonByType = new int[Person.T_SPACE_GUNNER + 1];
+        int[] countPersonByType = new int[Person.T_NUM];
         int countTotal = 0;
         int countInjured = 0;
         int countMIA = 0;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8617,7 +8617,7 @@ public class Campaign implements Serializable, ITechManager {
 
         for (Person p : getPersonnel()) {
             // Add them to the total count
-            if (p.getPrimaryRole() <= Person.T_SPACE_GUNNER && !p.isPrisoner()
+            if (Person.isCombatRole(p.getPrimaryRole()) && !p.isPrisoner()
                     && !p.isBondsman() && p.isActive()) {
                 countPersonByType[p.getPrimaryRole()]++;
                 countTotal++;
@@ -8628,13 +8628,13 @@ public class Campaign implements Serializable, ITechManager {
                     countInjured++;
                 }
                 salary += p.getSalary();
-            } else if (p.getPrimaryRole() <= Person.T_SPACE_GUNNER
+            } else if (Person.isCombatRole(p.getPrimaryRole())
                     && p.getStatus() == Person.S_RETIRED) {
                 countRetired++;
-            } else if (p.getPrimaryRole() <= Person.T_SPACE_GUNNER
+            } else if (Person.isCombatRole(p.getPrimaryRole())
                     && p.getStatus() == Person.S_MIA) {
                 countMIA++;
-            } else if (p.getPrimaryRole() <= Person.T_SPACE_GUNNER
+            } else if (Person.isCombatRole(p.getPrimaryRole())
                     && p.getStatus() == Person.S_KIA) {
                 countKIA++;
             }
@@ -8648,10 +8648,12 @@ public class Campaign implements Serializable, ITechManager {
                 countTotal);
         sb.append(buffer);
 
-        for (int i = Person.T_NONE + 1; i <= Person.T_SPACE_GUNNER; i++) {
-            buffer = String.format("    %-30s    %4s\n", Person.getRoleDesc(i, getFaction().isClan()),
-                    countPersonByType[i]);
-            sb.append(buffer);
+        for (int i = 0; i <= Person.T_NUM; i++) {
+            if (Person.isCombatRole(i)) {
+                buffer = String.format("    %-30s    %4s\n", Person.getRoleDesc(i, getFaction().isClan()),
+                        countPersonByType[i]);
+                sb.append(buffer);
+            }
         }
 
         buffer = String.format("%-30s        %4s\n",
@@ -8685,7 +8687,7 @@ public class Campaign implements Serializable, ITechManager {
 
         for (Person p : getPersonnel()) {
             // Add them to the total count
-            if (p.getPrimaryRole() > Person.T_SPACE_GUNNER && !p.isPrisoner()
+            if (Person.isSupportRole(p.getPrimaryRole()) && !p.isPrisoner()
                     && !p.isBondsman() && p.isActive()) {
                 countPersonByType[p.getPrimaryRole()]++;
                 countTotal++;
@@ -8703,13 +8705,13 @@ public class Campaign implements Serializable, ITechManager {
                 if (p.getInjuries().size() > 0 || p.getHits() > 0) {
                     countInjured++;
                 }
-            } else if (p.getPrimaryRole() > Person.T_SPACE_GUNNER
+            } else if (Person.isSupportRole(p.getPrimaryRole())
                     && p.getStatus() == Person.S_RETIRED) {
                 countRetired++;
-            } else if (p.getPrimaryRole() > Person.T_SPACE_GUNNER
+            } else if (Person.isSupportRole(p.getPrimaryRole())
                     && p.getStatus() == Person.S_MIA) {
                 countMIA++;
-            } else if (p.getPrimaryRole() > Person.T_SPACE_GUNNER
+            } else if (Person.isSupportRole(p.getPrimaryRole())
                     && p.getStatus() == Person.S_KIA) {
                 countKIA++;
             }
@@ -8723,10 +8725,12 @@ public class Campaign implements Serializable, ITechManager {
                 countTotal);
         sb.append(buffer);
 
-        for (int i = Person.T_NAVIGATOR; i < Person.T_NUM; i++) {
-            buffer = String.format("    %-30s    %4s\n", Person.getRoleDesc(i, getFaction().isClan()),
-                    countPersonByType[i]);
-            sb.append(buffer);
+        for (int i = 0; i < Person.T_NUM; i++) {
+            if (Person.isSupportRole(i)) {
+                buffer = String.format("    %-30s    %4s\n", Person.getRoleDesc(i, getFaction().isClan()),
+                        countPersonByType[i]);
+                sb.append(buffer);
+            }
         }
 
         buffer = String.format("%-30s        %4s\n",

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5321,7 +5321,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public Person newPerson(int type) {
-        return newPerson(type, Person.T_NONE, getFactionCode());
+        return newPerson(type, getFactionCode());
     }
 
     public Person newPerson(int type, int secondary) {
@@ -5329,9 +5329,6 @@ public class Campaign implements Serializable, ITechManager {
     }
     
     public Person newPerson(int type, String factionCode) {
-        if (type == Person.T_LAM_PILOT) {
-            return newPerson(Person.T_MECHWARRIOR, Person.T_AERO_PILOT, factionCode);
-        }
         return newPerson(type, Person.T_NONE, factionCode);
     }
 
@@ -5344,6 +5341,10 @@ public class Campaign implements Serializable, ITechManager {
      * @return
      */
     public Person newPerson(int type, int secondary, String factionCode) {
+        if (type == Person.T_LAM_PILOT) {
+            type = Person.T_MECHWARRIOR;
+            secondary = Person.T_AERO_PILOT;
+        }
         boolean isFemale = getRNG().isFemale();
         Person person = new Person(this, factionCode);
         if (isFemale) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -125,6 +125,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public static final int T_ADMIN_TRA = 24;
     public static final int T_ADMIN_HR = 25; // End of support roles
     public static final int T_LAM_PILOT = 26; // Not a separate type, but an alias for MW + Aero pilot
+                                              // Does not count as either combat or support role
     public static final int T_NUM = 27;
 
     public static final int S_ACTIVE = 0;
@@ -2884,11 +2885,14 @@ public class Person implements Serializable, MekHqXmlSerializable {
     }
     
     /**
+     * Determines whether a role is considered a combat role. Note that T_LAM_PILOT is a special
+     * placeholder which is not used for either primary or secondary role and will return false.
+     * 
      * @param role A value that can be used for a person's primary or secondary role.
      * @return     Whether the role is considered a combat role
      */
     public static boolean isCombatRole(int role) {
-        return role <= T_NAVIGATOR;
+        return (role > T_NONE) && (role <= T_NAVIGATOR);
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -95,6 +95,9 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public static final int G_MALE = 0;
     public static final int G_FEMALE = 1;
 
+    /* If any new roles are added they should go at the end. They should also be accounted for
+     * in isCombatRole(int) or isSupportRole(int)
+     */
     public static final int T_NONE = 0;
     public static final int T_MECHWARRIOR = 1;
     public static final int T_AERO_PILOT = 2;
@@ -109,7 +112,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public static final int T_SPACE_PILOT = 11;
     public static final int T_SPACE_CREW = 12;
     public static final int T_SPACE_GUNNER = 13;
-    public static final int T_NAVIGATOR = 14;
+    public static final int T_NAVIGATOR = 14; // End of combat roles
     public static final int T_MECH_TECH = 15;
     public static final int T_MECHANIC = 16;
     public static final int T_AERO_TECH = 17;
@@ -120,7 +123,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public static final int T_ADMIN_COM = 22;
     public static final int T_ADMIN_LOG = 23;
     public static final int T_ADMIN_TRA = 24;
-    public static final int T_ADMIN_HR = 25;
+    public static final int T_ADMIN_HR = 25; // End of support roles
     public static final int T_LAM_PILOT = 26; // Not a separate type, but an alias for MW + Aero pilot
     public static final int T_NUM = 27;
 
@@ -2863,9 +2866,37 @@ public class Person implements Serializable, MekHqXmlSerializable {
             }
         }
     }
+    
+    /**
+     * @return true if this person has either a primary or a secondary role that is considered a combat
+     *         role
+     */
+    public boolean isCombat() {
+        return isCombatRole(primaryRole) || isCombatRole(primaryRole);
+    }
 
+    /**
+     * @return true if this person has either a primary or a secondary role that is considered a support
+     *         role
+     */
     public boolean isSupport() {
-        return primaryRole >= T_MECH_TECH || secondaryRole >= T_MECH_TECH;
+        return isSupportRole(primaryRole) || isSupportRole(secondaryRole);
+    }
+    
+    /**
+     * @param role A value that can be used for a person's primary or secondary role.
+     * @return     Whether the role is considered a combat role
+     */
+    public static boolean isCombatRole(int role) {
+        return role <= T_NAVIGATOR;
+    }
+    
+    /**
+     * @param role A value that can be used for a person's primary or secondary role.
+     * @return     Whether the role is considered a support role
+     */
+    public static boolean isSupportRole(int role) {
+        return (role >= T_MECH_TECH) && (role < T_LAM_PILOT);
     }
 
     public boolean canDrive(Entity ent) {

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -1,0 +1,39 @@
+package mekhq.campaign.personnel;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class PersonTest {
+
+    @Test
+    public void testIsCombatRoleReturnsTrueAtEdgesOfRange() {
+        assertTrue(Person.isCombatRole(Person.T_MECHWARRIOR));
+        assertTrue(Person.isCombatRole(Person.T_NAVIGATOR));
+    }
+
+    @Test
+    public void testIsCombatRoleReturnsOutsideRange() {
+        assertFalse(Person.isCombatRole(Person.T_NONE));
+        assertFalse(Person.isCombatRole(Person.T_MECH_TECH));
+        assertFalse(Person.isCombatRole(Person.T_NUM));
+        assertFalse(Person.isCombatRole(Person.T_LAM_PILOT));
+        assertFalse(Person.isCombatRole(-1));
+    }
+
+    @Test
+    public void testIsSupportRoleReturnsTrueAtEdgesOfRange() {
+        assertTrue(Person.isSupportRole(Person.T_MECH_TECH));
+        assertTrue(Person.isSupportRole(Person.T_ADMIN_HR));
+    }
+
+    @Test
+    public void testIsSupportRoleReturnsOutsideRange() {
+        assertFalse(Person.isSupportRole(Person.T_NONE));
+        assertFalse(Person.isSupportRole(Person.T_NAVIGATOR));
+        assertFalse(Person.isSupportRole(Person.T_NUM));
+        assertFalse(Person.isSupportRole(Person.T_LAM_PILOT));
+        assertFalse(Person.isSupportRole(-1));
+    }
+
+}


### PR DESCRIPTION
Goes beyond a simple fix and pulls the logic for deciding whether a role is combat or support to a central location in Person.