### PR TITLE
string identity comparison to .equals()

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -852,7 +852,7 @@ public class RandomFactionGenerator implements Serializable {
 								hintApplies(wars, inner, inner, date);
 					}
 					for (String f : l.opponents) {
-						if (f == opponent) {
+						if (f.equals(opponent)) {
 							return true;
 						}
 					}

--- a/MekHQ/src/mekhq/campaign/universe/StarUtil.java
+++ b/MekHQ/src/mekhq/campaign/universe/StarUtil.java
@@ -433,13 +433,13 @@ public final class StarUtil {
         if( subtypeValue % 100 == 0 ) { subtypeFormat = "%.0f"; } //$NON-NLS-1$
         else if( subtypeValue % 10 == 0 ) { subtypeFormat = "%.1f"; } //$NON-NLS-1$
         
-        if( luminosity == Planet.LUM_VI ) {
+        if( luminosity.equals(Planet.LUM_VI) ) {
             // subdwarfs
             return "sd" + getSpectralClassName(spectralClass) + String.format(subtypeFormat, subtypeValue / 100.0); //$NON-NLS-1$
-        } else if( luminosity == Planet.LUM_VI_PLUS ) {
+        } else if( luminosity.equals(Planet.LUM_VI_PLUS) ) {
             // extreme subdwarfs
             return "esd" + getSpectralClassName(spectralClass) + String.format(subtypeFormat, subtypeValue / 100.0); //$NON-NLS-1$
-        } else if( luminosity == Planet.LUM_VII ) {
+        } else if( luminosity.equals(Planet.LUM_VII) ) {
             // white dwarfs
             return String.format(Locale.ROOT, "D" + subtypeFormat, subtypeValue / 100.0); //$NON-NLS-1$
         } else {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -141,7 +141,7 @@ ActionListener {
                                 }
                             }
                         }
-                        if (cantTech != "") {
+                        if (!cantTech.equals("")) {
                             cantTech += "You will need to assign a tech manually.";
                             JOptionPane.showMessageDialog(null, cantTech, "Warning", JOptionPane.WARNING_MESSAGE);
                         }


### PR DESCRIPTION
Found via [static code analysis tool SpotBugs](https://spotbugs.readthedocs.io/).

> ES: Comparison of String objects using == or != (ES_COMPARING_STRINGS_WITH_EQ)
> 
> This code compares java.lang.String objects for reference equality using the == or != operators. Unless both strings are either constants in a source file, or have been interned using the String.intern() method, the same string value may be represented by two different String objects. Consider using the equals(Object) method instead.

This should have no visible impact to the user.