### PR TITLE
Refactor campaign data structures

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -250,7 +250,7 @@ public class Campaign implements Serializable, ITechManager {
     private Map<Integer, Scenario> scenarios = new LinkedHashMap<>();
     private List<Kill> kills = new ArrayList<>();
 
-    private Hashtable<String, Integer> duplicateNameHash = new Hashtable<String, Integer>();
+    private Map<String, Integer> duplicateNameHash = new HashMap<String, Integer>();
 
     private int astechPool;
     private int astechPoolMinutes;
@@ -6990,15 +6990,14 @@ public class Campaign implements Serializable, ITechManager {
      */
     private void checkDuplicateNamesDuringAdd(Entity entity) {
         if (duplicateNameHash.get(entity.getShortName()) == null) {
-            duplicateNameHash.put(entity.getShortName(), new Integer(1));
+            duplicateNameHash.put(entity.getShortName(), Integer.valueOf(1));
         } else {
-            int count = duplicateNameHash.get(entity.getShortName()).intValue();
+            int count = duplicateNameHash.get(entity.getShortName());
             count++;
-            duplicateNameHash.put(entity.getShortName(), new Integer(count));
+            duplicateNameHash.put(entity.getShortName(), Integer.valueOf(count));
             entity.duplicateMarker = count;
             entity.generateShortName();
             entity.generateDisplayName();
-
         }
     }
 
@@ -7021,8 +7020,8 @@ public class Campaign implements Serializable, ITechManager {
                         e.generateDisplayName();
                     }
                 }
-                duplicateNameHash.put(entity.getShortNameRaw(), new Integer(
-                        count - 1));
+                duplicateNameHash.put(entity.getShortNameRaw(), 
+                    Integer.valueOf(count - 1));
             } else {
                 duplicateNameHash.remove(entity.getShortNameRaw());
             }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1239,14 +1239,8 @@ public class Campaign implements Serializable, ITechManager {
             if (!u.isAvailable()) {
                 continue;
             }
-            if (u.isSalvage() || !u.isRepairable()) {
-                if (u.getSalvageableParts().size() > 0) {
-                    service.add(u);
-                }
-            } else {
-                if (u.getPartsNeedingFixing().size() > 0) {
-                    service.add(u);
-                }
+            if (u.isServiceable()) {
+                service.add(u);
             }
         }
         return service;
@@ -4211,7 +4205,7 @@ public class Campaign implements Serializable, ITechManager {
             unit.initializeParts(true);
             unit.runDiagnostic(false);
             if (!unit.isRepairable()) {
-                if (unit.getSalvageableParts().isEmpty()) {
+                if (!unit.hasSalvageableParts()) {
                     // we shouldnt get here but some units seem to stick around
                     // for some reason
                     retVal.removeUnit(unit.getId());

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -244,8 +244,7 @@ public class Campaign implements Serializable, ITechManager {
     private Hashtable<UUID, Unit> unitIds = new Hashtable<UUID, Unit>();
     private Map<UUID, Person> personnel = new LinkedHashMap<>();
     private Map<UUID, Ancestors> ancestors = new LinkedHashMap<>();
-    private ArrayList<Part> parts = new ArrayList<Part>();
-    private Hashtable<Integer, Part> partIds = new Hashtable<Integer, Part>();
+    private Map<Integer, Part> parts = new LinkedHashMap<>();
     private Map<Integer, Force> forceIds = new LinkedHashMap<>();
     private Map<Integer, Mission> missions = new LinkedHashMap<>();
     private Map<Integer, Scenario> scenarios = new LinkedHashMap<>();
@@ -1327,8 +1326,7 @@ public class Campaign implements Serializable, ITechManager {
                 return;
             }
         }
-        parts.add(p);
-        partIds.put(new Integer(id), p);
+        parts.put(Integer.valueOf(id), p);
         MekHQ.triggerEvent(new PartNewEvent(p));
     }
 
@@ -1408,8 +1406,7 @@ public class Campaign implements Serializable, ITechManager {
                 }
             }
         }
-        parts.add(p);
-        partIds.put(p.getId(), p);
+        parts.put(p.getId(), p);
 
         if (p.getId() > lastPartId) {
             lastPartId = p.getId();
@@ -1420,8 +1417,8 @@ public class Campaign implements Serializable, ITechManager {
     /**
      * @return an <code>ArrayList</code> of SupportTeams in the campaign
      */
-    public ArrayList<Part> getParts() {
-        return parts;
+    public Collection<Part> getParts() {
+        return parts.values();
     }
 
     private int getQuantity(Part p) {
@@ -1471,7 +1468,7 @@ public class Campaign implements Serializable, ITechManager {
         piu.setStoreCount(0);
         piu.setTransferCount(0);
         piu.setPlannedCount(0);
-        for(Part p : parts) {
+        for(Part p : getParts()) {
             PartInUse newPiu = getPartInUse(p);
             if(piu.equals(newPiu)) {
                 updatePartInUseData(piu, p);
@@ -1490,7 +1487,7 @@ public class Campaign implements Serializable, ITechManager {
     public Set<PartInUse> getPartsInUse() {
         // java.util.Set doesn't supply a get(Object) method, so we have to use a java.util.Map
         Map<PartInUse, PartInUse> inUse = new HashMap<PartInUse, PartInUse>();
-        for(Part p : parts) {
+        for(Part p : getParts()) {
             PartInUse piu = getPartInUse(p);
             if(null == piu) {
                 continue;
@@ -1524,7 +1521,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public Part getPart(int id) {
-        return partIds.get(new Integer(id));
+        return parts.get(Integer.valueOf(id));
     }
 
     public Force getForce(int id) {
@@ -2887,7 +2884,7 @@ public class Campaign implements Serializable, ITechManager {
                 u.getRefit().setTeamId(null);
             }
         }
-        for (Part p : parts) {
+        for (Part p : getParts()) {
             if (tech.getId().equals(p.getTeamId())) {
                 p.setTeamId(null);
             }
@@ -2930,8 +2927,7 @@ public class Campaign implements Serializable, ITechManager {
             // if this is a test unit, then we won't remove the part because its not there
             return;
         }
-        parts.remove(part);
-        partIds.remove(new Integer(part.getId()));
+        parts.remove(Integer.valueOf(part.getId()));
         //remove child parts as well
         for(int childId : part.getChildPartIds()) {
             Part childPart = getPart(childId);
@@ -3500,7 +3496,7 @@ public class Campaign implements Serializable, ITechManager {
         pw1.println("\t</specialAbilities>");
         rskillPrefs.writeToXml(pw1, 1);
         // parts is the biggest so it goes last
-        writeArrayAndHashToXml(pw1, 1, "parts", parts, partIds); // Parts
+        writeMapToXml(pw1, 1, "parts", parts); // Parts
 
         writeGameOptions(pw1);
 
@@ -3958,8 +3954,7 @@ public class Campaign implements Serializable, ITechManager {
         // Process parts...
         ArrayList<Part> spareParts = new ArrayList<Part>();
         ArrayList<Part> removeParts = new ArrayList<Part>();
-        for (int x = 0; x < retVal.parts.size(); x++) {
-            Part prt = retVal.parts.get(x);
+        for (Part prt : retVal.getParts()) {
             Unit u = retVal.getUnit(prt.getUnitId());
             prt.setUnit(u);
             if (null != u) {
@@ -4412,7 +4407,7 @@ public class Campaign implements Serializable, ITechManager {
             p.fixIdReferences(uHash, pHash);
         }
         retVal.forces.fixIdReferences(uHash);
-        for (Part p : retVal.parts) {
+        for (Part p : retVal.getParts()) {
             p.fixIdReferences(uHash, pHash);
         }
         ArrayList<Kill> ghostKills = new ArrayList<Kill>();

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4395,8 +4395,8 @@ public class Campaign implements Serializable, ITechManager {
 
     private static void fixIdReferences(Campaign retVal) {
         // set up translation hashes
-        Hashtable<Integer, UUID> uHash = new Hashtable<Integer, UUID>();
-        Hashtable<Integer, UUID> pHash = new Hashtable<Integer, UUID>();
+        Map<Integer, UUID> uHash = new HashMap<>();
+        Map<Integer, UUID> pHash = new HashMap<>();
         for (Unit u : retVal.units) {
             uHash.put(u.getOldId(), u.getId());
         }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -246,7 +246,7 @@ public class Campaign implements Serializable, ITechManager {
     private Map<UUID, Ancestors> ancestors = new LinkedHashMap<>();
     private ArrayList<Part> parts = new ArrayList<Part>();
     private Hashtable<Integer, Part> partIds = new Hashtable<Integer, Part>();
-    private Hashtable<Integer, Force> forceIds = new Hashtable<Integer, Force>();
+    private Map<Integer, Force> forceIds = new LinkedHashMap<>();
     private Map<Integer, Mission> missions = new LinkedHashMap<>();
     private Map<Integer, Scenario> scenarios = new LinkedHashMap<>();
     private List<Kill> kills = new ArrayList<>();
@@ -354,7 +354,7 @@ public class Campaign implements Serializable, ITechManager {
         Ranks.initializeRankSystems();
         ranks = Ranks.getRanksFromSystem(Ranks.RS_SL);
         forces = new Force(name);
-        forceIds.put(new Integer(lastForceId), forces);
+        forceIds.put(Integer.valueOf(lastForceId), forces);
         lastForceId++;
         lances = new Hashtable<Integer, Lance>();
         finances = new Finances();
@@ -750,11 +750,11 @@ public class Campaign implements Serializable, ITechManager {
         force.setId(id);
         superForce.addSubForce(force, true);
         force.setScenarioId(superForce.getScenarioId());
-        forceIds.put(new Integer(id), force);
+        forceIds.put(Integer.valueOf(id), force);
         lastForceId = id;
 
         if (campaignOptions.getUseAtB() && force.getUnits().size() > 0) {
-            if (null == lances.get(id)) {
+            if (null == lances.get(Integer.valueOf(id))) {
                 lances.put(id, new Lance(force.getId(), this));
             }
         }
@@ -1528,7 +1528,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public Force getForce(int id) {
-        return forceIds.get(new Integer(id));
+        return forceIds.get(Integer.valueOf(id));
     }
 
     public ArrayList<String> getCurrentReport() {
@@ -2948,7 +2948,7 @@ public class Campaign implements Serializable, ITechManager {
 
     public void removeForce(Force force) {
         int fid = force.getId();
-        forceIds.remove(new Integer(fid));
+        forceIds.remove(Integer.valueOf(fid));
         // clear forceIds of all personnel with this force
         for (UUID uid : force.getUnits()) {
             Unit u = getUnit(uid);
@@ -3930,8 +3930,9 @@ public class Campaign implements Serializable, ITechManager {
         long timestamp = System.currentTimeMillis();
 
         // loop through forces to set force id
-        for (int fid : retVal.forceIds.keySet()) {
-            Force f = retVal.forceIds.get(fid);
+        for (Map.Entry<Integer, Force> mf : retVal.forceIds.entrySet()) {
+            int fid = mf.getKey();
+            Force f = mf.getValue();
             Scenario s = retVal.getScenario(f.getScenarioId());
             if (null != s
                     && (null == f.getParentForce() || !f.getParentForce().isDeployed())) {
@@ -5827,10 +5828,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public ArrayList<Force> getAllForces() {
-        ArrayList<Force> allForces = new ArrayList<Force>();
-        for (int x : forceIds.keySet()) {
-            allForces.add(forceIds.get(x));
-        }
+        ArrayList<Force> allForces = new ArrayList<Force>(forceIds.values());
         return allForces;
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -249,8 +249,8 @@ public class Campaign implements Serializable, ITechManager {
     private Hashtable<Integer, Part> partIds = new Hashtable<Integer, Part>();
     private Hashtable<Integer, Force> forceIds = new Hashtable<Integer, Force>();
     private Map<Integer, Mission> missions = new LinkedHashMap<>();
-    private Hashtable<Integer, Scenario> scenarioIds = new Hashtable<Integer, Scenario>();
-    private ArrayList<Kill> kills = new ArrayList<Kill>();
+    private Map<Integer, Scenario> scenarios = new LinkedHashMap<>();
+    private List<Kill> kills = new ArrayList<>();
 
     private Hashtable<String, Integer> duplicateNameHash = new Hashtable<String, Integer>();
 
@@ -792,7 +792,7 @@ public class Campaign implements Serializable, ITechManager {
      * @param scenario
      */
     public void addScenarioToHash(Scenario scenario) {
-        scenarioIds.put(scenario.getId(), scenario);
+        scenarios.put(scenario.getId(), scenario);
     }
 
     /**
@@ -902,7 +902,7 @@ public class Campaign implements Serializable, ITechManager {
         int id = lastScenarioId + 1;
         s.setId(id);
         m.addScenario(s);
-        scenarioIds.put(new Integer(id), s);
+        scenarios.put(Integer.valueOf(id), s);
         lastScenarioId = id;
         MekHQ.triggerEvent(new ScenarioNewEvent(s));
     }
@@ -931,7 +931,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public Scenario getScenario(int id) {
-        return scenarioIds.get(new Integer(id));
+        return scenarios.get(Integer.valueOf(id));
     }
 
     public CurrentLocation getLocation() {
@@ -2909,7 +2909,7 @@ public class Campaign implements Serializable, ITechManager {
         if (null != mission) {
             mission.removeScenario(scenario.getId());
         }
-        scenarioIds.remove(new Integer(id));
+        scenarios.remove(Integer.valueOf(id));
         MekHQ.triggerEvent(new ScenarioChangedEvent(scenario));
     }
 
@@ -2920,7 +2920,7 @@ public class Campaign implements Serializable, ITechManager {
         if (null != mission) {
             for (Scenario scenario : mission.getScenarios()) {
                 scenario.clearAllForcesAndPersonnel(this);
-                scenarioIds.remove(scenario.getId());
+                scenarios.remove(scenario.getId());
             }
             mission.clearScenarios();
         }

--- a/MekHQ/src/mekhq/campaign/Kill.java
+++ b/MekHQ/src/mekhq/campaign/Kill.java
@@ -25,7 +25,7 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.Map;
 import java.util.UUID;
 
 import org.w3c.dom.Node;
@@ -155,7 +155,7 @@ public class Kill implements Serializable {
 		
 	}
 	
-	public void fixIdReferences(Hashtable<Integer, UUID> pHash) {
+	public void fixIdReferences(Map<Integer, UUID> pHash) {
     	pilotId = pHash.get(oldPilotId);
     }
 	

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -578,7 +578,7 @@ public class Force implements Serializable {
     	return o instanceof Force && ((Force)o).getId() == id && ((Force)o).getFullName().equals(getFullName());
     }
 
-	public void fixIdReferences(Hashtable<Integer, UUID> uHash) {
+	public void fixIdReferences(Map<Integer, UUID> uHash) {
 		for(int oid : oldUnits) {
 			UUID nid = uHash.get(oid);
 			if(null != nid) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Hashtable;
+import java.util.Map;
 import java.util.StringJoiner;
 import java.util.UUID;
 
@@ -1187,7 +1187,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 		return teamId != null;
 	}
 
-	public void fixIdReferences(Hashtable<Integer, UUID> uHash, Hashtable<Integer, UUID> pHash) {
+	public void fixIdReferences(Map<Integer, UUID> uHash, Map<Integer, UUID> pHash) {
     	unitId = uHash.get(oldUnitId);
     	refitId = uHash.get(oldRefitId);
     	teamId = pHash.get(oldTeamId);

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -2002,7 +2002,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 	    return Part.T_BOTH;
 	}
 
-	public void fixIdReferences(Hashtable<Integer, UUID> uHash, Hashtable<Integer, UUID> pHash) {
+	public void fixIdReferences(Map<Integer, UUID> uHash, Map<Integer, UUID> pHash) {
 		assignedTechId = pHash.get(oldTechId);
 		if(null != newArmorSupplies) {
 			newArmorSupplies.fixIdReferences(uHash, pHash);

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3370,7 +3370,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return oldId;
     }
 
-    public void fixIdReferences(Hashtable<Integer, UUID> uHash, Hashtable<Integer, UUID> pHash) {
+    public void fixIdReferences(Map<Integer, UUID> uHash, Map<Integer, UUID> pHash) {
         unitId = uHash.get(oldUnitId);
         doctorId = pHash.get(oldDoctorId);
     }

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -328,9 +328,7 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         setNonAdminPersonnelCount(0);
         technicians = 0;
 
-        List<Person> personnelList =
-                new ArrayList<>(getCampaign().getActivePersonnel());
-        for (Person p : personnelList) {
+        for (Person p : getCampaign().getActivePersonnel()) {
             if (p.isAdmin() || p.isDoctor()) {
                 continue;
             }

--- a/MekHQ/src/mekhq/campaign/report/HangarReport.java
+++ b/MekHQ/src/mekhq/campaign/report/HangarReport.java
@@ -1207,7 +1207,9 @@ public class HangarReport extends Report {
         int countPresent = 0;
         int countDamaged = 0;
         int countDeployed = 0;
+        int total = 0;
         for (Unit u : getCampaign().getUnits()) {
+            total++;
             if (u.isPresent()) {
                 countPresent++;
             } else {
@@ -1221,7 +1223,7 @@ public class HangarReport extends Report {
             }
         }
         
-        return "Total Units: "+getCampaign().getUnits().size()+
+        return "Total Units: "+total+
                 "\n  Present: "+countPresent+
                 "\n  In Transit: "+countInTransit+
                 "\n  Damaged: "+countDamaged+

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3813,7 +3813,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         return oldId;
     }
 
-    public void fixIdReferences(Hashtable<Integer, UUID> uHash, Hashtable<Integer, UUID> peopleHash) {
+    public void fixIdReferences(Map<Integer, UUID> uHash, Map<Integer, UUID> peopleHash) {
         for(int oid : oldDrivers) {
             UUID nid = peopleHash.get(oid);
             if(null != nid) {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -520,6 +520,20 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     }
 
     /**
+     * Determines if this unit can be serviced.
+     * 
+     * @return <code>true</code> if the unit has parts that are salvageable or in
+     *         need of repair.
+     */
+    public boolean isServiceable() {
+        if (isSalvage() || !isRepairable()) {
+            return hasSalvageableParts();
+        } else {
+            return hasPartsNeedingFixing();
+        }
+    }
+
+    /**
      * Is the given location on the entity destroyed?
      *
      * @param loc
@@ -577,6 +591,26 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     public ArrayList<IPartWork> getPartsNeedingFixing() {
     	return getPartsNeedingFixing(false);
     }
+
+    /**
+     * Determines if this unit has parts in need of repair.
+     * 
+     * @return <code>true</code> if the unit has parts that are in need of repair.
+     */
+    public boolean hasPartsNeedingFixing() {
+        boolean onlyNotBeingWorkedOn = false;
+        for (Part part : parts) {
+            if (part.needsFixing() && isPartAvailableForRepairs(part, onlyNotBeingWorkedOn)) {
+                return true;
+            }
+        }
+        for (PodSpace pod : podSpace) {
+            if (pod.needsFixing() && isPartAvailableForRepairs(pod, onlyNotBeingWorkedOn)) {
+                return true;
+            }
+        }
+        return false;
+    }
     
     public ArrayList<IPartWork> getPartsNeedingFixing(boolean onlyNotBeingWorkedOn) {
         ArrayList<IPartWork> brokenParts = new ArrayList<IPartWork>();
@@ -595,6 +629,26 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
     public ArrayList<IPartWork> getSalvageableParts() {
     	return getSalvageableParts(false);
+    }
+
+    /**
+     * Determines if this unit has parts that are salvageable.
+     * 
+     * @return <code>true</code> if the unit has parts that are salvageable.
+     */
+    public boolean hasSalvageableParts() {
+        boolean onlyNotBeingWorkedOn = false;
+        for (Part part : parts) {
+            if (part.isSalvaging() && isPartAvailableForRepairs(part, onlyNotBeingWorkedOn)) {
+                return true;
+            }
+        }
+        for (PodSpace pod : podSpace) {
+            if (pod.hasSalvageableParts() && isPartAvailableForRepairs(pod, onlyNotBeingWorkedOn)) {
+                return true;
+            }
+        }
+        return false;
     }
     
     public ArrayList<IPartWork> getSalvageableParts(boolean onlyNotBeingWorkedOn) {

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -527,7 +527,7 @@ public final class HangarTab extends CampaignGuiTab {
                 selectedUUID = u.getId();
             }
         }
-        unitModel.setData(getCampaign().getUnits());
+        unitModel.setData(getCampaign().getCopyOfUnits());
         // try to put the focus back on same person if they are still available
         for (int row = 0; row < unitTable.getRowCount(); row++) {
             Unit u = unitModel.getUnit(unitTable.convertRowIndexToModel(row));

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -631,11 +631,11 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         }
         getCampaign().fixPart(part, selectedTech);
         if (null != u) {
-            if (!u.isRepairable() && u.getSalvageableParts().size() == 0) {
+            if (!u.isRepairable() && !u.hasSalvageableParts()) {
                 selectedRow = -1;
                 getCampaign().removeUnit(u.getId());
             }
-            if (!getCampaign().getServiceableUnits().contains(u)) {
+            if (!u.isServiceable()) {
                 selectedRow = -1;
             }
             u.refreshPodSpace();

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -83,7 +83,7 @@ public class TaskTableMouseAdapter extends MouseInputAdapter implements ActionLi
                 }
                 Unit u = p.getUnit();
                 gui.getCampaign().addReport(((Part)p).scrap());
-                if (null != u && !u.isRepairable() && u.getSalvageableParts().size() == 0) {
+                if (null != u && !u.isRepairable() && !u.hasSalvageableParts()) {
                     gui.getCampaign().removeUnit(u.getId());
                 }
                 MekHQ.triggerEvent(new UnitChangedEvent(u));

--- a/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
@@ -177,9 +177,8 @@ public class MassRepairSalvageDialog extends JDialog {
 
 		unitList = new ArrayList<Unit>();
 
-		for (int i = 0; i < campaignGUI.getCampaign().getServiceableUnits().size(); i++) {
-			Unit unit = campaignGUI.getCampaign().getServiceableUnits().get(i);
-
+		for (Unit unit : campaignGUI.getCampaign().getServiceableUnits()) {
+			
 			if (!MassRepairService.isValidMRMSUnit(unit)) {
 				continue;
 			}

--- a/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
@@ -30,6 +30,9 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.UUID;
 
@@ -71,7 +74,7 @@ public class PayCollateralDialog extends JDialog {
     private boolean paid;
     private Loan loan;
     
-    private ArrayList<JCheckBox> unitBoxes;
+    private Map<JCheckBox, UUID> unitBoxes;
     private ArrayList<JCheckBox> assetBoxes;
     private Map<JSlider, Integer> partSliders;
     private JProgressBar barAmount;
@@ -115,12 +118,13 @@ public class PayCollateralDialog extends JDialog {
         gridBagConstraints.weighty = 0.0;
         panInfo.add(barAmount, gridBagConstraints);
         
-        unitBoxes = new ArrayList<JCheckBox>();
+        unitBoxes = new LinkedHashMap<>();
         JCheckBox box;
         int i = 0;
         int j = 0;
         JPanel pnlUnits = new JPanel(new GridBagLayout());
-        for(Unit u : campaign.getUnits()) {
+        Collection<Unit> units = campaign.getUnits();
+        for(Unit u : units) {
             j++;
             box = new JCheckBox(u.getName() + " (" + DecimalFormat.getInstance().format(u.getSellValue()) + "C-bills)");
             box.setSelected(false);
@@ -131,14 +135,14 @@ public class PayCollateralDialog extends JDialog {
                     updateAmount();
                 }
             });
-            unitBoxes.add(box);
+            unitBoxes.put(box, u.getId());
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = i;
             gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
             gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
             gridBagConstraints.weightx = 1.0;
-            if(j == (campaign.getUnits().size())) {
+            if(j == (units.size())) {
                 gridBagConstraints.weighty = 1.0;
             }
             gridBagConstraints.insets = new java.awt.Insets(5, 5, 0, 0);
@@ -295,10 +299,9 @@ public class PayCollateralDialog extends JDialog {
     
     private void updateAmount() {
         long amount = 0;
-        for(int i = 0; i < unitBoxes.size(); i++) {
-            JCheckBox box = unitBoxes.get(i);
-            if(box.isSelected()) {
-                amount += campaign.getUnits().get(i).getSellValue();
+        for (Map.Entry<JCheckBox, UUID> m : unitBoxes.entrySet()) {
+            if (m.getKey().isSelected()) {
+                amount += campaign.getUnit(m.getValue()).getSellValue();
             }
         }
 
@@ -307,8 +310,8 @@ public class PayCollateralDialog extends JDialog {
             if(quantity > 0) {
                 amount += campaign.getPart(m.getValue()).getCurrentValue() * quantity;
             }
-            
         }
+
         for(int i = 0; i < assetBoxes.size(); i++) {
             JCheckBox box = assetBoxes.get(i);
             if(box.isSelected()) {
@@ -326,11 +329,10 @@ public class PayCollateralDialog extends JDialog {
     }
     
     public ArrayList<UUID> getUnits() {
-        ArrayList<UUID> uid = new ArrayList<UUID>();
-        for(int i = 0; i < unitBoxes.size(); i++) {
-            JCheckBox box = unitBoxes.get(i);
-            if(box.isSelected()) {
-                uid.add(campaign.getUnits().get(i).getId());
+        ArrayList<UUID> uid = new ArrayList<>();
+        for (Map.Entry<JCheckBox, UUID> u : unitBoxes.entrySet()) {
+            if (u.getKey().isSelected()) {
+                uid.add(u.getValue());
             }
         }
         return uid;

--- a/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
@@ -73,7 +73,7 @@ public class PayCollateralDialog extends JDialog {
     
     private ArrayList<JCheckBox> unitBoxes;
     private ArrayList<JCheckBox> assetBoxes;
-    private ArrayList<JSlider> partSliders;
+    private Map<JSlider, Integer> partSliders;
     private JProgressBar barAmount;
     private JButton btnPay;
     private JButton btnDontPay;
@@ -150,12 +150,13 @@ public class PayCollateralDialog extends JDialog {
         scrUnits.setMinimumSize(new java.awt.Dimension(400, 300));
         scrUnits.setPreferredSize(new java.awt.Dimension(400, 300));
                 
-        partSliders = new ArrayList<JSlider>();
+        partSliders = new LinkedHashMap<>();
         JPanel pnlParts = new JPanel(new GridBagLayout());
         i = 0;
         j = 0;
         JSlider partSlider;
-        for(Part p : campaign.getSpareParts()) {
+        ArrayList<Part> spareParts = campaign.getSpareParts();
+        for(Part p : spareParts) {
             j++;
             int quantity = p.getQuantity();
             if(p instanceof AmmoStorage) {
@@ -176,7 +177,7 @@ public class PayCollateralDialog extends JDialog {
                 }
             });
             partSlider.setEnabled(p.isPresent() && !p.isReservedForRefit() && !p.isReservedForReplacement());
-            partSliders.add(partSlider);
+            partSliders.put(partSlider, p.getId());
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = i;
@@ -185,7 +186,7 @@ public class PayCollateralDialog extends JDialog {
             gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
             gridBagConstraints.insets = new java.awt.Insets(5, 5, 0, 0);
             gridBagConstraints.weightx = 0.0;
-            if(j == campaign.getSpareParts().size()) {
+            if(j == spareParts.size()) {
                 gridBagConstraints.weighty = 1.0;
             }
             pnlParts.add(partSlider, gridBagConstraints);
@@ -300,10 +301,11 @@ public class PayCollateralDialog extends JDialog {
                 amount += campaign.getUnits().get(i).getSellValue();
             }
         }
-        for(int i = 0; i < partSliders.size(); i++) {
-            int quantity = partSliders.get(i).getValue();
+
+        for (Map.Entry<JSlider, Integer> m : partSliders.entrySet()) {
+            int quantity = m.getKey().getValue();
             if(quantity > 0) {
-                amount += campaign.getSpareParts().get(i).getCurrentValue() * quantity;
+                amount += campaign.getPart(m.getValue()).getCurrentValue() * quantity;
             }
             
         }
@@ -336,10 +338,10 @@ public class PayCollateralDialog extends JDialog {
     
     public ArrayList<int[]> getParts() {
         ArrayList<int[]> parts = new ArrayList<int[]>();
-        for(int i = 0; i < partSliders.size(); i++) {
-            int quantity = partSliders.get(i).getValue();
+        for (Map.Entry<JSlider, Integer> m : partSliders.entrySet()) {
+            int quantity = m.getKey().getValue();
             if(quantity > 0) {
-                int[] array = {campaign.getSpareParts().get(i).getId(), quantity};
+                int[] array = {m.getValue(), quantity};
                 parts.add(array);
             }
         }

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -599,7 +599,7 @@ import mekhq.gui.BasicInfo;
         }
 
         public void refreshData() {
-            setData(getCampaign().getPersonnel());
+            setData(new ArrayList<>(getCampaign().getPersonnel()));
         }
 
         public TableCellRenderer getRenderer(boolean graphic, IconPackage icons) {

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -269,7 +269,7 @@ public class UnitTableModel extends DataTableModel {
     }
     
     public void refreshData() {
-        setData(getCampaign().getUnits());
+        setData(getCampaign().getCopyOfUnits());
     }
 
     public TableCellRenderer getRenderer(boolean graphic, IconPackage icons) {

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -323,7 +323,7 @@ public class UnitTableModel extends DataTableModel {
                 } else if ((null != u) && !u.isFunctional()) {
                     setBackground(new Color(205, 92, 92));
                 } else if ((null != u)
-                        && (u.getPartsNeedingFixing().size() > 0)) {
+                        && u.hasPartsNeedingFixing()) {
                     setBackground(new Color(238, 238, 0));
                 } else if (u.getEntity() instanceof Infantry
                         && u.getActiveCrew().size() < u.getFullCrewSize()) {

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -191,8 +191,7 @@ public class MassRepairService {
 	public static void massRepairSalvageAllUnits(CampaignGUI campaignGUI) {
 		List<Unit> units = new ArrayList<Unit>();
 
-		for (int i = 0; i < campaignGUI.getCampaign().getServiceableUnits().size(); i++) {
-			Unit unit = campaignGUI.getCampaign().getServiceableUnits().get(i);
+		for (Unit unit : campaignGUI.getCampaign().getServiceableUnits()) {
 
 			if (!isValidMRMSUnit(unit)) {
 				continue;

--- a/MekHQ/src/mekhq/service/PartsAcquisitionService.java
+++ b/MekHQ/src/mekhq/service/PartsAcquisitionService.java
@@ -102,9 +102,8 @@ public class PartsAcquisitionService {
 
 	public static void buildPartsList(Campaign campaign) {
 		acquisitionMap = new HashMap<String, List<IAcquisitionWork>>();
-		List<Unit> unitList = campaign.getServiceableUnits();
 
-		for (Unit unit : unitList) {
+		for (Unit unit : campaign.getServiceableUnits()) {
 			ArrayList<IAcquisitionWork> unitPartsList = campaign.getAcquisitionsForUnit(unit.getId());
 
 			for (IAcquisitionWork aw : unitPartsList) {


### PR DESCRIPTION
This PR addresses a big TODO in Campaign.java to not double down on `ArrayList<>` and `Hashtable<>`:
```java
    // TODO: do we really need to track this in an array and hashtable?
    // It seems like we could track in a hashtable and then iterate through the
    // keys of the hash
    // to create an arraylist on demand
```
The general strategy was to replace true hash tables with `HashMap<>` and any hash table that needed insertion-order iteration with a `LinkedHashMap<>`. Each commit details the migration of one of the sets of data structures and is easiest to review when done individually.

Few performance gains can be expected given the small numbers of items in each collection, however, I paid some attention to over allocation (or re-allocation in a loop) with some of the more frequently used data structures. There are further improvements in this regard which I plan to explore after this PR.

I encountered unit test failures in `CampaignOpsReputationTest.java`, related to factions (which were unmodified in this PR). I believe this is unrelated to my changes:
```
java.lang.NullPointerException
	at mekhq.campaign.rating.CampaignOpsReputation.calcNeededAdmins(CampaignOpsReputation.java:349)
	at mekhq.campaign.rating.CampaignOpsReputation.initValues(CampaignOpsReputation.java:378)
	at mekhq.campaign.rating.CampaignOpsReputationTest.testCalculateUnitRatingScore(CampaignOpsReputationTest.java:923)
```