### PR TITLE
Feature: Mass mothball/reactivate

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1681,6 +1681,25 @@ public class Campaign implements Serializable, ITechManager {
     public ArrayList<Person> getTechs() {
         return getTechs(false, null, true, false);
     }
+    
+    /**
+     * Gets a list of all techs of a specific role type
+     * @param roleType The filter role type
+     * @return Collection of all techs that match the given tech role
+     */
+    public List<Person> getTechsByRole(int roleType) {
+        List<Person> techs = getTechs(false, null, false, false);
+        List<Person> retval = new ArrayList<>();
+        
+        for(Person tech : techs) {
+            if((tech.getPrimaryRole() == roleType) ||
+                    (tech.getSecondaryRole() == roleType)) {
+                retval.add(tech);
+            }       
+        }
+        
+        return techs;
+    }
 
     public List<Person> getAdmins() {
         List<Person> admins = new ArrayList<Person>();

--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -1,0 +1,94 @@
+package mekhq.campaign.unit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import megamek.common.Dropship;
+import megamek.common.Infantry;
+import megamek.common.Jumpship;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.personnel.Person;
+
+/**
+ * This class is used to store information about a particular unit that is
+ * lost when a unit is mothballed, so that it may be restored to as close to
+ * its prior state as possible when the unit is reactivated.
+ * @author NickAragua
+ *
+ */
+public class MothballInfo {
+    private UUID techID;
+    private int forceID;
+    private List<UUID> driverIDs;
+    private List<UUID> gunnerIDs;
+    private List<UUID> vesselCrewIDs;
+    private UUID techOfficerID;
+    private UUID navigatorID;
+    
+    /**
+     * Creates a set of mothball info for a given unit
+     * @param unit The unit to work with
+     */
+    public MothballInfo(Unit unit) {
+        techID = unit.getTechId();
+        forceID = unit.getForceId();
+        driverIDs = (List<UUID>) unit.getDriverIDs().clone();
+        gunnerIDs = (List<UUID>) unit.getGunnerIDs().clone();
+        vesselCrewIDs = (List<UUID>) unit.getVesselCrewIDs().clone();
+        techOfficerID = unit.getTechOfficerID();
+        navigatorID = unit.getNavigatorID();
+    }
+    
+    /**
+     * Restore a unit's pilot, assigned tech and force, to the best of our ability
+     * @param unit The unit to restore
+     * @param campaign The campaign in which this is happening
+     */
+    public void restorePreMothballInfo(Unit unit, Campaign campaign) 
+    {
+        Person tech = campaign.getPerson(techID);
+        if(tech != null) {
+            unit.setTech(tech);
+        }
+        
+        for(UUID driverID : driverIDs) {
+            Person driver = campaign.getPerson(driverID);
+            
+            if(driver != null) {
+                unit.addDriver(driver);
+            }
+        }
+        
+        for(UUID gunnerID : gunnerIDs) {
+            Person gunner = campaign.getPerson(gunnerID);
+            
+            if(gunner != null) {
+                unit.addGunner(gunner);
+            }
+        }
+        
+        for(UUID vesselCrewID : vesselCrewIDs) {
+            Person vesselCrew = campaign.getPerson(vesselCrewID);
+            
+            if(vesselCrew != null) {
+                unit.addVesselCrew(vesselCrew);
+            }
+        }
+        
+        Person techOfficer = campaign.getPerson(techOfficerID);
+        if(techOfficer != null) {
+            unit.setTechOfficer(techOfficer);
+        }
+        
+        Person navigator = campaign.getPerson(navigatorID);
+        if(navigator != null) {
+            unit.setNavigator(navigator);
+        }
+        
+        if(campaign.getForce(forceID) != null) {
+            campaign.addUnitToForce(unit, forceID);
+        }
+    }
+}

--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -1,14 +1,19 @@
 package mekhq.campaign.unit;
 
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import megamek.common.Dropship;
-import megamek.common.Infantry;
-import megamek.common.Jumpship;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import mekhq.MekHQ;
+import mekhq.MekHqXmlSerializable;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.Refit;
 import mekhq.campaign.personnel.Person;
 
 /**
@@ -18,7 +23,7 @@ import mekhq.campaign.personnel.Person;
  * @author NickAragua
  *
  */
-public class MothballInfo {
+public class MothballInfo implements MekHqXmlSerializable {
     private UUID techID;
     private int forceID;
     private List<UUID> driverIDs;
@@ -26,6 +31,15 @@ public class MothballInfo {
     private List<UUID> vesselCrewIDs;
     private UUID techOfficerID;
     private UUID navigatorID;
+
+    /**
+     * Parameterless constructor, used for deserialization.
+     */
+    private MothballInfo() {
+        driverIDs = new ArrayList<>();
+        gunnerIDs = new ArrayList<>();
+        vesselCrewIDs = new ArrayList<>();
+    }
     
     /**
      * Creates a set of mothball info for a given unit
@@ -90,5 +104,88 @@ public class MothballInfo {
         if(campaign.getForce(forceID) != null) {
             campaign.addUnitToForce(unit, forceID);
         }
+    }
+
+    /**
+     * Serializer method implemented in MekHQ pattern
+     */
+    @Override
+    public void writeToXml(PrintWriter pw1, int indent) {
+        pw1.println(MekHqXmlUtil.indentStr(indent) + "<mothballInfo>");
+        
+        if(techID != null) {
+            pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<techID>" + techID.toString() + "</techID>");
+        }
+        
+        if(forceID > 0) {
+            pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<forceID>" + forceID + "</forceID>");
+        }
+        
+        if(driverIDs.size() > 0) {
+            for(UUID driverID : driverIDs) {
+                pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<driverID>" + driverID.toString() + "</driverID>");
+            }
+        }
+        
+        if(gunnerIDs.size() > 0) {
+            for(UUID gunnerID : gunnerIDs) {
+                pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<gunnerID>" + gunnerID.toString() + "</gunnerID>");
+            }
+        }
+        
+        if(vesselCrewIDs.size() > 0) {
+            for(UUID vesselCrewID : vesselCrewIDs) {
+                pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<vesselCrewID>" + vesselCrewID.toString() + "</vesselCrewID>");
+            }
+        }
+        
+        if(techOfficerID != null) {
+            pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<techOfficerID>" + techOfficerID.toString() + "</techOfficerID>");
+        }
+        
+        if(navigatorID != null) {
+            pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<navigatorID>" + navigatorID.toString() + "</navigatorID>");
+        }
+        
+        pw1.println(MekHqXmlUtil.indentStr(indent) + "</mothballInfo>");
+    }
+    
+    /**
+     * Deserializer method implemented in standard MekHQ pattern.
+     * @return Instance of MothballInfo
+     */
+    public static MothballInfo generateInstanceFromXML(Node wn, Version version) {
+        final String METHOD_NAME = "generateInstanceFromXML(Node,Version)";
+        
+        MothballInfo retVal = new MothballInfo();
+        
+        NodeList nl = wn.getChildNodes();
+
+        try {
+            for (int x=0; x<nl.getLength(); x++) {
+                Node wn2 = nl.item(x);
+
+                if (wn2.getNodeName().equalsIgnoreCase("techID")) {
+                    retVal.techID = UUID.fromString(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("forceID")) {
+                    retVal.forceID = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("driverID")) {
+                    retVal.driverIDs.add(UUID.fromString(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("gunnerID")) {
+                    retVal.gunnerIDs.add(UUID.fromString(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("vesselCrewID")) {
+                    retVal.vesselCrewIDs.add(UUID.fromString(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("techOfficerID")) {
+                    retVal.techOfficerID = UUID.fromString(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("navigatorID")) {
+                    retVal.navigatorID = UUID.fromString(wn2.getTextContent());
+                }
+            }
+        } catch (Exception ex) {
+            // Doh!
+            MekHQ.getLogger().log(Unit.class, METHOD_NAME, ex);
+        }
+        
+        return retVal;
     }
 }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1472,6 +1472,11 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     +lastMaintenanceReport
                     +"]]></lastMaintenanceReport>");
         }
+        
+        if(null != mothballInfo) {
+            mothballInfo.writeToXml(pw1, indentLvl);
+        }
+        
         pw1.println(MekHqXmlUtil.indentStr(indentLvl) + "</unit>");
     }
 
@@ -1568,6 +1573,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     retVal.fluffName = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("lastMaintenanceReport")) {
                     retVal.lastMaintenanceReport = wn2.getTextContent();
+                } else if (wn2.getNodeName().equalsIgnoreCase("mothballInfo")) {
+                    retVal.mothballInfo = MothballInfo.generateInstanceFromXML(wn2, version);
                 }
             }
         } catch (Exception ex) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -141,6 +141,7 @@ import mekhq.gui.dialog.DataLoadingDialog;
 import mekhq.gui.dialog.GMToolsDialog;
 import mekhq.gui.dialog.HireBulkPersonnelDialog;
 import mekhq.gui.dialog.MaintenanceReportDialog;
+import mekhq.gui.dialog.MassMothballDialog;
 import mekhq.gui.dialog.MekHQAboutBox;
 import mekhq.gui.dialog.MercRosterDialog;
 import mekhq.gui.dialog.NewRecruitDialog;
@@ -282,6 +283,11 @@ public class CampaignGUI extends JPanel {
     public void showGMToolsDialog() {
         GMToolsDialog gmTools = new GMToolsDialog(getFrame(), this);
         gmTools.setVisible(true);
+    }
+    
+    public void showMassMothballDialog(Unit[] units, boolean activate) {
+        MassMothballDialog mothballDialog = new MassMothballDialog(getFrame(), units, getCampaign(), activate);
+        mothballDialog.setVisible(true);
     }
 
     public void showAdvanceDaysDialog() {

--- a/MekHQ/src/mekhq/gui/dialog/MassMothballDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassMothballDialog.java
@@ -1,0 +1,224 @@
+package mekhq.gui.dialog;
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.border.Border;
+import javax.swing.border.LineBorder;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+
+import megamek.common.UnitType;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.event.UnitChangedEvent;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.adapter.UnitTableMouseAdapter;
+
+public class MassMothballDialog extends JDialog implements ActionListener, ListSelectionListener {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = -7435381378836891774L;
+    
+    Map<Integer, List<Unit>> unitsByType = new HashMap<>();
+    Map<Integer, JList<Person>> techListsByUnitType = new HashMap<>(); 
+    Map<Integer, JLabel> timeLabelsByUnitType = new HashMap<>();
+    Campaign campaign;
+    boolean activating;
+    
+    
+    public MassMothballDialog(Frame parent, Unit[] units, Campaign campaign, boolean activate) {
+        super(parent, "Mass Mothball/Activate");
+        setLocationRelativeTo(parent);
+        
+        sortUnitsByType(units);
+        this.campaign = campaign;
+        
+        getContentPane().setLayout(new GridLayout(5, 2, 2, 2));
+        
+        JLabel instructionLabel = new JLabel();
+        instructionLabel.setText("Choose the techs to carry out mothball/reactivation operations on the displayed units.");
+        getContentPane().add(instructionLabel);
+        
+        addTableHeaders();
+        
+        for(int unitType : unitsByType.keySet()) {
+            addUnitTypePanel(unitType);
+        }
+        
+        addExecuteButton(activate);
+        
+        //this.setPreferredSize(getContentPane().getPreferredSize());
+        this.setResizable(false);
+        this.pack();
+        this.validate();
+    }
+    
+    private void addTableHeaders() {
+        JPanel headerPanel = new JPanel();
+        headerPanel.setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridwidth = 1;
+        gbc.weightx = .3;
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.fill = GridBagConstraints.BOTH;
+        
+        JLabel labelUnitNames = new JLabel();
+        labelUnitNames.setText("Units to Process");
+        headerPanel.add(labelUnitNames, gbc);
+           
+        JLabel labelTechs = new JLabel();
+        labelTechs.setText("Available Techs");
+        headerPanel.add(labelTechs, gbc);
+        
+        JLabel labelPlaceHolder = new JLabel();
+        labelPlaceHolder.setText(" ");
+        headerPanel.add(labelPlaceHolder, gbc);
+        
+        getContentPane().add(headerPanel);
+    }
+    
+    private void addUnitTypePanel(int unitType) {
+        JPanel unitTypePanel = new JPanel();
+        unitTypePanel.setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridwidth = 1;
+        gbc.weightx = .3;
+        gbc.gridy = 0;
+        gbc.fill = GridBagConstraints.BOTH;
+        gbc.anchor = GridBagConstraints.NORTHWEST;
+        
+        for(Unit unit : unitsByType.get(unitType)) {
+            JLabel unitLabel = new JLabel();
+            unitLabel.setText(unit.getName());
+            unitTypePanel.add(unitLabel, gbc);
+            gbc.gridy++;
+        }
+        
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        gbc.gridheight = GridBagConstraints.REMAINDER;
+
+        JList<Person> techList = new JList<Person>();
+        DefaultListModel<Person> listModel = new DefaultListModel<Person>();
+        
+        for(Person tech : campaign.getTechs()) {
+            if(tech.canTech(unitsByType.get(unitType).get(0).getEntity())) {
+                listModel.addElement(tech);
+            }
+        }
+        
+        techList.setModel(listModel);
+        techList.addListSelectionListener(this);
+        unitTypePanel.add(techList, gbc);
+        techListsByUnitType.put(unitType, techList);
+        
+        gbc.gridx = 2;
+        JLabel labelTotalTime = new JLabel();
+        labelTotalTime.setText("<html>Completion Time: <span color='red'>Never</span></html>");
+        timeLabelsByUnitType.put(unitType, labelTotalTime);
+        unitTypePanel.add(labelTotalTime, gbc);
+        
+        getContentPane().add(unitTypePanel);
+    }
+    
+    private void addExecuteButton(boolean activate) {
+        JButton buttonExecute = new JButton();
+        buttonExecute.setText(activate ? "Activate" : "Mothball");
+        buttonExecute.setActionCommand(activate ? UnitTableMouseAdapter.COMMAND_ACTIVATE : UnitTableMouseAdapter.COMMAND_MOTHBALL);
+        buttonExecute.addActionListener(this);
+        getContentPane().add(buttonExecute);
+    }
+    
+    private void sortUnitsByType(Unit[] units) {
+        for(int x = 0; x < units.length; x++) {
+            int unitType = UnitType.determineUnitTypeCode(units[x].getEntity());
+            
+            if(!unitsByType.containsKey(unitType)) {
+                unitsByType.put(unitType, new ArrayList<>());
+            }
+            
+            unitsByType.get(unitType).add(units[x]);
+        }
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        
+        if(e.getActionCommand() != UnitTableMouseAdapter.COMMAND_MOTHBALL &&
+                e.getActionCommand() != UnitTableMouseAdapter.COMMAND_ACTIVATE) {
+            return;
+        }
+        
+        for(int unitType : unitsByType.keySet()) {
+            List<Person> selectedTechs = techListsByUnitType.get(unitType).getSelectedValuesList();
+            int techIndex = 0;
+            
+            // this is a "naive" approach, where we assign each of the selected techs
+            // to approximately # units / # techs in mothball/reactivation tasks
+            for(Unit unit : unitsByType.get(unitType)) {                
+                unit.startMothballing(selectedTechs.get(techIndex).getId());
+                MekHQ.triggerEvent(new UnitChangedEvent(unit));
+                
+                if(techIndex == selectedTechs.size() - 1) {
+                    techIndex = 0;
+                } else {
+                    techIndex++;
+                }
+            }
+        }
+        
+        this.setVisible(false);
+    }
+
+    @Override
+    public void valueChanged(ListSelectionEvent e) {
+        // TODO Auto-generated method stub
+        JList<Person> techList = (JList<Person>) e.getSource();
+        
+        int unitType = -1;
+        // this is mildly kludgy:
+        // we scan the 'tech lists by unit type' dictionary to determine the unit type
+        // since the number of tech lists is limited by the number of unit types, it shouldn't be too problematic for performance
+        for(int key : techListsByUnitType.keySet()) {
+            if(techListsByUnitType.get(key).equals(techList)) {
+                unitType = key;
+                break;
+            }
+        }
+        
+        // time to do the work is # units * 2 if mothballing * work day in minutes;
+        int workTime = unitsByType.get(unitType).size() * (activating ? 1 : 2) * Unit.TECH_WORK_DAY;
+        // a unit can only be mothballed by one tech, so it's pointless to assign more techs to the task
+        int numTechs = Math.min(techList.getSelectedValuesList().size(), unitsByType.get(unitType).size());
+        
+        timeLabelsByUnitType.get(unitType).setText(getCompletionTimeText(workTime / numTechs));
+    }
+    
+    private String getCompletionTimeText(int completionTime) {
+        if(completionTime > 0) {
+            return String.format("Completion Time: %d minutes", completionTime);
+        } else {
+            return "<html>Completion Time: <span color='red'>Never</span></html>";
+        }
+    }
+
+    
+}


### PR DESCRIPTION
Implements the ability for the user to mothball and reactivate large numbers of units of different types at a time. All units selected must be either active & available or mothballed for the menu item to show up.

- Tells you which techs are doing maintenance currently
- Tells you approximate time the operations will take
- Schedule as many mothballs as you want at a time
- Reactivating a unit will do its best to put the crew/tech back and put the unit back into the force it came from. 
- Mothball information persists across saves so you can mothball, save, then reactivate

![image](https://user-images.githubusercontent.com/29387808/42919106-5d1d7828-8ade-11e8-964e-03b6fa1456c2.png)
