### PR TITLE
Allow Ransom if 'Capture' is allowed but not AtB random capture #549

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1306,8 +1306,9 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                 popup.add(newMenuItem(resourceMap.getString("free.text"), CMD_FREE, !person.isFree())); //$NON-NLS-1$
             }
             
-            if(gui.getCampaign().getCampaignOptions().getUseAtB() &&
-                    gui.getCampaign().getCampaignOptions().getUseAtBCapture()
+            if(gui.getCampaign().getCampaignOptions().getUseAtB()
+                    && (gui.getCampaign().getCampaignOptions().getUseAtBCapture()
+                        || gui.getCampaign().getCampaignOptions().capturePrisoners())
                     && StaticChecks.areAllPrisoners(selected)) {
                 popup.add(newMenuItem(resourceMap.getString("ransom.text"), CMD_RANSOM));
                 popup.add(newMenuItem(resourceMap.getString("recruit.text"), CMD_RECRUIT, //$NON-NLS-1$


### PR DESCRIPTION
Addresses #549, allowing ransom if 'Capture enemies in scenario' is enabled but AtB's random capture is not. This still requires AtB rules to be enabled.