### PR TITLE
Fix for #819: Dropshop Baydoor unrepairable

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
@@ -65,6 +65,23 @@ public class MissingBayDoor extends MissingPart {
     }
 
     @Override
+    public void fix() {
+        Part replacement = findReplacement(false);
+        if(null != replacement) {
+            Part actualReplacement = replacement.clone();
+            unit.addPart(actualReplacement);
+            campaign.addPart(actualReplacement, 0);
+            replacement.decrementQuantity();
+            remove(false);
+            Part bayPart = campaign.getPart(parentPartId);
+            if (null != bayPart) {
+                bayPart.addChildPart(actualReplacement);
+                bayPart.updateConditionFromPart();
+            }
+        }
+    }
+
+    @Override
     public int getLocation() {
         return Entity.LOC_NONE;
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
@@ -92,6 +92,23 @@ public class MissingCubicle extends MissingPart {
     }
 
     @Override
+    public void fix() {
+        Part replacement = findReplacement(false);
+        if(null != replacement) {
+            Part actualReplacement = replacement.clone();
+            unit.addPart(actualReplacement);
+            campaign.addPart(actualReplacement, 0);
+            replacement.decrementQuantity();
+            remove(false);
+            Part bayPart = campaign.getPart(parentPartId);
+            if (null != bayPart) {
+                bayPart.addChildPart(actualReplacement);
+                bayPart.updateConditionFromPart();
+            }
+        }
+    }
+
+    @Override
     public boolean isAcceptableReplacement(Part part, boolean refit) {
         return (part instanceof Cubicle)
                 && (((Cubicle) part).getBayType() == bayType);

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -148,8 +148,12 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		campaign.removePart(this);
 		if(null != unit) {
 			unit.removePart(this);
-		}	
+		}
 		setUnit(null);
+		Part parentPart = campaign.getPart(parentPartId);
+		if (null != parentPart) {
+		    parentPart.removeChildPart(this.getId());
+		}
 	}
 	
 	public abstract boolean isAcceptableReplacement(Part part, boolean refit);


### PR DESCRIPTION
Transport bays are a single structure in Entity but have multiple distinct parts in MekHQ. The TransportBayPart tracks doors and cubicles as child parts. When fixing a missing bay door or cubicle the new part was not getting added as a child part and the Entity was not getting updated with the new state.