### PR TITLE
Replace custom XML escaping with Apache Commons

### DIFF
--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -16,6 +16,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
@@ -481,46 +483,19 @@ public class MekHqXmlUtil {
 		return retVal;
 	}
 
-    /** Escaping code for XML borrowed from org.json.XML
-      * Full license and code available https://github.com/douglascrockford/JSON-java/blob/master/XML.java
+    /** Escapes a string to store in an XML element.
       * @param string The string to be encoded
       * @return An encoded copy of the string
-     **/
+      */
     public static String escape(String string) {
-        if (StringUtil.isNullOrEmpty(string)) {
-            return string;
-        }
-        StringBuffer sb = new StringBuffer();
-        for (int i = 0, length = string.length(); i < length; i++) {
-            char c = string.charAt(i);
-            switch (c) {
-            case '&':
-                sb.append("&amp;");
-                break;
-            case '<':
-                sb.append("&lt;");
-                break;
-            case '>':
-                sb.append("&gt;");
-                break;
-            case '"':
-                sb.append("&quot;");
-                break;
-            case '\'':
-                sb.append("&apos;");
-                break;
-            default:
-                sb.append(c);
-            }
-        }
-        return sb.toString();
+        return StringEscapeUtils.escapeXml10(string);
     }
 
     /**
      * Unescape...well, it reverses escaping...
-    **/
+     */
     public static String unEscape(String string) {
-      return string.replaceAll( "&amp;", "&" ).replaceAll( "&lt;", "<" ).replaceAll( "&gt;", ">" ).replaceAll( "&quot;", "\"" ).replaceAll( "&apos", "\'" );
+      return StringEscapeUtils.unescapeXml(string);
     }
 
     public static String getEntityNameFromXmlString(Node node) {


### PR DESCRIPTION
While investigating #814 I noticed odd XML entity escapes in the uploaded campaign file.
```xml
<entityStub>&amp;lt;html&amp;gt;Shi-ping Ts&amp;apos;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;ai (4/6), &amp;lt;i&amp;gt;LRM Carrier (Standard) #2&amp;lt;/i&amp;gt;&amp;lt;/html&amp;gt;</entityStub>
```
It appears that the string for unescaping `&apos;` was missing the trailing semi-colon. I noticed Apache Commons was available and instead switched to their XML encoding and decoding methods.