### PR TITLE
Fix for adding phantom heat sinks when restoring aerospace unit

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
@@ -126,9 +126,11 @@ public class AeroHeatSink extends Part {
 
     @Override
     public void fix() {
+        boolean fixed = needsFixing();
         super.fix();
-        if(null != unit && unit.getEntity() instanceof Aero) {
-            ((Aero)unit.getEntity()).setHeatSinks(((Aero)unit.getEntity()).getHeatSinks()+1);
+        if(fixed && (null != unit)
+                && unit.getEntity() instanceof Aero) {
+            ((Aero) unit.getEntity()).setHeatSinks(((Aero) unit.getEntity()).getHeatSinks() + 1);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1030,10 +1030,17 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 	@Override
 	public void fix() {
 		hits = 0;
-		skillMin = SkillType.EXP_GREEN;
+		resetRepairSettings();
+	}
+
+    /**
+     * Sets minimum skill, shorthanded mod, and rush job/extra time setting to defaults.
+     */
+    public void resetRepairSettings() {
+        skillMin = SkillType.EXP_GREEN;
 		shorthandedMod = 0;
 		mode = WorkTime.NORMAL;
-	}
+    }
 
 	@Override
 	public String fail(int rating) {

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -514,8 +514,10 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                         } else {
                             if(part.needsFixing()) {
                                 needsCheck = true;
+                                part.fix();
+                            } else {
+                                part.resetRepairSettings();
                             }
-                            part.fix();
                             part.resetTimeSpent();
                             part.resetOvertime();
                             part.setTeamId(null);


### PR DESCRIPTION
Reported in issue #819 

Restore unit calls fix() on every part whether or not it needs fixing, presumably for the side effects of resetting other values. AeroHeatSink#fix() adds a heat sink without checking whether it was damaged, so this was fixing the damaged ones and adding an extra of all the undamaged ones for each iteration of the loop.

I separated the side effects of fix() so they can be called independently. For extra safety I added a check to AeroHeatSink so it will only add a heat sink if was actually fixed, in case fix() gets called somewhere else without checking whether it needed fixing.