### PR TITLE
Use factionCode passed to newPerson when checking for Bloodname.

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5465,7 +5465,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         //check for Bloodname
         if (person.isClanner()) {
-            checkBloodnameAdd(person, type);
+            checkBloodnameAdd(person, type, factionCode);
         }
 
         return person;
@@ -5576,11 +5576,59 @@ public class Campaign implements Serializable, ITechManager {
         }
     }
 
+    /**
+     * If the person does not already have a bloodname, assigns a chance of having one based on
+     * skill and rank. If the roll indicates there should be a bloodname, one is assigned as
+     * appropriate to the person's phenotype and the player's faction.
+     * 
+     * @param person       The Bloodname candidate
+     * @param type         The phenotype index
+     */
     public void checkBloodnameAdd(Person person, int type) {
-        checkBloodnameAdd(person, type, false);
+        checkBloodnameAdd(person, type, false, this.factionCode);
+    }
+    
+    /**
+     * If the person does not already have a bloodname, assigns a chance of having one based on
+     * skill and rank. If the roll indicates there should be a bloodname, one is assigned as
+     * appropriate to Clan and phenotype.
+     * 
+     * @param person       The Bloodname candidate
+     * @param type         The phenotype index
+     * @param factionCode  The shortName of the faction the person belongs to. Note that there
+     *                     is a chance of having a Bloodname that is unique to a different Clan
+     *                     as this person could have been captured.
+     */
+    public void checkBloodnameAdd(Person person, int type, String factionCode) {
+        checkBloodnameAdd(person, type, false, factionCode);
+    }
+    
+    /**
+     * If the person does not already have a bloodname, assigns a chance of having one based on
+     * skill and rank. If the roll indicates there should be a bloodname, one is assigned as
+     * appropriate to the person's phenotype and the player's faction.
+     * 
+     * @param person       The Bloodname candidate
+     * @param type         The phenotype index
+     * @param ignoreDice   If true, skips the random roll and assigns a Bloodname automatically
+     */
+    public void checkBloodnameAdd(Person person, int type, boolean ignoreDice) {
+        checkBloodnameAdd(person, type, ignoreDice, this.factionCode);
     }
 
-    public void checkBloodnameAdd(Person person, int type, boolean ignoreDice) {
+    /**
+     * If the person does not already have a bloodname, assigns a chance of having one based on
+     * skill and rank. If the roll indicates there should be a bloodname, one is assigned as
+     * appropriate to Clan and phenotype.
+     * 
+     * @param person       The Bloodname candidate
+     * @param type         The phenotype index
+     * @param ignoreDice   If true, skips the random roll and assigns a Bloodname automatically
+     * @param factionCode  The shortName of the faction the person belongs to. Note that there
+     *                     is a chance of having a Bloodname that is unique to a different Clan
+     *                     as this person could have been captured.
+     */
+    public void checkBloodnameAdd(Person person, int type, boolean ignoreDice, String factionCode) {
         // Person already has a bloodname?
         if (person.getBloodname().length() > 0) {
             int result = JOptionPane.showConfirmDialog(null,
@@ -5693,7 +5741,10 @@ public class Campaign implements Serializable, ITechManager {
                         phenotype = Bloodname.P_PROTOMECH;
                         break;
                 }
-                person.setBloodname(Bloodname.randomBloodname(factionCode, phenotype, getGameYear()).getName());
+                Bloodname bloodname = Bloodname.randomBloodname(factionCode, phenotype, getGameYear());
+                if (null != bloodname) {
+                    person.setBloodname(bloodname.getName());
+                }
             }
         }
         MekHQ.triggerEvent(new PersonChangedEvent(person));

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
@@ -39,6 +39,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import megamek.common.Compute;
+import megamek.common.annotations.Nullable;
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
 
@@ -252,14 +253,25 @@ public class Bloodname implements Serializable {
 		return retVal;
 	}
 
-	public static Bloodname randomBloodname(String factionCode, int phenotype, int year) {
+    /**
+     * Determines a likely Bloodname based on Clan, phenotype, and year.
+     * 
+     * @param faction The faction code for the Clan; must exist in data/names/bloodnames/clans.xml
+     * @param phenotype One of the Person.PHENOTYPE_* constants
+     * @param year The current campaign year
+     * @return An object representing the chosen Bloodname
+     * 
+     * Though based as much as possible on official sources, the method employed here involves a
+     * considerable amount of speculation.
+     */
+	public static @Nullable Bloodname randomBloodname(String factionCode, int phenotype, int year) {
 		return randomBloodname(Clan.getClan(factionCode), phenotype, year);
 	}
 
 	/**
 	 * Determines a likely Bloodname based on Clan, phenotype, and year.
 	 * 
-	 * @param faction The faction code for the Clan; must exist in data/names/bloodnames/clans.xml
+	 * @param faction The Clan faction; must exist in data/names/bloodnames/clans.xml
 	 * @param phenotype One of the Person.PHENOTYPE_* constants
 	 * @param year The current campaign year
 	 * @return An object representing the chosen Bloodname
@@ -267,7 +279,7 @@ public class Bloodname implements Serializable {
 	 * Though based as much as possible on official sources, the method employed here involves a
 	 * considerable amount of speculation.
 	 */
-	public static Bloodname randomBloodname(Clan faction, int phenotype, int year) {
+	public static @Nullable Bloodname randomBloodname(Clan faction, int phenotype, int year) {
 	    if (null == faction) {
 	        MekHQ.getLogger().log(Bloodname.class, "randomBloodname(Clan,int,int)", LogLevel.ERROR, //$NON-NLS-1$
 	                "Random Bloodname attempted for a clan that does not exist." //$NON-NLS-1$


### PR DESCRIPTION
Fixes #824 
Introduced by #726 

Added overloaded versions of checkBloodnameAdd so that newPerson can pass the factionCode. Without this it attempts to generate a Bloodname using the player's faction instead of the captured prisoner's faction. Also check the return value of randomBloodname for null before attempting to access it.