### PR TITLE
Adds pkgdir and .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,10 @@
 /logs/
 .DS_Store
 MekHQ/MekHQ.iml
+
+# Build directories
+MekHQ/pkgdir
+
+# IDE directories
 MekHQ/.idea/
+/.vscode


### PR DESCRIPTION
When packaging MekHQ the temporary work in `pkgdir` generates a lot of traffic in an IDE tracking possible git files. I've added it to `.gitignore`. I've also added `/.vscode` to compliment the IntelliJ project ignore.