### PR TITLE
Fix two bugs in Edit Injuries dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
@@ -54,9 +54,9 @@ import mekhq.gui.model.FilterableComboBoxModel;
  * @author  Ralgith
  */
 public class EditInjuryEntryDialog extends JDialog {
-	private static final long serialVersionUID = -8038099101234445018L;
+    private static final long serialVersionUID = -8038099101234445018L;
     @SuppressWarnings("unused")
-	private Frame frame; // FIXME: Unusued => Unneeded?
+    private Frame frame; // FIXME: Unusued => Unneeded?
     private Injury injury;
     
     private JButton btnClose;
@@ -86,7 +86,7 @@ public class EditInjuryEntryDialog extends JDialog {
     }
 
     private void initComponents() {
-    	GridBagConstraints gridBagConstraints;
+        GridBagConstraints gridBagConstraints;
 
         locations = new BodyLocationChoice[BodyLocation.values().length];
         int i = 0;
@@ -97,15 +97,15 @@ public class EditInjuryEntryDialog extends JDialog {
         types = InjuryType.getAllTypes().stream()
             .map((type) -> new InjuryTypeChoice(type))
             .collect(Collectors.toList()).toArray(new InjuryTypeChoice[0]);
-    	String[] tf = { "True", "False" };
-    	txtDays = new JTextArea();
+        String[] tf = { "True", "False" };
+        txtDays = new JTextArea();
         ddLocation = new JComboBox<>(locations);
-    	ddType = new JComboBox<>(types);
-    	ddTypeModel = new FilterableComboBoxModel<InjuryTypeChoice>(ddType.getModel());
-    	ddType.setModel(ddTypeModel);
-    	ddTypeModel.setFilter(it -> {
-    	    BodyLocation loc = ((BodyLocationChoice) ddLocation.getSelectedItem()).loc;
-    	    return it.type.isValidInLocation(loc);
+        ddType = new JComboBox<>(types);
+        ddTypeModel = new FilterableComboBoxModel<InjuryTypeChoice>(ddType.getModel());
+        ddType.setModel(ddTypeModel);
+        ddTypeModel.setFilter(it -> {
+            BodyLocation loc = ((BodyLocationChoice) ddLocation.getSelectedItem()).loc;
+            return it.type.isValidInLocation(loc);
         });
 
         for (BodyLocationChoice choice : locations) {
@@ -121,12 +121,12 @@ public class EditInjuryEntryDialog extends JDialog {
                 break;
             }
         }
-    	
-    	txtFluff = new JTextArea();
-    	txtHits = new JTextArea();
-    	ddPermanent = new JComboBox<String>(tf);
-    	ddWorkedOn = new JComboBox<String>(tf);
-    	ddExtended = new JComboBox<String>(tf);
+        
+        txtFluff = new JTextArea();
+        txtHits = new JTextArea();
+        ddPermanent = new JComboBox<String>(tf);
+        ddWorkedOn = new JComboBox<String>(tf);
+        ddExtended = new JComboBox<String>(tf);
         btnOK = new JButton();
         btnClose = new JButton();
         panBtn = new JPanel();
@@ -146,8 +146,8 @@ public class EditInjuryEntryDialog extends JDialog {
         txtDays.setLineWrap(true);
         txtDays.setWrapStyleWord(true);
         txtDays.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder("Days Remaining"),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createTitledBorder("Days Remaining"),
+                    BorderFactory.createEmptyBorder(5,5,5,5)));
         txtDays.setPreferredSize(new Dimension(250,75));
         txtDays.setMinimumSize(new Dimension(250,75));
         gridBagConstraints = new GridBagConstraints();
@@ -163,8 +163,8 @@ public class EditInjuryEntryDialog extends JDialog {
         ddLocation.setName("ddLocation");
         ddLocation.setEditable(false);
         ddLocation.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder("Location on Body"),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createTitledBorder("Location on Body"),
+                    BorderFactory.createEmptyBorder(5,5,5,5)));
         ddLocation.setPreferredSize(new Dimension(250,75));
         ddLocation.setMinimumSize(new Dimension(250,75));
         ddLocation.addActionListener(new ActionListener() {
@@ -193,8 +193,8 @@ public class EditInjuryEntryDialog extends JDialog {
         ddType.setName("ddType");
         ddType.setEditable(false);
         ddType.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder("Type of Injury"),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createTitledBorder("Type of Injury"),
+                    BorderFactory.createEmptyBorder(5,5,5,5)));
         ddType.setPreferredSize(new Dimension(250,75));
         ddType.setMinimumSize(new Dimension(250,75));
         gridBagConstraints = new GridBagConstraints();
@@ -213,8 +213,8 @@ public class EditInjuryEntryDialog extends JDialog {
         txtFluff.setLineWrap(true);
         txtFluff.setWrapStyleWord(true);
         txtFluff.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder("Fluff Message"),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createTitledBorder("Fluff Message"),
+                    BorderFactory.createEmptyBorder(5,5,5,5)));
         txtFluff.setPreferredSize(new Dimension(250,75));
         txtFluff.setMinimumSize(new Dimension(250,75));
         gridBagConstraints = new GridBagConstraints();
@@ -233,8 +233,8 @@ public class EditInjuryEntryDialog extends JDialog {
         txtHits.setLineWrap(true);
         txtHits.setWrapStyleWord(true);
         txtHits.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder("Number of Hits"),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createTitledBorder("Number of Hits"),
+                    BorderFactory.createEmptyBorder(5,5,5,5)));
         txtHits.setPreferredSize(new Dimension(250,75));
         txtHits.setMinimumSize(new Dimension(250,75));
         gridBagConstraints = new GridBagConstraints();
@@ -251,8 +251,8 @@ public class EditInjuryEntryDialog extends JDialog {
         ddPermanent.setName("ddPermanent");
         ddPermanent.setEditable(false);
         ddPermanent.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder("Is Permanent"),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createTitledBorder("Is Permanent"),
+                    BorderFactory.createEmptyBorder(5,5,5,5)));
         ddPermanent.setPreferredSize(new Dimension(250,75));
         ddPermanent.setMinimumSize(new Dimension(250,75));
         gridBagConstraints = new GridBagConstraints();
@@ -269,8 +269,8 @@ public class EditInjuryEntryDialog extends JDialog {
         ddWorkedOn.setName("ddWorkedOn");
         ddWorkedOn.setEditable(false);
         ddWorkedOn.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder("Doctor Has Worked On"),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createTitledBorder("Doctor Has Worked On"),
+                    BorderFactory.createEmptyBorder(5,5,5,5)));
         ddWorkedOn.setPreferredSize(new Dimension(250,75));
         ddWorkedOn.setMinimumSize(new Dimension(250,75));
         gridBagConstraints = new GridBagConstraints();
@@ -287,8 +287,8 @@ public class EditInjuryEntryDialog extends JDialog {
         ddExtended.setName("ddExtended");
         ddExtended.setEditable(true);
         ddExtended.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder("Was Extended Time"),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createTitledBorder("Was Extended Time"),
+                    BorderFactory.createEmptyBorder(5,5,5,5)));
         ddExtended.setPreferredSize(new Dimension(250,75));
         ddExtended.setMinimumSize(new Dimension(250,75));
         gridBagConstraints = new GridBagConstraints();
@@ -327,37 +327,37 @@ public class EditInjuryEntryDialog extends JDialog {
     }
     
     private void btnOKActionPerformed(ActionEvent evt) {
-    	injury.setTime(Integer.parseInt(txtDays.getText()));
-    	injury.setHits(Integer.parseInt(txtHits.getText()));
-    	injury.setFluff(txtFluff.getText());
+        injury.setTime(Integer.parseInt(txtDays.getText()));
+        injury.setHits(Integer.parseInt(txtHits.getText()));
+        injury.setFluff(txtFluff.getText());
         injury.setLocation(((BodyLocationChoice) ddLocation.getSelectedItem()).loc);
         injury.setType(((InjuryTypeChoice)ddType.getSelectedItem()).type);
-    	if (ddPermanent.getSelectedIndex() == 0) {
-    		injury.setPermanent(true);
-    	} else {
-    		injury.setPermanent(false);
-    	}
-    	if (ddWorkedOn.getSelectedIndex() == 0) {
-    		injury.setWorkedOn(true);
-    	} else {
-    		injury.setWorkedOn(false);
-    	}
-    	if (ddExtended.getSelectedIndex() == 0) {
-    		injury.setExtended(true);
-    	} else {
-    		injury.setExtended(false);
-    	}
-    	injury.setUUID(UUID.randomUUID());
-    	this.setVisible(false);
+        if (ddPermanent.getSelectedIndex() == 0) {
+            injury.setPermanent(true);
+        } else {
+            injury.setPermanent(false);
+        }
+        if (ddWorkedOn.getSelectedIndex() == 0) {
+            injury.setWorkedOn(true);
+        } else {
+            injury.setWorkedOn(false);
+        }
+        if (ddExtended.getSelectedIndex() == 0) {
+            injury.setExtended(true);
+        } else {
+            injury.setExtended(false);
+        }
+        injury.setUUID(UUID.randomUUID());
+        this.setVisible(false);
     }
 
     private void btnCloseActionPerformed(ActionEvent evt) {
-    	injury = null;
-    	this.setVisible(false);
+        injury = null;
+        this.setVisible(false);
     }
     
     public Injury getEntry() {
-    	return injury;
+        return injury;
     }
     
     private static class BodyLocationChoice {

--- a/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
@@ -1,6 +1,7 @@
 /*
  * EditInjuryEntryDialog.java
  * 
+ * Copyright (C) 2018 MegaMek team
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  * 
  * This file is part of MekHQ.
@@ -98,15 +99,29 @@ public class EditInjuryEntryDialog extends JDialog {
             .collect(Collectors.toList()).toArray(new InjuryTypeChoice[0]);
     	String[] tf = { "True", "False" };
     	txtDays = new JTextArea();
-    	ddLocation = new JComboBox<>(locations);
+        ddLocation = new JComboBox<>(locations);
     	ddType = new JComboBox<>(types);
     	ddTypeModel = new FilterableComboBoxModel<InjuryTypeChoice>(ddType.getModel());
     	ddType.setModel(ddTypeModel);
     	ddTypeModel.setFilter(it -> {
     	    BodyLocation loc = ((BodyLocationChoice) ddLocation.getSelectedItem()).loc;
     	    return it.type.isValidInLocation(loc);
-    	});
-    	ddTypeModel.updateFilter();
+        });
+
+        for (BodyLocationChoice choice : locations) {
+            if (injury.getLocation() == choice.loc) {
+                ddLocation.setSelectedItem(choice);
+                break;
+            }
+        }
+
+        for (InjuryTypeChoice choice : types) {
+            if (injury.getType() == choice.type) {
+                ddType.setSelectedItem(choice);
+                break;
+            }
+        }
+    	
     	txtFluff = new JTextArea();
     	txtHits = new JTextArea();
     	ddPermanent = new JComboBox<String>(tf);
@@ -145,12 +160,6 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         panMain.add(txtDays, gridBagConstraints);
         
-        for(BodyLocationChoice choice : locations) {
-            if(injury.getLocation() == choice.loc) {
-                ddLocation.setSelectedItem(choice);
-                break;
-            }
-        }
         ddLocation.setName("ddLocation");
         ddLocation.setEditable(false);
         ddLocation.setBorder(BorderFactory.createCompoundBorder(
@@ -158,6 +167,19 @@ public class EditInjuryEntryDialog extends JDialog {
 	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
         ddLocation.setPreferredSize(new Dimension(250,75));
         ddLocation.setMinimumSize(new Dimension(250,75));
+        ddLocation.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                ddTypeModel.updateFilter();
+
+                BodyLocation loc = ((BodyLocationChoice) ddLocation.getSelectedItem()).loc;
+                InjuryType type = ((InjuryTypeChoice) ddType.getSelectedItem()).type;
+                if (!type.isValidInLocation(loc)) {
+                    ddType.setSelectedItem(ddTypeModel.getElementAt(0));
+                }
+            }
+        });
+
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
@@ -167,13 +189,7 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panMain.add(ddLocation, gridBagConstraints);
-        
-        for(InjuryTypeChoice choice : types) {
-            if(injury.getType() == choice.type) {
-                ddType.setSelectedItem(choice);
-                break;
-            }
-        } 
+
         ddType.setName("ddType");
         ddType.setEditable(false);
         ddType.setBorder(BorderFactory.createCompoundBorder(
@@ -309,7 +325,6 @@ public class EditInjuryEntryDialog extends JDialog {
         getContentPane().add(panBtn, BorderLayout.PAGE_END);
         pack();
     }
-
     
     private void btnOKActionPerformed(ActionEvent evt) {
     	injury.setTime(Integer.parseInt(txtDays.getText()));

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
@@ -199,7 +199,8 @@ public class EditPersonnelInjuriesDialog extends JDialog {
     }
     
     private void deleteEntry() {
-    	person.getInjuries().remove(injuriesTable.getSelectedRow());
+		Injury entry = injuryModel.getEntryAt(injuriesTable.getSelectedRow());
+    	person.removeInjury(entry);
     	refreshTable();
     }
     

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
@@ -1,7 +1,7 @@
 /*
  * EditPersonnelInjuriesDialog.java
  * 
- * Copyright (C) 2009-2016 MegaMek team
+ * Copyright (C) 2009-2018 MegaMek team
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  * 
  * This file is part of MekHQ.
@@ -56,7 +56,7 @@ import mekhq.campaign.personnel.Person;
  * @author  Ralgith
  */
 public class EditPersonnelInjuriesDialog extends JDialog {
-	private static final long serialVersionUID = -8038099101234445018L;
+    private static final long serialVersionUID = -8038099101234445018L;
     private Frame frame;
     /*private Campaign campaign;
     private int days;*/
@@ -130,8 +130,8 @@ public class EditPersonnelInjuriesDialog extends JDialog {
         
         injuriesTable = new JTable(injuryModel);
         injuriesTable.setName("injuriesTable"); // NOI18N
-		TableColumn column = null;
-		int width = 0;
+        TableColumn column = null;
+        int width = 0;
         for (int i = 0; i < InjuryTableModel.N_COL; i++) {
             column = injuriesTable.getColumnModel().getColumn(i);
             column.setPreferredWidth(injuryModel.getColumnWidth(i));
@@ -140,19 +140,19 @@ public class EditPersonnelInjuriesDialog extends JDialog {
         }
         setMinimumSize(new Dimension(width, 500));
         injuriesTable.setIntercellSpacing(new Dimension(0, 0));
-		injuriesTable.setShowGrid(false);
-		injuriesTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-		injuriesTable.getSelectionModel().addListSelectionListener(
-				new ListSelectionListener() {
-					@Override
+        injuriesTable.setShowGrid(false);
+        injuriesTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        injuriesTable.getSelectionModel().addListSelectionListener(
+                new ListSelectionListener() {
+                    @Override
                     public void valueChanged(
-							ListSelectionEvent evt) {
-						injuriesTableValueChanged(evt);
-					}
-				});
-		scrollInjuryTable = new JScrollPane();
-		scrollInjuryTable.setName("scrollInjuryTable"); // NOI18N
-		scrollInjuryTable.setViewportView(injuriesTable);
+                            ListSelectionEvent evt) {
+                        injuriesTableValueChanged(evt);
+                    }
+                });
+        scrollInjuryTable = new JScrollPane();
+        scrollInjuryTable.setName("scrollInjuryTable"); // NOI18N
+        scrollInjuryTable.setViewportView(injuriesTable);
         getContentPane().add(scrollInjuryTable, BorderLayout.CENTER);
 
         
@@ -171,77 +171,77 @@ public class EditPersonnelInjuriesDialog extends JDialog {
 
     
     private void btnOKActionPerformed(ActionEvent evt) {//GEN-FIRST:event_btnHireActionPerformed
-    	this.setVisible(false);
+        this.setVisible(false);
     }
     
     private void injuriesTableValueChanged(ListSelectionEvent evt) {
-		int row = injuriesTable.getSelectedRow();
-		btnDelete.setEnabled(row != -1);
-		btnEdit.setEnabled(row != -1);
-	}
+        int row = injuriesTable.getSelectedRow();
+        btnDelete.setEnabled(row != -1);
+        btnEdit.setEnabled(row != -1);
+    }
     
     private void addEntry() {
-    	EditInjuryEntryDialog eied = new EditInjuryEntryDialog(frame, true, new Injury());
-		eied.setVisible(true);
-		if(null != eied.getEntry()) {
-			person.addInjury(eied.getEntry());
-		}
-		refreshTable();
+        EditInjuryEntryDialog eied = new EditInjuryEntryDialog(frame, true, new Injury());
+        eied.setVisible(true);
+        if(null != eied.getEntry()) {
+            person.addInjury(eied.getEntry());
+        }
+        refreshTable();
     }
     
     private void editEntry() {
-    	Injury entry = injuryModel.getEntryAt(injuriesTable.getSelectedRow());
-    	if(null != entry) {
-    		EditInjuryEntryDialog eied = new EditInjuryEntryDialog(frame, true, entry);
-    		eied.setVisible(true);
-    		refreshTable();
-    	}
+        Injury entry = injuryModel.getEntryAt(injuriesTable.getSelectedRow());
+        if(null != entry) {
+            EditInjuryEntryDialog eied = new EditInjuryEntryDialog(frame, true, entry);
+            eied.setVisible(true);
+            refreshTable();
+        }
     }
     
     private void deleteEntry() {
-		Injury entry = injuryModel.getEntryAt(injuriesTable.getSelectedRow());
-    	person.removeInjury(entry);
-    	refreshTable();
+        Injury entry = injuryModel.getEntryAt(injuriesTable.getSelectedRow());
+        person.removeInjury(entry);
+        refreshTable();
     }
     
     private void refreshTable() {
-		int selectedRow = injuriesTable.getSelectedRow();
-    	injuryModel.setData(person.getInjuries());
-    	if(selectedRow != -1) {
-    		if(injuriesTable.getRowCount() > 0) {
-    			if(injuriesTable.getRowCount() == selectedRow) {
-    				injuriesTable.setRowSelectionInterval(selectedRow-1, selectedRow-1);
-    			} else {
-    				injuriesTable.setRowSelectionInterval(selectedRow, selectedRow);
-    			}
-    		}
-    	}
+        int selectedRow = injuriesTable.getSelectedRow();
+        injuryModel.setData(person.getInjuries());
+        if(selectedRow != -1) {
+            if(injuriesTable.getRowCount() > 0) {
+                if(injuriesTable.getRowCount() == selectedRow) {
+                    injuriesTable.setRowSelectionInterval(selectedRow-1, selectedRow-1);
+                } else {
+                    injuriesTable.setRowSelectionInterval(selectedRow, selectedRow);
+                }
+            }
+        }
     }
     
     /**
-	 * A table model for displaying parts - similar to the one in CampaignGUI, but not exactly
-	 */
-	public class InjuryTableModel extends AbstractTableModel {
-		private static final long serialVersionUID = 534443424190075264L;
+     * A table model for displaying parts - similar to the one in CampaignGUI, but not exactly
+     */
+    public class InjuryTableModel extends AbstractTableModel {
+        private static final long serialVersionUID = 534443424190075264L;
 
-		protected String[] columnNames;
-		protected ArrayList<Injury> data;
+        protected String[] columnNames;
+        protected ArrayList<Injury> data;
 
-		public final static int COL_DAYS	=	0;
-		public final static int COL_LOCATION =	1;
-		public final static int COL_TYPE	=	2;
-		public final static int COL_FLUFF	=	3;
-		public final static int COL_HITS	=	4;
-		public final static int COL_PERMANENT =	5;
-		public final static int COL_WORKEDON =	6;
-		public final static int COL_EXTENDED =	7;
+        public final static int COL_DAYS	=	0;
+        public final static int COL_LOCATION =	1;
+        public final static int COL_TYPE	=	2;
+        public final static int COL_FLUFF	=	3;
+        public final static int COL_HITS	=	4;
+        public final static int COL_PERMANENT =	5;
+        public final static int COL_WORKEDON =	6;
+        public final static int COL_EXTENDED =	7;
         public final static int N_COL		=	8;
-		
-		public InjuryTableModel(ArrayList<Injury> entries) {
-			data = entries;
-		}
-		
-		@Override
+        
+        public InjuryTableModel(ArrayList<Injury> entries) {
+            data = entries;
+        }
+        
+        @Override
         public int getRowCount() {
             return data.size();
         }
@@ -254,111 +254,111 @@ public class EditPersonnelInjuriesDialog extends JDialog {
         @Override
         public String getColumnName(int column) {
             switch(column) {
-        	case COL_DAYS:
-        		return "Days Remaining";
-        	case COL_LOCATION:
-        		return "Location on Body";
-        	case COL_TYPE:
-        		return "Type of Injury";
-        	case COL_FLUFF:
+            case COL_DAYS:
+                return "Days Remaining";
+            case COL_LOCATION:
+                return "Location on Body";
+            case COL_TYPE:
+                return "Type of Injury";
+            case COL_FLUFF:
                 return "Fluff Message";
-        	case COL_HITS:
-        		return "Number of Hits";
-        	case COL_PERMANENT:
-        		return "Is Permanent";
-        	case COL_WORKEDON:
-        		return "Doctor Has Worked On";
-        	case COL_EXTENDED:
-        		return "Was Extended Time";
+            case COL_HITS:
+                return "Number of Hits";
+            case COL_PERMANENT:
+                return "Is Permanent";
+            case COL_WORKEDON:
+                return "Doctor Has Worked On";
+            case COL_EXTENDED:
+                return "Was Extended Time";
                 default:
                     return "?";
             }
         }
 
-		@Override
+        @Override
         public Object getValueAt(int row, int col) {
-	        Injury entry;
-	        if(data.isEmpty()) {
-	        	return "";
-	        } else {
-	        	entry = (Injury)data.get(row);
-	        }
-	        if(col == COL_DAYS) {
-				return Integer.toString(entry.getTime());
-			}
-	        if(col == COL_LOCATION) {
-				return entry.getLocationName();
-			}
-	        if(col == COL_TYPE) {
-				return entry.getType().getName(entry.getLocation(), entry.getHits());
-			}
-			if(col == COL_FLUFF) {
-				return entry.getFluff();
-			}
-			if(col == COL_HITS) {
-				return Integer.toString(entry.getHits());
-			}
-			if(col == COL_PERMANENT) {
-				return Boolean.toString(entry.isPermanent());
-			}
-			if(col == COL_WORKEDON) {
-				return Boolean.toString(entry.isWorkedOn());
-			}
-			if(col == COL_EXTENDED) {
-				return Boolean.toString(entry.getExtended());
-			}
-			return "?";
-		}
-		
-		@Override
-		public boolean isCellEditable(int row, int col) {
-			return false;
-		}
-		
-		@Override
-		public Class<? extends Object> getColumnClass(int c) {
-			return getValueAt(0, c).getClass();
-		}
+            Injury entry;
+            if(data.isEmpty()) {
+                return "";
+            } else {
+                entry = (Injury)data.get(row);
+            }
+            if(col == COL_DAYS) {
+                return Integer.toString(entry.getTime());
+            }
+            if(col == COL_LOCATION) {
+                return entry.getLocationName();
+            }
+            if(col == COL_TYPE) {
+                return entry.getType().getName(entry.getLocation(), entry.getHits());
+            }
+            if(col == COL_FLUFF) {
+                return entry.getFluff();
+            }
+            if(col == COL_HITS) {
+                return Integer.toString(entry.getHits());
+            }
+            if(col == COL_PERMANENT) {
+                return Boolean.toString(entry.isPermanent());
+            }
+            if(col == COL_WORKEDON) {
+                return Boolean.toString(entry.isWorkedOn());
+            }
+            if(col == COL_EXTENDED) {
+                return Boolean.toString(entry.getExtended());
+            }
+            return "?";
+        }
+        
+        @Override
+        public boolean isCellEditable(int row, int col) {
+            return false;
+        }
+        
+        @Override
+        public Class<? extends Object> getColumnClass(int c) {
+            return getValueAt(0, c).getClass();
+        }
 
-		public Injury getEntryAt(int row) {
-			return (Injury) data.get(row);
-		}
-		
-		 public int getColumnWidth(int c) {
+        public Injury getEntryAt(int row) {
+            return (Injury) data.get(row);
+        }
+        
+         public int getColumnWidth(int c) {
             switch(c) {
             case COL_DAYS:
             case COL_HITS:
             case COL_PERMANENT:
             case COL_WORKEDON:
             case COL_EXTENDED:
-            	return 110;
+                return 110;
             case COL_TYPE:
-            	return 150;
+                return 150;
             case COL_FLUFF:
             case COL_LOCATION:
-        		return 200;     
+                return 200;     
             default:
                 return 50;
             }
         }
         
         public int getAlignment(int col) {
-        	switch(col) {
-        	case COL_DAYS:
-        	case COL_HITS:
-        	case COL_PERMANENT:
-        	case COL_WORKEDON:
-        	case COL_EXTENDED:
-        		return SwingConstants.CENTER;
-        	default:
-	        	return SwingConstants.LEFT;
-        	}
+            switch(col) {
+            case COL_DAYS:
+            case COL_HITS:
+            case COL_PERMANENT:
+            case COL_WORKEDON:
+            case COL_EXTENDED:
+                return SwingConstants.CENTER;
+            default:
+                return SwingConstants.LEFT;
+            }
         }
 
         public String getTooltip(int row, int col) {
-        	switch(col) {
+            switch(col) {
             default:
-            	return null;
+                return null;
             }
         }
         
@@ -369,29 +369,29 @@ public class EditPersonnelInjuriesDialog extends JDialog {
         }
         
         public InjuryTableModel.Renderer getRenderer() {
-			return new InjuryTableModel.Renderer();
-		}
+            return new InjuryTableModel.Renderer();
+        }
 
-		public class Renderer extends DefaultTableCellRenderer {
+        public class Renderer extends DefaultTableCellRenderer {
 
-			private static final long serialVersionUID = 9054581142945717303L;
+            private static final long serialVersionUID = 9054581142945717303L;
 
-			@Override
+            @Override
             public Component getTableCellRendererComponent(JTable table,
-					Object value, boolean isSelected, boolean hasFocus,
-					int row, int column) {
-				super.getTableCellRendererComponent(table, value, isSelected,
-						hasFocus, row, column);
-				setOpaque(true);
-				int actualCol = table.convertColumnIndexToModel(column);
-				int actualRow = table.convertRowIndexToModel(row);
-				setHorizontalAlignment(getAlignment(actualCol));
-				setToolTipText(getTooltip(actualRow, actualCol));
-				
-				return this;
-			}
+                    Object value, boolean isSelected, boolean hasFocus,
+                    int row, int column) {
+                super.getTableCellRendererComponent(table, value, isSelected,
+                        hasFocus, row, column);
+                setOpaque(true);
+                int actualCol = table.convertColumnIndexToModel(column);
+                int actualRow = table.convertRowIndexToModel(row);
+                setHorizontalAlignment(getAlignment(actualCol));
+                setToolTipText(getTooltip(actualRow, actualCol));
+                
+                return this;
+            }
 
-		}
-	}
+        }
+    }
 
 }


### PR DESCRIPTION
Fixes two bugs in the Edit Injuries dialog:
1. You could not delete injuries from the dialog.
2. The Injury Type combo box did not update w.r.t. the location being changed.

Whitespace in both files wrangled to project default of 4 spaces in a separate commit to keep review clean.