### PR TITLE
Packaging fixes

### DIFF
--- a/MekHQ/build.xml
+++ b/MekHQ/build.xml
@@ -118,7 +118,7 @@
                 <attribute name="Class-Path" value=". ${classpath.manifest} ${megamek} ${megameklab}"/>
             </manifest>
             <fileset dir="${src}" includes="**/*.properties"/>
-			<metainf dir="${src}/META-INF" includes="**/services/*"/>
+			<metainf dir="${src}/META-INF" includes="services/**"/>
         </jar>
         <echo message="Built-By: ${user.name}"/>
         <echo message="Main-Class: ${class.main}"/>

--- a/MekHQ/packaging.xml
+++ b/MekHQ/packaging.xml
@@ -183,6 +183,7 @@
                 <include name="fonts/" />
                 <include name="mapgen/" />
      			<include name="names/bloodnames/" />
+                <include name="images/awards/" />
                 <include name="images/force/" />
                 <include name="images/portraits/" />
                 <include name="images/fluff/mech/*.png" />

--- a/MekHQ/packaging.xml
+++ b/MekHQ/packaging.xml
@@ -241,7 +241,7 @@
                 <attribute name="Class-Path" value="${dataclasspath} ${classpath.manifest} ${megamek} ${megameklab}"/>
             </manifest>
                 <fileset dir="${pkgdir}/${srcdir}" includes="**/*.properties"/>
-				<metainf dir="${pkgdir}/${srcdir}" includes="META-INF/services/*"/>
+				<metainf dir="${pkgdir}/${srcdir}/META-INF" includes="services/**"/>
             </jar>
 
             <!-- Ensure that the log directory exists. -->

--- a/MekHQ/packaging.xml
+++ b/MekHQ/packaging.xml
@@ -513,6 +513,7 @@
     <property name="megameklab" value="MegaMekLab.jar"/>
     <property name="dir.build.test" location="${builddir}/test"/>
     <property name="dir.test.src" location="unittests"/>
+    <property name="dir.build.resources" location="${builddir}/resources"/>
     <property name="libdir.test" value="lib-test"/>
 
     <path id="classpath">
@@ -535,11 +536,14 @@
     <path id="classpath.run-unittest">
         <path refid="classpath.compile-unittest"/>
         <pathelement location="${dir.build.test}"/>
+        <pathelement location="${pkgbuilddir}"/>
+        <pathelement location="${dir.build.resources}"/>
     </path>
 
     <target name="tests-compile" unless="${skip.tests}">
         <delete dir="${dir.build.test}"/>
         <mkdir dir="${dir.build.test}"/>
+        
         <javac srcdir="${dir.test.src}" destdir="${dir.build.test}" encoding="UTF-8" includeantruntime="false"
                debug="true">
             <classpath refid="classpath.compile-unittest"/>
@@ -549,8 +553,14 @@
     <target depends="tests-compile" name="tests-run" unless="${skip.tests}">
         <delete dir="${dir.build.teststaging}"/>
         <delete dir="${dir.build.testreport}"/>
+        <delete dir="${dir.build.resources}"/>
         <mkdir dir="${dir.build.teststaging}"/>
         <mkdir dir="${dir.build.testreport}"/>
+        <copy todir="${dir.build.resources}" encoding="UTF-8">
+            <fileset dir="${pkgdir}/${srcdir}" >
+                <include name="**/*.properties" />
+            </fileset>
+        </copy>
 
         <junit fork="true" maxmemory="256m" showoutput="true" printsummary="yes" forkmode="once" haltonfailure="true"
                haltonerror="true" failureproperty="tests.failed">

--- a/MekHQ/packaging_local.xml
+++ b/MekHQ/packaging_local.xml
@@ -235,9 +235,9 @@
 				<attribute name="Main-Class" value="${jarmainclass}"/>
 				<attribute name="Class-Path" value="${dataclasspath} ${classpath.manifest} ${megamek} ${megameklab}"/>
 			</manifest>
-				<fileset dir="${localdir}/${srcdir}" includes="**/*.properties"/>
-				<metainf dir="${srcdir}/META-INF" includes="services/**"/>
-			</jar>
+			<fileset dir="${localdir}/${srcdir}" includes="**/*.properties"/>
+			<metainf dir="${srcdir}/META-INF" includes="services/**"/>
+		</jar>
 
 			<!-- Ensure that the log directory exists. -->
 			<mkdir dir="${localdir}/${logdir}" />
@@ -465,6 +465,7 @@
 
 	<property name="dir.build.teststaging" location="${builddir}/teststaging"/>
 	<property name="dir.build.testreport" location="${builddir}/testreport"/>
+	<property name="dir.build.resources" location="${builddir}/resources"/>
 	<property name="class.main" value="mekhq.MekHQ"/>
 	<property name="megamek" value="MegaMek.jar"/>
 	<property name="megameklab" value="MegaMekLab.jar"/>
@@ -492,6 +493,7 @@
 	<path id="classpath.run-unittest">
 		<path refid="classpath.compile-unittest"/>
 		<pathelement location="${dir.build.test}"/>
+		<pathelement location="${dir.build.resources}"/>
 	</path>
 
 	<target name="tests-compile" unless="${skip.tests}">
@@ -506,8 +508,14 @@
 	<target depends="tests-compile" name="tests-run" unless="${skip.tests}">
 		<delete dir="${dir.build.teststaging}"/>
 		<delete dir="${dir.build.testreport}"/>
+		<delete dir="${dir.build.resources}"/>
 		<mkdir dir="${dir.build.teststaging}"/>
 		<mkdir dir="${dir.build.testreport}"/>
+        <copy todir="${dir.build.resources}" encoding="UTF-8">
+            <fileset dir="${srcdir}" >
+                <include name="**/*.properties" />
+            </fileset>
+        </copy>
 
 		<junit fork="true" maxmemory="256m" showoutput="true" printsummary="yes" forkmode="once" haltonfailure="true"
 			   haltonerror="true" failureproperty="tests.failed">

--- a/MekHQ/packaging_local.xml
+++ b/MekHQ/packaging_local.xml
@@ -164,6 +164,7 @@
                 <include name="fonts/" />
                 <include name="mapgen/" />
                 <include name="names/bloodnames/" />
+                <include name="images/awards/" />
                 <include name="images/force/" />
                 <include name="images/portraits/" />
                 <include name="images/fluff/mech/*.png" />

--- a/MekHQ/packaging_local.xml
+++ b/MekHQ/packaging_local.xml
@@ -236,7 +236,7 @@
 				<attribute name="Class-Path" value="${dataclasspath} ${classpath.manifest} ${megamek} ${megameklab}"/>
 			</manifest>
 				<fileset dir="${localdir}/${srcdir}" includes="**/*.properties"/>
-				<metainf dir="${localdir}/$srcdir}" includes="META-INF/services/*"/>
+				<metainf dir="${srcdir}/META-INF" includes="services/**"/>
 			</jar>
 
 			<!-- Ensure that the log directory exists. -->


### PR DESCRIPTION
Fixes three problems in the build scripts:

1. Include data/images/awards in release packages.
2. Put the services folder into META-INF instead of META-INF/META-INF (fixes #842)
3. Put the resource files on the build path when running the unit tests, since there are tests that use tokenized strings.