### PR TITLE
Separate bot retreat destination edges - MekHQ

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -44,7 +44,7 @@ import megamek.client.RandomSkillsGenerator;
 import megamek.client.RandomUnitGenerator;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.HomeEdge;
+import megamek.client.bot.princess.CardinalEdge;
 import megamek.client.bot.princess.PrincessException;
 import megamek.common.Board;
 import megamek.common.Compute;
@@ -2243,30 +2243,30 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                         "Error getting Princess default behaviors"); //$NON-NLS-1$
                 MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
             }
-            behaviorSettings.setHomeEdge(findHomeEdge(home));
+            behaviorSettings.setRetreatEdge(CardinalEdge.NEAREST_OR_NONE);
         }
 
         /* Convert from MM's Board to Princess's HomeEdge */
-        public HomeEdge findHomeEdge(int start) {
+        public CardinalEdge findCardinalEdge(int start) {
             switch (start) {
             case Board.START_N:
-                return HomeEdge.NORTH;
+                return CardinalEdge.NORTH;
             case Board.START_S:
-                return HomeEdge.SOUTH;
+                return CardinalEdge.SOUTH;
             case Board.START_E:
-                return HomeEdge.EAST;
+                return CardinalEdge.EAST;
             case Board.START_W:
-                return HomeEdge.WEST;
+                return CardinalEdge.WEST;
             case Board.START_NW:
-                return (Compute.randomInt(2) == 0)?HomeEdge.NORTH:HomeEdge.WEST;
+                return (Compute.randomInt(2) == 0) ? CardinalEdge.NORTH : CardinalEdge.WEST;
             case Board.START_NE:
-                return (Compute.randomInt(2) == 0)?HomeEdge.NORTH:HomeEdge.EAST;
+                return (Compute.randomInt(2) == 0) ? CardinalEdge.NORTH : CardinalEdge.EAST;
             case Board.START_SW:
-                return (Compute.randomInt(2) == 0)?HomeEdge.SOUTH:HomeEdge.WEST;
+                return (Compute.randomInt(2) == 0) ? CardinalEdge.SOUTH : CardinalEdge.WEST;
             case Board.START_SE:
-                return (Compute.randomInt(2) == 0)?HomeEdge.SOUTH:HomeEdge.EAST;
+                return (Compute.randomInt(2) == 0) ? CardinalEdge.SOUTH : CardinalEdge.EAST;
             default:
-                return HomeEdge.getHomeEdge(Compute.randomInt(4));
+                return CardinalEdge.getCardinalEdge(Compute.randomInt(4));
             }
         }
 
@@ -2334,8 +2334,12 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             this.behaviorSettings = behaviorSettings;
         }
 
-        public void setHomeEdge(int i) {
-            behaviorSettings.setHomeEdge(findHomeEdge(i));
+        public void setDestinationEdge(int i) {
+            behaviorSettings.setDestinationEdge(findCardinalEdge(i));
+        }
+        
+        public void setRetreatEdge(int i) {
+            behaviorSettings.setRetreatEdge(findCardinalEdge(i));
         }
 
         public void writeToXml(PrintWriter pw1, int indent) {
@@ -2357,12 +2361,12 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             pw1.println(MekHqXmlUtil.indentStr(indent+1) + "<behaviorSettings>");
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "verbosity", behaviorSettings.getVerbosity().toString());
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "forcedWithdrawal", behaviorSettings.isForcedWithdrawal());
-            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "goHome", behaviorSettings.shouldGoHome());
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "autoFlee", behaviorSettings.shouldAutoFlee());
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "selfPreservationIndex", behaviorSettings.getSelfPreservationIndex());
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "fallShameIndex", behaviorSettings.getFallShameIndex());
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "hyperAggressionIndex", behaviorSettings.getHyperAggressionIndex());
-            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "homeEdge", behaviorSettings.getHomeEdge().ordinal());
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "destinationEdge", behaviorSettings.getDestinationEdge().ordinal());
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "retreatEdge", behaviorSettings.getRetreatEdge().ordinal());
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "herdMentalityIndex", behaviorSettings.getHerdMentalityIndex());
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+2, "braveryIndex", behaviorSettings.getBraveryIndex());
             pw1.println(MekHqXmlUtil.indentStr(indent+1) + "</behaviorSettings>");
@@ -2417,8 +2421,6 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                             behaviorSettings.setVerbosity(LogLevel.getLogLevel(wn3.getTextContent()));
                         } else if (wn3.getNodeName().equalsIgnoreCase("forcedWithdrawal")) {
                             behaviorSettings.setForcedWithdrawal(Boolean.parseBoolean(wn3.getTextContent()));
-                        } else if (wn3.getNodeName().equalsIgnoreCase("goHome")) {
-                            behaviorSettings.setGoHome(Boolean.parseBoolean(wn3.getTextContent()));
                         } else if (wn3.getNodeName().equalsIgnoreCase("autoFlee")) {
                             behaviorSettings.setAutoFlee(Boolean.parseBoolean(wn3.getTextContent()));
                         } else if (wn3.getNodeName().equalsIgnoreCase("selfPreservationIndex")) {
@@ -2427,8 +2429,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                             behaviorSettings.setFallShameIndex(Integer.parseInt(wn3.getTextContent()));
                         } else if (wn3.getNodeName().equalsIgnoreCase("hyperAggressionIndex")) {
                             behaviorSettings.setHyperAggressionIndex(Integer.parseInt(wn3.getTextContent()));
-                        } else if (wn3.getNodeName().equalsIgnoreCase("homeEdge")) {
-                            behaviorSettings.setHomeEdge(Integer.parseInt(wn3.getTextContent()));
+                        } else if (wn3.getNodeName().equalsIgnoreCase("destinationEdge")) {
+                            behaviorSettings.setDestinationEdge(Integer.parseInt(wn3.getTextContent()));
+                        } else if (wn3.getNodeName().equalsIgnoreCase("retreatEdge")) {
+                            behaviorSettings.setRetreatEdge(Integer.parseInt(wn3.getTextContent()));
                         } else if (wn3.getNodeName().equalsIgnoreCase("herdMentalityIndex")) {
                             behaviorSettings.setHerdMentalityIndex(Integer.parseInt(wn3.getTextContent()));
                         } else if (wn3.getNodeName().equalsIgnoreCase("braveryIndex")) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -2244,6 +2244,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
             }
             behaviorSettings.setRetreatEdge(CardinalEdge.NEAREST_OR_NONE);
+            behaviorSettings.setDestinationEdge(CardinalEdge.NEAREST_OR_NONE);
         }
 
         /* Convert from MM's Board to Princess's HomeEdge */

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -93,7 +93,6 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
 		addCivilianUnits(otherForce, 8, campaign);
 		BotForce civilianForce = new BotForce("Base Civilian Units", isAttacker() ? 2 : 1, defenderStart, defenderHome, otherForce);
 		civilianForce.setBehaviorSettings(BehaviorSettingsFactory.getInstance().COWARDLY_BEHAVIOR);
-		civilianForce.setHomeEdge(defenderHome); // setting behavior settings rewrites home edge, so we set it again
 		addBotForce(civilianForce);
 
 		ArrayList<Entity> turretForce = new ArrayList<>();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -3,8 +3,10 @@ package mekhq.campaign.mission.atb.scenario;
 import java.util.ArrayList;
 
 import megamek.client.bot.princess.BehaviorSettingsFactory;
+import megamek.client.bot.princess.CardinalEdge;
 import megamek.client.bot.princess.PrincessException;
 import megamek.common.Board;
+import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import mekhq.campaign.Campaign;
@@ -48,16 +50,18 @@ public class ChaseBuiltInScenario extends AtBScenario {
 	@Override
 	public void setExtraMissionForces(Campaign campaign, ArrayList<Entity> allyEntities,
 			ArrayList<Entity> enemyEntities) {
-		int enemyStart = Board.START_S;
-		int playerHome = Board.START_N;
+	    boolean startNorth = Compute.d6() > 3;
+	    
+	    int destinationEdge = startNorth ? Board.START_S : Board.START_N;
+	    int startEdge = startNorth ? Board.START_N : Board.START_S;
 
-		setStart(Board.START_S);
-		setEnemyHome(Board.START_N);
+		setStart(startEdge);
+		setEnemyHome(destinationEdge);
 
 		BotForce allyEntitiesForce = null;
 
 		if (allyEntities.size() > 0) {
-			allyEntitiesForce = getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities);
+			allyEntitiesForce = getAllyBotForce(getContract(campaign), getStart(), destinationEdge, allyEntities);
 			addBotForce(allyEntitiesForce);
 		}
 
@@ -66,16 +70,19 @@ public class ChaseBuiltInScenario extends AtBScenario {
 		addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT, 0,
 				-1, campaign);
 
-		BotForce botForce = getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities);
+		BotForce botForce = getEnemyBotForce(getContract(campaign), startEdge, getEnemyHome(), enemyEntities);
 
 		try {
 			if (isAttacker()) {
 				if (null != allyEntitiesForce) {
 					allyEntitiesForce
 							.setBehaviorSettings(BehaviorSettingsFactory.getInstance().ESCAPE_BEHAVIOR.getCopy());
+					
+					allyEntitiesForce.setDestinationEdge(destinationEdge);
 				}
 			} else {
 				botForce.setBehaviorSettings(BehaviorSettingsFactory.getInstance().ESCAPE_BEHAVIOR.getCopy());
+				botForce.setDestinationEdge(destinationEdge);
 			}
 		} catch (PrincessException e) {
 			e.printStackTrace();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
@@ -84,7 +84,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
 			if (isAttacker()) {
 				BotForce bf = new BotForce("Civilians", 1, otherStart, playerHome, otherForce);
 				bf.setBehaviorSettings(BehaviorSettingsFactory.getInstance().ESCAPE_BEHAVIOR.getCopy());
-				bf.getBehaviorSettings().setHomeEdge(bf.findHomeEdge(otherHome));
+				bf.setDestinationEdge(otherHome);
 				
 				addBotForce(bf);
 				
@@ -94,7 +94,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
 			} else {
 				BotForce bf = new BotForce("Civilians", 2, otherStart, enemyStart, otherForce);
 				bf.setBehaviorSettings(BehaviorSettingsFactory.getInstance().ESCAPE_BEHAVIOR.getCopy());
-				bf.getBehaviorSettings().setHomeEdge(bf.findHomeEdge(otherHome));
+				bf.setDestinationEdge(otherHome);
 				
 				addBotForce(bf);
 			}

--- a/MekHQ/src/mekhq/gui/dialog/PrincessBehaviorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PrincessBehaviorDialog.java
@@ -21,149 +21,37 @@
 
 package mekhq.gui.dialog;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Hashtable;
 
-import javax.swing.DefaultListModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JDialog;
 import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JList;
 import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.JTextField;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingConstants;
-import javax.swing.border.LineBorder;
-import javax.swing.border.TitledBorder;
 
 import megamek.client.bot.princess.BehaviorSettings;
-import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.PrincessException;
-import megamek.client.ui.Messages;
-import megamek.client.ui.swing.HelpDialog;
+import megamek.client.ui.swing.BotConfigDialog;
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
 
-/**
- * Code copied from megamek.client.ui.swing.BotConfigDialog and modified
- * to function as a BehaviorSettings editor rather than a BotClient generator.
- * 
- */
-
-public class PrincessBehaviorDialog extends JDialog implements ActionListener {
+public class PrincessBehaviorDialog extends BotConfigDialog implements ActionListener {
 
     /**
 	 * 
 	 */
 	private static final long serialVersionUID = -1697757949925940582L;
-	
-	private static final String UNIT_TARGET = Messages.getString("BotConfigDialog.targetUnit");
-    private static final String BUILDING_TARGET = Messages.getString("BotConfigDialog.targetBuilding");
 
-	private BehaviorSettings princessBehavior;
-    private BehaviorSettingsFactory behaviorSettingsFactory = BehaviorSettingsFactory.getInstance();
-
-    private JComboBox<String> verbosityCombo;
-    private JTextField targetId;
-    private JComboBox<String> targetTypeCombo;
-    private JButton addTargetButton;
-    private JButton removeTargetButton;
-    private JButton princessHelpButton;
-    private JList<String> targetsList;
-    private DefaultListModel<String> targetsListModel = new DefaultListModel<>();
-    private JCheckBox forcedWithdrawalCheck;
-    private JCheckBox goHomeCheck;
-    private JCheckBox autoFleeCheck;
-    private JComboBox<String> homeEdgeCombo; //The board edge to be used in a forced withdrawal.
-    private JSlider aggressionSlidebar;
-    private JSlider fallShameSlidebar;
-    private JSlider herdingSlidebar;
-    private JSlider selfPreservationSlidebar;
-    private JSlider braverySlidebar;
-    private JComboBox<String> princessBehaviorNames;
-
-    private JTextField nameField;
-    public boolean dialogAborted = true; // did user not click Ok button?
-
-    private final JButton butOK = new JButton(Messages.getString("Okay")); //$NON-NLS-1$
-
-
-	public PrincessBehaviorDialog(JFrame parent,
-			BehaviorSettings princessBehavior, String name) {
-		super(parent, name + " behavior", true);
-		try {
-			this.princessBehavior = princessBehavior.getCopy();
-		} catch (PrincessException e) {
-			e.printStackTrace();
-		}
-		
-        setLayout(new BorderLayout());
-        JScrollPane princessScroll = new JScrollPane(princessPanel());
-        add(princessScroll, BorderLayout.CENTER);
-        butOK.addActionListener(this);
-
-        add(okayPanel(), BorderLayout.SOUTH);
-        nameField.setText(name);
-        validate();
-        pack();
-        setSize(new Dimension(600, 600));
-        setLocationRelativeTo(parent);		
+	public PrincessBehaviorDialog(JFrame parent, BehaviorSettings princessBehavior, String name) {
+	    super(parent, null);
+	    
+	    this.princessBehavior = princessBehavior;
+	    this.setName(name);
+	    
+	    this.nameField.setText(name);
+	    super.setPrincessFields();
 	}
 	
 	public BehaviorSettings getBehaviorSettings() {
 		return princessBehavior;
 	}
-
-    private boolean resetPrincessBehavior() {
-        princessBehavior = behaviorSettingsFactory.getBehavior((String) princessBehaviorNames.getSelectedItem());
-        if (princessBehavior == null) {
-            princessBehavior = new BehaviorSettings();
-            return false;
-        }
-        return true;
-    }
-
-    private void setPrincessFields() {
-        if (princessBehavior.getVerbosity() != null) {
-            verbosityCombo.setSelectedItem(princessBehavior.getVerbosity().toString());
-        } else {
-            verbosityCombo.setSelectedIndex(0);
-        }
-        forcedWithdrawalCheck.setSelected(princessBehavior.isForcedWithdrawal());
-        goHomeCheck.setSelected(princessBehavior.shouldGoHome());
-        autoFleeCheck.setSelected(princessBehavior.shouldAutoFlee());
-        autoFleeCheck.setEnabled(goHomeCheck.isSelected());
-        selfPreservationSlidebar.setValue(princessBehavior.getSelfPreservationIndex());
-        aggressionSlidebar.setValue(princessBehavior.getHyperAggressionIndex());
-        fallShameSlidebar.setValue(princessBehavior.getFallShameIndex());
-        homeEdgeCombo.setSelectedIndex(princessBehavior.getHomeEdge().getIndex());
-        herdingSlidebar.setValue(princessBehavior.getHerdMentalityIndex());
-        braverySlidebar.setValue(princessBehavior.getBraveryIndex());
-        targetsListModel.clear();
-        for (String t : princessBehavior.getStrategicBuildingTargets()) {
-            //noinspection unchecked
-            targetsListModel.addElement(t);
-        }
-        repaint();
-    }
 
     private void getPrincessFields() {
         LogLevel logLevel = LogLevel.getLogLevel((String) verbosityCombo.getSelectedItem());
@@ -171,303 +59,14 @@ public class PrincessBehaviorDialog extends JDialog implements ActionListener {
             princessBehavior.setVerbosity(logLevel);
         }
     	princessBehavior.setForcedWithdrawal(forcedWithdrawalCheck.isSelected());
-    	princessBehavior.setGoHome(goHomeCheck.isSelected());
     	princessBehavior.setAutoFlee(autoFleeCheck.isSelected());
     	princessBehavior.setSelfPreservationIndex(selfPreservationSlidebar.getValue());
     	princessBehavior.setHyperAggressionIndex(aggressionSlidebar.getValue());
     	princessBehavior.setFallShameIndex(fallShameSlidebar.getValue());
-    	princessBehavior.setHomeEdge(homeEdgeCombo.getSelectedIndex());
+    	princessBehavior.setDestinationEdge(destinationEdgeCombo.getSelectedIndex());
+    	princessBehavior.setRetreatEdge(retreatEdgeCombo.getSelectedIndex());
     	princessBehavior.setHerdMentalityIndex(herdingSlidebar.getValue());
     	princessBehavior.setBraveryIndex(braverySlidebar.getValue());
-    	//Strategic targets?
-    }
-
-    private JLabel buildSliderLabel(String caption) {
-        Font slideFont = new Font(Font.SANS_SERIF, Font.PLAIN, 8);
-        JLabel label = new JLabel(caption);
-        label.setFont(slideFont);
-        return label;
-    }
-
-    private JSlider buildSlider(String minMsgProperty, String maxMsgProperty, String toolTip, String title) {
-        JSlider thisSlider = new JSlider(SwingConstants.HORIZONTAL, 0, 10, 5);
-        Hashtable<Integer, JLabel> sliderLabels = new Hashtable<>(3);
-        sliderLabels.put(0, buildSliderLabel("0 - " + minMsgProperty));
-        sliderLabels.put(10, buildSliderLabel("10 - " + maxMsgProperty));
-        sliderLabels.put(5, buildSliderLabel("5"));
-        thisSlider.setToolTipText(toolTip);
-        thisSlider.setLabelTable(sliderLabels);
-        thisSlider.setPaintLabels(true);
-        thisSlider.setMinorTickSpacing(1);
-        thisSlider.setMajorTickSpacing(2);
-        thisSlider.setSnapToTicks(true);
-        thisSlider.setBorder(new TitledBorder(new LineBorder(Color.black), title));
-        thisSlider.setEnabled(true);
-
-        return thisSlider;
-    }
-
-    private JPanel okayPanel() {
-        JPanel panel = new JPanel(new FlowLayout(FlowLayout.CENTER, 2, 2));
-
-        JPanel namepanel = new JPanel(new FlowLayout());
-        namepanel.add(new JLabel(Messages.getString("BotConfigDialog.nameLabel")));
-        nameField = new JTextField();
-        nameField.setText(Messages.getString("BotConfigDialog.namefield.default"));
-        nameField.setColumns(12);
-        nameField.setToolTipText(Messages.getString("BotConfigDialog.namefield.tooltip"));
-        namepanel.add(nameField);
-        panel.add(namepanel);
-
-        butOK.addActionListener(this);
-        panel.add(butOK);
-
-        panel.validate();
-        return panel;
-    }
-
-    private JPanel buildSliderPanel() {
-        JPanel panel = new JPanel();
-
-        GridBagConstraints constraints = new GridBagConstraints();
-        GridBagLayout layout = new GridBagLayout();
-        panel.setLayout(layout);
-
-        //Initialize constraints.
-        constraints.gridheight = 1;
-        constraints.gridwidth = 0;
-        constraints.weightx = 1;
-        constraints.weighty = 1;
-        constraints.insets = new Insets(0, 0, 0, 0);
-        constraints.anchor = GridBagConstraints.NORTHWEST;
-        constraints.fill = GridBagConstraints.HORIZONTAL;
-
-        //Row 1
-        constraints.gridy = 0;
-        constraints.gridx = 0;
-        braverySlidebar = buildSlider(Messages.getString("BotConfigDialog.braverySliderMin"),
-                                      Messages.getString("BotConfigDialog.braverySliderMax"),
-                                      Messages.getString("BotConfigDialog.braveryTooltip"),
-                                      Messages.getString("BotConfigDialog.braverySliderTitle"));
-        panel.add(braverySlidebar, constraints);
-
-        //Row 2
-        constraints.gridy++;
-        selfPreservationSlidebar = buildSlider(Messages.getString("BotConfigDialog.selfPreservationSliderMin"),
-                                               Messages.getString("BotConfigDialog.selfPreservationSliderMax"),
-                                               Messages.getString("BotConfigDialog.selfPreservationTooltip"),
-                                               Messages.getString("BotConfigDialog.selfPreservationSliderTitle"));
-        panel.add(selfPreservationSlidebar, constraints);
-
-        //Row 3
-        constraints.gridy++;
-        aggressionSlidebar = buildSlider(Messages.getString("BotConfigDialog.aggressionSliderMin"),
-                                         Messages.getString("BotConfigDialog.aggressionSliderMax"),
-                                         Messages.getString("BotConfigDialog.aggressionTooltip"),
-                                         Messages.getString("BotConfigDialog.aggressionSliderTitle"));
-        panel.add(aggressionSlidebar, constraints);
-
-        //Row 4
-        constraints.gridy++;
-        herdingSlidebar = buildSlider(Messages.getString("BotConfigDialog.herdingSliderMin"),
-                                      Messages.getString("BotConfigDialog.herdingSliderMax"),
-                                      Messages.getString("BotConfigDialog.herdingToolTip"),
-                                      Messages.getString("BotConfigDialog.herdingSliderTitle"));
-        panel.add(herdingSlidebar, constraints);
-
-        //Row 5
-        constraints.gridy++;
-        fallShameSlidebar = buildSlider(Messages.getString("BotConfigDialog.fallShameSliderMin"),
-                                        Messages.getString("BotConfigDialog.fallShameSliderMax"),
-                                        Messages.getString("BotConfigDialog.fallShameToolTip"),
-                                        Messages.getString("BotConfigDialog.fallShameSliderTitle"));
-        panel.add(fallShameSlidebar, constraints);
-
-        panel.setBorder(new TitledBorder(new LineBorder(Color.black, 1), "Behavior Settings"));
-
-        return panel;
-    }
-
-    private JPanel princessPanel() {
-
-        //Setup layout.
-        JPanel panel = new JPanel();
-        GridBagConstraints constraints = new GridBagConstraints();
-        GridBagLayout layout = new GridBagLayout();
-        panel.setLayout(layout);
-
-        //Initialize constraints.
-        constraints.gridheight = 1;
-        constraints.gridwidth = 1;
-        constraints.insets = new Insets(2, 2, 2, 2);
-        constraints.anchor = GridBagConstraints.NORTHWEST;
-        constraints.fill = GridBagConstraints.HORIZONTAL;
-
-        //Row 1 Column 1
-        constraints.gridy = 0;
-        constraints.gridx = 0;
-        JLabel behaviorNameLabel = new JLabel(Messages.getString("BotConfigDialog.behaviorNameLabel"));
-        panel.add(behaviorNameLabel, constraints);
-
-        //Row 1 Column 2
-        constraints.gridx++;
-        constraints.gridwidth = 2;
-        princessBehaviorNames = new JComboBox<>(behaviorSettingsFactory.getBehaviorNames());
-        princessBehaviorNames.setSelectedItem(BehaviorSettingsFactory.DEFAULT_BEHAVIOR_DESCRIPTION);
-        princessBehaviorNames.setToolTipText(Messages.getString("BotConfigDialog.behaviorToolTip"));
-        princessBehaviorNames.addActionListener(this);
-        princessBehaviorNames.setEditable(true);
-        panel.add(princessBehaviorNames, constraints);
-
-        //Row 2 Column 1
-        constraints.gridx = 0;
-        constraints.gridwidth = 1;
-        constraints.gridy++;
-        JLabel verbosityLabel = new JLabel(Messages.getString("BotConfigDialog.verbosityLabel"));
-        panel.add(verbosityLabel, constraints);
-
-        //Row 2 Column 2;
-        constraints.gridx++;
-        constraints.gridwidth = 2;
-        verbosityCombo = new JComboBox<>(LogLevel.getLogLevelNames());
-        verbosityCombo.setToolTipText(Messages.getString("BotConfigDialog.verbosityToolTip"));
-        verbosityCombo.setSelectedIndex(0);
-        panel.add(verbosityCombo, constraints);
-
-        //Row 3 Column 1.
-        constraints.gridy++;
-        constraints.gridx = 0;
-        constraints.gridwidth = 1;
-        forcedWithdrawalCheck = new JCheckBox(Messages.getString("BotConfigDialog.forcedWithdrawalCheck"));
-        forcedWithdrawalCheck.setToolTipText(Messages.getString("BotConfigDialog.forcedWithdrawalTooltip"));
-        panel.add(forcedWithdrawalCheck, constraints);
-
-        //Row 3 Column 2.
-        constraints.gridx++;
-        goHomeCheck = new JCheckBox(Messages.getString("BotConfigDialog.goHomeCheck"));
-        goHomeCheck.setToolTipText(Messages.getString("BotConfigDialog.goHomeTooltip"));
-        goHomeCheck.addActionListener(this);
-        panel.add(goHomeCheck, constraints);
-
-        //Row 3 Column 3.
-        constraints.gridx++;
-        autoFleeCheck = new JCheckBox(Messages.getString("BotConfigDialog.autoFleeCheck"));
-        autoFleeCheck.setToolTipText(Messages.getString("BotConfigDialog.autoFleeTooltip"));
-        autoFleeCheck.addActionListener(this);
-        autoFleeCheck.setEnabled(false);
-        panel.add(autoFleeCheck, constraints);
-
-        //Row 4 Column 1.
-        constraints.gridy++;
-        constraints.gridx = 0;
-        JLabel homeEdgeLabel = new JLabel(Messages.getString("BotConfigDialog.homeEdgeLabel"));
-        layout.setConstraints(homeEdgeLabel, constraints);
-        panel.add(homeEdgeLabel);
-
-        //Row 4 Column 2.
-        constraints.gridx++;
-        constraints.gridwidth = 2;
-        homeEdgeCombo = new JComboBox<>(new String[]{Messages.getString("BotConfigDialog.northEdge"),
-                                                     Messages.getString("BotConfigDialog.southEdge"),
-                                                     Messages.getString("BotConfigDialog.westEdge"),
-                                                     Messages.getString("BotConfigDialog.eastEdge")});
-        homeEdgeCombo.setToolTipText(Messages.getString("BotConfigDialog.homeEdgeTooltip"));
-        homeEdgeCombo.setSelectedIndex(0);
-        panel.add(homeEdgeCombo, constraints);
-
-        //Row 5.
-        constraints.gridx = 0;
-        constraints.gridy++;
-        constraints.gridwidth = 3;
-        JPanel sliderPanel = buildSliderPanel();
-        layout.setConstraints(sliderPanel, constraints);
-        panel.add(sliderPanel);
-
-        //Row 6 Column 1.
-        constraints.gridy++;
-        constraints.gridx = 0;
-        constraints.gridwidth = 1;
-        JLabel targetsLabel = new JLabel(Messages.getString("BotConfigDialog.targetsLabel"));
-        panel.add(targetsLabel, constraints);
-
-        //Row 6 Column 2.
-        constraints.gridx++;
-        targetTypeCombo = new JComboBox<>(new String[]{BUILDING_TARGET, UNIT_TARGET});
-        targetTypeCombo.setToolTipText(Messages.getString("BotConfigDialog.targetTypeTooltip"));
-        targetTypeCombo.setSelectedIndex(0);
-        panel.add(targetTypeCombo, constraints);
-
-        // Row 6 Column 3.
-        constraints.gridx++;
-        targetId = new JTextField();
-        targetId.setToolTipText(Messages.getString("BotConfigDialog.princessTargetIdToolTip"));
-        targetId.setColumns(4);
-        panel.add(targetId, constraints);
-
-        //Row 7.
-        constraints.gridy++;
-        constraints.gridx = 0;
-        constraints.gridwidth = 3;
-        panel.add(buildStrategicTargetsButtonPanel(), constraints);
-
-        //Row 8
-        constraints.gridy++;
-        constraints.gridx = 0;
-        constraints.gridwidth = 3;
-        targetsList = new JList<>(targetsListModel);
-        targetsList.setToolTipText(Messages.getString("BotConfigDialog.princessStrategicTargetsToolTip"));
-        targetsList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        targetsList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        targetsList.setLayoutOrientation(JList.VERTICAL);
-        JScrollPane targetScroller = new JScrollPane(targetsList);
-        targetScroller.setAlignmentX(LEFT_ALIGNMENT);
-        panel.add(targetScroller, constraints);
-
-        //Row 9, Column 2
-        constraints.gridy++;
-        constraints.gridx = 1;
-        constraints.gridwidth = 1;
-        princessHelpButton = new JButton(Messages.getString("BotConfigDialog.princessHelpButtonCaption"));
-        princessHelpButton.addActionListener(this);
-        panel.add(princessHelpButton, constraints);
-
-        setPrincessFields();
-        panel.validate();
-        return panel;
-    }
-
-    private JPanel buildStrategicTargetsButtonPanel() {
-        JPanel panel = new JPanel(new FlowLayout(FlowLayout.CENTER, 1, 1));
-        addTargetButton = new JButton(Messages.getString("BotConfigDialog.princessAddTargetButtonCaption"));
-        addTargetButton.setToolTipText(Messages.getString("BotConfigDialog.princessAddTargetButtonToolTip"));
-        addTargetButton.addActionListener(this);
-        panel.add(addTargetButton);
-
-        removeTargetButton = new JButton(Messages.getString("BotConfigDialog.princessRemoveTargetButtonCaption"));
-        removeTargetButton.setToolTipText(Messages.getString("BotConfigDialog.princessRemoveTargetButtonToolTip"));
-        removeTargetButton.addActionListener(this);
-        panel.add(removeTargetButton);
-
-        return panel;
-    }
-
-    private void launchPrincessHelp() {
-        try {
-            // Get the correct help file.
-            StringBuilder helpPath = new StringBuilder("file:///");
-            helpPath.append(System.getProperty("user.dir"));
-            if (!helpPath.toString().endsWith(File.separator)) {
-                helpPath.append(File.separator);
-            }
-            helpPath.append(Messages.getString("BotConfigDialog.princessHelpPath"));
-            URL helpUrl = new URL(helpPath.toString());
-
-            // Launch the help dialog.
-            HelpDialog helpDialog = new HelpDialog(Messages.getString("BotConfigDialog.princessHelp.title"), helpUrl);
-            helpDialog.setVisible(true);
-        } catch (MalformedURLException e) {
-            handleError("launchPrincessHelp", e);
-        }
     }
 
     public void actionPerformed(ActionEvent e) {
@@ -475,26 +74,8 @@ public class PrincessBehaviorDialog extends JDialog implements ActionListener {
         	getPrincessFields();
             dialogAborted = false;
             setVisible(false);
-
-        } else if (addTargetButton.equals(e.getSource())) {
-            String data = targetTypeCombo.getSelectedItem() + ": " + targetId.getText();
-            targetsListModel.addElement(data);
-
-        } else if (removeTargetButton.equals(e.getSource())) {
-            targetsListModel.removeElementAt(targetsList.getSelectedIndex());
-
-        } else if (princessBehaviorNames.equals(e.getSource())) {
-        	if (resetPrincessBehavior()) {
-        		setPrincessFields();
-        	}
-
-        } else if (goHomeCheck.equals(e.getSource())) {
-            if (!goHomeCheck.isSelected()) {
-                autoFleeCheck.setSelected(false);
-            }
-            autoFleeCheck.setEnabled(goHomeCheck.isSelected());
-        } else if (princessHelpButton.equals(e.getSource())) {
-            launchPrincessHelp();
+        } else {
+            super.actionPerformed(e);
         }
     }
 
@@ -504,6 +85,7 @@ public class PrincessBehaviorDialog extends JDialog implements ActionListener {
         MekHQ.getLogger().log(getClass(), method, t);
     }
 
+    @Override
     public String getBotName() {
         return nameField.getText();
     }

--- a/MekHQ/src/mekhq/gui/dialog/PrincessBehaviorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PrincessBehaviorDialog.java
@@ -42,7 +42,11 @@ public class PrincessBehaviorDialog extends BotConfigDialog implements ActionLis
 	public PrincessBehaviorDialog(JFrame parent, BehaviorSettings princessBehavior, String name) {
 	    super(parent, null);
 	    
-	    this.princessBehavior = princessBehavior;
+	    try {
+	        this.princessBehavior = princessBehavior.getCopy();
+	    } catch(Exception e) {
+	        handleError("PrincessBehaviorDialog", e);
+	    }
 	    this.setName(name);
 	    
 	    this.nameField.setText(name);
@@ -52,7 +56,7 @@ public class PrincessBehaviorDialog extends BotConfigDialog implements ActionLis
 	public BehaviorSettings getBehaviorSettings() {
 		return princessBehavior;
 	}
-
+	
     private void getPrincessFields() {
         LogLevel logLevel = LogLevel.getLogLevel((String) verbosityCombo.getSelectedItem());
         if (null != logLevel) {

--- a/MekHQ/src/mekhq/resources/AtBScenarioBuiltIn.properties
+++ b/MekHQ/src/mekhq/resources/AtBScenarioBuiltIn.properties
@@ -8,9 +8,9 @@ battleDetails.extraction.attacker.observations=Defender controls the battlefield
 battleDetails.extraction.defender.victory=Must destroy all enemy's civilian units and 1/3 of other units before the end of turn 10.
 battleDetails.extraction.defender.observations=Defender controls the battlefield after the battle.
 
-battleDetails.chase.attacker.victory=Must reach north edge with 50% of starting forces.
+battleDetails.chase.attacker.victory=Must reach the narrow edge opposite from the start with 50% of starting forces.
 battleDetails.chase.attacker.observations=Defender controls the battlefield after the battle.
-battleDetails.chase.defender.victory=Must prevent at least 50% of enemy from reaching the north edge.
+battleDetails.chase.defender.victory=Must prevent at least 50% of enemy from reaching the narrow edge opposite from the start.
 battleDetails.chase.defender.observations=Defender controls the battlefield after the battle.
 
 battleDetails.holdTheLine.attacker.victory=Must destroy 1/2 of the enemy units while having less than 1/3 of your own forces destroyed.


### PR DESCRIPTION
- Adjustments to MekHQ to make it work with the new separate bot retreat/destination edges. 
- Refactor the MekHQ bot config dialog to inherit from the Megamek dialog and make use of that functionality, rather than being a copy + paste.
- Upgrade to the Chase scenario so that the player/bot units can start on the north or south edges.