### PR TITLE
Address XXE vulnerabilities in XML parsers

### DIFF
--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -61,9 +61,24 @@ public class MekHqXmlUtil {
 			// instance of the builder factory, as long as it is
 			// XXE safe.
 			dbf = DocumentBuilderFactory.newInstance();
+
+			//
+			// Adapted from: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#JAXP_DocumentBuilderFactory.2C_SAXParserFactory_and_DOM4J
+			//
+			// "...The JAXP DocumentBuilderFactory setFeature method allows a
+			// developer to control which implementation-specific XML processor
+			// features are enabled or disabled. The features can either be set
+			// on the factory or the underlying XMLReader setFeature method. 
+			// Each XML processor implementation has its own features that 
+			// govern how DTDs and external entities are processed."
+			//
+			// "[disable] these as well, per Timothy Morgan's 2014 paper: 'XML 
+			// Schema, DTD, and Entity Attacks'"
 			dbf.setXIncludeAware(false);
 			dbf.setExpandEntityReferences(false);
 
+			// "This is the PRIMARY defense. If DTDs (doctypes) are disallowed,
+			// almost all XML entity attacks are prevented"
 			String FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
 			dbf.setFeature(FEATURE, true);
 
@@ -85,9 +100,18 @@ public class MekHqXmlUtil {
 			// hit this method. It is Ok to have more than one
 			// instance of the builder factory, as long as it is
 			// XXE safe.
+
+			//
+			// For further background, see newSafeDocumentBuilder()
+			//
 			dbf = DocumentBuilderFactory.newInstance();
 			dbf.setXIncludeAware(false);
 			dbf.setExpandEntityReferences(false);
+
+			//
+			// "If you can't completely disable DTDs, then at least do the 
+			// following:"
+			//
 
 			// Disable external entities
 			String FEATURE = "http://xml.org/sax/features/external-general-entities";
@@ -120,6 +144,16 @@ public class MekHqXmlUtil {
 			// instance of the parser factory, as long as it is
 			// XXE safe.
 			spf = SAXParserFactory.newInstance();
+
+			//
+			// Adapted from: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#JAXB_Unmarshaller
+			//
+			// "Since a javax.xml.bind.Unmarshaller parses XML and does not
+			// support any flags for disabling XXE, it’s imperative to parse 
+			// the untrusted XML through a configurable secure parser first, 
+			// generate a source object as a result, and pass the source
+			// object to the Unmarshaller."
+			//
 			spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
 			spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 			spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);

--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -8,6 +8,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Vector;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
@@ -36,6 +40,33 @@ import megamek.common.logging.LogLevel;
 import megamek.common.util.StringUtil;
 
 public class MekHqXmlUtil {
+	private static DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY;
+
+	/**
+	 * Creates a DocumentBuilder safe from XML external entities
+	 * attacks, and XML entity expansion attacks.
+	 * @return A DocumentBuilder safe to use to read untrusted XML.
+	 */
+	public static DocumentBuilder newSafeDocumentBuilder() throws ParserConfigurationException {
+		DocumentBuilderFactory dbf = DOCUMENT_BUILDER_FACTORY;
+		if (null == dbf) {
+			// At worst we may do this twice if multiple threads
+			// hit this method. It is Ok to have more than one
+			// instance of the builder factory, as long as it is
+			// XXE safe.
+			dbf = DocumentBuilderFactory.newInstance();
+			dbf.setXIncludeAware(false);
+			dbf.setExpandEntityReferences(false);
+
+			String FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+			dbf.setFeature(FEATURE, true);
+
+			DOCUMENT_BUILDER_FACTORY = dbf;
+		}
+
+		return dbf.newDocumentBuilder();
+	}
+
 	public static void writeSimpleXmlTag(PrintWriter pw1, int indent, String name, String val) {
 		for (int x=0; x<indent; x++)
 			pw1.print("\t");

--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -1,6 +1,7 @@
 package mekhq;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
@@ -106,7 +107,12 @@ public class MekHqXmlUtil {
 		return dbf.newDocumentBuilder();
 	}
 
-	public static Source createSafeXmlSource(InputSource inputSource) throws SAXException, ParserConfigurationException {
+    /**
+     * Creates a JAXB compatible Source safe from XML external entities
+     * attacks, and XML entity expansion attacks.
+     * @return A Source safe to use to read untrusted XML from a JAXB unmarshaller.
+     */
+	public static Source createSafeXmlSource(InputStream inputStream) throws SAXException, ParserConfigurationException {
 		SAXParserFactory spf = SAX_PARSER_FACTORY;
 		if (null == spf) {
 			// At worst we may do this twice if multiple threads
@@ -121,7 +127,7 @@ public class MekHqXmlUtil {
 			SAX_PARSER_FACTORY = spf;
 		}
 
-		return new SAXSource(spf.newSAXParser().getXMLReader(), inputSource);
+		return new SAXSource(spf.newSAXParser().getXMLReader(), new InputSource(inputStream));
 	}
 
 	public static void writeSimpleXmlTag(PrintWriter pw1, int indent, String name, String val) {

--- a/MekHQ/src/mekhq/campaign/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/AtBConfiguration.java
@@ -34,7 +34,6 @@ import java.util.ResourceBundle;
 import java.util.function.Function;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -48,6 +47,7 @@ import megamek.common.TargetRoll;
 import megamek.common.UnitType;
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.rating.IUnitRating;
@@ -352,12 +352,10 @@ public class AtBConfiguration implements Serializable {
         MekHQ.getLogger().log(AtBConfiguration.class, METHOD_NAME, LogLevel.INFO,
                 "Starting load of AtB configuration data from XML..."); //$NON-NLS-1$
 
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		Document xmlDoc = null;
-		
 		try {
 			FileInputStream fis = new FileInputStream("data/universe/atbconfig.xml");
-			DocumentBuilder db = dbf.newDocumentBuilder();
+			DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 	
 			xmlDoc = db.parse(fis);
 		} catch (FileNotFoundException ex) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -55,7 +55,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.swing.JOptionPane;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.joda.time.DateTime;
 import org.w3c.dom.DOMException;
@@ -3746,12 +3745,12 @@ public class Campaign implements Serializable, ITechManager {
         // Initialize variables.
         Campaign retVal = new Campaign();
         retVal.app = app;
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+
         Document xmlDoc = null;
 
         try {
             // Using factory get an instance of document builder
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/campaign/ExtraData.java
+++ b/MekHQ/src/mekhq/campaign/ExtraData.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign;
 
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -197,15 +196,6 @@ public class ExtraData {
             return (ExtraData) unmarshaller.unmarshal(wn);
         } catch(JAXBException e) {
             MekHQ.getLogger().log(ExtraData.class, "createFromXml(Node)", e);
-            return null;
-        }
-    }
-    
-    public static ExtraData createFromXml(InputStream is) {
-        try {
-            return (ExtraData) unmarshaller.unmarshal(is);
-        } catch(JAXBException e) {
-            MekHQ.getLogger().log(ExtraData.class, "createFromXml(InputStream)", e);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/campaign/GamePreset.java
+++ b/MekHQ/src/mekhq/campaign/GamePreset.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -158,11 +157,10 @@ public class GamePreset implements MekHqXmlSerializable {
 
 		GamePreset preset = new GamePreset();
 
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
         try {
             // Using factory get an instance of document builder
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/campaign/personnel/AwardsFactory.java
+++ b/MekHQ/src/mekhq/campaign/personnel/AwardsFactory.java
@@ -25,14 +25,12 @@ import mekhq.campaign.AwardSet;
 import mekhq.campaign.LogEntry;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -127,7 +125,7 @@ public class AwardsFactory {
             }
         } catch (Exception ex) {
             // Doh!
-            MekHQ.getLogger().log(LogEntry.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(LogEntry.class, METHOD_NAME, ex);
         }
 
         return generateNew(set, name, date);
@@ -150,11 +148,10 @@ public class AwardsFactory {
 
             try {
                 InputStream inputStream = new FileInputStream(file);
-                InputSource inputSource = new InputSource(inputStream);
                 JAXBContext jaxbContext = JAXBContext.newInstance(AwardSet.class, Award.class);
                 Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 
-                awardSet = unmarshaller.unmarshal(MekHqXmlUtil.createSafeXmlSource(inputSource), AwardSet.class).getValue();
+                awardSet = unmarshaller.unmarshal(MekHqXmlUtil.createSafeXmlSource(inputStream), AwardSet.class).getValue();
 
                 Map<String, Award> tempAwardMap = new HashMap<>();
                 String currentSetName = file.getName().replaceFirst("[.][^.]+$", "");
@@ -163,8 +160,6 @@ public class AwardsFactory {
                     tempAwardMap.put(award.getName(), award);
                 }
                 awardsMap.put(currentSetName, tempAwardMap);
-
-                inputStream.close();
             } catch (SAXException | ParserConfigurationException e) {
                 MekHQ.getLogger().error(AwardsFactory.class, "loadAwards", e);
             } catch (FileNotFoundException e) {

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -42,6 +41,7 @@ import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 
 /**
  * @author Neoancient
@@ -457,11 +457,10 @@ public class Bloodname implements Serializable {
 			return;
 		}
 
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		Document doc = null;
 
 		try {
-			DocumentBuilder db = dbf.newDocumentBuilder();
+			DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 			doc = db.parse(fis);
 		} catch (Exception ex) {
 			System.err.println(ex.getMessage());
@@ -614,11 +613,10 @@ class Clan {
 			return;
 		}
 
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		Document doc = null;
 
 		try {
-			DocumentBuilder db = dbf.newDocumentBuilder();
+			DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 			doc = db.parse(fis);
 		} catch (Exception ex) {
 			System.err.println(ex.getMessage());

--- a/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
+++ b/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
@@ -4,7 +4,6 @@
 package mekhq.campaign.personnel;
 
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,9 +13,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.EntityResolver;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 import megamek.common.logging.LogLevel;
 import megamek.common.options.IOption;

--- a/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
+++ b/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
@@ -4,6 +4,7 @@
 package mekhq.campaign.personnel;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,6 +14,9 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import megamek.common.logging.LogLevel;
 import megamek.common.options.IOption;
@@ -67,7 +71,7 @@ public class CustomOption {
         try {
             FileInputStream fis = new FileInputStream("data/universe/customspa.xml");
             // Using factory get an instance of document builder
-            DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+            DocumentBuilder db = MekHqXmlUtil.newUnsafeDocumentBuilder();
 
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
+++ b/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -19,6 +18,7 @@ import megamek.common.logging.LogLevel;
 import megamek.common.options.IOption;
 import megamek.common.options.PilotOptions;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 
 /**
  * Parses custom SPA file and passes data to the PersonnelOption constructor so the custom
@@ -61,14 +61,13 @@ public class CustomOption {
         final String METHOD_NAME = "getCustomAbilities()"; //$NON-NLS-1$
         List<CustomOption> retVal = new ArrayList<>();
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
 
 
         try {
             FileInputStream fis = new FileInputStream("data/universe/customspa.xml");
             // Using factory get an instance of document builder
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/campaign/personnel/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Ranks.java
@@ -30,7 +30,6 @@ import java.util.Vector;
 
 import javax.swing.JOptionPane;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -127,14 +126,13 @@ public class Ranks {
         MekHQ.getLogger().log(Ranks.class, METHOD_NAME, LogLevel.INFO,
                 "Starting load of Rank Systems from XML..."); //$NON-NLS-1$
         // Initialize variables.
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
     
         
         try {
             FileInputStream fis = new FileInputStream("data/universe/ranks.xml");
             // Using factory get an instance of document builder
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
     
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Vector;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -444,14 +443,12 @@ public class SpecialAbility implements MekHqXmlSerializable {
         edgeTriggers = new Hashtable<>();
         implants = new Hashtable<>();
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
-
 
         try {
             FileInputStream fis = new FileInputStream("data/universe/defaultspa.xml");
             // Using factory get an instance of document builder
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.joda.time.DateTime;
 import org.w3c.dom.DOMException;
@@ -52,6 +51,7 @@ import org.w3c.dom.NodeList;
 import megamek.common.EquipmentType;
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.Part;
@@ -358,13 +358,12 @@ public class Faction {
         // Initialize variables.
         factions = new HashMap<>();
         factionIdMap = new HashMap<>();
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        Document xmlDoc = null;
 
+        Document xmlDoc = null;
 
         try(FileInputStream fis = new FileInputStream("data/universe/factions.xml")) {
             // Using factory get an instance of document builder
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/campaign/universe/News.java
+++ b/MekHQ/src/mekhq/campaign/universe/News.java
@@ -11,7 +11,6 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.joda.time.DateTime;
 import org.w3c.dom.Document;
@@ -21,6 +20,7 @@ import org.w3c.dom.NodeList;
 
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 
 /**
  * Instead of making this a static like Planets, we are just going to reload a years
@@ -80,14 +80,13 @@ public class News {
             int id = 0;
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO,
                     "Starting load of news data for " + year + " from XML..."); //$NON-NLS-1$
+
             // Initialize variables.
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             Document xmlDoc = null;
-        
-            
+
             try(FileInputStream fis = new FileInputStream("data/universe/news.xml")) {
                 // Using factory get an instance of document builder
-                DocumentBuilder db = dbf.newDocumentBuilder();
+                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
         
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/campaign/universe/Planets.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planets.java
@@ -51,12 +51,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.stream.StreamSource;
 
 import org.joda.time.DateTime;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import megamek.common.EquipmentType;
@@ -87,7 +85,7 @@ public class Planets {
             // For debugging only!
             // unmarshaller.setEventHandler(new javax.xml.bind.helpers.DefaultValidationEventHandler());
         } catch(JAXBException e) {
-            MekHQ.getLogger().log(Planets.class, "<init>", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(Planets.class, "<init>", e); //$NON-NLS-1$
         }
     }
     
@@ -362,7 +360,7 @@ public class Planets {
             source.getChannel().position(0);
 
             LocalPlanetList planets = unmarshaller.unmarshal(
-                    MekHqXmlUtil.createSafeXmlSource(new InputSource(is)), LocalPlanetList.class).getValue();
+                    MekHqXmlUtil.createSafeXmlSource(is), LocalPlanetList.class).getValue();
 
             // Run through the list again, this time creating and updating planets as we go
             for( Planet planet : planets.list ) {

--- a/MekHQ/src/mekhq/campaign/universe/Planets.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planets.java
@@ -50,17 +50,21 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.stream.StreamSource;
 
 import org.joda.time.DateTime;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import megamek.common.EquipmentType;
 import megamek.common.logging.LogLevel;
 import megamek.common.util.EncodeControl;
 import mekhq.FileParser;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.campaign.universe.Planet.PlanetaryEvent;
 
@@ -358,7 +362,7 @@ public class Planets {
             source.getChannel().position(0);
 
             LocalPlanetList planets = unmarshaller.unmarshal(
-                    new StreamSource(is), LocalPlanetList.class).getValue();
+                    MekHqXmlUtil.createSafeXmlSource(new InputSource(is)), LocalPlanetList.class).getValue();
 
             // Run through the list again, this time creating and updating planets as we go
             for( Planet planet : planets.list ) {
@@ -378,10 +382,12 @@ public class Planets {
                     planetList.remove(planetId);
                 }
             }
+        } catch (SAXException | ParserConfigurationException e) {
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
         } catch (JAXBException e) {
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
         } catch(IOException e) {
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
         }
     }
     

--- a/MekHQ/src/mekhq/campaign/universe/RATManager.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATManager.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -53,6 +52,7 @@ import megamek.common.UnitType;
 import megamek.common.event.Subscribe;
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.event.OptionsChangedEvent;
 
 /**
@@ -153,13 +153,12 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
         File f = new File(RATINFO_DIR, fileNames.get(name));
         FileInputStream fis = null;
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
         DocumentBuilder db;
 
         try {
             fis = new FileInputStream(f);
-            db = dbf.newDocumentBuilder();
+            db = MekHqXmlUtil.newSafeDocumentBuilder();
             xmlDoc = db.parse(fis);
             fis.close();
         } catch (Exception ex) {
@@ -234,13 +233,12 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
         File f = new File(ALT_FACTION);
         FileInputStream fis = null;
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
         DocumentBuilder db;
 
         try {
             fis = new FileInputStream(f);
-            db = dbf.newDocumentBuilder();
+            db = MekHqXmlUtil.newSafeDocumentBuilder();
             xmlDoc = db.parse(fis);
             fis.close();
         } catch (Exception ex) {
@@ -286,7 +284,6 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
         
         allCollections = new HashMap<>();
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         Document xmlDoc = null;
         DocumentBuilder db;
 
@@ -302,7 +299,7 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
             if (f.getName().endsWith(".xml")) {
                 try {
                     fis = new FileInputStream(f);
-                    db = dbf.newDocumentBuilder();
+                    db = MekHqXmlUtil.newSafeDocumentBuilder();
                     xmlDoc = db.parse(fis);
                     fis.close();
                 } catch (Exception ex) {

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.TreeSet;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -46,6 +45,7 @@ import org.w3c.dom.NodeList;
 import megamek.common.Compute;
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.campaign.CampaignOptions;
 
@@ -204,12 +204,12 @@ public class RandomFactionGenerator implements Serializable {
 	    
 	    MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO,
 	            "Starting load of faction hint data from XML..."); //$NON-NLS-1$
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+
 		Document xmlDoc = null;
 		
 		try {
 			FileInputStream fis = new FileInputStream("data/universe/factionhints.xml"); //$NON-NLS-1$
-			DocumentBuilder db = dbf.newDocumentBuilder();
+			DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 	
 			xmlDoc = db.parse(fis);
 		} catch (Exception ex) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -68,7 +68,6 @@ import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.filechooser.FileFilter;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -93,6 +92,7 @@ import megamek.common.options.PilotOptions;
 import megamek.common.util.EncodeControl;
 import mekhq.IconPackage;
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
@@ -2381,12 +2381,11 @@ public class CampaignGUI extends JPanel {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, //$NON-NLS-1$
                     "Starting load of personnel file from XML..."); //$NON-NLS-1$
             // Initialize variables.
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             Document xmlDoc = null;
 
             try {
                 // Using factory get an instance of document builder
-                DocumentBuilder db = dbf.newDocumentBuilder();
+                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);
@@ -2673,12 +2672,11 @@ public class CampaignGUI extends JPanel {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, //$NON-NLS-1$
                     "Starting load of parts file from XML..."); //$NON-NLS-1$
             // Initialize variables.
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             Document xmlDoc = null;
 
             try {
                 // Using factory get an instance of document builder
-                DocumentBuilder db = dbf.newDocumentBuilder();
+                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);
@@ -2764,12 +2762,11 @@ public class CampaignGUI extends JPanel {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, //$NON-NLS-1$
                     "Starting load of options file from XML..."); //$NON-NLS-1$
             // Initialize variables.
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             Document xmlDoc = null;
 
             try {
                 // Using factory get an instance of document builder
-                DocumentBuilder db = dbf.newDocumentBuilder();
+                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);

--- a/MekHQ/src/mekhq/gui/view/Paperdoll.java
+++ b/MekHQ/src/mekhq/gui/view/Paperdoll.java
@@ -60,8 +60,14 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlValue;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Source;
+
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.personnel.BodyLocation;
 import mekhq.gui.utilities.MultiplyComposite;
 
@@ -105,12 +111,13 @@ public class Paperdoll extends Component {
         enableEvents(AWTEvent.MOUSE_EVENT_MASK | AWTEvent.MOUSE_MOTION_EVENT_MASK);
     }
     
-    public void loadShapeData(InputStream is) throws JAXBException {
+    public void loadShapeData(InputStream is) throws JAXBException, SAXException, ParserConfigurationException {
         final String METHOD_NAME = "loadShapeData(InputStream)"; //$NON-NLS-1$
         
         JAXBContext context = JAXBContext.newInstance(OverlayLocDataList.class, OverlayLocData.class);
         Unmarshaller unmarshaller = context.createUnmarshaller();
-        OverlayLocDataList dataList = (OverlayLocDataList) unmarshaller.unmarshal(is);
+        Source inputSource = MekHqXmlUtil.createSafeXmlSource(new InputSource(is));
+        OverlayLocDataList dataList = (OverlayLocDataList) unmarshaller.unmarshal(inputSource);
         if(null != dataList.locs) {
             dataList.locs.forEach(data -> {
                 locShapes.put(data.loc, data.genPath());

--- a/MekHQ/src/mekhq/gui/view/Paperdoll.java
+++ b/MekHQ/src/mekhq/gui/view/Paperdoll.java
@@ -63,7 +63,6 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Source;
 
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import mekhq.MekHQ;
@@ -103,7 +102,7 @@ public class Paperdoll extends Component {
         try {
             loadShapeData(is);
         } catch(Exception ex) {
-            MekHQ.getLogger().log(getClass(), "<init>(InputStream)", ex);
+            MekHQ.getLogger().error(getClass(), "<init>(InputStream)", ex);
         }
         
         highlightColor = null;
@@ -116,7 +115,7 @@ public class Paperdoll extends Component {
         
         JAXBContext context = JAXBContext.newInstance(OverlayLocDataList.class, OverlayLocData.class);
         Unmarshaller unmarshaller = context.createUnmarshaller();
-        Source inputSource = MekHqXmlUtil.createSafeXmlSource(new InputSource(is));
+        Source inputSource = MekHqXmlUtil.createSafeXmlSource(is);
         OverlayLocDataList dataList = (OverlayLocDataList) unmarshaller.unmarshal(inputSource);
         if(null != dataList.locs) {
             dataList.locs.forEach(data -> {
@@ -141,7 +140,7 @@ public class Paperdoll extends Component {
             try {
                 mt.waitForAll();
             } catch(InterruptedException iex) {
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, iex);
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, iex);
             }
         } else {
             base = new BufferedImage(DEFAULT_WIDTH, DEFAULT_HEIGHT, BufferedImage.TYPE_INT_ARGB);


### PR DESCRIPTION
Addresses:
- DocumentBuilderFactory
- JAXB Unmarshaller

Custom SPA currently uses XML entities and an inline DOCTYPE parser. `newUnsafeDocumentBuilder` addressees this need, but isn't protected against entity expansion attacks. That would allow a DoS, but from a file unlikely to be shared and easily inspected for tainted code.