### PR TITLE
Bug: fix GM Mode Add XP subtracting one (1) XP if cancelled

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -877,12 +877,14 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                 pvcda.setVisible(true);
 
                 int ia = pvcda.getValue();
+                if (ia <= 0) {
+                    // <0 indicates Cancellation
+                    // =0 is a No-Op
+                    return;
+                }
+
                 for (Person person : people) {
-                    int i2 = ia;
-                    if ((ia + person.getXp()) < 0) {
-                        i2 = -person.getXp();
-                    }
-                    person.setXp(person.getXp() + i2);
+                    person.setXp(person.getXp() + ia);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;

--- a/MekHQ/src/mekhq/gui/dialog/PopupValueChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PopupValueChoiceDialog.java
@@ -11,8 +11,6 @@ import java.awt.Frame;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.util.ResourceBundle;
@@ -22,9 +20,10 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
-import javax.swing.JTextField;
+import javax.swing.JFormattedTextField;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.WindowConstants;
+import javax.swing.text.DefaultFormatter;
 
 import megamek.common.util.EncodeControl;
 
@@ -32,7 +31,7 @@ import megamek.common.util.EncodeControl;
  *
  * @author natit
  */
-public class PopupValueChoiceDialog extends JDialog implements WindowListener, KeyListener {
+public class PopupValueChoiceDialog extends JDialog implements WindowListener {
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private JButton btnDone;
@@ -40,7 +39,7 @@ public class PopupValueChoiceDialog extends JDialog implements WindowListener, K
     private JPanel pnlButton;
     private JSpinner value;
     private SpinnerNumberModel model;
-    private JTextField jtf;
+    private JFormattedTextField jtf;
     private int max;
     private int min;
     // End of variables declaration//GEN-END:variables
@@ -86,7 +85,8 @@ public class PopupValueChoiceDialog extends JDialog implements WindowListener, K
         value = new JSpinner(model);
         value.setEditor(new JSpinner.NumberEditor(value,"#")); //prevent digit grouping, e.g. 1,000
         jtf = ((JSpinner.DefaultEditor) value.getEditor()).getTextField();
-        jtf.addKeyListener(this);
+        DefaultFormatter df = (DefaultFormatter)jtf.getFormatter();
+        df.setCommitsOnValidEdit(true);
 
 		ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PopupValueChoiceDialog", new EncodeControl()); //$NON-NLS-1$
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
@@ -151,7 +151,6 @@ public class PopupValueChoiceDialog extends JDialog implements WindowListener, K
     	return (Integer)value.getValue();
     }
 
-
     @Override
     public void windowActivated(WindowEvent arg0) {
     }
@@ -183,37 +182,4 @@ public class PopupValueChoiceDialog extends JDialog implements WindowListener, K
     @Override
     public void windowOpened(WindowEvent arg0) {
     }
-
-	@Override
-	public void keyTyped(KeyEvent e) {
-	}
-
-	@Override
-	public void keyPressed(KeyEvent e) {
-	}
-
-	@Override
-	public void keyReleased(KeyEvent e) {
-		// checking JSpinner values to enforce min-max ranges is sort of a pain, you can't do it with a ChangeListener
-		// https://stackoverflow.com/questions/32340476/manually-typing-in-text-in-javafx-spinner-is-not-updating-the-value-unless-user
-		// https://stackoverflow.com/questions/3949382/jspinner-value-change-events
-		// so we have to use a KeyListener and then force the values explicitly
-        try {
-            Integer newValue = Integer.valueOf(jtf.getText());
-            if (newValue > max) {
-            	value.setValue(max);
-            	jtf.setText(String.valueOf(max));
-            } else if (newValue < min) {
-            	value.setValue(min);
-            	jtf.setText(String.valueOf(min));
-            } else {
-            	value.setValue(newValue);
-            	jtf.setText(String.valueOf(newValue));
-            }
-        } catch(NumberFormatException ex) {
-            //Not a number in text field
-        	value.setValue(min);
-        	jtf.setText(String.valueOf(min));
-        }
-	}
 }


### PR DESCRIPTION
Fixes a small logic error with the result of `PopupValueChoiceDialog` resolving #866, and implements #859 by using the default formatter's commit on valid value logic. At worst putting in an invalid value without causing the field to update will add 1 XP. This is more desirable than the odd behavior where you can't type because of the automatic validation.