### PR TITLE
Bug: refit armor may not be attached to a unit on load, fixes #857

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4186,9 +4186,12 @@ public class Campaign implements Serializable, ITechManager {
                 unit.getRefit().reCalc();
                 if (null == unit.getRefit().getNewArmorSupplies()
                         && unit.getRefit().getNewArmorSuppliesId() > 0) {
-                    unit.getRefit().setNewArmorSupplies(
-                            (Armor) retVal.getPart(unit.getRefit()
-                                    .getNewArmorSuppliesId()));
+                    Armor armorSupplies = (Armor) retVal.getPart(
+                            unit.getRefit().getNewArmorSuppliesId());
+                    unit.getRefit().setNewArmorSupplies(armorSupplies);
+                    if (null == armorSupplies.getUnit()) {
+                        armorSupplies.setUnit(unit);
+                    }
                 }
                 if (!unit.getRefit().isCustomJob()
                         && !unit.getRefit().kitFound()) {


### PR DESCRIPTION
On load, armor from a refit may not have a unit attached. This eventually raises an NPE (#857). This resolves the issue on campaign load by ensuring the refitted armor is attached to a unit (if the armor's unit is `null`).