### PR TITLE
Fix #858

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3178,9 +3178,7 @@ public class Campaign implements Serializable, ITechManager {
      */
     public void addReport(String r) {
         if (this.getCampaignOptions().historicalDailyLog()) {
-            String htmlStripped = r.replaceAll("\\<[^>]*>",""); //remote HTML tags
-            //add the new items to our in-memory cache
-            addInMemoryLogHistory(new LogEntry(getDate(), htmlStripped));
+            addInMemoryLogHistory(new LogEntry(getDate(), r));
         }
         addReportInternal(r);
     }

--- a/MekHQ/src/mekhq/campaign/LogEntry.java
+++ b/MekHQ/src/mekhq/campaign/LogEntry.java
@@ -39,9 +39,10 @@ import mekhq.MekHqXmlUtil;
  */
 public class LogEntry implements Cloneable, MekHqXmlSerializable {
 
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss"); //$NON-NLS-1$
-    // LATER SimpleDateFormat is not thread-safe: use throw-away instances or switch to java.time
-    // private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("", Locale.ENGLISH);
+    private static final SimpleDateFormat dateFormat() {
+        // LATER centralise date formatting so that every class doesn't have its own format and - possibly - switch to java.time
+        return new SimpleDateFormat("yyyy-MM-dd hh:mm:ss"); //$NON-NLS-1$
+    }
 
     public LogEntry(Date date, String desc) {
         this(date, desc, null);
@@ -85,7 +86,7 @@ public class LogEntry implements Cloneable, MekHqXmlSerializable {
     public void writeToXml(PrintWriter pw, int indent) {
         StringBuilder sb = new StringBuilder();
         sb.append(MekHqXmlUtil.indentStr(indent)).append("<logEntry>"); //$NON-NLS-1$
-        if (date != null)    sb.append("<date>").append(DATE_FORMAT.format(date)).append("</date>"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (date != null)    sb.append("<date>").append(dateFormat().format(date)).append("</date>"); //$NON-NLS-1$ //$NON-NLS-2$
         assert desc != null; sb.append("<desc>").append(MekHqXmlUtil.escape(desc)).append("</desc>"); //$NON-NLS-1$ //$NON-NLS-2$
         if (type != null)    sb.append("<type>").append(MekHqXmlUtil.escape(type)).append("</type>");  //$NON-NLS-1$//$NON-NLS-2$
         sb.append("</logEntry>"); //$NON-NLS-1$
@@ -109,7 +110,7 @@ public class LogEntry implements Cloneable, MekHqXmlSerializable {
                 } else if (nname.equals("type")) { //$NON-NLS-1$
                     type = MekHqXmlUtil.unEscape(node.getTextContent());
                 } else if (nname.equals("date")) { //$NON-NLS-1$
-                    date = DATE_FORMAT.parse(node.getTextContent().trim());
+                    date = dateFormat().parse(node.getTextContent().trim());
                 }
             }
         } catch (Exception ex) {
@@ -123,7 +124,7 @@ public class LogEntry implements Cloneable, MekHqXmlSerializable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        if (null != date) sb.append("[").append(DATE_FORMAT.format(date)).append("] "); //$NON-NLS-1$ //$NON-NLS-2$
+        if (null != date) sb.append("[").append(dateFormat().format(date)).append("] "); //$NON-NLS-1$ //$NON-NLS-2$
         sb.append(desc);
         if (null != type) sb.append(" (").append(type).append(")");  //$NON-NLS-1$//$NON-NLS-2$
         return sb.toString();

--- a/MekHQ/src/mekhq/campaign/LogEntry.java
+++ b/MekHQ/src/mekhq/campaign/LogEntry.java
@@ -39,120 +39,120 @@ import mekhq.MekHqXmlUtil;
  */
 public class LogEntry implements Cloneable, MekHqXmlSerializable {
 
-	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss"); //$NON-NLS-1$
-	// LATER SimpleDateFormat is not thread-safe: use throw-away instances or switch to java.time
-	// private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("", Locale.ENGLISH);
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss"); //$NON-NLS-1$
+    // LATER SimpleDateFormat is not thread-safe: use throw-away instances or switch to java.time
+    // private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("", Locale.ENGLISH);
 
-	public LogEntry(Date date, String desc) {
-		this(date, desc, null);
-	}
-	
-	public LogEntry(Date date, String desc, String type) {
-		this.date = date;
-		this.desc = desc != null ? desc : ""; //$NON-NLS-1$
-		this.type = type;
-	}
+    public LogEntry(Date date, String desc) {
+        this(date, desc, null);
+    }
+    
+    public LogEntry(Date date, String desc, String type) {
+        this.date = date;
+        this.desc = desc != null ? desc : ""; //$NON-NLS-1$
+        this.type = type;
+    }
 
-	private Date date;
-	private String desc; // non-null
-	private String type;
+    private Date date;
+    private String desc; // non-null
+    private String type;
 
-	public Date getDate() {
-		return date;
-	}
-	
-	public void setDate(Date date) {
-		this.date = date;
-	}
-	
-	public String getDesc() {
-		return desc;
-	}
-	
-	public void setDesc(String desc) {
-		this.desc = desc != null ? desc : ""; //$NON-NLS-1$
-	}
-	
-	public String getType() {
-		return type;
-	}
-	
-	public void setType(String type) {
-		this.type = type;
-	}
+    public Date getDate() {
+        return date;
+    }
+    
+    public void setDate(Date date) {
+        this.date = date;
+    }
+    
+    public String getDesc() {
+        return desc;
+    }
+    
+    public void setDesc(String desc) {
+        this.desc = desc != null ? desc : ""; //$NON-NLS-1$
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
 
-	@Override
-	public void writeToXml(PrintWriter pw, int indent) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(MekHqXmlUtil.indentStr(indent)).append("<logEntry>"); //$NON-NLS-1$
-		if (date != null)    sb.append("<date>").append(DATE_FORMAT.format(date)).append("</date>"); //$NON-NLS-1$ //$NON-NLS-2$
-		assert desc != null; sb.append("<desc>").append(MekHqXmlUtil.escape(desc)).append("</desc>"); //$NON-NLS-1$ //$NON-NLS-2$
-		if (type != null)    sb.append("<type>").append(MekHqXmlUtil.escape(type)).append("</type>");  //$NON-NLS-1$//$NON-NLS-2$
-		sb.append("</logEntry>"); //$NON-NLS-1$
-		pw.println(sb.toString());
-	}
+    @Override
+    public void writeToXml(PrintWriter pw, int indent) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(MekHqXmlUtil.indentStr(indent)).append("<logEntry>"); //$NON-NLS-1$
+        if (date != null)    sb.append("<date>").append(DATE_FORMAT.format(date)).append("</date>"); //$NON-NLS-1$ //$NON-NLS-2$
+        assert desc != null; sb.append("<desc>").append(MekHqXmlUtil.escape(desc)).append("</desc>"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (type != null)    sb.append("<type>").append(MekHqXmlUtil.escape(type)).append("</type>");  //$NON-NLS-1$//$NON-NLS-2$
+        sb.append("</logEntry>"); //$NON-NLS-1$
+        pw.println(sb.toString());
+    }
 
-	public static LogEntry generateInstanceFromXML(Node wn) {
-		final String METHOD_NAME = "generateInstanceFromXML(Node)"; //$NON-NLS-1$
+    public static LogEntry generateInstanceFromXML(Node wn) {
+        final String METHOD_NAME = "generateInstanceFromXML(Node)"; //$NON-NLS-1$
 
-		Date   date = null;
-		String desc = null;
-		String type = null;
+        Date   date = null;
+        String desc = null;
+        String type = null;
 
-		try {
-			NodeList nl = wn.getChildNodes();
-			for (int x = 0; x < nl.getLength(); x++) {
-				Node   node = nl.item(x);
-				String nname = node.getNodeName();
-				if (nname.equalsIgnoreCase("desc")) { //$NON-NLS-1$
-					desc = MekHqXmlUtil.unEscape(node.getTextContent());
-				} else if (nname.equalsIgnoreCase("type")) { //$NON-NLS-1$
-					type = MekHqXmlUtil.unEscape(node.getTextContent());
-				} else if (nname.equalsIgnoreCase("date")) { //$NON-NLS-1$
-					date = DATE_FORMAT.parse(node.getTextContent().trim());
-				}
-			}
-		} catch (Exception ex) {
-			MekHQ.getLogger().error(LogEntry.class, METHOD_NAME, ex);
-			return null;
-		}
+        try {
+            NodeList nl = wn.getChildNodes();
+            for (int x = 0; x < nl.getLength(); x++) {
+                Node   node = nl.item(x);
+                String nname = node.getNodeName();
+                if (nname.equalsIgnoreCase("desc")) { //$NON-NLS-1$
+                    desc = MekHqXmlUtil.unEscape(node.getTextContent());
+                } else if (nname.equalsIgnoreCase("type")) { //$NON-NLS-1$
+                    type = MekHqXmlUtil.unEscape(node.getTextContent());
+                } else if (nname.equalsIgnoreCase("date")) { //$NON-NLS-1$
+                    date = DATE_FORMAT.parse(node.getTextContent().trim());
+                }
+            }
+        } catch (Exception ex) {
+            MekHQ.getLogger().error(LogEntry.class, METHOD_NAME, ex);
+            return null;
+        }
 
-		return new LogEntry(date, desc, type);
-	}
+        return new LogEntry(date, desc, type);
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder();
-		if (null != date) sb.append("[").append(DATE_FORMAT.format(date)).append("] "); //$NON-NLS-1$ //$NON-NLS-2$
-		sb.append(desc);
-		if (null != type) sb.append(" (").append(type).append(")");  //$NON-NLS-1$//$NON-NLS-2$
-		return sb.toString();
-	}
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (null != date) sb.append("[").append(DATE_FORMAT.format(date)).append("] "); //$NON-NLS-1$ //$NON-NLS-2$
+        sb.append(desc);
+        if (null != type) sb.append(" (").append(type).append(")");  //$NON-NLS-1$//$NON-NLS-2$
+        return sb.toString();
+    }
 
-	@Override
-	public LogEntry clone() {
-		return new LogEntry(date, desc, type);
-	}
+    @Override
+    public LogEntry clone() {
+        return new LogEntry(date, desc, type);
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((date == null) ? 0 : date.hashCode());
-		result = prime * result + desc.hashCode();
-		result = prime * result + ((type == null) ? 0 : type.hashCode());
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((date == null) ? 0 : date.hashCode());
+        result = prime * result + desc.hashCode();
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (obj == null) return false;
-		if (getClass() != obj.getClass()) return false;
-		LogEntry other = (LogEntry) obj;
-		return Objects.equals(date, other.date)
-		    && desc.equals(other.desc)
-		    && Objects.equals(type, other.type);
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        LogEntry other = (LogEntry) obj;
+        return Objects.equals(date, other.date)
+            && desc.equals(other.desc)
+            && Objects.equals(type, other.type);
+    }
 
 }

--- a/MekHQ/src/mekhq/campaign/LogEntry.java
+++ b/MekHQ/src/mekhq/campaign/LogEntry.java
@@ -104,11 +104,11 @@ public class LogEntry implements Cloneable, MekHqXmlSerializable {
             for (int x = 0; x < nl.getLength(); x++) {
                 Node   node = nl.item(x);
                 String nname = node.getNodeName();
-                if (nname.equalsIgnoreCase("desc")) { //$NON-NLS-1$
+                if (nname.equals("desc")) { //$NON-NLS-1$
                     desc = MekHqXmlUtil.unEscape(node.getTextContent());
-                } else if (nname.equalsIgnoreCase("type")) { //$NON-NLS-1$
+                } else if (nname.equals("type")) { //$NON-NLS-1$
                     type = MekHqXmlUtil.unEscape(node.getTextContent());
-                } else if (nname.equalsIgnoreCase("date")) { //$NON-NLS-1$
+                } else if (nname.equals("date")) { //$NON-NLS-1$
                     date = DATE_FORMAT.parse(node.getTextContent().trim());
                 }
             }

--- a/MekHQ/src/mekhq/campaign/LogEntry.java
+++ b/MekHQ/src/mekhq/campaign/LogEntry.java
@@ -136,12 +136,7 @@ public class LogEntry implements Cloneable, MekHqXmlSerializable {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((date == null) ? 0 : date.hashCode());
-        result = prime * result + desc.hashCode();
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-        return result;
+        return Objects.hash(date, desc, type);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/LogEntry.java
+++ b/MekHQ/src/mekhq/campaign/LogEntry.java
@@ -35,116 +35,124 @@ import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 
 /**
- *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class LogEntry implements MekHqXmlSerializable {
-    private String type;
-    private Date date;
-    private String desc;
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+public class LogEntry implements Cloneable, MekHqXmlSerializable {
 
-    public LogEntry() {
-        this(null, "", null);
-    }
-    
-    public LogEntry(Date date, String desc) {
-        this(date, desc, null);
-    }
-    
-    public LogEntry(Date date, String desc, String type) {
-        this.date = date;
-        this.desc = Objects.requireNonNull(desc);
-        this.type = type;
-    }
-    
-    public void setDate(Date d) {
-        this.date = d;
-    }
-    
-    public Date getDate() {
-        return date;
-    }
+	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss"); //$NON-NLS-1$
+	// LATER SimpleDateFormat is not thread-safe: use throw-away instances or switch to java.time
+	// private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("", Locale.ENGLISH);
 
-    public String getDateString() {
-        return date.toString();
-    }
+	public LogEntry(Date date, String desc) {
+		this(date, desc, null);
+	}
+	
+	public LogEntry(Date date, String desc, String type) {
+		this.date = date;
+		this.desc = desc != null ? desc : ""; //$NON-NLS-1$
+		this.type = type;
+	}
 
-    public void setDesc(String d) {
-        this.desc = Objects.requireNonNull(d);
-    }
-    
-    public String getDesc() {
-        return desc;
-    }
-    
-    public void setType(String type) {
-        this.type = type;
-    }
-    
-    public String getType() {
-        return type;
-    }
-    
-    public boolean isType(String type) {
-        return Objects.equals(this.type, type);
-    }
-    
-    @Override
-    public void writeToXml(PrintWriter pw1, int indent) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(MekHqXmlUtil.indentStr(indent)).append("<logEntry>");
-        if(null != date) {
-            sb.append("<date>").append(DATE_FORMAT.format(date)).append("</date>");
-        }
-        sb.append("<desc>").append(MekHqXmlUtil.escape(desc)).append("</desc>");
-        if(null != type) {
-            sb.append("<type>").append(MekHqXmlUtil.escape(type)).append("</type>");
-        }
-        sb.append("</logEntry>");
-        pw1.println(sb.toString());
-    }
-    
-    public static LogEntry generateInstanceFromXML(Node wn) {
-        final String METHOD_NAME = "generateInstanceFromXML(Node)"; //$NON-NLS-1$
+	private Date date;
+	private String desc; // non-null
+	private String type;
 
-        LogEntry retVal = new LogEntry();
-        
-        try {    
-            // Okay, now load fields!
-            NodeList nl = wn.getChildNodes();
-            
-            for (int x=0; x<nl.getLength(); x++) {
-                Node wn2 = nl.item(x);
-                
-                if (wn2.getNodeName().equalsIgnoreCase("desc")) {
-                    retVal.desc = wn2.getTextContent();
-                } else if (wn2.getNodeName().equalsIgnoreCase("type")) {
-                    retVal.type = wn2.getTextContent();
-                } else if (wn2.getNodeName().equalsIgnoreCase("date")) {
-                    retVal.date = DATE_FORMAT.parse(wn2.getTextContent().trim());
-                }
-            }
-        } catch (Exception ex) {
-            // Doh!
-            MekHQ.getLogger().log(LogEntry.class, METHOD_NAME, ex);
-        }
-        
-        return retVal;
-    }
-    
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        if(null != date) {
-            sb.append("[").append(DATE_FORMAT.format(date)).append("] ");
-        }
-        sb.append(desc);
-        return sb.toString();
-    }
-    
-    @Override
-    public LogEntry clone() {
-        return new LogEntry(getDate(), getDesc(), getType());
-    }
+	public Date getDate() {
+		return date;
+	}
+	
+	public void setDate(Date date) {
+		this.date = date;
+	}
+	
+	public String getDesc() {
+		return desc;
+	}
+	
+	public void setDesc(String desc) {
+		this.desc = desc != null ? desc : ""; //$NON-NLS-1$
+	}
+	
+	public String getType() {
+		return type;
+	}
+	
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	@Override
+	public void writeToXml(PrintWriter pw, int indent) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(MekHqXmlUtil.indentStr(indent)).append("<logEntry>"); //$NON-NLS-1$
+		if (date != null)    sb.append("<date>").append(DATE_FORMAT.format(date)).append("</date>"); //$NON-NLS-1$ //$NON-NLS-2$
+		assert desc != null; sb.append("<desc>").append(MekHqXmlUtil.escape(desc)).append("</desc>"); //$NON-NLS-1$ //$NON-NLS-2$
+		if (type != null)    sb.append("<type>").append(MekHqXmlUtil.escape(type)).append("</type>");  //$NON-NLS-1$//$NON-NLS-2$
+		sb.append("</logEntry>"); //$NON-NLS-1$
+		pw.println(sb.toString());
+	}
+
+	public static LogEntry generateInstanceFromXML(Node wn) {
+		final String METHOD_NAME = "generateInstanceFromXML(Node)"; //$NON-NLS-1$
+
+		Date   date = null;
+		String desc = null;
+		String type = null;
+
+		try {
+			NodeList nl = wn.getChildNodes();
+			for (int x = 0; x < nl.getLength(); x++) {
+				Node   node = nl.item(x);
+				String nname = node.getNodeName();
+				if (nname.equalsIgnoreCase("desc")) { //$NON-NLS-1$
+					desc = MekHqXmlUtil.unEscape(node.getTextContent());
+				} else if (nname.equalsIgnoreCase("type")) { //$NON-NLS-1$
+					type = MekHqXmlUtil.unEscape(node.getTextContent());
+				} else if (nname.equalsIgnoreCase("date")) { //$NON-NLS-1$
+					date = DATE_FORMAT.parse(node.getTextContent().trim());
+				}
+			}
+		} catch (Exception ex) {
+			MekHQ.getLogger().error(LogEntry.class, METHOD_NAME, ex);
+			return null;
+		}
+
+		return new LogEntry(date, desc, type);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		if (null != date) sb.append("[").append(DATE_FORMAT.format(date)).append("] "); //$NON-NLS-1$ //$NON-NLS-2$
+		sb.append(desc);
+		if (null != type) sb.append(" (").append(type).append(")");  //$NON-NLS-1$//$NON-NLS-2$
+		return sb.toString();
+	}
+
+	@Override
+	public LogEntry clone() {
+		return new LogEntry(date, desc, type);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((date == null) ? 0 : date.hashCode());
+		result = prime * result + desc.hashCode();
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) return true;
+		if (obj == null) return false;
+		if (getClass() != obj.getClass()) return false;
+		LogEntry other = (LogEntry) obj;
+		return Objects.equals(date, other.date)
+		    && desc.equals(other.desc)
+		    && Objects.equals(type, other.type);
+	}
+
 }

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -396,7 +396,7 @@ public class MedicalViewDialog extends JDialog {
         panel.setLayout(new BoxLayout(panel, BoxLayout.PAGE_AXIS));
         panel.add(genLabel(resourceMap.getString("medicalHistory.text"))); //$NON-NLS-1$
         Map<String, List<LogEntry>> groupedEntries = p.getPersonnelLog().stream()
-            .filter(entry -> entry.isType(Person.LOGTYPE_MEDICAL))
+            .filter(entry -> Person.LOGTYPE_MEDICAL.equals(entry.getType()))
             .sorted((entry1, entry2) -> entry1.getDate().compareTo(entry2.getDate()))
             .collect(Collectors.groupingBy(entry -> DATE_FORMAT.format(entry.getDate())));
         groupedEntries.entrySet().stream()

--- a/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
@@ -1,15 +1,20 @@
 /*
- * MegaMek - Copyright (C) 2018 - The MegaMek Team
+ * Copyright (c) 2018 The MegaMek Team. All rights reserved.
  *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
+ * This file is part of MekHQ.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign;
 

--- a/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
@@ -14,32 +14,32 @@ import org.xml.sax.InputSource;
 
 public class LogEntryTest {
 
-	@Test
-	public void testNullDescriptionBecomesEmpty() {
-		Assert.assertEquals("", new LogEntry(null, null).getDesc()); //$NON-NLS-1$
-	}
+    @Test
+    public void testNullDescriptionBecomesEmpty() {
+        Assert.assertEquals("", new LogEntry(null, null).getDesc()); //$NON-NLS-1$
+    }
 
-	@Test
-	public void testXmlMarshalling() throws Exception {
-		checkMarshalling(new LogEntry(null, null, null));
-		checkMarshalling(new LogEntry(new Date(0l), "", ""));  //$NON-NLS-1$//$NON-NLS-2$
-		checkMarshalling(new LogEntry(new Date(0l), "<desc>Some description</desc>", "<type>Some type</type>")); //$NON-NLS-1$ //$NON-NLS-2$
-		checkMarshalling(new LogEntry(new Date(0l), "Some <em>xml-fragment</em> description", "Some <em>xml-fragment</em> type")); //$NON-NLS-1$ //$NON-NLS-2$
-	}
+    @Test
+    public void testXmlMarshalling() throws Exception {
+        checkMarshalling(new LogEntry(null, null, null));
+        checkMarshalling(new LogEntry(new Date(0l), "", ""));  //$NON-NLS-1$//$NON-NLS-2$
+        checkMarshalling(new LogEntry(new Date(0l), "<desc>Some description</desc>", "<type>Some type</type>")); //$NON-NLS-1$ //$NON-NLS-2$
+        checkMarshalling(new LogEntry(new Date(0l), "Some <em>xml-fragment</em> description", "Some <em>xml-fragment</em> type")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
 
-	private static void checkMarshalling(LogEntry le) throws Exception {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		
-		PrintWriter pw = new PrintWriter(baos);
-		le.writeToXml(pw, 0);
-		pw.close();
-		
-		Node node = DocumentBuilderFactory.newInstance()
-		                                  .newDocumentBuilder()
-		                                  .parse(new InputSource(new ByteArrayInputStream(baos.toByteArray())))
-		                                  .getDocumentElement();
-		
-		Assert.assertEquals(le, LogEntry.generateInstanceFromXML(node));
-	}
+    private static void checkMarshalling(LogEntry le) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        PrintWriter pw = new PrintWriter(baos);
+        le.writeToXml(pw, 0);
+        pw.close();
+
+        Node node = DocumentBuilderFactory.newInstance()
+                                          .newDocumentBuilder()
+                                          .parse(new InputSource(new ByteArrayInputStream(baos.toByteArray())))
+                                          .getDocumentElement();
+        
+        Assert.assertEquals(le, LogEntry.generateInstanceFromXML(node));
+    }
 
 }

--- a/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
@@ -1,3 +1,20 @@
+/*
+ * MekHQ
+ * Copyright (C) 2018  MekHQ team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package mekhq.campaign;
 
 import java.io.ByteArrayInputStream;

--- a/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
@@ -1,0 +1,45 @@
+package mekhq.campaign;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.util.Date;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+
+public class LogEntryTest {
+
+	@Test
+	public void testNullDescriptionBecomesEmpty() {
+		Assert.assertEquals("", new LogEntry(null, null).getDesc()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testXmlMarshalling() throws Exception {
+		checkMarshalling(new LogEntry(null, null, null));
+		checkMarshalling(new LogEntry(new Date(0l), "", ""));  //$NON-NLS-1$//$NON-NLS-2$
+		checkMarshalling(new LogEntry(new Date(0l), "<desc>Some description</desc>", "<type>Some type</type>")); //$NON-NLS-1$ //$NON-NLS-2$
+		checkMarshalling(new LogEntry(new Date(0l), "Some <em>xml-fragment</em> description", "Some <em>xml-fragment</em> type")); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static void checkMarshalling(LogEntry le) throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		
+		PrintWriter pw = new PrintWriter(baos);
+		le.writeToXml(pw, 0);
+		pw.close();
+		
+		Node node = DocumentBuilderFactory.newInstance()
+		                                  .newDocumentBuilder()
+		                                  .parse(new InputSource(new ByteArrayInputStream(baos.toByteArray())))
+		                                  .getDocumentElement();
+		
+		Assert.assertEquals(le, LogEntry.generateInstanceFromXML(node));
+	}
+
+}

--- a/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/LogEntryTest.java
@@ -1,19 +1,15 @@
 /*
- * MekHQ
- * Copyright (C) 2018  MekHQ team
+ * MegaMek - Copyright (C) 2018 - The MegaMek Team
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  */
 package mekhq.campaign;
 


### PR DESCRIPTION
Escaped XML was not correctly unescaped in
LogEntry.generateInstanceFromXML(); this removes the need for the
workaround of stripping HTML tags in Campaign