### PR TITLE
Fixes generation of AtBContracts with 0 req. lances

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -435,10 +435,9 @@ public class AtBContract extends Contract implements Serializable {
         if (isSubcontract()) {
             requiredLances = 1;
         } else {
-            int required = Math.max(getEffectiveNumUnits(campaign) / 6, 1);
-            if (campaign.getCampaignOptions().getAdjustPaymentForStrategy() &&
-                    required > maxDeployedLances) {
-                multiplier *= (double)maxDeployedLances / (double)required;
+            requiredLances = Math.max(getEffectiveNumUnits(campaign) / 6, 1);
+            if (requiredLances > maxDeployedLances && campaign.getCampaignOptions().getAdjustPaymentForStrategy()) {
+                multiplier *= (double)maxDeployedLances / (double)requiredLances;
                 requiredLances = maxDeployedLances;
             }
         }


### PR DESCRIPTION
Changeset
https://github.com/MegaMek/mekhq/pull/812/files?utf8=%E2%9C%93&diff=unified&w=1
inadvertently created an execution path in
AtBContract.calculatePaymentMultiplier() that would leave requiredLances
unitialized - this initializes requiredLances to #units/6, restoring the behaviour
prior to that changeset.