### PR TITLE
Janitor: Cleanup deprecated `MMLogger.log()` calls

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -81,7 +81,7 @@ public class AtBGameThread extends GameThread {
         } catch (Exception ex) {
             MekHQ.getLogger().log(getClass(), "run", LogLevel.ERROR, //$NON-NLS-1$
                     "MegaMek client failed to connect to server"); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), "run", ex); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "run", ex); //$NON-NLS-1$
             return;
         }
 
@@ -117,7 +117,7 @@ public class AtBGameThread extends GameThread {
                 } catch (FileNotFoundException ex) {
                     MekHQ.getLogger().log(getClass(), "run", LogLevel.ERROR, //$NON-NLS-1$
                             "Could not load map file data/mapgen/" + scenario.getMap() + ".xml"); //$NON-NLS-1$
-                    MekHQ.getLogger().log(getClass(), "run", ex); //$NON-NLS-1$
+                    MekHQ.getLogger().error(getClass(), "run", ex); //$NON-NLS-1$
                 }
                 mapSettings.setBoardSize(scenario.getMapX(), scenario.getMapY());
                 mapSettings.setMapSize(1,  1);
@@ -238,7 +238,7 @@ public class AtBGameThread extends GameThread {
                 	} catch (Exception e) {
                         MekHQ.getLogger().log(getClass(), "run", LogLevel.ERROR, //$NON-NLS-1$
                                 "Could not connect with Bot name " + bf.getName()); //$NON-NLS-1$
-                        MekHQ.getLogger().log(getClass(), "run", e); //$NON-NLS-1$
+                        MekHQ.getLogger().error(getClass(), "run", e); //$NON-NLS-1$
                 	}
                 	swingGui.getBots().put(name, botClient);
                 	
@@ -251,7 +251,7 @@ public class AtBGameThread extends GameThread {
             	Thread.sleep(50);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().log(getClass(), "run", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "run", e); //$NON-NLS-1$
         }
         finally {
 	        client.die();
@@ -305,7 +305,7 @@ public class AtBGameThread extends GameThread {
 				botClient.sendPlayerInfo();
 			}
 		} catch (Exception e) {
-            MekHQ.getLogger().log(getClass(), "configureBot", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "configureBot", e); //$NON-NLS-1$
 		}    	
     }
 }

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -84,7 +84,7 @@ class GameThread extends Thread implements CloseClientListener {
         } catch (Exception ex) {
             MekHQ.getLogger().log(getClass(), "run()", LogLevel.ERROR,
                     "MegaMek client failed to connect to server"); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), "run()", ex);
+            MekHQ.getLogger().error(getClass(), "run()", ex);
             return;
         }
 
@@ -131,7 +131,7 @@ class GameThread extends Thread implements CloseClientListener {
             	Thread.sleep(50);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().log(getClass(), "run()", e);
+            MekHQ.getLogger().error(getClass(), "run()", e);
         }
         finally {
 	        client.die();

--- a/MekHQ/src/mekhq/IconPackage.java
+++ b/MekHQ/src/mekhq/IconPackage.java
@@ -110,7 +110,7 @@ public class IconPackage {
             try {
                 mt.loadFromFile("mechset.txt");
             } catch (IOException ex) {
-                MekHQ.getLogger().log(getClass(), "loadDirectories()", ex);
+                MekHQ.getLogger().error(getClass(), "loadDirectories()", ex);
                 //TODO: do something here
             }
         }
@@ -210,7 +210,7 @@ public class IconPackage {
                     }
                 }
             } catch (Exception err) {
-                MekHQ.getLogger().log(IconPackage.class, METHOD_NAME, err);
+                MekHQ.getLogger().error(IconPackage.class, METHOD_NAME, err);
             } finally {
                 if (null != g2d) {
                     g2d.dispose();
@@ -234,7 +234,7 @@ public class IconPackage {
                 }
                 retVal = scaledImage;
             } catch (Exception err) {
-                MekHQ.getLogger().log(IconPackage.class, METHOD_NAME, err);
+                MekHQ.getLogger().error(IconPackage.class, METHOD_NAME, err);
             }
         }
         

--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -1547,7 +1547,7 @@ public class Utilities {
                             // Ignore this file then
                             MekHQ.getLogger().log(Utilities.class, METHOD_NAME, LogLevel.ERROR,
                                     "Exception trying to parse " + file.getPath() + " - ignoring."); //$NON-NLS-1$ //$NON-NLS-2$
-                            MekHQ.getLogger().log(Utilities.class, METHOD_NAME, ex);
+                            MekHQ.getLogger().error(Utilities.class, METHOD_NAME, ex);
                         }
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/AtBConfiguration.java
@@ -173,7 +173,7 @@ public class AtBConfiguration implements Serializable {
 					} catch (ParseException ex) {
                         MekHQ.getLogger().log(getClass(), METHOD_NAME,
                                 LogLevel.ERROR, "Error parsing default date for hiring hall on " + fields[2]); //$NON-NLS-1$
-                        MekHQ.getLogger().log(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+                        MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
 					}
 				}
 				break;
@@ -364,7 +364,7 @@ public class AtBConfiguration implements Serializable {
 			retVal.setAllValuesToDefaults();
 			return retVal;
 		} catch (Exception ex) {
-            MekHQ.getLogger().log(AtBConfiguration.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(AtBConfiguration.class, METHOD_NAME, ex);
 			return retVal;
 		}
 		
@@ -442,7 +442,7 @@ public class AtBConfiguration implements Serializable {
 				} catch (Exception ex) {
                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                             "Could not parse weight class attribute for enemy forces table"); //$NON-NLS-1$
-                    MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+                    MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
 				}							
 			}
 		}
@@ -475,7 +475,7 @@ public class AtBConfiguration implements Serializable {
 						} catch (ParseException ex) {
 		                    MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
 		                            "Error parsing date for hiring hall on " + wn2.getTextContent()); //$NON-NLS-1$
-		                    MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+		                    MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
 						}
 						hiringHalls.add(new DatedRecord<String>(start, end, wn2.getTextContent()));
 						break;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -663,7 +663,7 @@ public class Campaign implements Serializable, ITechManager {
         } catch (Exception ex) {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                     "Unable to load unit: " + ms.getEntryName()); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
         }
         Entity en = mechFileParser.getEntity();
 
@@ -3394,7 +3394,7 @@ public class Campaign implements Serializable, ITechManager {
         try {
             mechFileParser = new MechFileParser(mechSummary.getSourceFile());
         } catch (EntityLoadingException ex) {
-            MekHQ.getLogger().log(Campaign.class, "getBrandNewUndamagedEntity(String)", ex);
+            MekHQ.getLogger().error(Campaign.class, "getBrandNewUndamagedEntity(String)", ex);
         }
         if (mechFileParser == null) {
             return null;
@@ -3685,7 +3685,7 @@ public class Campaign implements Serializable, ITechManager {
             try {
                 mechFileParser = new MechFileParser(ms.getSourceFile());
             } catch (EntityLoadingException ex) {
-                MekHQ.getLogger().log(Campaign.class, "writeCustoms(PrintWriter)", ex);
+                MekHQ.getLogger().error(Campaign.class, "writeCustoms(PrintWriter)", ex);
             }
             if (mechFileParser == null) {
                 continue;
@@ -3742,7 +3742,7 @@ public class Campaign implements Serializable, ITechManager {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);
         } catch (Exception ex) {
-            MekHQ.getLogger().log(Campaign.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Campaign.class, METHOD_NAME, ex);
         }
 
         Element campaignEle = xmlDoc.getDocumentElement();

--- a/MekHQ/src/mekhq/campaign/ExtraData.java
+++ b/MekHQ/src/mekhq/campaign/ExtraData.java
@@ -89,7 +89,7 @@ public class ExtraData {
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             u = context.createUnmarshaller();
         } catch(Exception ex) {
-            MekHQ.getLogger().log(ExtraData.class, "<init>", ex);
+            MekHQ.getLogger().error(ExtraData.class, "<init>", ex);
         }
         marshaller = m;
         unmarshaller = u;
@@ -179,7 +179,7 @@ public class ExtraData {
         try {
             marshaller.marshal(this, writer);
         } catch(JAXBException e) {
-            MekHQ.getLogger().log(getClass(), "writeToXml(Writer)", e);
+            MekHQ.getLogger().error(getClass(), "writeToXml(Writer)", e);
         }
     }
     
@@ -187,7 +187,7 @@ public class ExtraData {
         try {
             marshaller.marshal(this, os);
         } catch(JAXBException e) {
-            MekHQ.getLogger().log(getClass(), "writeToXml(OutputStream)", e);
+            MekHQ.getLogger().error(getClass(), "writeToXml(OutputStream)", e);
         }
     }
     
@@ -195,7 +195,7 @@ public class ExtraData {
         try {
             return (ExtraData) unmarshaller.unmarshal(wn);
         } catch(JAXBException e) {
-            MekHQ.getLogger().log(ExtraData.class, "createFromXml(Node)", e);
+            MekHQ.getLogger().error(ExtraData.class, "createFromXml(Node)", e);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/campaign/GamePreset.java
+++ b/MekHQ/src/mekhq/campaign/GamePreset.java
@@ -165,7 +165,7 @@ public class GamePreset implements MekHqXmlSerializable {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);
         } catch (Exception ex) {
-            MekHQ.getLogger().log(GamePreset.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(GamePreset.class, METHOD_NAME, ex);
             return preset;
         }
 

--- a/MekHQ/src/mekhq/campaign/JumpPath.java
+++ b/MekHQ/src/mekhq/campaign/JumpPath.java
@@ -188,7 +188,7 @@ public class JumpPath implements Serializable {
 			// Errrr, apparently either the class name was invalid...
 			// Or the listed name doesn't exist.
 			// Doh!
-            MekHQ.getLogger().log(JumpPath.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(JumpPath.class, METHOD_NAME, ex);
 		}
 		
 		return retVal;

--- a/MekHQ/src/mekhq/campaign/Kill.java
+++ b/MekHQ/src/mekhq/campaign/Kill.java
@@ -127,7 +127,7 @@ public class Kill implements Serializable {
 			// Errrr, apparently either the class name was invalid...
 			// Or the listed name doesn't exist.
 			// Doh!
-		    MekHQ.getLogger().log(Kill.class, METHOD_NAME, ex);
+		    MekHQ.getLogger().error(Kill.class, METHOD_NAME, ex);
 		}
 		return retVal;
 	}

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -478,7 +478,7 @@ public class Force implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(Force.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Force.class, METHOD_NAME, ex);
         }
         
         return retVal;

--- a/MekHQ/src/mekhq/campaign/force/ForceStub.java
+++ b/MekHQ/src/mekhq/campaign/force/ForceStub.java
@@ -231,7 +231,7 @@ public class ForceStub implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(ForceStub.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(ForceStub.class, METHOD_NAME, ex);
         }
         
         return retVal;

--- a/MekHQ/src/mekhq/campaign/force/Lance.java
+++ b/MekHQ/src/mekhq/campaign/force/Lance.java
@@ -518,7 +518,7 @@ public class Lance implements Serializable, MekHqXmlSerializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().log(Lance.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Lance.class, METHOD_NAME, ex);
         }
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/force/UnitStub.java
+++ b/MekHQ/src/mekhq/campaign/force/UnitStub.java
@@ -128,7 +128,7 @@ public class UnitStub implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(UnitStub.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(UnitStub.class, METHOD_NAME, ex);
         }
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -888,7 +888,7 @@ public class ContractMarket implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(ContractMarket.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(ContractMarket.class, METHOD_NAME, ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -283,7 +283,7 @@ public class PersonnelMarket {
                         MekHQ.getLogger().log(PersonnelMarket.class, METHOD_NAME, LogLevel.ERROR,
                                 "Unable to load entity: " + ms.getSourceFile() + ": " //$NON-NLS-1$
                                         + ms.getEntryName() + ": " + ex.getMessage()); //$NON-NLS-1$
-                        MekHQ.getLogger().log(PersonnelMarket.class, METHOD_NAME, ex);
+                        MekHQ.getLogger().error(PersonnelMarket.class, METHOD_NAME, ex);
         			}
                     if (null != en) {
                     	retVal.attachedEntities.put(id, en);
@@ -308,7 +308,7 @@ public class PersonnelMarket {
         	// Errrr, apparently either the class name was invalid...
         	// Or the listed name doesn't exist.
         	// Doh!
-            MekHQ.getLogger().log(PersonnelMarket.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(PersonnelMarket.class, METHOD_NAME, ex);
         }
 
         // All personnel need the rank reference fixed

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -208,7 +208,7 @@ public class ShoppingList implements MekHqXmlSerializable {
             }
         } catch (Exception ex) {
             // Doh!
-            MekHQ.getLogger().log(ShoppingList.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(ShoppingList.class, METHOD_NAME, ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/market/UnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/UnitMarket.java
@@ -392,7 +392,7 @@ public class UnitMarket implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(UnitMarket.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(UnitMarket.class, METHOD_NAME, ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -709,7 +709,7 @@ public class AtBContract extends Contract implements Serializable {
                     en = null;
                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                             "Unable to load entity: " + msl.get(0).getSourceFile() + ": " + msl.get(0).getEntryName() + ": " + ex.getMessage()); //$NON-NLS-1$
-                    MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+                    MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
                 }
                 
             }

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -980,7 +980,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             en = null;
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                     "Unable to load entity: " + ms.getSourceFile() + ": " + ms.getEntryName() + ": " + ex.getMessage()); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             return null;
         }
 
@@ -1065,7 +1065,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         } catch (Exception ex) {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                     "Unable to load unit: " + name); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
         }
         if (mechFileParser == null) {
             return null;
@@ -1879,7 +1879,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                         } catch (Exception e) {
                             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                     "Error loading allied unit in scenario"); //$NON-NLS-1$
-                            MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+                            MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                         }
                         if (en != null) {
                             alliesPlayer.add(en);
@@ -1903,7 +1903,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                         } catch (Exception e) {
                             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                     "Error loading allied unit in scenario"); //$NON-NLS-1$
-                            MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+                            MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                         }
                         if (en != null) {
                             bigBattleAllies.add(en);
@@ -1935,7 +1935,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                                 } catch (Exception e) {
                                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                             "Error loading allied unit in scenario"); //$NON-NLS-1$
-                                    MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+                                    MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                                 }
                                 if (null != en) {
                                     specMissionEnemies.get(weightClass).add(en);
@@ -1952,7 +1952,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 } catch (Exception e) {
                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                             "Error loading allied unit in scenario"); //$NON-NLS-1$
-                    MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+                    MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                     bf = null;
                 }
                 if (null != bf) {
@@ -2214,7 +2214,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             } catch (PrincessException ex) {
                 MekHQ.getLogger().log(getClass(), "BotForce()", LogLevel.ERROR, //$NON-NLS-1$
                         "Error getting Princess default behaviors"); //$NON-NLS-1$
-                MekHQ.getLogger().log(getClass(), "BotForce()", ex); //$NON-NLS-1$
+                MekHQ.getLogger().error(getClass(), "BotForce()", ex); //$NON-NLS-1$
             }
         };
 
@@ -2241,7 +2241,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             } catch (PrincessException ex) {
                 MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                         "Error getting Princess default behaviors"); //$NON-NLS-1$
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             }
             behaviorSettings.setRetreatEdge(CardinalEdge.NEAREST_OR_NONE);
             behaviorSettings.setDestinationEdge(CardinalEdge.NEAREST_OR_NONE);
@@ -2406,7 +2406,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                             } catch (Exception e) {
                                 MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                         "Error loading allied unit in scenario"); //$NON-NLS-1$
-                                MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+                                MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                             }
                             if (en != null) {
                                 entityList.add(en);

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -320,7 +320,7 @@ public class Mission implements Serializable, MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(Mission.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Mission.class, METHOD_NAME, ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -410,7 +410,7 @@ public class Scenario implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(Scenario.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Scenario.class, METHOD_NAME, ex);
         }
         
         return retVal;

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -801,7 +801,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 			// Errrr, apparently either the class name was invalid...
 			// Or the listed name doesn't exist.
 			// Doh!
-		    MekHQ.getLogger().log(Part.class, METHOD_NAME, ex);
+		    MekHQ.getLogger().error(Part.class, METHOD_NAME, ex);
 		}
 
 		// Refit protection of unit id

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1779,7 +1779,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 			}
 		} catch (Exception ex) {
 			// Doh!
-            MekHQ.getLogger().log(Refit.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Refit.class, METHOD_NAME, ex);
 		}
 
 		return retVal;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -410,7 +410,7 @@ public class EquipmentPart extends Part {
 		try {
 			return unit != null && unit.getEntity() != null && unit.getEntity().getEquipment(equipmentNum) != null && unit.isLocationDestroyed(unit.getEntity().getEquipment(equipmentNum).getLocation());
 		} catch (Exception e) {
-		    MekHQ.getLogger().log(getClass(), "isMountedOnDestroyedLocation()", e);
+		    MekHQ.getLogger().error(getClass(), "isMountedOnDestroyedLocation()", e);
 		}
 		return false;
 		/*if(null == unit) {

--- a/MekHQ/src/mekhq/campaign/personnel/Ancestors.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Ancestors.java
@@ -220,7 +220,7 @@ public class Ancestors implements Serializable, MekHqXmlSerializable {
 			// Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-		    MekHQ.getLogger().log(Ancestors.class, "generateInstanceFromXML(Node,Campaign,Version)", e); //$NON-NLS-1$
+		    MekHQ.getLogger().error(Ancestors.class, "generateInstanceFromXML(Node,Campaign,Version)", e); //$NON-NLS-1$
 		}
 		
 		return retVal;

--- a/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
+++ b/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
@@ -72,7 +72,7 @@ public class CustomOption {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);
         } catch (Exception ex) {
-            MekHQ.getLogger().log(CustomOption.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(CustomOption.class, METHOD_NAME, ex);
         }
 
         Element spaEle = xmlDoc.getDocumentElement();

--- a/MekHQ/src/mekhq/campaign/personnel/Injury.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Injury.java
@@ -66,7 +66,7 @@ public class Injury {
             // For debugging only!
             // unmarshaller.setEventHandler(new javax.xml.bind.helpers.DefaultValidationEventHandler());
         } catch(JAXBException e) {
-            MekHQ.getLogger().log(Injury.class, "<init>", e);
+            MekHQ.getLogger().error(Injury.class, "<init>", e);
         }
     } 
     
@@ -79,7 +79,7 @@ public class Injury {
         try {    
             return unmarshaller.unmarshal(wn, Injury.class).getValue();
         } catch (Exception ex) {
-            MekHQ.getLogger().log(Injury.class, "generateInstanceFromXML(Node)", ex); //$NON-NLS-1$
+            MekHQ.getLogger().error(Injury.class, "generateInstanceFromXML(Node)", ex); //$NON-NLS-1$
         }
         return null;
     }
@@ -284,7 +284,7 @@ public class Injury {
         try {
             marshaller.marshal(this, pw1);
         } catch(JAXBException ex) {
-            MekHQ.getLogger().log(getClass(), "writeToXml(PrintWriter,int)", ex); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "writeToXml(PrintWriter,int)", ex); //$NON-NLS-1$
         }
     }
     

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1913,7 +1913,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(Person.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Person.class, METHOD_NAME, ex);
         }
 
         if (retVal.id == null) {

--- a/MekHQ/src/mekhq/campaign/personnel/Rank.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Rank.java
@@ -201,7 +201,7 @@ public class Rank implements MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(Rank.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Rank.class, METHOD_NAME, ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/personnel/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Ranks.java
@@ -137,7 +137,7 @@ public class Ranks {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);
         } catch (Exception ex) {
-            MekHQ.getLogger().log(Ranks.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Ranks.class, METHOD_NAME, ex);
         }
     
         Element ranksEle = xmlDoc.getDocumentElement();
@@ -515,7 +515,7 @@ public class Ranks {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(Ranks.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Ranks.class, METHOD_NAME, ex);
         }
         
         return retVal;

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -112,7 +112,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
 		} catch (Exception e) {
             MekHQ.getLogger().log(RetirementDefectionTracker.class, METHOD_NAME, LogLevel.ERROR,
                     "Error parsing net worth in financial report"); //$NON-NLS-1$
-            MekHQ.getLogger().log(RetirementDefectionTracker.class, METHOD_NAME, e);
+            MekHQ.getLogger().error(RetirementDefectionTracker.class, METHOD_NAME, e);
 		}
 		int totalShares = 0;
 		for (Person p : campaign.getActivePersonnel()) {
@@ -725,7 +725,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(RetirementDefectionTracker.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(RetirementDefectionTracker.class, METHOD_NAME, ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/personnel/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Skill.java
@@ -199,7 +199,7 @@ public class Skill implements Serializable, MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(Skill.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Skill.class, METHOD_NAME, ex);
         }
         
         return retVal;

--- a/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
@@ -162,7 +162,7 @@ public class SkillPrereq implements MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(SkillPrereq.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(SkillPrereq.class, METHOD_NAME, ex);
         }
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillType.java
@@ -504,7 +504,7 @@ public class SkillType implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(SkillType.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(SkillType.class, METHOD_NAME, ex);
         }
         if(version.getMinorVersion() < 3) {
             //need to change negotiation and scrounge to be countUp=false with
@@ -557,7 +557,7 @@ public class SkillType implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(SkillType.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(SkillType.class, METHOD_NAME, ex);
         }
         hash.put(retVal.name, retVal);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -339,7 +339,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(SpecialAbility.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(SpecialAbility.class, METHOD_NAME, ex);
         }
 
         if(retVal.displayName.isEmpty()) {
@@ -418,7 +418,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().log(SpecialAbility.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(SpecialAbility.class, METHOD_NAME, ex);
         }
 
         if(retVal.displayName.isEmpty()) {
@@ -453,7 +453,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);
         } catch (Exception ex) {
-            MekHQ.getLogger().log(SpecialAbility.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(SpecialAbility.class, METHOD_NAME, ex);
         }
 
         Element spaEle = xmlDoc.getDocumentElement();

--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -186,7 +186,7 @@ public class MothballInfo implements MekHqXmlSerializable {
             }
         } catch (Exception ex) {
             // Doh!
-            MekHQ.getLogger().log(Unit.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Unit.class, METHOD_NAME, ex);
         }
         
         return retVal;

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1633,7 +1633,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             }
         } catch (Exception ex) {
             // Doh!
-            MekHQ.getLogger().log(Unit.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Unit.class, METHOD_NAME, ex);
         }
 
         if (retVal.id == null) {
@@ -2729,7 +2729,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             MekHQ.getLogger().log(Unit.class, "addBayAmmoBin(EquipmentType, Mounted)",
                     LogLevel.ERROR, "Location full exception attempting to add " + etype.getDesc()
                     + " to unit " + getName());
-            MekHQ.getLogger().log(Unit.class, "addBayAmmoBin(EquipmentType, Mounted)", ex);
+            MekHQ.getLogger().error(Unit.class, "addBayAmmoBin(EquipmentType, Mounted)", ex);
             return null;
         }
         

--- a/MekHQ/src/mekhq/campaign/unit/UnitOrder.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitOrder.java
@@ -376,7 +376,7 @@ public class UnitOrder extends Unit implements IAcquisitionWork, MekHqXmlSeriali
             }
         } catch (Exception ex) {
             // Doh!
-            MekHQ.getLogger().log(UnitOrder.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(UnitOrder.class, METHOD_NAME, ex);
         }
         
         retVal.initializeParts(false);

--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
@@ -119,7 +119,7 @@ public class UnitTechProgression {
         } catch (InterruptedException e) {
             task.cancel(true);
         } catch (ExecutionException e) {
-            MekHQ.getLogger().log(UnitTechProgression.class,
+            MekHQ.getLogger().error(UnitTechProgression.class,
                     "getProgression(MechSummary,int,boolean)", e);
         }
         return null;
@@ -137,7 +137,7 @@ public class UnitTechProgression {
         } catch (EntityLoadingException ex) {
             MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR,
                     "Exception loading entity " + ms.getName());
-            MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(BuildMapTask.class, METHOD_NAME, ex);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -368,7 +368,7 @@ public class Faction {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(fis);
         } catch (Exception ex) {
-            MekHQ.getLogger().log(Faction.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Faction.class, METHOD_NAME, ex);
         }
 
         Element factionEle = xmlDoc.getDocumentElement();

--- a/MekHQ/src/mekhq/campaign/universe/News.java
+++ b/MekHQ/src/mekhq/campaign/universe/News.java
@@ -45,7 +45,7 @@ public class News {
             // For debugging only!
             unmarshaller.setEventHandler(new javax.xml.bind.helpers.DefaultValidationEventHandler());
         } catch(JAXBException e) {
-            MekHQ.getLogger().log(News.class, "<init>", e);
+            MekHQ.getLogger().error(News.class, "<init>", e);
         }
     }
 
@@ -91,7 +91,7 @@ public class News {
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);
             } catch (Exception ex) {
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             }
         
             Element newsEle = xmlDoc.getDocumentElement();
@@ -122,7 +122,7 @@ public class News {
                         try {
                             newsItem = (NewsItem) unmarshaller.unmarshal(wn);
                         } catch(JAXBException e) {
-                            MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+                            MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                             continue;
                         }
                         if(null == newsItem.getDate()) {

--- a/MekHQ/src/mekhq/campaign/universe/Planets.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planets.java
@@ -116,7 +116,7 @@ public class Planets {
                     Thread.sleep(10);
                 }
             } catch(InterruptedException iex) {
-                MekHQ.getLogger().log(Planets.class, "reload(boolean)", iex); //$NON-NLS-1$
+                MekHQ.getLogger().error(Planets.class, "reload(boolean)", iex); //$NON-NLS-1$
             }
         }
     }
@@ -282,7 +282,7 @@ public class Planets {
         try {
             marshaller.marshal(planet, out);
         } catch (Exception e) {
-            MekHQ.getLogger().log(getClass(), "writePlanet(OutputStream,Planet)", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "writePlanet(OutputStream,Planet)", e); //$NON-NLS-1$
         }
     }
     
@@ -290,7 +290,7 @@ public class Planets {
         try {
             marshaller.marshal(planet, out);
         } catch (Exception e) {
-            MekHQ.getLogger().log(getClass(), "writePlanet(Writer,Planet)", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "writePlanet(Writer,Planet)", e); //$NON-NLS-1$
         }
     }
     
@@ -299,7 +299,7 @@ public class Planets {
         try {
             marshaller.marshal(event, out);
         } catch (Exception e) {
-            MekHQ.getLogger().log(getClass(), "writePlanet(OutputStream,Planet.PlanetaryEvent)", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "writePlanet(OutputStream,Planet.PlanetaryEvent)", e); //$NON-NLS-1$
         }
     }
     
@@ -307,7 +307,7 @@ public class Planets {
         try {
             marshaller.marshal(event, out);
         } catch (Exception e) {
-            MekHQ.getLogger().log(getClass(), "writePlanet(Writer,Planet.PlanetaryEvent)", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "writePlanet(Writer,Planet.PlanetaryEvent)", e); //$NON-NLS-1$
         }
     }
     
@@ -315,7 +315,7 @@ public class Planets {
         try {
             return (Planet.PlanetaryEvent) unmarshaller.unmarshal(node);
         } catch (JAXBException e) {
-            MekHQ.getLogger().log(getClass(), "readPlanetaryEvent(Node)", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "readPlanetaryEvent(Node)", e); //$NON-NLS-1$
         }
         return null;
     }
@@ -326,7 +326,7 @@ public class Planets {
         try {
             marshaller.marshal(temp, out);
         } catch (Exception e) {
-            MekHQ.getLogger().log(getClass(), "writePlanets(OutputStream,List<Planet>)", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "writePlanets(OutputStream,List<Planet>)", e); //$NON-NLS-1$
         }
     }
     
@@ -336,7 +336,7 @@ public class Planets {
         try {
             generatePlanets();
         } catch (ParseException e) {
-            MekHQ.getLogger().log(getClass(), "initialize()", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "initialize()", e); //$NON-NLS-1$
         }
     }
     
@@ -703,7 +703,7 @@ public class Planets {
             try(FileInputStream fis = new FileInputStream(defaultFilePath)) { //$NON-NLS-1$
                 updatePlanets(fis);
             } catch (Exception ex) {
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             }
             
             // Step 3: Load all the xml files within the planets subdirectory, if it exists

--- a/MekHQ/src/mekhq/campaign/universe/RATManager.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATManager.java
@@ -165,7 +165,7 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
             ex.printStackTrace();
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                     "While loading RAT info from " + f.getName() + ": "); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             return false;
         }
 
@@ -244,7 +244,7 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
         } catch (Exception ex) {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO,
                     "While loading altFactions: "); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
         }
 
         Element elem = xmlDoc.getDocumentElement();
@@ -305,7 +305,7 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
                 } catch (Exception ex) {
                     MekHQ.getLogger().log(RATManager.class, METHOD_NAME, LogLevel.ERROR,
                             "While loading RAT info from " + f.getName() + ": "); //$NON-NLS-1$
-                    MekHQ.getLogger().log(RATManager.class, METHOD_NAME, ex);
+                    MekHQ.getLogger().error(RATManager.class, METHOD_NAME, ex);
                 }
                 Element elem = xmlDoc.getDocumentElement();
                 NodeList nl = elem.getChildNodes();

--- a/MekHQ/src/mekhq/campaign/universe/StarUtil.java
+++ b/MekHQ/src/mekhq/campaign/universe/StarUtil.java
@@ -630,9 +630,9 @@ public final class StarUtil {
                 }
                 iconDataLoaded = true;
             } catch (FileNotFoundException e) {
-                MekHQ.getLogger().log(StarUtil.class, METHOD_NAME, e);
+                MekHQ.getLogger().error(StarUtil.class, METHOD_NAME, e);
             } catch (IOException e) {
-                MekHQ.getLogger().log(StarUtil.class, METHOD_NAME, e);
+                MekHQ.getLogger().error(StarUtil.class, METHOD_NAME, e);
             }
         }
         return ICON_DATA.get(Utilities.nonNull(planet.getIcon(), "default"));

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1619,7 +1619,7 @@ public class CampaignGUI extends JPanel {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, //$NON-NLS-1$
                     "Campaign saved to " + file); //$NON-NLS-1$
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
             JOptionPane
                     .showMessageDialog(
                             getFrame(),
@@ -1774,7 +1774,7 @@ public class CampaignGUI extends JPanel {
         try {
             loadListFile(true);
         } catch (IOException ex) {
-            MekHQ.getLogger().log(getClass(), "miLoadForcesActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miLoadForcesActionPerformed(ActionEvent)", ex);
         }
     }// GEN-LAST:event_miLoadForcesActionPerformed
 
@@ -1782,7 +1782,7 @@ public class CampaignGUI extends JPanel {
         try {
             loadPlanetTSVFile();
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), "miLoadPlanetsActionPerformed", ex);
+            MekHQ.getLogger().error(getClass(), "miLoadPlanetsActionPerformed", ex);
         }
     }
     
@@ -1790,7 +1790,7 @@ public class CampaignGUI extends JPanel {
         try {
             loadPersonFile();
         } catch (IOException ex) {
-            MekHQ.getLogger().log(getClass(), "miImportPersonActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miImportPersonActionPerformed(ActionEvent)", ex);
         }
     }// GEN-LAST:event_miImportPersonActionPerformed
 
@@ -1798,7 +1798,7 @@ public class CampaignGUI extends JPanel {
         try {
             savePersonFile();
         } catch (IOException ex) {
-            MekHQ.getLogger().log(getClass(), "miExportPersonActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miExportPersonActionPerformed(ActionEvent)", ex);
         }
     }// GEN-LAST:event_miExportPersonActionPerformed
 
@@ -1806,7 +1806,7 @@ public class CampaignGUI extends JPanel {
         try {
             saveOptionsFile("xml", resourceMap.getString("dlgSaveCampaignXML.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedCampaignSettings");
         } catch (IOException ex) {
-            MekHQ.getLogger().log(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
     }// GEN-LAST:event_miExportPersonActionPerformed
 
@@ -1814,7 +1814,7 @@ public class CampaignGUI extends JPanel {
         try {
             exportPlanets("xml", resourceMap.getString("dlgSavePlanetsXML.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedPlanets");
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
     }
     
@@ -1822,7 +1822,7 @@ public class CampaignGUI extends JPanel {
         try {
             exportFinances("csv", resourceMap.getString("dlgSaveFinancesCSV.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedFinances");
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
     }
     
@@ -1830,7 +1830,7 @@ public class CampaignGUI extends JPanel {
         try {
             exportPersonnel("csv", resourceMap.getString("dlgSavePersonnelCSV.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedPersonnel");
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
     }
     
@@ -1838,7 +1838,7 @@ public class CampaignGUI extends JPanel {
         try {
             exportUnits("csv", resourceMap.getString("dlgSaveUnitsCSV.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedUnits");
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
     }
     
@@ -1846,7 +1846,7 @@ public class CampaignGUI extends JPanel {
         try {
             loadOptionsFile();
         } catch (IOException ex) {
-            MekHQ.getLogger().log(getClass(), "miImportOptionsActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miImportOptionsActionPerformed(ActionEvent)", ex);
         }
     }// GEN-LAST:event_miExportPersonActionPerformed
 
@@ -1854,7 +1854,7 @@ public class CampaignGUI extends JPanel {
         try {
             loadPartsFile();
         } catch (IOException ex) {
-            MekHQ.getLogger().log(getClass(), "miImportPartsActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miImportPartsActionPerformed(ActionEvent)", ex);
         }
     }// GEN-LAST:event_miImportPersonActionPerformed
 
@@ -1862,7 +1862,7 @@ public class CampaignGUI extends JPanel {
         try {
             savePartsFile();
         } catch (IOException ex) {
-            MekHQ.getLogger().log(getClass(), "miExportPartsActionPerformed(ActionEvent)", ex);
+            MekHQ.getLogger().error(getClass(), "miExportPartsActionPerformed(ActionEvent)", ex);
         }
     }// GEN-LAST:event_miExportPersonActionPerformed
 
@@ -2382,7 +2382,7 @@ public class CampaignGUI extends JPanel {
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);
             } catch (Exception ex) {
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
             }
 
             Element personnelEle = xmlDoc.getDocumentElement();
@@ -2540,7 +2540,7 @@ public class CampaignGUI extends JPanel {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, //$NON-NLS-1$
                     "Personnel saved to " + file); //$NON-NLS-1$
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
             JOptionPane
                     .showMessageDialog(
                             getFrame(),
@@ -2614,7 +2614,7 @@ public class CampaignGUI extends JPanel {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, //$NON-NLS-1$
                     "Campaign Options saved saved to " + file); //$NON-NLS-1$
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
             JOptionPane
                     .showMessageDialog(
                             getFrame(),
@@ -2673,7 +2673,7 @@ public class CampaignGUI extends JPanel {
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);
             } catch (Exception ex) {
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
             }
 
             Element partsEle = xmlDoc.getDocumentElement();
@@ -2763,7 +2763,7 @@ public class CampaignGUI extends JPanel {
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);
             } catch (Exception ex) {
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
             }
 
             Element partsEle = xmlDoc.getDocumentElement();
@@ -2972,7 +2972,7 @@ public class CampaignGUI extends JPanel {
                 MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, //$NON-NLS-1$
                         "Parts saved to " + file); //$NON-NLS-1$
 	        } catch (Exception ex) {
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
 	            JOptionPane
 	                    .showMessageDialog(
 	                            getFrame(),

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -217,7 +217,7 @@ public class MekLabTab extends CampaignGuiTab {
         try {
             entity = (new MechFileParser(mechSummary.getSourceFile(), mechSummary.getEntryName())).getEntity();
         } catch (EntityLoadingException ex) {
-            MekHQ.getLogger().log(getClass(), "loadUnit(Unit)", ex); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "loadUnit(Unit)", ex); //$NON-NLS-1$
         }
         entity.setYear(unit.campaign.getCalendar().get(Calendar.YEAR));
         UnitUtil.updateLoadedUnit(entity);
@@ -251,7 +251,7 @@ public class MekLabTab extends CampaignGuiTab {
         try {
             entity = (new MechFileParser(mechSummary.getSourceFile(), mechSummary.getEntryName())).getEntity();
         } catch (EntityLoadingException ex) {
-            MekHQ.getLogger().log(getClass(), "resetUnit()", ex); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "resetUnit()", ex); //$NON-NLS-1$
         }
         entity.setYear(unit.campaign.getCalendar().get(Calendar.YEAR));
         UnitUtil.updateLoadedUnit(entity);

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -4399,7 +4399,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO,
                     "Campaign options saved to " + file); //$NON-NLS-1$
         } catch (Exception ex) {
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             JOptionPane
                     .showMessageDialog(
                             null,

--- a/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
@@ -292,7 +292,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 					}
 				}
 			} catch (EntityLoadingException ex) {
-			    MekHQ.getLogger().log(getClass(), "populateRefits()", ex); //$NON-NLS-1$
+			    MekHQ.getLogger().error(getClass(), "populateRefits()", ex); //$NON-NLS-1$
 			}		
 		}
         refitModel = new RefitTableModel(refits);

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -183,7 +183,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
             contentPane.add(dateField, BorderLayout.SOUTH);
             dateField.setColumns(10);
         } catch (ParseException e) {
-            MekHQ.getLogger().log(getClass(), "<init>(Frame,GregorianCalendar)", e);
+            MekHQ.getLogger().error(getClass(), "<init>(Frame,GregorianCalendar)", e);
         }
 
         setResizable(false);

--- a/MekHQ/src/mekhq/gui/dialog/EditTransactionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditTransactionDialog.java
@@ -75,7 +75,7 @@ public class EditTransactionDialog extends JDialog implements ActionListener, Fo
             add(buildMainPanel(), BorderLayout.CENTER);
             add(buildButtonPanel(), BorderLayout.SOUTH);
         } catch (ParseException e) {
-            MekHQ.getLogger().log(getClass(), "initGUI()", e);
+            MekHQ.getLogger().error(getClass(), "initGUI()", e);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -218,7 +218,7 @@ public class GMToolsDialog extends JDialog implements ActionListener {
                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                             "Failed to load entity " + ms.getName() + " from " //$NON-NLS-1$
                                     + ms.getSourceFile().toString()); //$NON-NLS-1$
-                    MekHQ.getLogger().log(getClass(), METHOD_NAME, e1);
+                    MekHQ.getLogger().error(getClass(), METHOD_NAME, e1);
                     unitPicked.setText("Failed to load entity " + ms.getName());
                 }
             }

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -127,12 +127,12 @@ public class MedicalViewDialog extends JDialog {
         try(InputStream fis = new FileInputStream(ip.getGuiElement("default_male_paperdoll"))) { //$NON-NLS-1$
             defaultMaleDoll = new Paperdoll(fis);
         } catch(IOException e) {
-            MekHQ.getLogger().log(getClass(), "<init>(Window,Campaign,Person,IconPackage)", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "<init>(Window,Campaign,Person,IconPackage)", e); //$NON-NLS-1$
         }
         try(InputStream fis = new FileInputStream(ip.getGuiElement("default_female_paperdoll"))) { //$NON-NLS-1$
             defaultFemaleDoll = new Paperdoll(fis);
         } catch(IOException e) {
-            MekHQ.getLogger().log(getClass(), "<init>(Window,Campaign,Person,IconPackage)", e); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "<init>(Window,Campaign,Person,IconPackage)", e); //$NON-NLS-1$
         }
         
         setPreferredSize(new Dimension(1024, 840));

--- a/MekHQ/src/mekhq/gui/dialog/PrincessBehaviorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PrincessBehaviorDialog.java
@@ -86,7 +86,7 @@ public class PrincessBehaviorDialog extends BotConfigDialog implements ActionLis
     private void handleError(String method, Throwable t) {
         JOptionPane.showMessageDialog(this, t.getMessage(),
                                       "ERROR", JOptionPane.ERROR_MESSAGE);
-        MekHQ.getLogger().log(getClass(), method, t);
+        MekHQ.getLogger().error(getClass(), method, t);
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/dialog/UnitMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnitMarketDialog.java
@@ -427,7 +427,7 @@ public class UnitMarketDialog extends JDialog {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                     "Unable to load mech: " + ms.getSourceFile() + ": " //$NON-NLS-1$
                     + ms.getEntryName() + ": " + e.getMessage()); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
             refreshOfferView();
             return;
 		}

--- a/MekHQ/src/mekhq/gui/dialog/UnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnitSelectorDialog.java
@@ -535,7 +535,7 @@ public class UnitSelectorDialog extends JDialog {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                     "Unable to load mech: " + ms.getSourceFile() + ": " //$NON-NLS-1$
                     + ms.getEntryName() + ": " + ex.getMessage()); //$NON-NLS-1$
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             refreshUnitView();
             return;
         }
@@ -571,7 +571,7 @@ public class UnitSelectorDialog extends JDialog {
             try {
                 mt.loadFromFile("mechset.txt");
             } catch (IOException ex) {
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
                 //TODO: do something here
                 return;
             }

--- a/MekHQ/src/mekhq/gui/sorter/RankSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/RankSorter.java
@@ -60,7 +60,7 @@ import mekhq.campaign.personnel.Ranks;
         	} catch (Exception e) {
                 MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.DEBUG,
                         String.format("[DEBUG] RankSorter Exception, s0: %s, s1: %s", s00, s11)); //$NON-NLS-1$
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
         		return 0;
         	}
         }

--- a/MekHQ/src/mekhq/module/AbstractServiceManager.java
+++ b/MekHQ/src/mekhq/module/AbstractServiceManager.java
@@ -60,7 +60,7 @@ abstract public class AbstractServiceManager<T extends MekHQModule> {
                 services.put(service.getModuleName(), service);
             }
         } catch (ServiceConfigurationError err) {
-            MekHQ.getLogger().log(getClass(), "loadServices()", err); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), "loadServices()", err); //$NON-NLS-1$
         }
     }
     

--- a/MekHQ/src/mekhq/module/ScriptPluginManager.java
+++ b/MekHQ/src/mekhq/module/ScriptPluginManager.java
@@ -82,7 +82,7 @@ public class ScriptPluginManager {
         } catch (FileNotFoundException | ScriptException e) {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                     "While parsing script " + script.getName());
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, e);
+            MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
         }
     }
 

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -205,7 +205,7 @@ public class AtBEventProcessor {
                 MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                         "Unable to load entity: " + ms.getSourceFile() + ": " //$NON-NLS-1$
                         + ms.getEntryName() + ": " + ex.getMessage()); //$NON-NLS-1$
-                MekHQ.getLogger().log(getClass(), METHOD_NAME, ex);
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             }
         } else {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,


### PR DESCRIPTION
This PR replaces all deprecated `MMLogger.log()` calls with `MMLogger.error()`.