### PR TITLE
Bug: Fix invariant to check if tech time available for maintenance

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8836,7 +8836,7 @@ public class Campaign implements Serializable, ITechManager {
         int minutesUsed = u.getMaintenanceTime();
         int astechsUsed = getAvailableAstechs(minutesUsed, false);
         boolean maintained = null != tech
-                && tech.getMinutesLeft() > minutesUsed && !tech.isMothballing();
+                && tech.getMinutesLeft() >= minutesUsed && !tech.isMothballing();
         boolean paidMaintenance = true;
         if (maintained) {
             // use the time


### PR DESCRIPTION
Invariant was incorrect to determine if a tech had enough time to perform maintenance; fixes #895.