### PR TITLE
Fix NPE in getPartInUse if EquipmentType is null

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1428,6 +1428,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         // Makes no sense buying those separately from the chasis
         if((p instanceof EquipmentPart)
+                && ((EquipmentPart) p).getType() != null
                 && (((EquipmentPart) p).getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION)))
         {
             return null;


### PR DESCRIPTION
Found during campaign load benchmarks:
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at mekhq.campaign.Campaign.getPartInUse(Campaign.java:1431)
	at mekhq.campaign.Campaign.getPartsInUse(Campaign.java:1496)
	at mekhq.gui.OverviewTab.refreshOverviewPartsInUse(OverviewTab.java:402)
	at mekhq.gui.OverviewTab.lambda$refreshOverview$0(OverviewTab.java:386)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```