### PR TITLE
Add .mailmap to MekHQ for git shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,38 @@
+Adam Brant <adam.brant@gmail.com> Adam Brant <31824363+LaserEye32@users.noreply.github.com>
+Akjosch <development@akjosch.de> Akjosch <Akjosch@users.noreply.github.com>
+arlith <arlith@users.noreply.github.com> <Arlith@users.noreply.github.com>
+arlith <arlith@users.noreply.github.com> arlith <arlith@users.sourceforge.net>
+arlith <arlith@users.noreply.github.com> Nicholas Walczak <nwalczak@bbn.com>
+arlith <arlith@users.noreply.github.com> Nicholas Walczak <arlith@users.noreply.github.com>
+beerockxs <sebastian@brocks.cc> Sebastian Brocks <sebastian@brocks.cc>
+BLOODWOLF333 <catlinross@hotmail.com> BLOODWOLF <CATLINROSS@HOTMAIL.COM>
+BLOODWOLF333 <catlinross@hotmail.com> Carr <CATLINROSS@HOTMAIL.COM>
+Carl Spain <neoancient@megamek.org> <neoancient.bt@gmail.com>
+Carl Spain <neoancient@megamek.org> <neoancient@4d104363-cc00-4a03-b0b8-302e3804504c>
+Carl Spain <neoancient@megamek.org> neoancient <neoancient@megamek.org>
+Christopher Watford <christopher.watford@gmail.com> Christopher <christopher.watford@gmail.com>
+Cord Awtry <cord.awtry@gmail.com> <kipsta@gmail.com>
+Deric Page <dericpage@users.noreply.github.com> <Deric Page>
+Deric Page <dericpage@users.noreply.github.com> <dericpage@4d104363-cc00-4a03-b0b8-302e3804504c>
+Deric Page <dericpage@users.noreply.github.com> <deric.page@nisc.coop>
+Deric Page <dericpage@users.noreply.github.com> <deric.page@usa.net>
+Deric Page <dericpage@users.noreply.github.com> <dericpage@users.sourceforge.net>
+Dylan Myers <Dylan-M@users.noreply.github.com> Dylan Myers <dylan.myers@bluemedora.com>
+Dylan Myers <Dylan-M@users.noreply.github.com> Dylan Myers <ralgith@gmail.com>
+Hammer-GS <HammerGS@users.noreply.github.com> <hammer-gs@4d104363-cc00-4a03-b0b8-302e3804504c>
+Hammer-GS <HammerGS@users.noreply.github.com> HammerGS <driving@hotmail.com>
+Hammer-GS <HammerGS@users.noreply.github.com> Dave N <HammerGS@users.noreply.github.com>
+Hammer-GS <HammerGS@users.noreply.github.com> drivi <drivi@DESKTOP-T0L0AGJ>
+Hammer-GS <HammerGS@users.noreply.github.com> Hammer <drivingguy@hotmail.com> 
+Hammer-GS <HammerGS@users.noreply.github.com> HammerGS <drivingguy@hotmail.com>
+Hammer-GS <HammerGS@users.noreply.github.com> Hammer-GS <drivingguy@hotmail.com>
+Hammer-GS <HammerGS@users.noreply.github.com> Hammer-GS <hammer-gs@users.sourceforge.net>
+jayof9s <jayof9s@gmail.com> <jayof9s@4d104363-cc00-4a03-b0b8-302e3804504c>
+jayof9s <jayof9s@gmail.com> Alex <jayof9s@gmail.com>
+MKerensky <magnusmd@hotmail.com> Magnus Kerensky <magnusmd@hotmail.com>
+MKerensky <magnusmd@hotmail.com> mkerensky <magnusmd@hotmail.com>
+Qwertronix <dafranker@gmail.com> DaFranker <dafranker@gmail.com>
+SJuliez <juliez@outlook.de> Simon <juliez@outlook.de>
+Xenon <elementx54@github.com> Xenon <elementx54@gmail.com>
+Xenon <elementx54@github.com> Xenon <elementx54@users.noreply.github.com>
+Xenon <elementx54@github.com> Xenon54z <elementx54@gmail.com>


### PR DESCRIPTION
Began with MegaMek's `.mailmap` and extended it to cover the users and emails found via `git shortlog`.