### PR TITLE
Handle missing E0 rank

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2062,7 +2062,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         }
 
         // If we're set to a rank that no longer exists, demote ourself
-        while (getRank().getName(profession).equals("-")) {
+        while (getRank().getName(profession).equals("-") && (rank > 0)) {
             setRankNumeric(--rank);
         }
 

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3281,7 +3281,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 int sumEdge = 0;
                 int sumEdgeUsed = 0;
                 String engineerName = "Nobody";
-                int bestRank = -1;
+                int bestRank = Integer.MIN_VALUE;
                 for(UUID pid : vesselCrew) {
                     Person p = campaign.getPerson(pid);
                     if(null == p) {


### PR DESCRIPTION
When a rank name is missing for the profession the rank level is decremented until a rank name is found. This can drop the rank level below zero to RANK_BONDSMAN (-1). This is a misconfiguration of the custom ranks, but the way MekHQ handles it is confusing. By stopping at zero the rank is shown as - instead, which is easier for the user to figure out.

Fixes #917 