### PR TITLE
Ensure after fixPart is called that unusable units are removed

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2654,6 +2654,7 @@ public class Campaign implements Serializable, ITechManager {
         }
 
         // ok now we can check for other stuff we might need to do to units
+        List<UUID> unitsToRemove = new ArrayList<>();
         for (Unit u : getUnits()) {
             if (u.isRefitting()) {
                 refit(u.getRefit());
@@ -2664,7 +2665,12 @@ public class Campaign implements Serializable, ITechManager {
             if (!u.isPresent()) {
                 u.checkArrival();
             }
+            if (!u.isRepairable() && !u.hasSalvageableParts()) {
+                unitsToRemove.add(u.getId());
+            }
         }
+        // Remove any unrepairable, unsalvageable units
+        unitsToRemove.forEach(uid -> removeUnit(uid));
     }
 
     /** @return <code>true</code> if the new day arrived */

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -330,6 +330,14 @@ public class MassRepairService {
 			}
 		}
 
+		// Remove any units which after mass repair/salvage are no longer
+		// useable.
+		for (Unit u : units) {
+			if (!u.isRepairable() && !u.hasSalvageableParts()) {
+				campaignGUI.getCampaign().removeUnit(u.getId());
+			}
+		}
+
 		JOptionPane.showMessageDialog(campaignGUI.getFrame(), "Mass Repair/Salvage complete.", "Complete",
 				JOptionPane.INFORMATION_MESSAGE);
 	}


### PR DESCRIPTION
This attempts to fix the root cause of #860 and #911. From what I can tell, a normal repair task (in RepairTab) will check to see if the unit is no longer repairable and no longer has salvageable parts and remove it if that condition matches. The other repair place missing this logic is in MassRepairService and when we advance the day and complete multi-day repairs. This PR adds that logic to those two places.