### PR TITLE
Allow mothballed units in retirement dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -536,7 +536,7 @@ public class RetirementDefectionDialog extends JDialog {
 		ArrayList<UUID> unassignedASF = new ArrayList<UUID>();
 		ArrayList<UUID> availableUnits = new ArrayList<UUID>();
 		for (Unit u : hqView.getCampaign().getUnits()) {
-			if (!u.isAvailable()) {
+			if (!u.isAvailable() && !u.isMothballing() && !u.isMothballed()) {
 				continue;
 			}
 			availableUnits.add(u.getId());


### PR DESCRIPTION
This will allow units that are or are being mothballed to be given as reward in the retirement dialog