### PR TITLE
Add findbugs to build.gradle and start addressing its warnings

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'application'
     id 'maven-publish'
     id 'edu.sc.seis.launch4j' version '2.4.4'
+    id 'findbugs'
 }
 
 sourceSets {
@@ -104,6 +105,20 @@ task mmlJar (type: Jar) {
     inputs.dir "${mmlDir}/build/classes/java/main"
     inputs.dir "${mmlDir}/build/resources/main"
     outputs.file "${buildDir}/libs/${archiveName}"
+}
+
+findbugs {
+	ignoreFailures = true
+	effort = "default" // as of 2018-11, "max" causes StackOverflowError - try "max" again when findbugs is updated or after we address some reported issues
+	showProgress = true
+	reportLevel = "high" // set to "medium" and then "low" as we address issues
+}
+
+tasks.withType(FindBugs) {
+    reports {
+        xml.enabled false
+        html.enabled true
+    }
 }
 
 task stageFiles(type: Copy) {

--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -63,6 +63,7 @@ import javax.swing.table.TableModel;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.lang3.ArrayUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
@@ -1445,9 +1446,9 @@ public class Utilities {
         String roman = name;
 
         for (int i = 0; i < roman.length(); i++) {
-            int num = romanNumerals.toString().indexOf(roman.charAt(i));
+            int num = ArrayUtils.indexOf(romanNumerals, roman.charAt(i)); // untested
             if (i < roman.length()) {
-                int temp = romanNumerals.toString().indexOf(roman.charAt(i+1));
+                int temp = ArrayUtils.indexOf(romanNumerals, roman.charAt(i+1)); // untested
                 // If this is a larger number, then we need to combine them
                 if (temp > num) {
                     num = temp - num;

--- a/MekHQ/src/mekhq/campaign/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/AtBConfiguration.java
@@ -61,13 +61,8 @@ import mekhq.campaign.rating.IUnitRating;
  * tables in the rules, or they avoid hard-coding universe details.
  *
  */
-public class AtBConfiguration implements Serializable {
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 515628415152924457L;
-	
+public class AtBConfiguration {
+
 	/* Used to indicate size of lance or equivalent in opfor forces */
 	public static final String ORG_IS = "IS";
 	public static final String ORG_CLAN = "CLAN";

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2255,7 +2255,7 @@ public class Campaign implements Serializable, ITechManager {
 
     public Part fixWarehousePart(Part part, Person tech) {
         // get a new cloned part to work with and decrement original
-        Part repairable = part.clone();
+        Part repairable = part.copy();
         part.decrementQuantity();
         fixPart(repairable, tech);
         if (!(repairable instanceof OmniPod)) {
@@ -3576,12 +3576,12 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public void depodPart(Part part, int quantity) {
-        Part unpodded = part.clone();
+        Part unpodded = part.copy();
         unpodded.setOmniPodded(false);
         OmniPod pod = new OmniPod(unpodded, this);
         while (quantity > 0 && part.getQuantity() > 0) {
-            addPart(unpodded.clone(), 0);
-            addPart(pod.clone(), 0);
+            addPart(unpodded.copy(), 0);
+            addPart(pod.copy(), 0);
             part.decrementQuantity();
             quantity--;
         }
@@ -7215,7 +7215,7 @@ public class Campaign implements Serializable, ITechManager {
             // If we're assigned as a tech for any unit, remove us from it/them
             if (!person.getTechUnitIDs().isEmpty()) {
                 @SuppressWarnings("unchecked") // Broken assed Java returning Object from clone
-                ArrayList<UUID> techIDs = (ArrayList<UUID>) person.getTechUnitIDs().clone();
+                ArrayList<UUID> techIDs = new ArrayList<>(person.getTechUnitIDs());
                 for (UUID tuuid : techIDs) {
                     Unit t = getUnit(tuuid);
                     t.remove(person, true);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -26,7 +26,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -227,10 +226,9 @@ import mekhq.module.atb.AtBEventProcessor;
 /**
  * @author Taharqa The main campaign class, keeps track of teams and units
  */
-public class Campaign implements Serializable, ITechManager {
-    private static final String REPORT_LINEBREAK = "<br/><br/>"; //$NON-NLS-1$
+public class Campaign implements ITechManager {
 
-    private static final long serialVersionUID = -6312434701389973056L;
+    private static final String REPORT_LINEBREAK = "<br/><br/>"; //$NON-NLS-1$
 
     private UUID id;
 
@@ -287,8 +285,8 @@ public class Campaign implements Serializable, ITechManager {
     private Ranks ranks;
 
     private ArrayList<String> currentReport;
-    private transient String currentReportHTML;
-    private transient List<String> newReports;
+    private String currentReportHTML;
+    private List<String> newReports;
 
     //this is updated and used per gaming session, it is enabled/disabled via the Campaign options
     //we're re-using the LogEntry class that is used to store Personnel entries
@@ -296,7 +294,7 @@ public class Campaign implements Serializable, ITechManager {
 
     private boolean overtime;
     private boolean gmMode;
-    private transient boolean overviewLoadingValue = true;
+    private boolean overviewLoadingValue = true;
 
     private String camoCategory = Player.NO_CAMO;
     private String camoFileName = null;

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -22,7 +22,6 @@
 package mekhq.campaign;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -46,7 +45,7 @@ import mekhq.campaign.rating.UnitRatingMethod;
 /**
  * @author natit
  */
-public class CampaignOptions implements Serializable {
+public class CampaignOptions {
     private static final long serialVersionUID = 5698008431749303602L;
 
     public final static int TECH_INTRO = 0;

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -542,7 +542,6 @@ public class CampaignOptions {
         instantUnitMarketDelivery = false;
         useWeatherConditions = true;
     	useLightConditions = true;
-    	usePlanetaryConditions = true;
     	usePlanetaryConditions = false;
     	useLeadership = true;
     	useStrategy = true;

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -22,7 +22,6 @@
 package mekhq.campaign;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.util.Date;
 import java.util.Locale;
 
@@ -49,12 +48,7 @@ import mekhq.campaign.universe.Planets;
  *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class CurrentLocation implements Serializable {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4337642922571022697L;
+public class CurrentLocation {
 
     private Planet currentPlanet;
     //keep track of jump path

--- a/MekHQ/src/mekhq/campaign/JumpPath.java
+++ b/MekHQ/src/mekhq/campaign/JumpPath.java
@@ -22,7 +22,6 @@
 package mekhq.campaign;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.util.ArrayList;
 
 import org.joda.time.DateTime;
@@ -43,14 +42,10 @@ import mekhq.campaign.universe.Planet;
  * 
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class JumpPath implements Serializable {
+public class JumpPath {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 708430867050359759L;
 	private ArrayList<Planet> path;
-	
+
 	public JumpPath() {
 		path = new ArrayList<Planet>();
 	}

--- a/MekHQ/src/mekhq/campaign/Kill.java
+++ b/MekHQ/src/mekhq/campaign/Kill.java
@@ -159,8 +159,7 @@ public class Kill implements Serializable {
     	pilotId = pHash.get(oldPilotId);
     }
 	
-	@Override
-	public Kill clone() {
+	public Kill copy() {
 		return new Kill(getPilotId(), getWhatKilled(), getKilledByWhat(), getDate());
 	}
 	

--- a/MekHQ/src/mekhq/campaign/LogEntry.java
+++ b/MekHQ/src/mekhq/campaign/LogEntry.java
@@ -37,7 +37,7 @@ import mekhq.MekHqXmlUtil;
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class LogEntry implements Cloneable, MekHqXmlSerializable {
+public class LogEntry implements MekHqXmlSerializable {
 
     private static final SimpleDateFormat dateFormat() {
         // LATER centralise date formatting so that every class doesn't have its own format and - possibly - switch to java.time
@@ -130,8 +130,7 @@ public class LogEntry implements Cloneable, MekHqXmlSerializable {
         return sb.toString();
     }
 
-    @Override
-    public LogEntry clone() {
+    public LogEntry copy() {
         return new LogEntry(date, desc, type);
     }
 

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -985,7 +985,7 @@ public class ResolveScenarioTracker {
                         }
                     }
                 } else {
-                    if(e instanceof EjectedCrew & null != e.getCrew() && !e.getCrew().getExternalIdAsString().equals("-1")) {
+                    if(e instanceof EjectedCrew && null != e.getCrew() && !e.getCrew().getExternalIdAsString().equals("-1")) {
                         enemyEjections.put(UUID.fromString(e.getCrew().getExternalIdAsString()), (EjectedCrew)e);
                         continue;
                     }

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -23,7 +23,6 @@ package mekhq.campaign.finances;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
@@ -35,12 +34,11 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.ResourceBundle;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
 
 import megamek.common.logging.LogLevel;
 import megamek.common.util.EncodeControl;
@@ -59,12 +57,7 @@ import mekhq.campaign.mission.Contract;
  *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class Finances implements Serializable {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8533117455496219692L;
+public class Finances {
 
     private ResourceBundle resourceMap;
 

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -22,7 +22,6 @@
 package mekhq.campaign.market;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -61,12 +60,7 @@ import mekhq.campaign.universe.RandomFactionGenerator;
  * @author Neoancient
  *
  */
-public class ContractMarket implements Serializable {
-
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = 1303462872220110093L;
+public class ContractMarket {
 
 	public static int TYPE_ATBMONTHLY = 0;
 	//TODO: Implement a method that rolls each day to see whether a new contract appears or an offer disappears

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -124,7 +124,7 @@ public class PersonnelMarket {
 		}
 	}
 
-    /*
+    /**
      * Remove personnel from market on a new day
      * The better they are, the faster they disappear
      */
@@ -133,9 +133,7 @@ public class PersonnelMarket {
             List<Person> toRemove = method.removePersonnelForDay(c, personnel);
             if (null != toRemove) {
                 for (Person p : toRemove) {
-                	if (attachedEntities.contains(p.getId())) {
-                		attachedEntities.remove(p.getId());
-                	}
+                    attachedEntities.remove(p.getId());
                 }
                 personnel.removeAll(toRemove);
             }

--- a/MekHQ/src/mekhq/campaign/market/UnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/UnitMarket.java
@@ -22,7 +22,6 @@
 package mekhq.campaign.market;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Set;
@@ -52,14 +51,8 @@ import mekhq.campaign.universe.RandomFactionGenerator;
  * Generates units available for sale.
  * 
  * @author Neoancient
- *
  */
-public class UnitMarket implements Serializable {
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = -2085002038852079114L;
+public class UnitMarket {
 
 	public class MarketOffer {
 		public int market;

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -23,7 +23,6 @@
 package mekhq.campaign.mission;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -83,10 +82,8 @@ import mekhq.campaign.universe.Planets;
 
 /**
  * @author Neoancient
- *
  */
 public abstract class AtBScenario extends Scenario implements IAtBScenario {
-    private static final long serialVersionUID = 1148105510264408943L;
 
     public static final int BASEATTACK = 0;
     public static final int EXTRACTION = 1;
@@ -2192,11 +2189,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         rerollsRemaining--;
     }
 
-    public class BotForce implements Serializable, MekHqXmlSerializable {
-        /**
-         *
-         */
-        private static final long serialVersionUID = 8259058549964342518L;
+    public class BotForce implements MekHqXmlSerializable {
 
         private String name;
         private ArrayList<Entity> entityList;

--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -36,6 +36,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Transaction;
 import mekhq.campaign.parts.Part;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -161,10 +162,9 @@ public class Loot implements MekHqXmlSerializable {
                 +"</cash>");
         for(Entity e : units) {
             String lookupName = e.getChassis() + " " + e.getModel();
-            lookupName.replaceAll("\\s+$", "");
             pw1.println(MekHqXmlUtil.indentStr(indent+1)
                     +"<entityName>"
-                    +lookupName
+                    +StringEscapeUtils.escapeXml10(lookupName)
                     +"</entityName>");
         }
         for(Part p : parts) {

--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -58,9 +58,8 @@ public class Loot implements MekHqXmlSerializable {
         units = new ArrayList<Entity>();
         parts = new ArrayList<Part>();
     }
-    
-    @Override
-    public Object clone() {
+
+    public Loot copy() {
         Loot newLoot = new Loot();
         newLoot.name = name;
         newLoot.cash = cash;
@@ -68,7 +67,7 @@ public class Loot implements MekHqXmlSerializable {
         newLoot.parts = parts;
         return newLoot;
     }
-    
+
     public String getName() {
         return name;
     }

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -21,7 +21,6 @@
 package mekhq.campaign.mission;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.text.ParseException;
 import java.util.ArrayList;
 
@@ -46,12 +45,7 @@ import mekhq.campaign.universe.Planets;
  * 
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class Mission implements Serializable, MekHqXmlSerializable {
-
-    /**
-     * 
-     */
-    private static final long serialVersionUID = -5692134027829715149L;
+public class Mission implements MekHqXmlSerializable {
 
     public static final int S_ACTIVE = 0;
     public static final int S_SUCCESS = 1;

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -22,7 +22,6 @@
 package mekhq.campaign.mission;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -51,9 +50,8 @@ import mekhq.campaign.unit.Unit;
  * 
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class Scenario implements Serializable {
-    private static final long serialVersionUID = -2193761569359938090L;
-    
+public class Scenario {
+
     public static final int S_CURRENT  = 0;
     public static final int S_VICTORY  = 1;
     public static final int S_MVICTORY = 2;

--- a/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
@@ -61,9 +61,8 @@ public class AeroHeatSink extends Part {
             this.name = "Aero Double Heat Sink";
         }
     }
-    
-    @Override
-    public AeroHeatSink clone() {
+
+    public AeroHeatSink copy() {
         AeroHeatSink clone = new AeroHeatSink(getUnitTonnage(), type, omniPodded, campaign);
         clone.copyBaseData(this);
         return clone;

--- a/MekHQ/src/mekhq/campaign/parts/AeroLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroLifeSupport.java
@@ -67,13 +67,14 @@ public class AeroLifeSupport extends Part {
         	this.name = "Spacecraft Life Support";
         }
     }
-    
-    public AeroLifeSupport clone() {
-    	AeroLifeSupport clone = new AeroLifeSupport(getUnitTonnage(), cost, fighter, campaign);
+
+    @Override
+    public AeroLifeSupport copy() {
+        AeroLifeSupport clone = new AeroLifeSupport(getUnitTonnage(), cost, fighter, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
-        
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		int priorHits = hits;

--- a/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
@@ -62,13 +62,14 @@ public class AeroSensor extends Part {
         this.name = "Aerospace Sensors";
         this.largeCraft = lc;
     }
-    
-    public AeroSensor clone() {
-    	AeroSensor clone = new AeroSensor(getUnitTonnage(), largeCraft, campaign);
+
+    @Override
+    public AeroSensor copy() {
+        AeroSensor clone = new AeroSensor(getUnitTonnage(), largeCraft, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
-        
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		int priorHits = hits;

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -66,14 +66,15 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         }
 
     }
-    
-    public AmmoStorage clone() {
-    	AmmoStorage storage = new AmmoStorage(0, getType(), shots, campaign);
+
+    @Override
+    public AmmoStorage copy() {
+        AmmoStorage storage = new AmmoStorage(0, getType(), shots, campaign);
         storage.copyBaseData(this);
-    	storage.munition = this.munition;
-    	return storage;
+        storage.munition = this.munition;
+        return storage;
     }
-    
+
     @Override
     public double getTonnage() {
     	if(((AmmoType)type).getKgPerShot() > 0) {

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -73,8 +73,9 @@ public class Armor extends Part implements IAcquisitionWork {
         }
     }
 
-    public Armor clone() {
-    	Armor clone = new Armor(0, type, amount, -1, false, clan, campaign);
+    @Override
+    public Armor copy() {
+        Armor clone = new Armor(0, type, amount, -1, false, clan, campaign);
         clone.copyBaseData(this);
         return clone;
     }

--- a/MekHQ/src/mekhq/campaign/parts/Avionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/Avionics.java
@@ -55,13 +55,14 @@ public class Avionics extends Part {
         super(tonnage, c);
         this.name = "Avionics";
     }
-    
-    public Avionics clone() {
-    	Avionics clone = new Avionics(0, campaign);
+
+    @Override
+    public Avionics copy() {
+        Avionics clone = new Avionics(0, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
-        
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		int priorHits = hits;

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -55,13 +55,14 @@ public class BaArmor extends Armor implements IAcquisitionWork {
         // Amount is used for armor quantity, not tonnage
         super(tonnage, type, points, loc, false, clan, c);
     }
-    
-    public BaArmor clone() {
+
+    @Override
+    public BaArmor copy() {
         BaArmor clone = new BaArmor(0, amount, type, location, clan, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     @Override
     public double getTonnage() {
         return EquipmentType.getBaArmorWeightPerPoint(type, clan) * amount;

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -120,7 +120,8 @@ public class BattleArmorSuit extends Part {
         initializeExtraCostsAndTons();
     }
 
-    public BattleArmorSuit clone() {
+    @Override
+    public BattleArmorSuit copy() {
         BattleArmorSuit clone = new BattleArmorSuit(chassis, model, getUnitTonnage(), trooper, weightClass, groundMP, jumpMP, quad, clan, jumpType, campaign);
         clone.copyBaseData(this);
         clone.alternateCost = this.alternateCost;
@@ -446,7 +447,7 @@ public class BattleArmorSuit extends Part {
                 	addChildPart(part);
                 }
                 if(part instanceof BaArmor && ((BaArmor)part).getLocation() == trooper) {
-                    BaArmor armorClone = (BaArmor)part.clone();
+                    BaArmor armorClone = (BaArmor)part.copy();
                     armorClone.setAmount(((BaArmor)part).getAmount());
 	                armorClone.setParentPartId(getId());
                     campaign.addPart(armorClone, 0);
@@ -627,13 +628,13 @@ public class BattleArmorSuit extends Part {
     		//find method
 	        for(Part part : newUnit.getParts()) {
 	            if(part instanceof BattleArmorEquipmentPart && ((BattleArmorEquipmentPart)part).getTrooper() == BattleArmor.LOC_TROOPER_1) {
-	                Part newEquip = part.clone();
+	                Part newEquip = part.copy();
 	                newEquip.setParentPartId(getId());
 	                campaign.addPart(newEquip, 0);
 	                addChildPart(newEquip);
 	            }
 	            else if(part instanceof BaArmor && ((BaArmor)part).getLocation() == BattleArmor.LOC_TROOPER_1) {
-	            	BaArmor armorClone = (BaArmor)part.clone();
+	            	BaArmor armorClone = (BaArmor)part.copy();
                     armorClone.setAmount(newUnit.getEntity().getOArmor(BattleArmor.LOC_TROOPER_1));
 	                armorClone.setParentPartId(getId());
                     campaign.addPart(armorClone, 0);

--- a/MekHQ/src/mekhq/campaign/parts/BayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BayDoor.java
@@ -163,7 +163,7 @@ public class BayDoor extends Part {
     }
 
     @Override
-    public Part clone() {
+    public Part copy() {
         Part newPart = new BayDoor(getUnitTonnage(), campaign);
         copyBaseData(newPart);
         return newPart;

--- a/MekHQ/src/mekhq/campaign/parts/Cubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/Cubicle.java
@@ -177,7 +177,7 @@ public class Cubicle extends Part {
     }
 
     @Override
-    public Part clone() {
+    public Part copy() {
         Part part = new Cubicle(getUnitTonnage(), bayType, campaign);
         copyBaseData(part);
         return part;

--- a/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
+++ b/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
@@ -73,14 +73,15 @@ public class DropshipDockingCollar extends Part {
             name += " (Prototype)";
         }
     }
-    
-    public DropshipDockingCollar clone() {
-    	DropshipDockingCollar clone = new DropshipDockingCollar(getUnitTonnage(), campaign, collarType);
+
+    @Override
+    public DropshipDockingCollar copy() {
+        DropshipDockingCollar clone = new DropshipDockingCollar(getUnitTonnage(), campaign, collarType);
         clone.copyBaseData(this);
         clone.boomDamaged = boomDamaged;
-    	return clone;
+        return clone;
     }
-    
+
     public int getCollarType() {
         return collarType;
     }

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -63,11 +63,12 @@ public class EnginePart extends Part {
 		this.name = engine.getEngineName() + " Engine";
 	}
 
-	public EnginePart clone() {
-		EnginePart clone = new EnginePart(getUnitTonnage(), new Engine(engine.getRating(), engine.getEngineType(), engine.getFlags()), campaign, forHover);
+    @Override
+    public EnginePart copy() {
+        EnginePart clone = new EnginePart(getUnitTonnage(), new Engine(engine.getRating(), engine.getEngineType(), engine.getFlags()), campaign, forHover);
         clone.copyBaseData(this);
-		return clone;
-	}
+        return clone;
+    }
 
 	public Engine getEngine() {
 		return engine;

--- a/MekHQ/src/mekhq/campaign/parts/FireControlSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/FireControlSystem.java
@@ -58,13 +58,14 @@ public class FireControlSystem extends Part {
         this.cost = cost;
         this.name = "Fire Control System";
     }
-        
-    public FireControlSystem clone() {
-    	FireControlSystem clone = new FireControlSystem(0, cost, campaign);
+
+    @Override
+    public FireControlSystem copy() {
+        FireControlSystem clone = new FireControlSystem(0, cost, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
-    
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		int priorHits = hits;

--- a/MekHQ/src/mekhq/campaign/parts/InfantryArmorPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryArmorPart.java
@@ -342,12 +342,12 @@ public class InfantryArmorPart extends Part {
 		}
 	}
 
-	@Override
-	public Part clone() {
-		return new InfantryArmorPart(getUnitTonnage(), campaign, damageDivisor, encumbering, dest, sneak_camo, sneak_ecm, sneak_ir, spaceSuit);
-	}
-	
-	@Override
+    @Override
+    public Part copy() {
+        return new InfantryArmorPart(getUnitTonnage(), campaign, damageDivisor, encumbering, dest, sneak_camo, sneak_ecm, sneak_ir, spaceSuit);
+    }
+
+    @Override
     public boolean needsMaintenance() {
         return false;
     }

--- a/MekHQ/src/mekhq/campaign/parts/InfantryMotiveType.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryMotiveType.java
@@ -202,11 +202,11 @@ public class InfantryMotiveType extends Part {
 		}
 	}
 
-	@Override
-	public Part clone() {
-		return new InfantryMotiveType(0, campaign, mode);
-	}
-	
+    @Override
+    public Part copy() {
+        return new InfantryMotiveType(0, campaign, mode);
+    }
+
 	public EntityMovementMode getMovementMode() {
 		return mode;
 	}

--- a/MekHQ/src/mekhq/campaign/parts/LandingGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/LandingGear.java
@@ -54,13 +54,14 @@ public class LandingGear extends Part {
         super(tonnage, c);
         this.name = "Landing Gear";
     }
-        
-    public LandingGear clone() {
-    	LandingGear clone = new LandingGear(0, campaign);
+
+    @Override
+    public LandingGear copy() {
+        LandingGear clone = new LandingGear(0, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
-    
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		int priorHits = hits;

--- a/MekHQ/src/mekhq/campaign/parts/MekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekActuator.java
@@ -61,13 +61,14 @@ public class MekActuator extends Part {
 	public MekActuator() {
 		this(0, 0, null);
 	}
-	
-	public MekActuator clone() {
-		MekActuator clone = new MekActuator(getUnitTonnage(), type, location, campaign);
+
+    @Override
+    public MekActuator copy() {
+        MekActuator clone = new MekActuator(getUnitTonnage(), type, location, campaign);
         clone.copyBaseData(this);
-		return clone;
-	}
-	
+        return clone;
+    }
+
     public int getType() {
         return type;
     }

--- a/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
@@ -55,13 +55,14 @@ public class MekCockpit extends Part {
         this.name = Mech.getCockpitDisplayString(type);
         this.isClan = isClan;
     }
-	
-	public MekCockpit clone() {
-		MekCockpit clone = new MekCockpit(getUnitTonnage(), type, isClan, campaign);
+
+    @Override
+    public MekCockpit copy() {
+        MekCockpit clone = new MekCockpit(getUnitTonnage(), type, isClan, campaign);
         clone.copyBaseData(this);
-		return clone;
-	}
-	
+        return clone;
+    }
+
 	@Override
 	public double getTonnage() {
 		switch (type) {

--- a/MekHQ/src/mekhq/campaign/parts/MekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekGyro.java
@@ -62,10 +62,11 @@ public class MekGyro extends Part {
         this.isClan = isClan;
     }
 
-    public MekGyro clone() {
-    	MekGyro clone = new MekGyro(getUnitTonnage(), type, gyroTonnage, isClan, campaign);
+    @Override
+    public MekGyro copy() {
+        MekGyro clone = new MekGyro(getUnitTonnage(), type, gyroTonnage, isClan, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
 
     public int getType() {

--- a/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
@@ -48,13 +48,14 @@ public class MekLifeSupport extends Part {
         super(tonnage, c);
         this.name = "Mech Life Support System";
     }
-	
-	public MekLifeSupport clone() {
-		MekLifeSupport clone = new MekLifeSupport(getUnitTonnage(), campaign);
+
+    @Override
+    public MekLifeSupport copy() {
+        MekLifeSupport clone = new MekLifeSupport(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
-		return clone;
-	}
-	
+        return clone;
+    }
+
 	@Override
 	public double getTonnage() {
 		//TODO: what should this tonnage be?

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -63,17 +63,17 @@ public class MekLocation extends Part {
     public MekLocation() {
     	this(0, 0, 0, false, false, false, false, false, null);
     }
-    
-    public MekLocation clone() {
-    	MekLocation clone = new MekLocation(loc, getUnitTonnage(), structureType, clan,
-    	        tsm, forQuad, sensors, lifeSupport, campaign);
+
+    @Override
+    public MekLocation copy() {
+        MekLocation clone = new MekLocation(loc, getUnitTonnage(), structureType, clan, tsm, forQuad, sensors, lifeSupport, campaign);
         clone.copyBaseData(this);
-    	clone.percent = this.percent;
-    	clone.breached = this.breached;
-    	clone.blownOff = this.blownOff;
-    	return clone;
+        clone.percent = this.percent;
+        clone.breached = this.breached;
+        clone.blownOff = this.blownOff;
+        return clone;
     }
-    
+
     public int getLoc() {
         return loc;
     }

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -50,11 +50,12 @@ public class MekSensor extends Part {
         this.name = "Mech Sensors";
     }
 
-	public MekSensor clone() {
-		MekSensor clone = new MekSensor(getUnitTonnage(), campaign);
+    @Override
+    public MekSensor copy() {
+        MekSensor clone = new MekSensor(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
-		return clone;
-	}
+        return clone;
+    }
 
 	@Override
 	public double getTonnage() {

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -227,7 +227,7 @@ public class MissingBattleArmorSuit extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-        	BattleArmorSuit newSuit = (BattleArmorSuit)replacement.clone();
+        	BattleArmorSuit newSuit = (BattleArmorSuit)replacement.copy();
             //lets also clone the subparts
             unit.addPart(newSuit);
             //this is admittedly hacky, but lets go ahead and add something to the newSuit
@@ -262,7 +262,7 @@ public class MissingBattleArmorSuit extends MissingPart {
         			for(MissingBattleArmorEquipmentPart p : missingStuff) {
 	            		if(null != childPart && null != p.getUnit() && p.isAcceptableReplacement(childPart, false)) {
 	            			//then add child part and remove current part from unit and campaign
-	            			Part newPart = childPart.clone();
+	            			Part newPart = childPart.copy();
 	            			unit.addPart(newPart);
 	            			((EquipmentPart)newPart).setEquipmentNum(p.getEquipmentNum());
 	                        ((BattleArmorEquipmentPart)newPart).setTrooper(trooper);

--- a/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
@@ -68,7 +68,7 @@ public class MissingBayDoor extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement = replacement.clone();
+            Part actualReplacement = replacement.copy();
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
@@ -95,7 +95,7 @@ public class MissingCubicle extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement = replacement.clone();
+            Part actualReplacement = replacement.copy();
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
@@ -116,7 +116,7 @@ public class MissingMekActuator extends MissingPart {
 	public void fix() {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
-			Part actualReplacement = replacement.clone();
+			Part actualReplacement = replacement.copy();
 			unit.addPart(actualReplacement);
 			campaign.addPart(actualReplacement, 0);
 			replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -283,7 +283,7 @@ public class MissingMekLocation extends MissingPart {
 	public void fix() {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
-			Part actualReplacement = replacement.clone();
+			Part actualReplacement = replacement.copy();
 			unit.addPart(actualReplacement);
 			campaign.addPart(actualReplacement, 0);
 			replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -55,12 +55,13 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 	public MissingPart(int tonnage, boolean isOmniPodded, Campaign c) {
 		super(tonnage, isOmniPodded, c);
 	}
-	
-	public MissingPart clone() {
-		//should never be called
-		return null;
-	}
-	
+
+    @Override
+    public MissingPart copy() {
+        // should never be called
+        return null;
+    }
+
 	@Override
 	public long getStickerPrice() {
 		//missing parts aren't worth a thing
@@ -133,7 +134,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 	public void fix() {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
-			Part actualReplacement = replacement.clone();
+			Part actualReplacement = replacement.copy();
 			unit.addPart(actualReplacement);
 			campaign.addPart(actualReplacement, 0);
 			replacement.decrementQuantity();
@@ -395,7 +396,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		UUID teamId = getTeamId();
 		if(null != replacement && null != teamId) {
 			if(replacement.getQuantity() > 1) {
-				Part actualReplacement = replacement.clone();
+				Part actualReplacement = replacement.copy();
 				actualReplacement.setReserveId(teamId);
 				campaign.addPart(actualReplacement, 0);
 				replacementId = actualReplacement.getId();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
@@ -128,7 +128,7 @@ public class MissingProtomekArmActuator extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement = replacement.clone();
+            Part actualReplacement = replacement.copy();
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekJumpJet.java
@@ -111,7 +111,7 @@ public class MissingProtomekJumpJet extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement = replacement.clone();
+            Part actualReplacement = replacement.copy();
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLegActuator.java
@@ -99,7 +99,7 @@ public class MissingProtomekLegActuator extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement = replacement.clone();
+            Part actualReplacement = replacement.copy();
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
@@ -249,7 +249,7 @@ public class MissingProtomekLocation extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement = replacement.clone();
+            Part actualReplacement = replacement.copy();
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekSensor.java
@@ -99,7 +99,7 @@ public class MissingProtomekSensor extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement = replacement.clone();
+            Part actualReplacement = replacement.copy();
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingQuadVeeGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingQuadVeeGear.java
@@ -75,7 +75,7 @@ public class MissingQuadVeeGear extends MissingPart {
 
     @Override
     public double getTonnage() {
-        return Math.ceil(unitTonnage / 10);
+        return Math.ceil(unitTonnage / 10f);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingThrusters.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingThrusters.java
@@ -87,7 +87,7 @@ public class MissingThrusters extends MissingPart {
 	public void fix() {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
-			Part actualReplacement = replacement.clone();
+			Part actualReplacement = replacement.copy();
 			unit.addPart(actualReplacement);
 			campaign.addPart(actualReplacement, 0);
 			replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
@@ -110,7 +110,7 @@ public class MissingVeeStabiliser extends MissingPart {
 	public void fix() {
 		VeeStabiliser replacement = (VeeStabiliser)findReplacement(false);
 		if(null != replacement) {
-			VeeStabiliser actualReplacement = replacement.clone();
+			VeeStabiliser actualReplacement = replacement.copy();
 			unit.addPart(actualReplacement);
 			campaign.addPart(actualReplacement, 0);
 			replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
@@ -66,13 +66,14 @@ public class MotiveSystem extends Part {
 	public int getDifficulty() {
 		return -1;
 	}
-	
-	public MotiveSystem clone() {
-		MotiveSystem clone = new MotiveSystem(getUnitTonnage(), campaign);
+
+    @Override
+    public MotiveSystem copy() {
+        MotiveSystem clone = new MotiveSystem(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
         return clone;
-	}
-	
+    }
+
 	@Override
 	public int getBaseAvailability(int era) {
 		return RATING_B;

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -231,8 +231,8 @@ public class OmniPod extends Part {
     
     @Override
     public void fix() {
-        Part newPart = partType.clone();
-        Part oldPart = campaign.checkForExistingSparePart(newPart.clone());
+        Part newPart = partType.copy();
+        Part oldPart = campaign.checkForExistingSparePart(newPart.copy());
         if(null != oldPart) {
             newPart.setOmniPodded(true);
             campaign.addPart(newPart, 0);
@@ -320,7 +320,7 @@ public class OmniPod extends Part {
     }
 
     @Override
-    public Part clone() {
+    public Part copy() {
         Part p = new OmniPod(partType, campaign);
         p.copyBaseData(this);
         return p;

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1165,8 +1165,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 		shorthandedMod = i;
 	}
 
-	@Override
-	public abstract Part clone();
+    public abstract Part copy();
 
     protected void copyBaseData(Part part) {
         this.mode = part.mode;

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -19,7 +19,6 @@
 
 package mekhq.campaign.parts;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -47,10 +46,8 @@ import mekhq.campaign.work.IPartWork;
  * @author Neoancient
  *
  */
-public class PodSpace implements Serializable, IPartWork {
+public class PodSpace implements IPartWork {
 
-    private static final long serialVersionUID = -9022671736030862210L;
-    
     protected Campaign campaign;
     protected Unit unit;
     protected int location;

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -59,11 +59,7 @@ public class PodSpace implements IPartWork {
     protected int shorthandedMod = 0;
     
     protected boolean repairInPlace = false;
-    
-    public PodSpace() {
-        this(Entity.LOC_NONE, null);
-    }
-    
+
     public PodSpace(int location, Unit unit) {
         this.location = location;
         this.unit = unit;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
@@ -47,13 +47,14 @@ public class ProtomekArmActuator extends Part {
     public ProtomekArmActuator() {
         this(0, 0, null);
     }
-    
-    public ProtomekArmActuator clone() {
+
+    @Override
+    public ProtomekArmActuator copy() {
         ProtomekArmActuator clone = new ProtomekArmActuator(getUnitTonnage(), location, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     public ProtomekArmActuator(int tonnage, Campaign c) {
         this(tonnage, -1, c);
     }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
@@ -41,14 +41,14 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
         super(tonnage, -1, points, loc, false, clan, c);
         this.name = "Protomech Armor";
     }
-    
+
     @Override
-    public ProtomekArmor clone() {
+    public ProtomekArmor copy() {
         ProtomekArmor clone = new ProtomekArmor(0, 0, amount, clan, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     @Override
     public double getTonnage() {
         return 50 * amount/1000.0;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
@@ -51,7 +51,8 @@ public class ProtomekJumpJet extends Part {
         this(0, null);
     }
 
-    public ProtomekJumpJet clone() {
+    @Override
+    public ProtomekJumpJet copy() {
         ProtomekJumpJet clone = new ProtomekJumpJet(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
         return clone;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
@@ -44,12 +44,12 @@ public class ProtomekLegActuator extends Part {
         this(0, null);
     }
 
-    public ProtomekLegActuator clone() {
+    @Override
+    public ProtomekLegActuator copy() {
         ProtomekLegActuator clone = new ProtomekLegActuator(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
         return clone;
     }
-
 
     public ProtomekLegActuator(int tonnage, Campaign c) {
         super(tonnage, c);

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
@@ -107,7 +107,8 @@ public class ProtomekLocation extends Part {
         }
     }
 
-    public ProtomekLocation clone() {
+    @Override
+    public ProtomekLocation copy() {
         ProtomekLocation clone = new ProtomekLocation(loc, getUnitTonnage(), structureType, booster, forQuad, campaign);
         clone.copyBaseData(this);
         clone.percent = this.percent;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
@@ -44,12 +44,12 @@ public class ProtomekSensor extends Part {
         this(0, null);
     }
 
-    public ProtomekSensor clone() {
+    @Override
+    public ProtomekSensor copy() {
         ProtomekSensor clone = new ProtomekSensor(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
         return clone;
     }
-
 
     public ProtomekSensor(int tonnage, Campaign c) {
         super(tonnage, c);

--- a/MekHQ/src/mekhq/campaign/parts/QuadVeeGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/QuadVeeGear.java
@@ -44,8 +44,9 @@ public class QuadVeeGear extends Part {
         super(tonnage, c);
         this.name = "Conversion Gear";
     }
-    
-    public QuadVeeGear clone() {
+
+    @Override
+    public QuadVeeGear copy() {
         QuadVeeGear clone = new QuadVeeGear(0, campaign);
         clone.copyBaseData(this);
         return clone;

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -722,17 +722,17 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 		        // If the number changes we need to add them to either the warehouse at the end of
 		        // refit or the shopping list at the beginning.
                 for (int i = 0; i < oldCount - newCount; i++) {
-                    oldIntegratedHS.add(oldHS.clone());
+                    oldIntegratedHS.add(oldHS.copy());
                 }
                 for (int i = 0; i < newCount - oldCount; i++) {
-                    newIntegratedHS.add(oldHS.clone());
+                    newIntegratedHS.add(oldHS.copy());
                 }
 		    } else {
                 for (int i = 0; i < oldCount; i++) {
-                    oldIntegratedHS.add(oldHS.clone());
+                    oldIntegratedHS.add(oldHS.copy());
                 }
                 for (int i = 0; i < newCount; i++) {
-                    newIntegratedHS.add(newHS.clone());
+                    newIntegratedHS.add(newHS.copy());
                 }
                 updateRefitClass(CLASS_D);
 		    }
@@ -751,10 +751,10 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 		    if (oldHS != newHS) {
 		        Part hsPart = heatSinkPart(newEntity); // only single HS allowed, so they have to be of the same type
                 for (int i = oldHS; i < newHS; i++) {
-                    newIntegratedHS.add(hsPart.clone());
+                    newIntegratedHS.add(hsPart.copy());
                 }
                 for (int i = newHS; i < oldHS; i++) {
-                    oldIntegratedHS.add(hsPart.clone());
+                    oldIntegratedHS.add(hsPart.copy());
                 }
 		    }
 		}
@@ -951,7 +951,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 			if(newPart.isSpare()) {
 				if(newPart.getQuantity() > 1) {
 					newPart.decrementQuantity();
-					newPart = newPart.clone();
+					newPart = newPart.copy();
 					newPart.setRefitId(oldUnit.getId());
 					oldUnit.campaign.addPart(newPart, 0);
 					newNewUnitParts.add(newPart.getId());
@@ -1001,7 +1001,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 			    }
 			    if(null != replacement) {
 			        if(replacement.getQuantity() > 1) {
-			            Part actualReplacement = replacement.clone();
+			            Part actualReplacement = replacement.copy();
 			            actualReplacement.setRefitId(oldUnit.getId());
 			            oldUnit.campaign.addPart(actualReplacement, 0);
 			            newUnitParts.add(actualReplacement.getId());
@@ -2291,7 +2291,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
     }
 
     @Override
-    public Part clone() {
+    public Part copy() {
         // TODO Auto-generated method stub
         return null;
     }

--- a/MekHQ/src/mekhq/campaign/parts/Rotor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Rotor.java
@@ -49,16 +49,17 @@ public class Rotor extends TankLocation {
         this.name = "Rotor";
         this.damage = 0;
     }
-    
-    public Rotor clone() {
-    	Rotor clone = new Rotor(getUnitTonnage(), campaign);
+
+    @Override
+    public Rotor copy() {
+        Rotor clone = new Rotor(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
-    	clone.loc = this.loc;
-    	clone.damage = this.damage;
-    	clone.breached = this.breached;
-    	return clone;
+        clone.loc = this.loc;
+        clone.damage = this.damage;
+        clone.breached = this.breached;
+        return clone;
     }
- 
+
     @Override
     public boolean isSamePartType(Part part) {
         return part instanceof Rotor 

--- a/MekHQ/src/mekhq/campaign/parts/SpacecraftEngine.java
+++ b/MekHQ/src/mekhq/campaign/parts/SpacecraftEngine.java
@@ -65,13 +65,14 @@ public class SpacecraftEngine extends Part {
 		this.clan = clan;
 		this.name = "Spacecraft Engine";
 	}
-	
-	public SpacecraftEngine clone() {
-		SpacecraftEngine clone = new SpacecraftEngine(getUnitTonnage(), engineTonnage, campaign, clan);
+
+    @Override
+    public SpacecraftEngine copy() {
+        SpacecraftEngine clone = new SpacecraftEngine(getUnitTonnage(), engineTonnage, campaign, clan);
         clone.copyBaseData(this);
-		return clone;
-	}
-	
+        return clone;
+    }
+
 	@Override
 	public double getTonnage() {
 		return engineTonnage;

--- a/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
+++ b/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
@@ -74,15 +74,15 @@ public class StructuralIntegrity extends Part {
 		pointsNeeded = 0;
 		this.name = "Structural Integrity";
 	}
-	
-	public StructuralIntegrity clone() {
-		StructuralIntegrity clone = new StructuralIntegrity(getUnitTonnage(), campaign);
+
+    @Override
+    public StructuralIntegrity copy() {
+        StructuralIntegrity clone = new StructuralIntegrity(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
-		clone.pointsNeeded = this.pointsNeeded;
-		return clone;
-	}
-	
-	
+        clone.pointsNeeded = this.pointsNeeded;
+        return clone;
+    }
+
 	@Override
 	public long getStickerPrice() {
 		if(null != unit && unit.getEntity() instanceof Aero) {

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -59,16 +59,17 @@ public class TankLocation extends Part {
     public TankLocation() {
     	this(0, 0, null);
     }
-    
-    public TankLocation clone() {
-    	TankLocation clone = new TankLocation(loc, getUnitTonnage(), campaign);
+
+    @Override
+    public TankLocation copy() {
+        TankLocation clone = new TankLocation(loc, getUnitTonnage(), campaign);
         clone.copyBaseData(this);
-    	clone.loc = this.loc;
-    	clone.damage = this.damage;
-    	clone.breached = this.breached;
-    	return clone;
+        clone.loc = this.loc;
+        clone.damage = this.damage;
+        clone.breached = this.breached;
+        return clone;
     }
-    
+
     public int getLoc() {
         return loc;
     }

--- a/MekHQ/src/mekhq/campaign/parts/Thrusters.java
+++ b/MekHQ/src/mekhq/campaign/parts/Thrusters.java
@@ -61,13 +61,14 @@ public class Thrusters extends Part {
         isLeftThrusters = left;
         this.name = "Thrusters";
     }
-    
-    public Thrusters clone() {
-    	Thrusters clone = new Thrusters(0, campaign, isLeftThrusters);
+
+    @Override
+    public Thrusters copy() {
+        Thrusters clone = new Thrusters(0, campaign, isLeftThrusters);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
-        
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		if(null != unit && unit.getEntity() instanceof Aero) {

--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -240,7 +240,7 @@ public class TransportBayPart extends Part {
     }
 
     @Override
-    public Part clone() {
+    public Part copy() {
         // TODO Auto-generated method stub
         return null;
     }

--- a/MekHQ/src/mekhq/campaign/parts/Turret.java
+++ b/MekHQ/src/mekhq/campaign/parts/Turret.java
@@ -56,16 +56,17 @@ public class Turret extends TankLocation {
     	weight = 0;
     	this.name = "Turret";
     }
-    
-    public Turret clone() {
-    	Turret clone = new Turret(0, getUnitTonnage(), weight, campaign);
+
+    @Override
+    public Turret copy() {
+        Turret clone = new Turret(0, getUnitTonnage(), weight, campaign);
         clone.copyBaseData(this);
-    	clone.loc = this.loc;
-    	clone.damage = this.damage;
-    	clone.breached = this.breached;
-    	return clone;
+        clone.loc = this.loc;
+        clone.damage = this.damage;
+        clone.breached = this.breached;
+        return clone;
     }
-    
+
     public Turret(int loc, int tonnage, double weight, Campaign c) {
         super(loc, tonnage, c);
         this.weight = weight;

--- a/MekHQ/src/mekhq/campaign/parts/TurretLock.java
+++ b/MekHQ/src/mekhq/campaign/parts/TurretLock.java
@@ -55,13 +55,14 @@ public class TurretLock extends Part {
 	public int getDifficulty() {
 		return -1;
 	}
-	
-	public TurretLock clone() {
-		TurretLock clone = new TurretLock(campaign);
+
+    @Override
+    public TurretLock copy() {
+        TurretLock clone = new TurretLock(campaign);
         clone.copyBaseData(this);
         return clone;
-	}
-	
+    }
+
 	@Override
 	public long getStickerPrice() {
 		return 0;

--- a/MekHQ/src/mekhq/campaign/parts/VeeSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeSensor.java
@@ -48,12 +48,13 @@ public class VeeSensor extends Part {
         this.name = "Vehicle Sensors";
     }
 
-	public VeeSensor clone() {
-		VeeSensor clone = new VeeSensor(getUnitTonnage(), campaign);
+    @Override
+    public VeeSensor copy() {
+        VeeSensor clone = new VeeSensor(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
-		return clone;
-	}
-	
+        return clone;
+    }
+
     @Override
     public boolean isSamePartType(Part part) {
         return part instanceof VeeSensor;

--- a/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
@@ -52,12 +52,13 @@ public class VeeStabiliser extends Part {
         this.loc = loc;
         this.name = "Vehicle Stabiliser";
     }
-	
-	public VeeStabiliser clone() {
-		VeeStabiliser clone = new VeeStabiliser(getUnitTonnage(), 0, campaign);
+
+    @Override
+    public VeeStabiliser copy() {
+        VeeStabiliser clone = new VeeStabiliser(getUnitTonnage(), 0, campaign);
         clone.copyBaseData(this);
-		return clone;
-	}
+        return clone;
+    }
 
     @Override
     public boolean isSamePartType(Part part) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -90,15 +90,15 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         }
     }
 
-    public AmmoBin clone() {
-        AmmoBin clone = new AmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), shotsNeeded, oneShot,
-                omniPodded, campaign);
+    @Override
+    public AmmoBin copy() {
+        AmmoBin clone = new AmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), shotsNeeded, oneShot, omniPodded, campaign);
         clone.copyBaseData(this);
         clone.shotsNeeded = this.shotsNeeded;
         clone.munition = this.munition;
         return clone;
     }
-    
+
     /* Per TM, ammo for fighters is stored in the fuselage. This makes a difference for omnifighter
      * pod space, so we're going to stick them in LOC_NONE where the heat sinks are */ 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
@@ -69,10 +69,11 @@ public class BattleArmorEquipmentPart extends EquipmentPart {
         this.trooper = trooper;
     }
 
-    public EquipmentPart clone() {
+    @Override
+    public EquipmentPart copy() {
         BattleArmorEquipmentPart clone = new BattleArmorEquipmentPart(getUnitTonnage(), type, equipmentNum, trooper, campaign);
         clone.copyBaseData(this);
-        if(hasVariableTonnage(type)) {
+        if (hasVariableTonnage(type)) {
             clone.setEquipTonnage(equipTonnage);
         }
         return clone;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -114,13 +114,14 @@ public class EquipmentPart extends Part {
     	equipTonnage = ton;
     }
 
-    public EquipmentPart clone() {
-    	EquipmentPart clone = new EquipmentPart(getUnitTonnage(), type, equipmentNum, omniPodded, campaign);
+    @Override
+    public EquipmentPart copy() {
+        EquipmentPart clone = new EquipmentPart(getUnitTonnage(), type, equipmentNum, omniPodded, campaign);
         clone.copyBaseData(this);
-        if(hasVariableTonnage(type)) {
+        if (hasVariableTonnage(type)) {
             clone.setEquipTonnage(equipTonnage);
         }
-    	return clone;
+        return clone;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -567,9 +567,9 @@ public class EquipmentPart extends Part {
                 //int multiplier = entity.locationIsLeg(loc) ? 700 : 500;
                 //costValue = (int) Math.ceil(entity.getWeight() * multiplier);
             } else if (type.hasFlag(MiscType.F_HAND_WEAPON) && (type.hasSubType(MiscType.S_CLAW))) {
-                varCost = (int) Math.ceil(getUnitTonnage() * 200);
+                varCost = getUnitTonnage() * 200;
             } else if (type.hasFlag(MiscType.F_CLUB) && (type.hasSubType(MiscType.S_LANCE))) {
-                varCost = (int) Math.ceil(getUnitTonnage() * 150);
+                varCost = getUnitTonnage() * 150;
             }
 
         }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/HeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/HeatSink.java
@@ -44,13 +44,14 @@ public class HeatSink extends EquipmentPart {
     public HeatSink(int tonnage, EquipmentType et, int equipNum, boolean omniPodded, Campaign c) {
         super(tonnage, et, equipNum, omniPodded, c);
     }
-    
-    public HeatSink clone() {
-    	HeatSink clone = new HeatSink(getUnitTonnage(), getType(), getEquipmentNum(), omniPodded, campaign);
+
+    @Override
+    public HeatSink copy() {
+        HeatSink clone = new HeatSink(getUnitTonnage(), getType(), getEquipmentNum(), omniPodded, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
-    
+
     /**
      * Copied from megamek.common.Entity.getWeaponsAndEquipmentCost(StringBuffer detail, boolean ignoreAmmo)
      *

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryWeaponPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryWeaponPart.java
@@ -48,12 +48,12 @@ public class InfantryWeaponPart extends EquipmentPart {
         super(tonnage, et, equipNum, c);
         primary = p;
     }
-    
+
     @Override
-    public InfantryWeaponPart clone() {
-    	InfantryWeaponPart clone = new InfantryWeaponPart(getUnitTonnage(), getType(), getEquipmentNum(), campaign, primary);
+    public InfantryWeaponPart copy() {
+        InfantryWeaponPart clone = new InfantryWeaponPart(getUnitTonnage(), getType(), getEquipmentNum(), campaign, primary);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
 
 	@Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/JumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/JumpJet.java
@@ -47,13 +47,14 @@ public class JumpJet extends EquipmentPart {
         // account for compatibility)
         super(tonnage, et, equipNum, omniPodded, c);
     }
-    
-    public JumpJet clone() {
-    	JumpJet clone = new JumpJet(getUnitTonnage(), getType(), getEquipmentNum(), omniPodded, campaign);
+
+    @Override
+    public JumpJet copy() {
+        JumpJet clone = new JumpJet(getUnitTonnage(), getType(), getEquipmentNum(), omniPodded, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
-	
+
     @Override
     public double getTonnage() {
         double ton;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -72,13 +72,12 @@ public class LargeCraftAmmoBin extends AmmoBin {
     }
 
     @Override
-    public LargeCraftAmmoBin clone() {
-        LargeCraftAmmoBin clone = new LargeCraftAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(),
-                shotsNeeded, capacity, campaign);
+    public LargeCraftAmmoBin copy() {
+        LargeCraftAmmoBin clone = new LargeCraftAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), shotsNeeded, capacity, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     /**
      * @return The <code>Mounted</code> of the unit's <code>Entity</code> that contains this ammo bin,
      *         or null if there is no unit or the ammo bin is not in any bay.

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
@@ -54,13 +54,14 @@ public class MASC extends EquipmentPart {
         this.engineRating = rating;
         equipTonnage = calculateTonnage();
     }
-    
-    public MASC clone() {
-    	MASC clone = new MASC(getUnitTonnage(), getType(), getEquipmentNum(), campaign, engineRating, omniPodded);
+
+    @Override
+    public MASC copy() {
+        MASC clone = new MASC(getUnitTonnage(), getType(), getEquipmentNum(), campaign, engineRating, omniPodded);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
- 
+
     public void setUnit(Unit u) {
     	super.setUnit(u);
     	if(null != unit && null != unit.getEntity().getEngine()) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -99,7 +99,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
 		    
             //Check to see if munition types are different
 		    if (getType() == ((AmmoBin)replacement).getType()) {
-		        actualReplacement = replacement.clone();
+		        actualReplacement = replacement.copy();
 		    } else {
 		        actualReplacement = new AmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), 
 		                getFullShots(), isOneShot(), isOmniPodded(), campaign);

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
@@ -162,7 +162,7 @@ public class MissingBattleArmorEquipmentPart extends MissingEquipmentPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement = replacement.clone();
+            Part actualReplacement = replacement.copy();
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
@@ -165,7 +165,7 @@ public class MissingEquipmentPart extends MissingPart {
 	public void fix() {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
-			Part actualReplacement = replacement.clone();
+			Part actualReplacement = replacement.copy();
 			unit.addPart(actualReplacement);
 			campaign.addPart(actualReplacement, 0);
 			replacement.decrementQuantity();

--- a/MekHQ/src/mekhq/campaign/personnel/Ancestors.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Ancestors.java
@@ -1,8 +1,10 @@
 package mekhq.campaign.personnel;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.util.UUID;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
@@ -10,14 +12,8 @@ import mekhq.MekHqXmlUtil;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
 
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
+public class Ancestors implements MekHqXmlSerializable {
 
-public class Ancestors implements Serializable, MekHqXmlSerializable {
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = -6350146649504329173L;
 	// UUID
 	private UUID id;
 	private UUID fatherID;

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
@@ -717,10 +717,9 @@ class Fraction {
 		denominator = f.denominator;
 	}
 
-	@Override
-	public Object clone() {
-		return new Fraction(this);
-	}
+    public Fraction copy() {
+        return new Fraction(this);
+    }
 
 	@Override
 	public String toString() {

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
@@ -24,7 +24,6 @@ package mekhq.campaign.personnel;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -45,14 +44,8 @@ import mekhq.MekHqXmlUtil;
 
 /**
  * @author Neoancient
- *
- *
  */
-public class Bloodname implements Serializable {
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = 3958964485520416824L;
+public class Bloodname {
 
 	private static ArrayList<Bloodname> bloodnames;
 

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2714,7 +2714,7 @@ public class Person implements MekHqXmlSerializable {
                 if(!spa.isEligible(this)) {
                     continue;
                 }
-                if(generation & spa.getWeight() <= 0) {
+                if(generation && spa.getWeight() <= 0) {
                     continue;
                 }
                 eligible.add(spa);

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -22,7 +22,6 @@
 package mekhq.campaign.personnel;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -83,15 +82,14 @@ import mekhq.campaign.LogEntry;
 import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.mod.am.InjuryUtil;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Faction;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
-import mekhq.campaign.universe.Faction;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class Person implements Serializable, MekHqXmlSerializable {
-    private static final long serialVersionUID = -847642980395311152L;
+public class Person implements MekHqXmlSerializable {
 
     public static final int G_MALE = 0;
     public static final int G_FEMALE = 1;

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2910,7 +2910,7 @@ public class Person implements MekHqXmlSerializable {
      *         role
      */
     public boolean isCombat() {
-        return isCombatRole(primaryRole) || isCombatRole(primaryRole);
+        return isCombatRole(primaryRole) || isCombatRole(secondaryRole);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -60,13 +60,8 @@ import mekhq.campaign.mission.Mission;
  * in battle.
  *
  */
-public class RetirementDefectionTracker implements Serializable, MekHqXmlSerializable{
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 7245317499458320654L;
-	
+public class RetirementDefectionTracker implements MekHqXmlSerializable{
+
 	/* In case the dialog is closed after making the retirement rolls
 	 * and determining payouts but before the retirees have been paid,
 	 * we store those results to avoid making the rolls again.

--- a/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
@@ -98,7 +98,6 @@ public class SkillPrereq implements MekHqXmlSerializable {
         Enumeration<String> enumKeys = skillset.keys();
         while(enumKeys.hasMoreElements()) {
             String key = enumKeys.nextElement();
-            SkillType.getType(key).getName();
             int lvl = skillset.get(key);
             String skillLvl = "";
             if(lvl >= SkillType.EXP_GREEN) {

--- a/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
@@ -59,14 +59,13 @@ public class SkillPrereq implements MekHqXmlSerializable {
     public SkillPrereq() {
         skillset = new Hashtable<String, Integer>();
     }
-    
-    @SuppressWarnings("unchecked") // FIXME: Broken Java with it's Object clones
-	public SkillPrereq clone() {
-    	SkillPrereq clone = new SkillPrereq();
-    	clone.skillset = (Hashtable<String, Integer>)this.skillset.clone();
-    	return clone;
+
+    public SkillPrereq copy() {
+        SkillPrereq clone = new SkillPrereq();
+        clone.skillset = new Hashtable<>(skillset);
+        return clone;
     }
-    
+
     public boolean isEmpty() {
         return skillset.isEmpty();
     }

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -118,20 +118,19 @@ public class SpecialAbility implements MekHqXmlSerializable {
         weight = 1;
     }
 
-    @SuppressWarnings("unchecked") // FIXME: Broken Java with it's Object clones
-	public SpecialAbility clone() {
-    	SpecialAbility clone = new SpecialAbility(lookupName);
-    	clone.displayName = this.displayName;
-    	clone.desc = this.desc;
-    	clone.xpCost = this.xpCost;
-    	clone.weight = this.weight;
-    	clone.prereqAbilities = (Vector<String>)this.prereqAbilities.clone();
-    	clone.invalidAbilities = (Vector<String>)this.invalidAbilities.clone();
-    	clone.removeAbilities = (Vector<String>)this.removeAbilities.clone();
-    	clone.choiceValues = (Vector<String>)this.choiceValues.clone();
-    	clone.prereqSkills = (Vector<SkillPrereq>)this.prereqSkills.clone();
-    	clone.prereqMisc = new HashMap<>(this.prereqMisc);
-    	return clone;
+    public SpecialAbility copy() {
+        SpecialAbility clone = new SpecialAbility(lookupName);
+        clone.displayName = this.displayName;
+        clone.desc = this.desc;
+        clone.xpCost = this.xpCost;
+        clone.weight = this.weight;
+        clone.prereqAbilities = new Vector<>(prereqAbilities);
+        clone.invalidAbilities = new Vector<>(invalidAbilities);
+        clone.removeAbilities = new Vector<>(removeAbilities);
+        clone.choiceValues = new Vector<>(choiceValues);
+        clone.prereqSkills = new Vector<>(prereqSkills);
+        clone.prereqMisc = new HashMap<>(this.prereqMisc);
+        return clone;
     }
 
     public boolean isEligible(Person p) {
@@ -359,7 +358,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
             if (defaultSpecialAbilities != null && Version.versionCompare(v, "0.3.6-r1965")) {
                 if (defaultSpecialAbilities.get(retVal.lookupName) != null
                         && defaultSpecialAbilities.get(retVal.lookupName).getPrereqSkills() != null) {
-                    retVal.prereqSkills = (Vector<SkillPrereq>) defaultSpecialAbilities.get(retVal.lookupName).getPrereqSkills().clone();
+                    retVal.prereqSkills = new Vector<>(defaultSpecialAbilities.get(retVal.lookupName).getPrereqSkills());
                 }
             }
         }
@@ -676,7 +675,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
 
     @SuppressWarnings("unchecked")
     public static void trackDefaultSPA() {
-        defaultSpecialAbilities = (Hashtable<String, SpecialAbility>)specialAbilities.clone();
+        defaultSpecialAbilities = new Hashtable<>(specialAbilities);
     }
 
     public static void nullifyDefaultSPA() {

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -247,9 +247,6 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         int totalBattleArmor = 0;
         int forceTotal;
 
-        // Count total units for transport
-        getTotalCombatUnits();
-
         List<Unit> unitList = getCampaign().getCopyOfUnits();
         for (Unit u : unitList) {
             if (u == null) {

--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -13,7 +13,6 @@ import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.parts.Refit;
 import mekhq.campaign.personnel.Person;
 
 /**
@@ -40,7 +39,7 @@ public class MothballInfo implements MekHqXmlSerializable {
         gunnerIDs = new ArrayList<>();
         vesselCrewIDs = new ArrayList<>();
     }
-    
+
     /**
      * Creates a set of mothball info for a given unit
      * @param unit The unit to work with
@@ -48,13 +47,13 @@ public class MothballInfo implements MekHqXmlSerializable {
     public MothballInfo(Unit unit) {
         techID = unit.getTechId();
         forceID = unit.getForceId();
-        driverIDs = (List<UUID>) unit.getDriverIDs().clone();
-        gunnerIDs = (List<UUID>) unit.getGunnerIDs().clone();
-        vesselCrewIDs = (List<UUID>) unit.getVesselCrewIDs().clone();
+        driverIDs = new ArrayList<>(unit.getDriverIDs());
+        gunnerIDs = new ArrayList<>(unit.getGunnerIDs());
+        vesselCrewIDs = new ArrayList<>(unit.getVesselCrewIDs());
         techOfficerID = unit.getTechOfficerID();
         navigatorID = unit.getNavigatorID();
     }
-    
+
     /**
      * Restore a unit's pilot, assigned tech and force, to the best of our ability
      * @param unit The unit to restore

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1173,20 +1173,20 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 }
 
                 // fuel tanks
-                partsValue += 200 * js.getFuel() / js.getFuelPerTon();
+                partsValue += 200L * js.getFuel() / js.getFuelPerTon();
 
                 // armor
                 partsValue += js.getArmorWeight(js.locations()) * EquipmentType.getArmorCost(js.getArmorType(0));
 
                 // heat sinks
-                int sinkCost = 2000 + 4000 * js.getHeatType();// == HEAT_DOUBLE ? 6000:
+                long sinkCost = 2000 + 4000l * js.getHeatType();// == HEAT_DOUBLE ? 6000:
                                                            // 2000;
                 partsValue += sinkCost * js.getHeatSinks();
 
                 // grav deck
-                partsValue += 5000000 * js.getGravDeck();
-                partsValue += 10000000 * js.getGravDeckLarge();
-                partsValue += 40000000 * js.getGravDeckHuge();
+                partsValue += 5000000l  * js.getGravDeck();
+                partsValue += 10000000l * js.getGravDeckLarge();
+                partsValue += 40000000l * js.getGravDeckHuge();
 
                 // get bays
                 int baydoors = 0;

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1179,14 +1179,14 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 partsValue += js.getArmorWeight(js.locations()) * EquipmentType.getArmorCost(js.getArmorType(0));
 
                 // heat sinks
-                long sinkCost = 2000 + 4000l * js.getHeatType();// == HEAT_DOUBLE ? 6000:
+                long sinkCost = 2000L + 4000L * js.getHeatType();// == HEAT_DOUBLE ? 6000:
                                                            // 2000;
                 partsValue += sinkCost * js.getHeatSinks();
 
                 // grav deck
-                partsValue += 5000000l  * js.getGravDeck();
-                partsValue += 10000000l * js.getGravDeckLarge();
-                partsValue += 40000000l * js.getGravDeckHuge();
+                partsValue += 5000000L  * js.getGravDeck();
+                partsValue += 10000000L * js.getGravDeckLarge();
+                partsValue += 40000000L * js.getGravDeckHuge();
 
                 // get bays
                 int baydoors = 0;

--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
@@ -124,24 +124,23 @@ public class UnitTechProgression {
         }
         return null;
     }
-    
+
     private static ITechnology calcTechProgression(MechSummary ms, int techFaction) {
-        final String METHOD_NAME = "calcTechProgression(MechSummary, int)"; // $NON-NLS-1$
+        final String METHOD_NAME = "calcTechProgression(MechSummary, int)"; //$NON-NLS-1$
         try {
             Entity en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
             if (null == en) {
-                MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR,
-                        "Entity was null: " + ms.getName());
+                MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR, "Entity was null: " + ms.getName());
+                return null;
             }
             return en.factionTechLevel(techFaction);
         } catch (EntityLoadingException ex) {
-            MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR,
-                    "Exception loading entity " + ms.getName());
+            MekHQ.getLogger().log(BuildMapTask.class, METHOD_NAME, LogLevel.ERROR, "Exception loading entity " + ms.getName());
             MekHQ.getLogger().error(BuildMapTask.class, METHOD_NAME, ex);
             return null;
         }
     }
-    
+
     /**
      * Goes through all the entries in MechSummaryCache, loads them, and calculates the composite
      * tech level of all the equipment and construction options for a specific faction.

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -22,7 +22,6 @@
 
 package mekhq.campaign.universe;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,8 +74,7 @@ import mekhq.campaign.universe.Faction.Tag;
  */
 @XmlRootElement(name="planet")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class Planet implements Serializable {
-    private static final long serialVersionUID = -8699502165157515100L;
+public class Planet {
 
     // Star classification data and methods
     

--- a/MekHQ/src/mekhq/campaign/universe/StarUtil.java
+++ b/MekHQ/src/mekhq/campaign/universe/StarUtil.java
@@ -202,12 +202,14 @@ public final class StarUtil {
 
     private static final double[] RECHARGE_HOURS_CLASS_T = {
             7973.0, 13371.0, 21315.0, 35876.0, 70424.0, 134352.0, 215620.0, 32188.0, 569703.0, 892922.0, 10000000.0};
-    
-    private static final Set<String> VALID_WHITE_DWARF_SUBCLASSES = new TreeSet<String>();
+
+    private static final Set<String> VALID_WHITE_DWARF_SUBCLASSES = new TreeSet<>();
     static {
-        VALID_WHITE_DWARF_SUBCLASSES.addAll(Arrays.asList("", //$NON-NLS-1$
-            "A,B,O,Q,Z,AB,AO,AQ,AZ,BO,BQ,BZ,QZ,ABO,ABQ,ABZ,AOQ,AOZ,AQZ,BOQ," //$NON-NLS-1$
-            + "BOZ,BQZ,OQZ,ABOQ,ABOZ,ABQZ,AOQZ,BOQZ,ABOQZ,C,X".split(","))); //$NON-NLS-1$ //$NON-NLS-2$
+        VALID_WHITE_DWARF_SUBCLASSES.add(""); //$NON-NLS-1$
+        String csvSubclasses = "A,B,O,Q,Z,AB,AO,AQ,AZ,BO,BQ,BZ,QZ,ABO,ABQ,ABZ," //$NON-NLS-1$
+                             + "AOQ,AOZ,AQZ,BOQ,BOZ,BQZ,OQZ,ABOQ,ABOZ,ABQZ," //$NON-NLS-1$
+                             + "AOQZ,BOQZ,ABOQZ,C,X"; //$NON-NLS-1$
+        VALID_WHITE_DWARF_SUBCLASSES.addAll(Arrays.asList(csvSubclasses.split(","))); //$NON-NLS-1$
     }
 
     private static final String ICON_DATA_FILE = "images/universe/planet_icons.txt";
@@ -446,7 +448,7 @@ public final class StarUtil {
             // main class
             return String.format(Locale.ROOT, "%s" + subtypeFormat + "%s", //$NON-NLS-1$ //$NON-NLS-2$
                     getSpectralClassName(spectralClass),
-                    subtypeValue / 100.0, (null != luminosity ? luminosity : Planet.LUM_V));
+                    subtypeValue / 100.0, luminosity);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2218,6 +2218,7 @@ public class CampaignGUI extends JPanel {
                 xmlDoc = db.parse(fis);
             } catch (Exception ex) {
                 MekHQ.getLogger().error(getClass(), METHOD_NAME, ex); //$NON-NLS-1$
+                throw new RuntimeException(ex);
             }
 
             Element personnelEle = xmlDoc.getDocumentElement();
@@ -2257,11 +2258,9 @@ public class CampaignGUI extends JPanel {
                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR, //$NON-NLS-1$
                             "ERROR: Cannot load person who exists, ignoring. (Name: " //$NON-NLS-1$
                             + p.getFullName() + ")"); //$NON-NLS-1$
-                    p = null;
+                    return;
                 }
-                if (p != null) {
-                    getCampaign().addPersonWithoutId(p, true);
-                }
+                getCampaign().addPersonWithoutId(p, true);
 
                 // Clear some values we no longer should have set in case this
                 // has transferred campaigns or things in the campaign have

--- a/MekHQ/src/mekhq/gui/FileDialogs.java
+++ b/MekHQ/src/mekhq/gui/FileDialogs.java
@@ -56,7 +56,7 @@ public class FileDialogs {
      */
     public static Optional<File> savePersonnel(JFrame frame, Campaign campaign) {
 
-        String fileName = String.format( "%s%_ExportedPersonnel.prsx", //$NON-NLS-1$
+        String fileName = String.format( "%s%s_ExportedPersonnel.prsx", //$NON-NLS-1$
                                          campaign.getName(),
                                          campaign.getShortDateAsString() );
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -949,7 +949,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                     Kill kill = nkd.getKill();
                     if (people.length > 1) {
                         for (Person person : people) {
-                            Kill k = kill.clone();
+                            Kill k = kill.copy();
                             k.setPilotId(person.getId());
                             gui.getCampaign().addKill(k);
                         }
@@ -975,7 +975,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                 LogEntry entry = eeld.getEntry();
                 if (null != entry) {
                     for (Person person : people) {
-                        person.addLogEntry(entry.clone());
+                        person.addLogEntry(entry.copy());
                         MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                     }
                 }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -2324,11 +2324,11 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         tabOptions.addTab(resourceMap.getString("panMercenary.TabConstraints.tabTitle"), panMercenary); // NOI18N
 
         Set<String> spaNames = SpecialAbility.getAllSpecialAbilities().keySet();
-        //We need to create a temporary hash of special abilities that we can modify without
-        //changing the underlying one in case the user cancels the changes
+        // We need to create a temporary hash of special abilities that we can modify without
+        // changing the underlying one in case the user cancels the changes
         tempSPA = new Hashtable<String, SpecialAbility>();
-        for(String name : spaNames) {
-        	tempSPA.put(name, SpecialAbility.getAbility(name).clone());
+        for (String name : spaNames) {
+            tempSPA.put(name, SpecialAbility.getAbility(name).copy());
         }
 
         panXP.setName("panXP"); // NOI18N

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -108,7 +108,7 @@ public class CustomizeScenarioDialog extends javax.swing.JDialog {
         dateFormatter = new SimpleDateFormat("MM/dd/yyyy");
         loots = new ArrayList<Loot>();
         for(Loot loot : scenario.getLoot()) {
-            loots.add((Loot)loot.clone());
+            loots.add(loot.copy());
         }
         lootModel = new LootTableModel(loots);
         initComponents();

--- a/MekHQ/src/mekhq/gui/dialog/EditSpecialAbilityDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditSpecialAbilityDialog.java
@@ -310,7 +310,7 @@ public class EditSpecialAbilityDialog extends JDialog {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
             	EditSkillPrereqDialog nspd = new EditSkillPrereqDialog(null, new SkillPrereq());
             	nspd.setVisible(true);
-            	if(!nspd.wasCancelled() & !nspd.getPrereq().isEmpty()) {
+            	if(!nspd.wasCancelled() && !nspd.getPrereq().isEmpty()) {
                 	prereqSkills.add(nspd.getPrereq());
                 	refreshGUI();
                 }
@@ -467,7 +467,7 @@ public class EditSpecialAbilityDialog extends JDialog {
     private void editSkillPrereq(int i) {
     	EditSkillPrereqDialog nspd = new EditSkillPrereqDialog(null, prereqSkills.get(i));
     	nspd.setVisible(true);
-    	if(!nspd.wasCancelled() & !nspd.getPrereq().isEmpty()) {
+    	if(!nspd.wasCancelled() && !nspd.getPrereq().isEmpty()) {
         	prereqSkills.set(i, nspd.getPrereq());
         	refreshGUI();
         }

--- a/MekHQ/src/mekhq/gui/dialog/EditSpecialAbilityDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditSpecialAbilityDialog.java
@@ -76,17 +76,14 @@ public class EditSpecialAbilityDialog extends JDialog {
     private int currentXP;
 
 
-    @SuppressWarnings("unchecked")
-	public EditSpecialAbilityDialog(Frame parent, SpecialAbility spa, Hashtable<String, SpecialAbility> hash) {
+    public EditSpecialAbilityDialog(Frame parent, SpecialAbility spa, Hashtable<String, SpecialAbility> hash) {
         super(parent, true);
         this.ability = spa;
         this.allSPA = hash;
-        // FIXME: Java is broken, so we had to supress unchecked warnings for these 4 lines
-        // Basically, Vector<E>.clone() returns an Object instead of a new Vector<E> - DOH!
-        prereqAbilities = (Vector<String>)ability.getPrereqAbilities().clone();
-        invalidAbilities = (Vector<String>)ability.getInvalidAbilities().clone();
-        removeAbilities = (Vector<String>)ability.getRemovedAbilities().clone();
-        prereqSkills = (Vector<SkillPrereq>)ability.getPrereqSkills().clone();
+        prereqAbilities = new Vector<>(ability.getPrereqAbilities());
+        invalidAbilities = new Vector<>(ability.getInvalidAbilities());
+        removeAbilities = new Vector<>(ability.getRemovedAbilities());
+        prereqSkills = new Vector<>(ability.getPrereqSkills());
         cancelled = false;
         currentXP = ability.getCost();
         initComponents();

--- a/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
@@ -457,7 +457,7 @@ public class PartsStoreDialog extends javax.swing.JDialog {
 			campaign.getShoppingList().addShoppingItem(selectedPart.getAcquisitionWork(), quantity, campaign);
 		} else {
 			while(quantity > 0) {
-				campaign.addPart(selectedPart.clone(), 0);
+				campaign.addPart(selectedPart.copy(), 0);
 				quantity--;
 			}
 		}

--- a/MekHQ/src/mekhq/gui/dialog/SelectUnusedAbilityDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SelectUnusedAbilityDialog.java
@@ -136,20 +136,20 @@ public class SelectUnusedAbilityDialog extends JDialog {
         	}
 
             SpecialAbility spa;
-        	if (null != SpecialAbility.getDefaultAbility(name)) {
-        	    spa = SpecialAbility.getDefaultAbility(name).clone();
-        	} else {
-        	    spa = new SpecialAbility(name, displayName, desc);
-        	}
-        	EditSpecialAbilityDialog esad = new EditSpecialAbilityDialog(null, spa, currentSPA);
-        	esad.setVisible(true);
-        	if(!esad.wasCancelled()) {
-        		currentSPA.put(spa.getName(), spa);
-        	}
-    	}
-    	this.setVisible(false);
+            if (null != SpecialAbility.getDefaultAbility(name)) {
+                spa = SpecialAbility.getDefaultAbility(name).copy();
+            } else {
+                spa = new SpecialAbility(name, displayName, desc);
+            }
+            EditSpecialAbilityDialog esad = new EditSpecialAbilityDialog(null, spa, currentSPA);
+            esad.setVisible(true);
+            if (!esad.wasCancelled()) {
+                currentSPA.put(spa.getName(), spa);
+            }
+        }
+        this.setVisible(false);
     }
-    
+
     private void cancel() {
     	this.setVisible(false);
     	cancelled = true;

--- a/MekHQ/src/mekhq/gui/dialog/UnitMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnitMarketDialog.java
@@ -231,7 +231,6 @@ public class UnitMarketDialog extends JDialog {
         scrollTableUnits.setName("srcTablePersonnel"); // NOI18N
         scrollTableUnits.setPreferredSize(new java.awt.Dimension(500, 400));
 
-        gbc = new GridBagConstraints();
         tableUnits.setModel(marketModel);
         tableUnits.setName("tableUnits"); // NOI18N
         tableUnits.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -671,16 +671,15 @@ import mekhq.gui.BasicInfo;
                     setPortrait(p);
                     setText(p.getFullDesc(false), color);
                 }
-                if(actualCol == COL_ASSIGN) {
-                	if (loadAssignmentFromMarket) {
-                		Entity en = personnelMarket.getAttachedEntity(p);
-                		
-                		if (null == en) {
-                			setText("-", color);
-                		}
-                		
-                		setText(en.getDisplayName(), color);
-                	} else {
+                if (actualCol == COL_ASSIGN) {
+                    if (loadAssignmentFromMarket) {
+                        Entity en = personnelMarket.getAttachedEntity(p);
+                        if (null == en) {
+                            setText("-", color);
+                        } else {
+                            setText(en.getDisplayName(), color);
+                        }
+                    } else {
 	                    Unit u = getCampaign().getUnit(p.getUnitId());
 	                    if(!p.getTechUnitIDs().isEmpty()) {
 	                        u = getCampaign().getUnit(p.getTechUnitIDs().get(0));

--- a/MekHQ/src/mekhq/gui/utilities/JSuggestField.java
+++ b/MekHQ/src/mekhq/gui/utilities/JSuggestField.java
@@ -276,15 +276,14 @@ public class JSuggestField extends JTextField {
 		return true;
 	}
 
-	/**
-	 * Get all words that are available for suggestion.
-	 *
-	 * @return Vector containing Strings
-	 */
-	@SuppressWarnings("unchecked")
-	public Vector<String> getSuggestData() {
-		return (Vector<String>) data.clone();
-	}
+    /**
+     * Get all words that are available for suggestion.
+     *
+     * @return Vector containing Strings
+     */
+    public Vector<String> getSuggestData() {
+        return new Vector<>(data);
+    }
 
 	/**
 	 * Set preferred size for the drop-down that will appear.

--- a/MekHQ/src/mekhq/gui/utilities/JSuggestField.java
+++ b/MekHQ/src/mekhq/gui/utilities/JSuggestField.java
@@ -232,7 +232,7 @@ public class JSuggestField extends JTextField {
 					list.ensureIndexIsVisible(list.getSelectedIndex() - 1);
 					return;
 				} else if (e.getKeyCode() == KeyEvent.VK_ENTER
-						& list.getSelectedIndex() != -1 & suggestions.size() > 0) {
+						&& list.getSelectedIndex() != -1 && suggestions.size() > 0) {
 					setText((String) list.getSelectedValue());
 					lastChosenExistingVariable = list.getSelectedValue().toString();
 					fireActionEvent();

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -314,7 +314,10 @@ class RequiredLancesTableModel extends DataTableModel {
 	public static final int COL_TRAINING = 5;
 	public static final int COL_NUM = 6;
 
-    protected String[] columnNames = {"Contract", "Total", "Fight", "Defend", "Scout", "Training"};
+    public RequiredLancesTableModel() {
+        columnNames = new String[] { "Contract", "Total", "Fight", "Defend", "Scout", "Training" };
+    }
+
     
     private Campaign campaign;
     
@@ -323,16 +326,6 @@ class RequiredLancesTableModel extends DataTableModel {
     	data = new ArrayList<AtBContract>();
     }
 
-    @Override
-    public int getColumnCount() {
-        return COL_NUM;
-    }
-
-    @Override
-    public String getColumnName(int column) {
-    	return columnNames[column];
-    }
-	
     public int getColumnWidth(int col) {
         if (col == COL_CONTRACT) {
         	return 100;
@@ -420,7 +413,10 @@ class LanceAssignmentTableModel extends DataTableModel {
 	public static final int COL_ROLE = 3;
 	public static final int COL_NUM = 4;
 
-    protected String[] columnNames = {"Force", "Wt", "Mission", "Role"};
+    public LanceAssignmentTableModel() {
+        columnNames = new String[] { "Force", "Wt", "Mission", "Role" };
+    }
+
     private Campaign campaign;
     
     public LanceAssignmentTableModel(Campaign campaign) {
@@ -428,16 +424,6 @@ class LanceAssignmentTableModel extends DataTableModel {
     	data = new ArrayList<Lance>();
     }
 
-    @Override
-    public int getColumnCount() {
-        return COL_NUM;
-    }
-
-    @Override
-    public String getColumnName(int column) {
-    	return columnNames[column];
-    }
-	
     public int getColumnWidth(int col) {
     	switch (col) {
     	case COL_FORCE:


### PR DESCRIPTION
This PR adds findbugs to the MekHQ build (it's executed during `check` and doesn't fail the build no matter what) and also starts addresses most of the high-priority warnings produced by findbugs (the easier/most obvious ones).

For information on Findbugs, see:
https://docs.gradle.org/current/userguide/findbugs_plugin.html
http://findbugs.sourceforge.net/

**Note to reviewers**
This PR is probably best reviewed one commit at a time.
Also, the notes below can help speeding up the process for the first commits (where the same changes have been applied over and over).

### Commit 1. Add findbugs

This only adds findbugs to the gradle build.

### Commit 2. Renamed a bunch of clone() methods to copy()

The contract of `Object.clone()` is very specific and... the whole cloning mechanism is practically deprecated (not really deprecated, but it's in a state similar to `Vector`, `Hashtable` or the serialization machinarium: basically it's all old stuff that still works and will continue to do so, but that is considered surpassed nowadays).

Many classes (most notably, `Part` and its subclasses) implemented `clone()` in a way that is semantically correct, but different from what the `Object.clone()` contract prescribes (basically "implement `Cloneable`" and "obtain clone via `super.clone()`", ...).

Since it seemed to make little sense to fix the implementations to make them compliant with a surpassed specification, all the `clone()` methods have been renamed to `copy()`.

While I was at it, I also `grep -nr 'clone()' src/` and reviewed all the places where `clone()` was mentioned - basically, it's now only used for `Date`, `GregorianCalendar` and once for `Path2D`.

### Commit 3. Removed Serializable from a bunch of classes

Findbugs was (correctly) complaining that some classes (most notable: `Campaign` and `Person`) contained non-transient non-serializable fields. Since we are not using serialization anyways, I removed `Serializable` from the list of implemented interfaces in those classes.

### Commit 4. Findbugs "Correctness Warnings" addressed

- `Illegal format string "%s%\_ExportedPersonnel.prsx" in mekhq.gui.FileDialogs.savePersonnel(JFrame, Campaign)`
- `java.util.UUID is incompatible with expected argument type megamek.common.Entity in mekhq.campaign.market.PersonnelMarket.removePersonnelForDay(Campaign)`
- `Integral value cast to double and then passed to Math.ceil in mekhq.campaign.parts.equipment.EquipmentPart.resolveVariableCost(boolean)`
- `Integral value cast to double and then passed to Math.ceil in mekhq.campaign.parts.MissingQuadVeeGear.getTonnage()`
- `Field LanceAssignmentTableModel.columnNames masks field in superclass mekhq.gui.model.DataTableModel`
- `Field RequiredLancesTableModel.columnNames masks field in superclass mekhq.gui.model.DataTableModel`
- `Non-virtual method call in new mekhq.campaign.parts.PodSpace() passes null for non-null parameter of new PodSpace(int, Unit)`
- `Possible null pointer dereference of en in mekhq.campaign.unit.UnitTechProgression.calcTechProgression(MechSummary, int)`
- `Possible null pointer dereference of null in mekhq.gui.CampaignGUI.loadPersonFile()`
- `Possible null pointer dereference of en in mekhq.gui.model.PersonnelTableModel$VisualRenderer.getTableCellRendererComponent(JTable, Object, boolean, boolean, int, int)`
- `Nullcheck of luminosity at line 449 of value previously dereferenced in mekhq.campaign.universe.StarUtil.getSpectralType(Integer, Double, String)`
- `Repeated conditional test in mekhq.campaign.personnel.Person.isCombat()`
- `Return value of String.replaceAll(String, String) ignored in mekhq.campaign.mission.Loot.writeToXml(PrintWriter, int)`
- `Invocation of toString on String.split(String) in mekhq.campaign.universe.StarUtil.<static initializer for StarUtil>()`
- `Invocation of toString on Utilities.romanNumerals in mekhq.Utilities.getArabicNumberFromRomanNumerals(String)`

### Commit 5. Findbugs "Dodgy code Warnings" addressed

- `Dead store to gbc in mekhq.gui.dialog.UnitMarketDialog.initComponents()`
- `Result of integer multiplication cast to long in mekhq.campaign.unit.Unit.getSellValue()`
- `Potentially dangerous use of non-short-circuit logic in mekhq.campaign.personnel.Person.getEligibleSPAs(boolean)`
- `Potentially dangerous use of non-short-circuit logic in mekhq.campaign.ResolveScenarioTracker.loadUnitsAndPilots(File)`
- `Potentially dangerous use of non-short-circuit logic in mekhq.gui.dialog.EditSpecialAbilityDialog.editSkillPrereq(int)`
- `Potentially dangerous use of non-short-circuit logic in mekhq.gui.dialog.EditSpecialAbilityDialog$6.actionPerformed(ActionEvent)`
- `Potentially dangerous use of non-short-circuit logic in mekhq.gui.utilities.JSuggestField$5.keyReleased(KeyEvent)`
- `Return value of SkillType.getName() ignored, but method has no side effect`
- `Return value of getTotalCombatUnits() ignored, but method has no side effect`
- `Double assignment of field CampaignOptions.usePlanetaryConditions in new mekhq.campaign.CampaignOptions()`

This one is reported by findbugs, but seems to actually be ok:
- `Test for floating point equality in mekhq.campaign.universe.RegionPerimeter.isInsideRegion(double, double, List)` (line 115)

I don't know how this one should be fixed:
- `Test for floating point equality in mekhq.gui.MekLabTab.refreshRefitSummary()` (line 350)
