### PR TITLE
NPE when spouse is simply removed

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3341,6 +3341,20 @@ public class Campaign implements Serializable, ITechManager {
         }
     }
 
+    /**
+     * Cleans incongruent data present in the campaign
+     */
+    public void cleanUp(){
+        // Cleans non-existing spouses
+        for(Person p : personnel.values()){
+            if(p.hasSpouse()){
+                if(!personnel.containsKey(p.getSpouseID())){
+                    p.setSpouseID(null);
+                }
+            }
+        }
+    }
+
     public boolean isOvertimeAllowed() {
         return overtime;
     }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7184,7 +7184,7 @@ public class Campaign implements Serializable, ITechManager {
         if (status == Person.S_KIA) {
             person.addLogEntry(getDate(), "Killed in action");
             // Don't forget to tell the spouse
-            if (person.getSpouseID() != null) {
+            if (person.hasSpouse()) {
                 Person spouse = person.getSpouse();
                 spouse.addLogEntry(getDate(), "Spouse, " + person.getName() + ", killed in action");
                 spouse.setSpouseID(null);

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -996,6 +996,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return id;
     }
 
+    @Nullable
     public UUID getSpouseID() {
         return spouse;
     }
@@ -1004,8 +1005,16 @@ public class Person implements Serializable, MekHqXmlSerializable {
         this.spouse = spouse;
     }
 
+    @Nullable
     public Person getSpouse() {
         return campaign.getPerson(spouse);
+    }
+
+    public boolean hasSpouse(){
+        if(null == campaign.getPerson(spouse))
+            setSpouseID(null);
+
+        return (getSpouseID() != null);
     }
 
     public GregorianCalendar getDueDate() {
@@ -1080,17 +1089,19 @@ public class Person implements Serializable, MekHqXmlSerializable {
             return;
         }
         // Spouse NULL protection...
+        /*
         if((getSpouseID() != null) && (getSpouse() == null)) {
             setSpouseID(null);
         }
+        */
         if (!isDeployed()) {
             // Age limitations...
             if (getAge(campaign.getCalendar()) > 13 && getAge(campaign.getCalendar()) < 51) {
                 boolean concieved = false;
-                if (getSpouse() == null && campaign.getCampaignOptions().useUnofficialProcreationNoRelationship()) {
+                if (!hasSpouse() && campaign.getCampaignOptions().useUnofficialProcreationNoRelationship()) {
                     // 0.005% chance that this procreation attempt will create a child
                     concieved = (Compute.randomInt(100000) < 2);
-                } else if (getSpouse() != null) {
+                } else if (hasSpouse()) {
                     if (getSpouse().isActive() && !getSpouse().isDeployed() && getSpouse().getAge(campaign.getCalendar()) > 13) {
                         // 0.05% chance that this procreation attempt will create a child
                         concieved = (Compute.randomInt(10000) < 2);
@@ -1104,7 +1115,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                     int size = PREGNANCY_SIZE.getAsInt();
                     extraData.set(PREGNANCY_CHILDREN_DATA, size);
                     extraData.set(PREGNANCY_FATHER_DATA,
-                        (null != getSpouseID()) ? getSpouseID().toString() : null);
+                        (hasSpouse()) ? getSpouseID().toString() : null);
 
                     String sizeString = (size < PREGNANCY_MULTIPLE_NAMES.length) ? PREGNANCY_MULTIPLE_NAMES[size] : null;
                     if(null == sizeString) {
@@ -1130,7 +1141,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         int size = PREGNANCY_SIZE.getAsInt();
         extraData.set(PREGNANCY_CHILDREN_DATA, size);
         extraData.set(PREGNANCY_FATHER_DATA,
-            (null != getSpouseID()) ? getSpouseID().toString() : null);
+            (hasSpouse()) ? getSpouseID().toString() : null);
 
         String sizeString = (size < PREGNANCY_MULTIPLE_NAMES.length) ? PREGNANCY_MULTIPLE_NAMES[size] : null;
         if(null == sizeString) {
@@ -1158,7 +1169,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 !this.equals(p)
                 && (getAncestorsID() == null
                 || !campaign.getAncestors(getAncestorsID()).checkMutualAncestors(campaign.getAncestors(p.getAncestorsID())))
-                && p.getSpouseID() == null
+                && !p.hasSpouse()
                 && getGender() != p.getGender()
                 && p.getAge(campaign.getCalendar()) > 13
         );

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1011,9 +1011,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
     }
 
     public boolean hasSpouse(){
-        if(null == campaign.getPerson(spouse))
-            setSpouseID(null);
-
         return (getSpouseID() != null);
     }
 
@@ -1088,12 +1085,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         if(!isFemale() || isPregnant()) {
             return;
         }
-        // Spouse NULL protection...
-        /*
-        if((getSpouseID() != null) && (getSpouse() == null)) {
-            setSpouseID(null);
-        }
-        */
+
         if (!isDeployed()) {
             // Age limitations...
             if (getAge(campaign.getCalendar()) > 13 && getAge(campaign.getCalendar()) < 51) {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -762,6 +762,9 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                         JOptionPane.YES_NO_OPTION)) {
                     for (Person person : people) {
                         gui.getCampaign().removePerson(person.getId());
+                        if(person.hasSpouse()){
+                            person.getSpouse().setSpouseID(null);
+                        }
                     }
                 }
                 break;
@@ -1713,7 +1716,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
             if (oneSelected && person.isActive()) {
                 GregorianCalendar calendar = gui.getCampaign().getCalendar();
 
-                if ((person.getAge(calendar) > 13) && (person.getSpouseID() == null)) {
+                if ((person.getAge(calendar) > 13) && (!person.hasSpouse())) {
                     menu = new JMenu(resourceMap.getString("changeSpouse.text")); //$NON-NLS-1$
                     JMenuItem surnameMenu;
                     JMenu spouseMenu;
@@ -1776,7 +1779,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                     }
                     popup.add(menu);
                 }
-                if (person.getSpouseID() != null) {
+                if (person.hasSpouse()) {
                     menuItem = new JMenuItem(resourceMap.getString("removeSpouse.text")); //$NON-NLS-1$
                     menuItem.setActionCommand(CMD_REMOVE_SPOUSE);
                     menuItem.addActionListener(this);

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -193,6 +193,7 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
         			campaign = Campaign.createCampaignFromXMLFileInputStream(fis, app);
         			// Restores all transient attributes from serialized objects
         			campaign.restore();
+        			campaign.cleanUp();
         			fis.close();
         		} catch (NullEntityException ex) {
         			JOptionPane.showMessageDialog(null,

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -727,7 +727,7 @@ public class PersonViewPanel extends JPanel {
             secondy = firsty;
         }
 
-        if (null != person.getSpouseID()) {
+        if (person.hasSpouse()) {
             secondy++;
             lblSpouse1.setName("lblSpouse1"); // NOI18N //$NON-NLS-1$
             lblSpouse1.setText(resourceMap.getString("lblSpouse1.text")); //$NON-NLS-1$


### PR DESCRIPTION
Fixes #905 

To check if some has spouse, use the new `Person.hasSpouse()` method, which checks if the actual spouse exists. Refrain from comparing `Person.getSpouse()` and `Person.getSpouseID()` with `null` as they are not safe. 

When a person is deleted and has a spouse, their spouse's spouseID will be set to null, just like in a divorce, to avoid this issue.