### PR TITLE
Fix for issue #856 - added bulletproofing to customize atb contract dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -188,8 +188,10 @@ public class CustomizeAtBContractDialog extends JDialog {
     	btnEnemyCamo = new JButton();
         JLabel lblEnemyRating = new JLabel();
     	JLabel lblRequiredLances = new JLabel();
-    	spnRequiredLances = new JSpinner(new SpinnerNumberModel(contract.getRequiredLances(), 1,
-    			null, 1));
+    	
+    	int requiredLances = contract.getRequiredLances() > 0 ? contract.getRequiredLances() : 1; 
+    	
+    	spnRequiredLances = new JSpinner(new SpinnerNumberModel(requiredLances, 1, null, 1));
     	JLabel lblEnemyMorale = new JLabel();
         spnContractScoreArbitraryModifier = new JSpinner(
                 new SpinnerNumberModel(contract.getContractScoreArbitraryModifier(),


### PR DESCRIPTION
This seems to have been caused by errors in the "required lances" calculation logic. That has since been fixed, but older save games may have bad data, so we introduce logic into the Customize AtB Contract dialog to make it more fault-tolerant.