### PR TITLE
Load VTOL locations when loading campaign

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2107,6 +2107,10 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                             Turret turret = new Turret(i, (int)getEntity().getWeight(), campaign);
                             addPart(turret);
                             partsToAdd.add(turret);
+                        } else {
+                            TankLocation tankLocation = new TankLocation(i, (int) getEntity().getWeight(), campaign);
+                            addPart(tankLocation);
+                            partsToAdd.add(tankLocation);
                         }
                     } else if(i == Tank.LOC_TURRET) {
                          if(((Tank)entity).hasNoTurret()) {


### PR DESCRIPTION
This fixes an issue with loading VTOLs from campaign files with damaged internal structure - they can't be repaired for because the "internal" locations don't get generated for them.