### PR TITLE
Do not use spare parts during GM restore

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
@@ -125,9 +125,9 @@ public class AeroHeatSink extends Part {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         boolean fixed = needsFixing();
-        super.fix(hasInfiniteResources);
+        super.fix(gmMode);
         if(fixed && (null != unit)
                 && unit.getEntity() instanceof Aero) {
             ((Aero) unit.getEntity()).setHeatSinks(((Aero) unit.getEntity()).getHeatSinks() + 1);

--- a/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
@@ -125,9 +125,9 @@ public class AeroHeatSink extends Part {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         boolean fixed = needsFixing();
-        super.fix();
+        super.fix(hasInfiniteResources);
         if(fixed && (null != unit)
                 && unit.getEntity() instanceof Aero) {
             ((Aero) unit.getEntity()).setHeatSinks(((Aero) unit.getEntity()).getHeatSinks() + 1);

--- a/MekHQ/src/mekhq/campaign/parts/AeroLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroLifeSupport.java
@@ -150,8 +150,8 @@ public class AeroLifeSupport extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setLifeSupport(true);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/AeroLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroLifeSupport.java
@@ -150,8 +150,8 @@ public class AeroLifeSupport extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setLifeSupport(true);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
@@ -148,8 +148,8 @@ public class AeroSensor extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setSensorHits(0);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
@@ -148,8 +148,8 @@ public class AeroSensor extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setSensorHits(0);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -187,12 +187,6 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 	public TechAdvancement getTechAdvancement() {
 	    return type.getTechAdvancement();
 	}
-	
-	@Override
-	public void fix() {
-		//nothing to fix
-		return;
-	}
 
 	@Override
 	public MissingPart getMissingPart() {

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -313,11 +313,11 @@ public class Armor extends Part implements IAcquisitionWork {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		int amountFound = hasInfiniteResources ? amountNeeded : Math.min(getAmountAvailable(), amountNeeded);
+	public void fix(boolean gmMode) {
+		int amountFound = gmMode ? amountNeeded : Math.min(getAmountAvailable(), amountNeeded);
 		int fixAmount = Math.min(amount + amountFound, unit.getEntity().getOArmor(location, rear));
 		unit.getEntity().setArmor(fixAmount, location, rear);
-		if (!hasInfiniteResources) {
+		if (!gmMode) {
 			changeAmountAvailable(-1 * amountFound);
 		}
 		updateConditionFromEntity(false);

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -313,14 +313,15 @@ public class Armor extends Part implements IAcquisitionWork {
 	}
 
 	@Override
-	public void fix() {
-		int amountFound = Math.min(getAmountAvailable(), amountNeeded);
+	public void fix(boolean hasInfiniteResources) {
+		int amountFound = hasInfiniteResources ? amountNeeded : Math.min(getAmountAvailable(), amountNeeded);
 		int fixAmount = Math.min(amount + amountFound, unit.getEntity().getOArmor(location, rear));
 		unit.getEntity().setArmor(fixAmount, location, rear);
-		changeAmountAvailable(-1 * amountFound);
+		if (!hasInfiniteResources) {
+			changeAmountAvailable(-1 * amountFound);
+		}
 		updateConditionFromEntity(false);
-		skillMin = SkillType.EXP_GREEN;
-		shorthandedMod = 0;
+		resetRepairSettings();
 	}
 
 	@Override

--- a/MekHQ/src/mekhq/campaign/parts/Avionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/Avionics.java
@@ -152,8 +152,8 @@ public class Avionics extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit) {
 		    if (unit.getEntity() instanceof Aero) {
 		        ((Aero)unit.getEntity()).setAvionicsHits(0);

--- a/MekHQ/src/mekhq/campaign/parts/Avionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/Avionics.java
@@ -152,8 +152,8 @@ public class Avionics extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit) {
 		    if (unit.getEntity() instanceof Aero) {
 		        ((Aero)unit.getEntity()).setAvionicsHits(0);

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -415,8 +415,8 @@ public class BattleArmorSuit extends Part {
     }
     
     @Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
         if(null != unit) {
             unit.getEntity().setInternal(unit.getEntity().getOInternal(trooper), trooper);
         }

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -415,8 +415,8 @@ public class BattleArmorSuit extends Part {
     }
     
     @Override
-    public void fix() {
-        super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
         if(null != unit) {
             unit.getEntity().setInternal(unit.getEntity().getOInternal(trooper), trooper);
         }

--- a/MekHQ/src/mekhq/campaign/parts/BayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BayDoor.java
@@ -76,8 +76,8 @@ public class BayDoor extends Part {
     }
     
     @Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
         Part bayPart = campaign.getPart(parentPartId);
         if (null != bayPart) {
             Bay bay = ((TransportBayPart) bayPart).getBay();

--- a/MekHQ/src/mekhq/campaign/parts/BayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BayDoor.java
@@ -76,8 +76,8 @@ public class BayDoor extends Part {
     }
     
     @Override
-    public void fix() {
-        super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
         Part bayPart = campaign.getPart(parentPartId);
         if (null != bayPart) {
             Bay bay = ((TransportBayPart) bayPart).getBay();

--- a/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
+++ b/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
@@ -131,8 +131,8 @@ public class DropshipDockingCollar extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		boomDamaged = false;
 		if(null != unit && unit.getEntity() instanceof Dropship) {
 			((Dropship)unit.getEntity()).setDamageDockCollar(false);

--- a/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
+++ b/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
@@ -131,8 +131,8 @@ public class DropshipDockingCollar extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		boomDamaged = false;
 		if(null != unit && unit.getEntity() instanceof Dropship) {
 			((Dropship)unit.getEntity()).setDamageDockCollar(false);

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -215,8 +215,8 @@ public class EnginePart extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit) {
 		    if(unit.getEntity() instanceof Mech) {
 		        unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE);

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -215,8 +215,8 @@ public class EnginePart extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit) {
 		    if(unit.getEntity() instanceof Mech) {
 		        unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE);

--- a/MekHQ/src/mekhq/campaign/parts/FireControlSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/FireControlSystem.java
@@ -145,8 +145,8 @@ public class FireControlSystem extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setFCSHits(0);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/FireControlSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/FireControlSystem.java
@@ -145,8 +145,8 @@ public class FireControlSystem extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setFCSHits(0);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/LandingGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/LandingGear.java
@@ -129,8 +129,8 @@ public class LandingGear extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if (null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setGearHit(false);
 		} else if (null != unit && unit.getEntity() instanceof LandAirMech) {

--- a/MekHQ/src/mekhq/campaign/parts/LandingGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/LandingGear.java
@@ -129,8 +129,8 @@ public class LandingGear extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if (null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setGearHit(false);
 		} else if (null != unit && unit.getEntity() instanceof LandAirMech) {

--- a/MekHQ/src/mekhq/campaign/parts/MekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekActuator.java
@@ -178,8 +178,8 @@ public class MekActuator extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, type, location);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekActuator.java
@@ -178,8 +178,8 @@ public class MekActuator extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, type, location);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
@@ -144,8 +144,8 @@ public class MekCockpit extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
@@ -144,8 +144,8 @@ public class MekCockpit extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekGyro.java
@@ -158,8 +158,8 @@ public class MekGyro extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekGyro.java
@@ -158,8 +158,8 @@ public class MekGyro extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
@@ -84,8 +84,8 @@ public class MekLifeSupport extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_LIFE_SUPPORT);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
@@ -84,8 +84,8 @@ public class MekLifeSupport extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_LIFE_SUPPORT);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -283,8 +283,8 @@ public class MekLocation extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(isBlownOff()) {
 			blownOff = false;
 			unit.getEntity().setLocationBlownOff(loc, false);

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -283,8 +283,8 @@ public class MekLocation extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(isBlownOff()) {
 			blownOff = false;
 			unit.getEntity().setLocationBlownOff(loc, false);

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -93,8 +93,8 @@ public class MekSensor extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -93,8 +93,8 @@ public class MekSensor extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit) {
 			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -224,7 +224,7 @@ public class MissingBattleArmorSuit extends MissingPart {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
         	BattleArmorSuit newSuit = (BattleArmorSuit)replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -224,7 +224,7 @@ public class MissingBattleArmorSuit extends MissingPart {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
         	BattleArmorSuit newSuit = (BattleArmorSuit)replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
@@ -65,7 +65,7 @@ public class MissingBayDoor extends MissingPart {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
@@ -65,7 +65,7 @@ public class MissingBayDoor extends MissingPart {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
@@ -92,7 +92,7 @@ public class MissingCubicle extends MissingPart {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
@@ -92,7 +92,7 @@ public class MissingCubicle extends MissingPart {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
@@ -113,7 +113,7 @@ public class MissingMekActuator extends MissingPart {
 	}
 
 	@Override 
-	public void fix() {
+	public void fix(boolean hasInfiniteResources) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
@@ -113,7 +113,7 @@ public class MissingMekActuator extends MissingPart {
 	}
 
 	@Override 
-	public void fix(boolean hasInfiniteResources) {
+	public void fix(boolean gmMode) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -280,7 +280,7 @@ public class MissingMekLocation extends MissingPart {
 	}
 
 	@Override
-	public void fix() {
+	public void fix(boolean hasInfiniteResources) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -280,7 +280,7 @@ public class MissingMekLocation extends MissingPart {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
+	public void fix(boolean gmMode) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -125,12 +125,12 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 	
 	@Override
 	public String succeed() {	
-		fix();
+		fix(false);
 		return " <font color='green'><b> replaced.</b></font>";
 	}
 	
 	@Override 
-	public void fix() {
+	public void fix(boolean hasInfiniteParts) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
@@ -125,7 +125,7 @@ public class MissingProtomekArmActuator extends MissingPart {
     }
 
     @Override 
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
@@ -125,7 +125,7 @@ public class MissingProtomekArmActuator extends MissingPart {
     }
 
     @Override 
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekJumpJet.java
@@ -108,7 +108,7 @@ public class MissingProtomekJumpJet extends MissingPart {
     }
 
     @Override 
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekJumpJet.java
@@ -108,7 +108,7 @@ public class MissingProtomekJumpJet extends MissingPart {
     }
 
     @Override 
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLegActuator.java
@@ -96,7 +96,7 @@ public class MissingProtomekLegActuator extends MissingPart {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLegActuator.java
@@ -96,7 +96,7 @@ public class MissingProtomekLegActuator extends MissingPart {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
@@ -246,7 +246,7 @@ public class MissingProtomekLocation extends MissingPart {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
@@ -246,7 +246,7 @@ public class MissingProtomekLocation extends MissingPart {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekSensor.java
@@ -96,7 +96,7 @@ public class MissingProtomekSensor extends MissingPart {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekSensor.java
@@ -96,7 +96,7 @@ public class MissingProtomekSensor extends MissingPart {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingThrusters.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingThrusters.java
@@ -84,7 +84,7 @@ public class MissingThrusters extends MissingPart {
 	}
 
 	@Override 
-	public void fix(boolean hasInfiniteResources) {
+	public void fix(boolean gmMode) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingThrusters.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingThrusters.java
@@ -84,7 +84,7 @@ public class MissingThrusters extends MissingPart {
 	}
 
 	@Override 
-	public void fix() {
+	public void fix(boolean hasInfiniteResources) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
@@ -107,7 +107,7 @@ public class MissingVeeStabiliser extends MissingPart {
 	}
 	
 	@Override 
-	public void fix() {
+	public void fix(boolean hasInfiniteResources) {
 		VeeStabiliser replacement = (VeeStabiliser)findReplacement(false);
 		if(null != replacement) {
 			VeeStabiliser actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
@@ -107,7 +107,7 @@ public class MissingVeeStabiliser extends MissingPart {
 	}
 	
 	@Override 
-	public void fix(boolean hasInfiniteResources) {
+	public void fix(boolean gmMode) {
 		VeeStabiliser replacement = (VeeStabiliser)findReplacement(false);
 		if(null != replacement) {
 			VeeStabiliser actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
@@ -133,8 +133,8 @@ public class MotiveSystem extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		damage = 0;
 		penalty = 0;
 		if(null != unit && unit.getEntity() instanceof Tank) {

--- a/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
@@ -133,8 +133,8 @@ public class MotiveSystem extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		damage = 0;
 		penalty = 0;
 		if(null != unit && unit.getEntity() instanceof Tank) {

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -230,7 +230,7 @@ public class OmniPod extends Part {
     }
     
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part newPart = partType.clone();
         Part oldPart = campaign.checkForExistingSparePart(newPart.clone());
         if(null != oldPart) {

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -230,7 +230,7 @@ public class OmniPod extends Part {
     }
     
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part newPart = partType.clone();
         Part oldPart = campaign.checkForExistingSparePart(newPart.clone());
         if(null != oldPart) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1050,7 +1050,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 	
 	@Override
-	public void fix(boolean hasInfiniteResources) {
+	public void fix(boolean gmMode) {
 		hits = 0;
 		resetRepairSettings();
 	}

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1050,7 +1050,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 	
 	@Override
-	public void fix() {
+	public void fix(boolean hasInfiniteResources) {
 		hits = 0;
 		resetRepairSettings();
 	}
@@ -1078,7 +1078,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 			remove(true);
 			return " <font color='green'><b> salvaged.</b></font>";
 		} else {
-			fix();
+			fix(false);
 			return " <font color='green'><b> fixed.</b></font>";
 		}
 	}

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -115,9 +115,9 @@ public class PodSpace implements Serializable, IPartWork {
         }
         updateConditionFromEntity(false);
     }
-    
+
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         shorthandedMod = 0;
         for (int pid : childPartIds) {
             final Part part = campaign.getPart(pid);
@@ -133,7 +133,7 @@ public class PodSpace implements Serializable, IPartWork {
         for (int pid : childPartIds) {
             final Part part = campaign.getPart(pid);
             if (part != null && part instanceof MissingPart) {
-                part.fix();
+                part.fix(hasInfiniteResources);
                 MekHQ.triggerEvent(new PartChangedEvent(part));
             }
         }
@@ -241,7 +241,7 @@ public class PodSpace implements Serializable, IPartWork {
             remove(true);
             return " <font color='green'><b> removed.</b></font>";
         } else {
-            fix();
+            fix(false);
             return " <font color='green'><b> fixed.</b></font>";
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -117,7 +117,7 @@ public class PodSpace implements Serializable, IPartWork {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         shorthandedMod = 0;
         for (int pid : childPartIds) {
             final Part part = campaign.getPart(pid);
@@ -133,7 +133,7 @@ public class PodSpace implements Serializable, IPartWork {
         for (int pid : childPartIds) {
             final Part part = campaign.getPart(pid);
             if (part != null && part instanceof MissingPart) {
-                part.fix(hasInfiniteResources);
+                part.fix(gmMode);
                 MekHQ.triggerEvent(new PartChangedEvent(part));
             }
         }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
@@ -115,8 +115,8 @@ public class ProtomekArmActuator extends Part {
     }
 
     @Override
-    public void fix() {
-        super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
         if(null != unit) {
             unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_ARMCRIT, location);
         }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
@@ -115,8 +115,8 @@ public class ProtomekArmActuator extends Part {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
         if(null != unit) {
             unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_ARMCRIT, location);
         }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
@@ -92,8 +92,8 @@ public class ProtomekJumpJet extends Part {
     }
 
     @Override
-    public void fix() {
-        super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
         if(null != unit) {
             //repair depending upon how many others are still damaged
             int damageJJ = getOtherDamagedJumpJets();

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
@@ -92,8 +92,8 @@ public class ProtomekJumpJet extends Part {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
         if(null != unit) {
             //repair depending upon how many others are still damaged
             int damageJJ = getOtherDamagedJumpJets();

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
@@ -81,8 +81,8 @@ public class ProtomekLegActuator extends Part {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
         if(null != unit) {
             unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_LEGCRIT, Protomech.LOC_LEG);
         }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
@@ -81,8 +81,8 @@ public class ProtomekLegActuator extends Part {
     }
 
     @Override
-    public void fix() {
-        super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
         if(null != unit) {
             unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_LEGCRIT, Protomech.LOC_LEG);
         }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
@@ -246,8 +246,8 @@ public class ProtomekLocation extends Part {
     }
 
     @Override
-    public void fix() {
-        super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
         if(isBlownOff()) {
             blownOff = false;
             unit.getEntity().setLocationBlownOff(loc, false);

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
@@ -246,8 +246,8 @@ public class ProtomekLocation extends Part {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
         if(isBlownOff()) {
             blownOff = false;
             unit.getEntity().setLocationBlownOff(loc, false);

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
@@ -81,8 +81,8 @@ public class ProtomekSensor extends Part {
     }
 
     @Override
-    public void fix() {
-        super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
         if(null != unit) {
             unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_HEADCRIT, Protomech.LOC_HEAD);
         }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
@@ -81,8 +81,8 @@ public class ProtomekSensor extends Part {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
         if(null != unit) {
             unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_HEADCRIT, Protomech.LOC_HEAD);
         }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1588,7 +1588,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 	}
 
 	@Override
-	public void fix() {
+    public void fix(boolean hasInfiniteResources) {
 		//do nothing
 	}
 

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1588,7 +1588,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 	}
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
 		//do nothing
 	}
 

--- a/MekHQ/src/mekhq/campaign/parts/Rotor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Rotor.java
@@ -69,8 +69,8 @@ public class Rotor extends TankLocation {
     }
 
 	@Override
-	public void fix() {
-		super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
 		damage--;
 		if(null != unit && unit.getEntity() instanceof VTOL) {
 		    int currIsVal = unit.getEntity().getInternal(VTOL.LOC_ROTOR); 

--- a/MekHQ/src/mekhq/campaign/parts/Rotor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Rotor.java
@@ -69,8 +69,8 @@ public class Rotor extends TankLocation {
     }
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
 		damage--;
 		if(null != unit && unit.getEntity() instanceof VTOL) {
 		    int currIsVal = unit.getEntity().getInternal(VTOL.LOC_ROTOR); 

--- a/MekHQ/src/mekhq/campaign/parts/SpacecraftEngine.java
+++ b/MekHQ/src/mekhq/campaign/parts/SpacecraftEngine.java
@@ -156,8 +156,8 @@ public class SpacecraftEngine extends Part {
     }
 
     @Override
-    public void fix() {
-        super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
         if(null != unit) {
             if(unit.getEntity() instanceof Aero) {
                 ((Aero)unit.getEntity()).setEngineHits(0);

--- a/MekHQ/src/mekhq/campaign/parts/SpacecraftEngine.java
+++ b/MekHQ/src/mekhq/campaign/parts/SpacecraftEngine.java
@@ -156,8 +156,8 @@ public class SpacecraftEngine extends Part {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
         if(null != unit) {
             if(unit.getEntity() instanceof Aero) {
                 ((Aero)unit.getEntity()).setEngineHits(0);

--- a/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
+++ b/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
@@ -148,8 +148,8 @@ public class StructuralIntegrity extends Part {
 
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
 		pointsNeeded = 0;
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setSI(((Aero)unit.getEntity()).get0SI());

--- a/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
+++ b/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
@@ -148,8 +148,8 @@ public class StructuralIntegrity extends Part {
 
 
 	@Override
-	public void fix() {
-		super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
 		pointsNeeded = 0;
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			((Aero)unit.getEntity()).setSI(((Aero)unit.getEntity()).get0SI());

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -155,8 +155,8 @@ public class TankLocation extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
 		if(isBreached()) {
 			breached = false;
 			unit.getEntity().setLocationStatus(loc, ILocationExposureStatus.NORMAL, true);

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -155,8 +155,8 @@ public class TankLocation extends Part {
 	}
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
 		if(isBreached()) {
 			breached = false;
 			unit.getEntity().setLocationStatus(loc, ILocationExposureStatus.NORMAL, true);

--- a/MekHQ/src/mekhq/campaign/parts/Thrusters.java
+++ b/MekHQ/src/mekhq/campaign/parts/Thrusters.java
@@ -155,8 +155,8 @@ public class Thrusters extends Part {
 	}
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			if (isLeftThrusters) {
 				((Aero)unit.getEntity()).setLeftThrustHits(0);

--- a/MekHQ/src/mekhq/campaign/parts/Thrusters.java
+++ b/MekHQ/src/mekhq/campaign/parts/Thrusters.java
@@ -155,8 +155,8 @@ public class Thrusters extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
 		if(null != unit && unit.getEntity() instanceof Aero) {
 			if (isLeftThrusters) {
 				((Aero)unit.getEntity()).setLeftThrustHits(0);

--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -158,8 +158,8 @@ public class TransportBayPart extends Part {
     }
     
     @Override
-    public void fix() {
-        super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
         Bay bay = getBay();
         if (null != bay) {
             bay.setBayDamage(0);

--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -158,8 +158,8 @@ public class TransportBayPart extends Part {
     }
     
     @Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
         Bay bay = getBay();
         if (null != bay) {
             bay.setBayDamage(0);

--- a/MekHQ/src/mekhq/campaign/parts/TurretLock.java
+++ b/MekHQ/src/mekhq/campaign/parts/TurretLock.java
@@ -96,8 +96,8 @@ public class TurretLock extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			((Tank)unit.getEntity()).unlockTurret();
 		}

--- a/MekHQ/src/mekhq/campaign/parts/TurretLock.java
+++ b/MekHQ/src/mekhq/campaign/parts/TurretLock.java
@@ -96,8 +96,8 @@ public class TurretLock extends Part {
 	}
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			((Tank)unit.getEntity()).unlockTurret();
 		}

--- a/MekHQ/src/mekhq/campaign/parts/VeeSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeSensor.java
@@ -71,8 +71,8 @@ public class VeeSensor extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			((Tank)unit.getEntity()).setSensorHits(0);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/VeeSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeSensor.java
@@ -71,8 +71,8 @@ public class VeeSensor extends Part {
 	}
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			((Tank)unit.getEntity()).setSensorHits(0);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
@@ -93,8 +93,8 @@ public class VeeStabiliser extends Part {
 	}
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
-        super.fix(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        super.fix(gmMode);
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			((Tank)unit.getEntity()).clearStabiliserHit(loc);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
@@ -93,8 +93,8 @@ public class VeeStabiliser extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+    public void fix(boolean hasInfiniteResources) {
+        super.fix(hasInfiniteResources);
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			((Tank)unit.getEntity()).clearStabiliserHit(loc);
 		}

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -309,12 +309,17 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     @Override
-    public void fix() {
-        loadBin();
+    public void fix(boolean hasInfiniteResources) {
+        loadBin(hasInfiniteResources);
     }
 
     public void loadBin() {
-        int shots = Math.min(getAmountAvailable(), getShotsNeeded());
+        loadBin(false);
+    }
+
+    protected void loadBin(boolean hasInfiniteResources) {
+        int shotsNeeded = getShotsNeeded();
+        int shots = hasInfiniteResources ? shotsNeeded : Math.min(getAmountAvailable(), shotsNeeded);
         if (null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if (null != mounted) {
@@ -330,7 +335,9 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                         mounted.setShotsLeft(shots);
                     }
 
-                    changeAmountAvailable(-1 * shots, (AmmoType)type);
+                    if (!hasInfiniteResources) {
+                        changeAmountAvailable(-1 * shots, (AmmoType)type);
+                    }
                     shotsNeeded -= shots;
                 }
                 else {
@@ -338,6 +345,8 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 }
             }
         }
+
+        resetRepairSettings();
     }
 
     public void setShotsNeeded(int shots) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -309,17 +309,17 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
-        loadBin(hasInfiniteResources);
+    public void fix(boolean gmMode) {
+        loadBin(gmMode);
     }
 
     public void loadBin() {
         loadBin(false);
     }
 
-    protected void loadBin(boolean hasInfiniteResources) {
+    protected void loadBin(boolean gmMode) {
         int shotsNeeded = getShotsNeeded();
-        int shots = hasInfiniteResources ? shotsNeeded : Math.min(getAmountAvailable(), shotsNeeded);
+        int shots = gmMode ? shotsNeeded : Math.min(getAmountAvailable(), shotsNeeded);
         if (null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if (null != mounted) {
@@ -335,7 +335,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                         mounted.setShotsLeft(shots);
                     }
 
-                    if (!hasInfiniteResources) {
+                    if (!gmMode) {
                         changeAmountAvailable(-1 * shots, (AmmoType)type);
                     }
                     shotsNeeded -= shots;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -146,8 +146,8 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
     }
     
     @Override
-    protected void loadBin(boolean hasInfiniteResources) {
-        int shots = hasInfiniteResources ? shotsNeeded : Math.min(getAmountAvailable(), shotsNeeded);
+    protected void loadBin(boolean gmMode) {
+        int shots = gmMode ? shotsNeeded : Math.min(getAmountAvailable(), shotsNeeded);
         int shotsPerTrooper = shots / getNumTroopers();
         shots = shotsPerTrooper * getNumTroopers();
         if(null != unit) {
@@ -166,7 +166,7 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
             }
         }
 
-        if (!hasInfiniteResources) {
+        if (!gmMode) {
             changeAmountAvailable(-1 * shots, (AmmoType)type);
         }
         shotsNeeded -= shots;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -146,8 +146,8 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
     }
     
     @Override
-    public void loadBin() {
-        int shots = Math.min(getAmountAvailable(), shotsNeeded);
+    protected void loadBin(boolean hasInfiniteResources) {
+        int shots = hasInfiniteResources ? shotsNeeded : Math.min(getAmountAvailable(), shotsNeeded);
         int shotsPerTrooper = shots / getNumTroopers();
         shots = shotsPerTrooper * getNumTroopers();
         if(null != unit) {
@@ -165,9 +165,14 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
                 }
             }
         }
-        changeAmountAvailable(-1 * shots, (AmmoType)type);
+
+        if (!hasInfiniteResources) {
+            changeAmountAvailable(-1 * shots, (AmmoType)type);
+        }
         shotsNeeded -= shots;
     }
+
+
     
     @Override
     public void unload() {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -206,8 +206,8 @@ public class EquipmentPart extends Part {
 	}
 
 	@Override
-	public void fix() {
-		super.fix();
+	public void fix(boolean hasInfiniteResources) {
+		super.fix(hasInfiniteResources);
 		if(null != unit) {
 			Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
 			if(null != mounted) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -206,8 +206,8 @@ public class EquipmentPart extends Part {
 	}
 
 	@Override
-	public void fix(boolean hasInfiniteResources) {
-		super.fix(hasInfiniteResources);
+	public void fix(boolean gmMode) {
+		super.fix(gmMode);
 		if(null != unit) {
 			Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
 			if(null != mounted) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -200,23 +200,23 @@ public class LargeCraftAmmoBin extends AmmoBin {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         if (shotsNeeded < 0) {
             unloadSingle();
         } else {
-            loadBinSingle(hasInfiniteResources);
+            loadBinSingle(gmMode);
         }
     }
     
-    public void loadBinSingle(boolean hasInfiniteResources) {
-        int shots = hasInfiniteResources ? shotsNeeded : Math.min(getAmountAvailable(), Math.min(shotsNeeded, ((AmmoType) type).getShots()));
+    public void loadBinSingle(boolean gmMode) {
+        int shots = gmMode ? shotsNeeded : Math.min(getAmountAvailable(), Math.min(shotsNeeded, ((AmmoType) type).getShots()));
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if(null != mounted && mounted.getType() instanceof AmmoType) {
                 mounted.setShotsLeft(mounted.getBaseShotsLeft() + shots);
             }
         }
-        if (!hasInfiniteResources) {
+        if (!gmMode) {
             changeAmountAvailable(-1 * shots, (AmmoType)type);
         }
         shotsNeeded -= shots;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -200,24 +200,28 @@ public class LargeCraftAmmoBin extends AmmoBin {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         if (shotsNeeded < 0) {
             unloadSingle();
         } else {
-            loadBinSingle();
+            loadBinSingle(hasInfiniteResources);
         }
     }
     
-    public void loadBinSingle() {
-        int shots = Math.min(getAmountAvailable(), Math.min(shotsNeeded, ((AmmoType) type).getShots()));
+    public void loadBinSingle(boolean hasInfiniteResources) {
+        int shots = hasInfiniteResources ? shotsNeeded : Math.min(getAmountAvailable(), Math.min(shotsNeeded, ((AmmoType) type).getShots()));
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if(null != mounted && mounted.getType() instanceof AmmoType) {
                 mounted.setShotsLeft(mounted.getBaseShotsLeft() + shots);
             }
         }
-        changeAmountAvailable(-1 * shots, (AmmoType)type);
+        if (!hasInfiniteResources) {
+            changeAmountAvailable(-1 * shots, (AmmoType)type);
+        }
         shotsNeeded -= shots;
+
+        resetRepairSettings();
     }
 
     public void unloadSingle() {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -83,7 +83,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
 	}
 
 	@Override 
-	public void fix() {
+    public void fix(boolean hasInfiniteResources) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 		    Part actualReplacement;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -83,7 +83,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
 	}
 
 	@Override 
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 		    Part actualReplacement;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
@@ -159,7 +159,7 @@ public class MissingBattleArmorEquipmentPart extends MissingEquipmentPart {
     }
 
     @Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
@@ -159,7 +159,7 @@ public class MissingBattleArmorEquipmentPart extends MissingEquipmentPart {
     }
 
     @Override
-    public void fix() {
+    public void fix(boolean hasInfiniteResources) {
         Part replacement = findReplacement(false);
         if(null != replacement) {
             Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
@@ -162,7 +162,7 @@ public class MissingEquipmentPart extends MissingPart {
 	}
 
 	@Override
-	public void fix() {
+    public void fix(boolean hasInfiniteResources) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
@@ -162,7 +162,7 @@ public class MissingEquipmentPart extends MissingPart {
 	}
 
 	@Override
-    public void fix(boolean hasInfiniteResources) {
+    public void fix(boolean gmMode) {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
 			Part actualReplacement = replacement.clone();

--- a/MekHQ/src/mekhq/campaign/work/IPartWork.java
+++ b/MekHQ/src/mekhq/campaign/work/IPartWork.java
@@ -60,7 +60,7 @@ public interface IPartWork extends IWork {
     
     void updateConditionFromEntity(boolean checkForDestruction);
     void updateConditionFromPart();
-    void fix();
+    void fix(boolean hasInfiniteResources);
     void remove(boolean salvage);
     MissingPart getMissingPart();
     

--- a/MekHQ/src/mekhq/campaign/work/IPartWork.java
+++ b/MekHQ/src/mekhq/campaign/work/IPartWork.java
@@ -60,7 +60,11 @@ public interface IPartWork extends IWork {
     
     void updateConditionFromEntity(boolean checkForDestruction);
     void updateConditionFromPart();
-    void fix(boolean hasInfiniteResources);
+    /**
+     * Completes a repair operation on the part.
+     * @param gmMode The operation is being completed in GM Mode.
+     */
+    void fix(boolean gmMode);
     void remove(boolean salvage);
     MissingPart getMissingPart();
     

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -519,7 +519,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                         if(part instanceof MissingPart) {
                             // We magically acquire a replacement part, then fix the missing one.
                             part.getCampaign().addPart(((MissingPart) part).getNewPart(), 0);
-                            part.fix();
+                            part.fix(true);
                             part.resetTimeSpent();
                             part.resetOvertime();
                             part.setTeamId(null);
@@ -529,7 +529,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                         } else {
                             if(part.needsFixing()) {
                                 needsCheck = true;
-                                part.fix();
+                                part.fix(true);
                             } else {
                                 part.resetRepairSettings();
                             }


### PR DESCRIPTION
- Adds a bool to Part::fix indicating if infinite resources are available for the fix
- Fixes bug where Armor work mode was sticky after a fix (was not restored to Normal)