### PR TITLE
Removed race condition when calculating faction border data.

### DIFF
--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -22,6 +22,7 @@ v0.45.2-SNAPSHOT
 + Issue #967: Fix bug where acquired Units could never be bought
 + PR #971: Feature allowing grouping personnel by their unit on the Personnel tab
 + Issue #865: Changing Award Date Does Not Update Award Tooltip
++ Issue #973: No contracts are offered at the start of an AtB campaign.
 
 v0.45.1 (2018-09-03 2300 UTC)
 + PR #864: Security - address XXE vulnerabilities in XML parsers

--- a/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
@@ -429,22 +429,20 @@ public class FactionBorderTracker {
      * The task that checks all planets within the region and notes which are controlled by which factions
      * and which are within a certain distance of another faction's systems.
      */
-    private void rebuildBorderData() {
+    private synchronized void rebuildBorderData() {
         cancelTask = false;
         try {
             List<Planet> planetList = new ArrayList<>();
             Set<Faction> factionSet = new HashSet<>();
             Set<Faction> oldFactions = new HashSet<>(borders.keySet());
-            synchronized (this) {
-                for (Planet planet : getPlanetList()) {
-                    if ((regionHex.radius < 0)
-                            || regionHex.contains(planet.getX(), planet.getY())) {
-                        planetList.add(planet);
-                        factionSet.addAll(planet.getFactionSet(now));
-                    }
-                    if (cancelTask) {
-                        return;
-                    }
+            for (Planet planet : getPlanetList()) {
+                if ((regionHex.radius < 0)
+                        || regionHex.contains(planet.getX(), planet.getY())) {
+                    planetList.add(planet);
+                    factionSet.addAll(planet.getFactionSet(now));
+                }
+                if (cancelTask) {
+                    return;
                 }
             }
             for (Faction f : factionSet) {
@@ -472,19 +470,15 @@ public class FactionBorderTracker {
                     return;
                 }
             }
-            synchronized (this) {
-                if (cancelTask) {
-                    return;
-                }
-                lastUpdate = now;
+            if (cancelTask) {
+                return;
             }
+            lastUpdate = now;
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "recalculate()", ex.getMessage());
         } finally {
-            synchronized (this) {
-                invalid = false;
-                notify();
-            }
+            invalid = false;
+            notify();
         }
     }
     


### PR DESCRIPTION
The AtB contract generator was running before the faction borders had been calculated. This is due to a race condition resulting from an attempt to optimize the faction calculation by limiting the amount of synchronized code. Removing the premature optimization and synchronizing the entire method fixes the race condition.

Fixes #973: No contracts are offered at the start of an AtB campaign