### PR TITLE
Reset all crew state when resetting entity and crew.

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2855,6 +2855,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     }
 
     public void resetPilotAndEntity() {
+        entity.getCrew().resetGameState();
         if (entity.getCrew().getSlotCount() > 1) {
             final String driveType = SkillType.getDrivingSkillFor(entity);
             final String gunType = SkillType.getGunnerySkillFor(entity);
@@ -2930,8 +2931,6 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             }
             entity.getCrew().setMissing(false, 0);
         }
-        entity.getCrew().resetFatigue();
-        entity.getCrew().setEjected(false);
 
         // Clear any stale game data that may somehow have gotten set incorrectly
         campaign.clearGameData(entity);


### PR DESCRIPTION
Fix for #949 
Depends on MegaMek branch reset_crew_state

Added a method to `Crew` in MegaMek that resets the game state. Replaced separate calls to resetFatigueCount and setEjected with a single method call. Moved it to the beginning of resetPilotAndEntity before MekHQ sets missing and hit count values.