### PR TITLE
Fix npe when determining whether a tech is mothballing.

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3004,7 +3004,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
             return false;
         }
         for (Unit u : campaign.getUnits()) {
-            if (u.isMothballing() && u.getTechId().equals(id)) {
+            if (u.isMothballing() && u.getTech().getId().equals(id)) {
                 return true;
             }
         }


### PR DESCRIPTION
Tangential issue to #979 
When checking whether a tech is tied up in mothballing, the tech's id is checked against getTechId() of every unit undergoing mothballing. For aerospace vessels this returns null, because the virtual engineer is used for all tech duties. Replacing getTechId() with getTech().getId() uses the engineer field instead if it's non-null.