### PR TITLE
Fix pattern matching in log entry updates and cache patterns

### DIFF
--- a/MekHQ/src/mekhq/campaign/log/LogEntryController.java
+++ b/MekHQ/src/mekhq/campaign/log/LogEntryController.java
@@ -47,7 +47,7 @@ public class LogEntryController {
      * @param person whose rank we want to generate the string
      * @return string with the rank
      */
-    public static String generateRankEntryString(Person person){
+    public static String generateRankEntryString(Person person) {
         String rankEntry = "";
         if (person.getRankNumeric() > 0) {
             String message = logEntriesResourceMap.getString("asA.text");
@@ -186,9 +186,7 @@ public class LogEntryController {
      * @return string with the new description.
      */
     public static String updateOldDescription(String description) {
-        String newDescription = "";
-
-        newDescription = updatePrisonerDescription(description);
+        String newDescription = updatePrisonerDescription(description);
         if (!newDescription.isEmpty()) {
             return newDescription;
         }

--- a/MekHQ/src/mekhq/campaign/log/LogEntryController.java
+++ b/MekHQ/src/mekhq/campaign/log/LogEntryController.java
@@ -55,9 +55,9 @@ public class LogEntryController {
      * @param description of the log entry
      * @return type of the log entry.
      */
-    public static LogEntryType determineTypeFromLogDescription(String description){
+    public static LogEntryType determineTypeFromLogDescription(String description) {
 
-        if(foundExpressionWithOneVariable("madeBondsmanBy.text", description) ||
+        if (foundExpressionWithOneVariable("madeBondsmanBy.text", description) ||
                 foundExpressionWithOneVariable("madePrisonerBy.text", description) ||
                 foundExpressionWithOneVariable("joined.text", description) ||
                 foundSingleExpression("freed.text", description) ||
@@ -76,25 +76,24 @@ public class LogEntryController {
                 foundExpressionWithOneVariable("retiredDueToWounds.text", description) ||
                 foundExpressionWithOneVariable("reassignedTo.text", description) ||
                 foundExpressionWithOneVariable("assignedTo.text", description) ||
-                foundExpressionWithOneVariable("removedFrom.text", description)
-                )
+                foundExpressionWithOneVariable("removedFrom.text", description)) {
             return LogEntryType.SERVICE;
+        }
 
-        if(foundExpressionWithOneVariable("spouseKia.text",description) ||
+        if (foundExpressionWithOneVariable("spouseKia.text", description) ||
                 foundExpressionWithOneVariable("divorcedFrom.text", description) ||
                 foundExpressionWithOneVariable("marries.text", description) ||
                 foundExpressionWithOneVariable("gained.text", description) ||
-                foundSingleExpression("gainedEdge.text", description)
-                )
+                foundSingleExpression("gainedEdge.text", description)) {
             return LogEntryType.PERSONAL;
+        }
 
-        if(foundExpressionWithOneVariable("removedAward.text", description) ||
-                foundExpressionWithTwoVariables("awarded.text", description)
-                )
+        if (foundExpressionWithOneVariable("removedAward.text", description) ||
+                foundExpressionWithTwoVariables("awarded.text", description)) {
             return LogEntryType.AWARD;
+        }
 
-
-        if(foundExpressionWithTwoVariables("severedSpine.text", description) ||
+        if (foundExpressionWithTwoVariables("severedSpine.text", description) ||
                 foundExpressionWithOneVariable("brokenRibPunctureDead.text", description) ||
                 foundExpressionWithOneVariable("brokenRibPuncture.text", description) ||
                 foundSingleExpression("developedEncephalopathy.text", description) ||
@@ -116,21 +115,21 @@ public class LogEntryController {
                 foundSingleExpression("dismissedFromInfirmary.text", description) ||
                 foundExpressionWithOneVariable("deliveredBaby.text", description) ||
                 foundSingleExpression("hasConceived.text", description) ||
-                foundExpressionWithOneVariable("hasConceived.text", description)
-                )
+                foundExpressionWithOneVariable("hasConceived.text", description)) {
             return LogEntryType.MEDICAL;
+        }
 
         return LogEntryType.CUSTOM;
     }
 
-    private static boolean foundSingleExpression(String logEntryProperty, String description){
+    private static boolean foundSingleExpression(String logEntryProperty, String description) {
         Pattern pattern = Pattern.compile(logEntriesResourceMap.getString(logEntryProperty));
         Matcher matcher = pattern.matcher(description);
 
         return matcher.matches();
     }
 
-    private static boolean foundExpressionWithOneVariable(String logEntryProperty, String description){
+    private static boolean foundExpressionWithOneVariable(String logEntryProperty, String description) {
         String message = logEntriesResourceMap.getString(logEntryProperty);
         Pattern pattern = Pattern.compile(MessageFormat.format(message, "(.*)"));
         Matcher matcher = pattern.matcher(description);
@@ -138,7 +137,7 @@ public class LogEntryController {
         return matcher.matches();
     }
 
-    private static boolean foundBeginningOfExpressionEndingWithMultilineAndTab(String logEntryProperty, String description){
+    private static boolean foundBeginningOfExpressionEndingWithMultilineAndTab(String logEntryProperty, String description) {
         String message = logEntriesResourceMap.getString(logEntryProperty);
         Pattern pattern = Pattern.compile(message + "((.|\\n)*)");
         Matcher matcher = pattern.matcher(description);
@@ -146,7 +145,7 @@ public class LogEntryController {
         return matcher.matches();
     }
 
-    private static boolean foundExpressionWithTwoVariables(String logEntryProperty, String description){
+    private static boolean foundExpressionWithTwoVariables(String logEntryProperty, String description) {
         String message = logEntriesResourceMap.getString(logEntryProperty);
         Pattern pattern = Pattern.compile(MessageFormat.format(message, "(.*)", "(.*)"));
         Matcher matcher = pattern.matcher(description);
@@ -154,7 +153,7 @@ public class LogEntryController {
         return matcher.matches();
     }
 
-    private static boolean foundExpressionWithThreeVariables(String logEntryProperty, String description){
+    private static boolean foundExpressionWithThreeVariables(String logEntryProperty, String description) {
         String message = logEntriesResourceMap.getString(logEntryProperty);
         Pattern pattern = Pattern.compile(MessageFormat.format(message, "(.*)", "(.*)", "(.*)"));
         Matcher matcher = pattern.matcher(description);
@@ -168,23 +167,27 @@ public class LogEntryController {
      * @param description to be changes
      * @return string with the new description.
      */
-    public static String updateOldDescription(String description){
+    public static String updateOldDescription(String description) {
         String newDescription = "";
 
         newDescription = updatePrisonerDescription(description);
-        if(!newDescription.isEmpty()) return newDescription;
+        if (!newDescription.isEmpty()) {
+            return newDescription;
+        }
 
         newDescription = updateBondsmanDescription(description);
-        if(!newDescription.isEmpty()) return newDescription;
+        if (!newDescription.isEmpty()) {
+            return newDescription;
+        }
 
         return "";
     }
 
-    private static String updatePrisonerDescription(String description){
+    private static String updatePrisonerDescription(String description) {
         Pattern pattern = Pattern.compile("Made Prisoner (.*)");
         Matcher matcher = pattern.matcher(description);
 
-        if(matcher.matches()){
+        if (matcher.matches()) {
             return MessageFormat.format(logEntriesResourceMap.getString("madePrisonerBy.text"), matcher.group(1));
         }
 
@@ -199,7 +202,7 @@ public class LogEntryController {
         Pattern pattern = Pattern.compile("Made Bondsman (.*)");
         Matcher matcher = pattern.matcher(description);
 
-        if(matcher.matches()){
+        if (matcher.matches()) {
             return MessageFormat.format(logEntriesResourceMap.getString("madeBondsmanBy.text"), matcher.group(1));
         }
 

--- a/MekHQ/src/mekhq/campaign/log/LogEntryController.java
+++ b/MekHQ/src/mekhq/campaign/log/LogEntryController.java
@@ -35,6 +35,9 @@ public class LogEntryController {
 
     private static ResourceBundle logEntriesResourceMap = ResourceBundle.getBundle("mekhq.resources.LogEntries", new EncodeControl());
 
+    private static Pattern madePrisonerPattern = Pattern.compile("Made Prisoner (.*)");
+    private static Pattern madeBondsmanPattern = Pattern.compile("Made Bondsman (.*)");
+
     /**
      * Generates a string with the rank of the person
      * @param person whose rank we want to generate the string
@@ -184,8 +187,8 @@ public class LogEntryController {
     }
 
     private static String updatePrisonerDescription(String description) {
-        Pattern pattern = Pattern.compile("Made Prisoner (.*)");
-        Matcher matcher = pattern.matcher(description);
+
+        Matcher matcher = madePrisonerPattern.matcher(description);
 
         if (matcher.matches()) {
             return MessageFormat.format(logEntriesResourceMap.getString("madePrisonerBy.text"), matcher.group(1));
@@ -198,9 +201,9 @@ public class LogEntryController {
         return "";
     }
 
-    private static String updateBondsmanDescription(String description){
-        Pattern pattern = Pattern.compile("Made Bondsman (.*)");
-        Matcher matcher = pattern.matcher(description);
+    private static String updateBondsmanDescription(String description) {
+
+        Matcher matcher = madeBondsmanPattern.matcher(description);
 
         if (matcher.matches()) {
             return MessageFormat.format(logEntriesResourceMap.getString("madeBondsmanBy.text"), matcher.group(1));

--- a/MekHQ/src/mekhq/campaign/log/LogEntryController.java
+++ b/MekHQ/src/mekhq/campaign/log/LogEntryController.java
@@ -188,11 +188,8 @@ public class LogEntryController {
             return MessageFormat.format(logEntriesResourceMap.getString("madePrisonerBy.text"), matcher.group(1));
         }
 
-        pattern = Pattern.compile("Made Prisoner");
-        matcher = pattern.matcher(description);
-
-        if(matcher.matches()){
-            return MessageFormat.format(logEntriesResourceMap.getString("madePrisoner.text"), matcher.group(1));
+        if (description.contains("Made Prisoner")) {
+            return logEntriesResourceMap.getString("madePrisoner.text");
         }
 
         return "";
@@ -206,11 +203,8 @@ public class LogEntryController {
             return MessageFormat.format(logEntriesResourceMap.getString("madeBondsmanBy.text"), matcher.group(1));
         }
 
-        pattern = Pattern.compile("Made Bondsman");
-        matcher = pattern.matcher(description);
-
-        if(matcher.matches()){
-            return MessageFormat.format(logEntriesResourceMap.getString("madeBondsman.text"), matcher.group(1));
+        if (description.contains("Made Bondsman")) {
+            return logEntriesResourceMap.getString("madeBondsman.text");
         }
 
         return "";


### PR DESCRIPTION
This PR does two things:

1. Fixes an exception raised when `Made Bondsman` or `Made Prisoner` did not include a name.
```
12:10:04,272 ERROR [mekhq.campaign.personnel.Person] {SwingWorker-pool-1-thread-1} 
No group 1
java.lang.IndexOutOfBoundsException: No group 1
    at java.util.regex.Matcher.group(Matcher.java:538)
    at mekhq.campaign.log.LogEntryController.updatePrisonerDescription(LogEntryController.java:195)
    at mekhq.campaign.log.LogEntryController.updateOldDescription(LogEntryController.java:174)
    at mekhq.campaign.log.LogEntryFactory.generateInstanceFromXML(LogEntryFactory.java:110)
    at mekhq.campaign.personnel.Person.generateInstanceFromXML(Person.java:1721)
...
```

2. Caches regular expression patterns so they are not recreated each time this is used (important on large campaign files).