### PR TITLE
Weekly Support Edge Refresh

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
@@ -17,6 +17,7 @@ lblImplants1.text=<html><b>Implants:</b></html>;
 lblAdvancedMedical1.text=<html><b>Injury Penalties:</b></html>;
 lblInjuries.text=<html><b>Injuries:</b></html>;
 lblEdge1.text=<html><b>Edge:</b></html>;
+lblEdgeAvail1.text=<html><b>Edge Available:</b></html>;
 lblSpouse1.text=<html><b>Spouse:</b></html>;
 lblChildren1.text=<html><b>Children:</b></html>;
 pnlInjuries.title=Injury Report

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2877,6 +2877,13 @@ public class Campaign implements Serializable, ITechManager {
                     u.resetPilotAndEntity();
                 }
             }
+            
+            // Reset edge points to the purchased value each week. This should only
+            // apply for support personnel - combat troops reset with each new mm game
+            if ((p.isAdmin() || p.isDoctor() || p.isEngineer() || p.isTech())
+                    && calendar.get(Calendar.DAY_OF_WEEK) == Calendar.MONDAY) {
+                p.resetCurrentEdge();
+            }
 
             if (getCampaignOptions().getIdleXP() > 0 && calendar.get(Calendar.DAY_OF_MONTH) == 1 && p.isActive()
                     && !p.isPrisoner()) { // Prisoners no
@@ -2892,7 +2899,6 @@ public class Campaign implements Serializable, ITechManager {
                     p.setIdleMonths(0);
                 }
             }
-
         }
 
         for (Person baby : babies) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1890,8 +1890,8 @@ public class Campaign implements Serializable, ITechManager {
         //If we get a natural 2 that isn't an automatic success, reroll if Edge is available and in use.
         if (getCampaignOptions().useSupportEdge()
                 && (doctor.getOptions().booleanOption(PersonnelOptions.EDGE_MEDICAL))) {
-            if (roll == 2  && doctor.getEdge() > 0 && target.getValue() != TargetRoll.AUTOMATIC_SUCCESS) {
-                doctor.setEdge(doctor.getEdge() - 1);
+            if (roll == 2  && doctor.getCurrentEdge() > 0 && target.getValue() != TargetRoll.AUTOMATIC_SUCCESS) {
+                doctor.setCurrentEdge(doctor.getCurrentEdge() - 1);
                 roll = Compute.d6(2);
                 report += medWork.fail(0) + "\n" + doctor.getHyperlinkedFullTitle() + " uses Edge to reroll:"
                         + " rolls " + roll + ":";
@@ -2221,8 +2221,8 @@ public class Campaign implements Serializable, ITechManager {
         if (roll < target.getValue()
                 && getCampaignOptions().useSupportEdge() 
                 && person.getOptions().booleanOption(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL)
-                && person.getEdge() > 0) {
-            person.setEdge(person.getEdge() - 1);
+                && person.getCurrentEdge() > 0) {
+            person.setCurrentEdge(person.getCurrentEdge() - 1);
             roll = Compute.d6(2);
             report += " <b>failed!</b> but uses Edge to reroll...getting a " + roll + ": ";
         }
@@ -2352,8 +2352,8 @@ public class Campaign implements Serializable, ITechManager {
                 report = report + ",  needs " + target.getValueAsString() + " and rolls " + roll + ": ";
                 if (roll < target.getValue() && getCampaignOptions().useSupportEdge()
                         && tech.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_FAILED_REFIT)
-                        && tech.getEdge() > 0) {
-                    tech.setEdge(tech.getEdge() - 1);
+                        && tech.getCurrentEdge() > 0) {
+                    tech.setCurrentEdge(tech.getCurrentEdge() - 1);
                     if (tech.isRightTechTypeFor(r)) {
                         roll = Compute.d6(2);
                     } else {
@@ -2513,14 +2513,14 @@ public class Campaign implements Serializable, ITechManager {
         //if we fail and would break a part, here's a chance to use Edge for a reroll...
         if (getCampaignOptions().useSupportEdge() 
                 && tech.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_BREAK_PART)
-                && tech.getEdge() > 0
+                && tech.getCurrentEdge() > 0
                 && target.getValue() != TargetRoll.AUTOMATIC_SUCCESS) {
             if ((getCampaignOptions().isDestroyByMargin()
                     && getCampaignOptions().getDestroyMargin() <= (target.getValue() - roll))
                     || (!getCampaignOptions().isDestroyByMargin() && (tech.getExperienceLevel(false) == SkillType.EXP_ELITE //if an elite, primary tech and destroy by margin is NOT on
                                     || tech.getPrimaryRole() == Person.T_SPACE_CREW)) // For vessel crews
                             && roll < target.getValue()) {
-                tech.setEdge(tech.getEdge() - 1);
+                tech.setCurrentEdge(tech.getCurrentEdge() - 1);
                 if (tech.isRightTechTypeFor(partWork)) {
                     roll = Compute.d6(2);
                 } else {

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
@@ -276,12 +276,12 @@ public final class InjuryUtil {
                 final int critTimeReduction = i.getTime() - (int) Math.floor(i.getTime() * 0.9);
                 //Reroll fumbled treatment check with Edge if applicable
                 if (roll < fumbleLimit && c.getCampaignOptions().useSupportEdge()
-                        && (doc.getOptions().booleanOption(PersonnelOptions.EDGE_MEDICAL) && doc.getEdge() > 0)) {
+                        && (doc.getOptions().booleanOption(PersonnelOptions.EDGE_MEDICAL) && doc.getCurrentEdge() > 0)) {
                     result.add(new GameEffect(
                     String.format("%s made a mistake, but used Edge to reroll.",
                             doc.getHyperlinkedFullTitle(), p.getHyperlinkedName(),
                             p.getGenderPronoun(Person.PRONOUN_HISHER), i.getName())));
-                    doc.setEdge(doc.getEdge() - 1);
+                    doc.setCurrentEdge(doc.getCurrentEdge() - 1);
                     roll = Compute.randomInt(100);
                 }
                 if(roll < fumbleLimit) {                    

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -238,6 +238,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     boolean commander;
     boolean isClanTech;
     int edgeUsedThisRound;
+    int currentEdge;
 
     //phenotype and background
     private int phenotype;
@@ -2789,6 +2790,30 @@ public class Person implements Serializable, MekHqXmlSerializable {
         }
     }
     
+    /**
+     * Resets support personnel edge points to the purchased level. Used for weekly refresh.
+     * 
+     */
+    public void resetCurrentEdge() {
+        setCurrentEdge(getEdge());
+    }
+    
+    /**
+     * Sets support personnel edge points to the value 'e'. Used for weekly refresh.
+     * @param e - integer used to track this person's edge points available for the current week
+     */
+    public void setCurrentEdge(int e) {
+        currentEdge = e;
+    }
+    
+    /**
+     *  Returns this person's currently available edge points. Used for weekly refresh.
+     * 
+     */
+    public int getCurrentEdge() {
+        return currentEdge;
+    }
+    
     public void setEdgeUsed(int e) {
         edgeUsedThisRound = e;
     }
@@ -2797,7 +2822,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return edgeUsedThisRound;
     }
 
-    /*
+    /**
      * This will set a specific edge trigger, regardless of the current status
      */
     public void setEdgeTrigger(String name, boolean status) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1533,7 +1533,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
 
             String advantages = null;
             String edge = null;
-            String edgeAvailable = null;
             String implants = null;
 
             //backwards compatability
@@ -1672,7 +1671,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("edge")) {
                     edge = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("edgeAvailable")) {
-                    edgeAvailable = wn2.getTextContent();
+                    retVal.currentEdge = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("implants")) {
                     implants = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("toughness")) {
@@ -1849,22 +1848,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
                     } catch (Exception e) {
                         MekHQ.getLogger().log(Person.class, METHOD_NAME, LogLevel.ERROR,
                                 "Error restoring edge: " + adv); //$NON-NLS-1$
-                    }
-                }
-            }
-            //Track edge usage for support personnel
-            if ((null != edgeAvailable) && (edgeAvailable.trim().length() > 0)) {
-                StringTokenizer st = new StringTokenizer(edgeAvailable, "::");
-                while (st.hasMoreTokens()) {
-                    String adv = st.nextToken();
-                    String advName = Crew.parseAdvantageName(adv);
-                    Object value = Crew.parseAdvantageValue(adv);
-
-                    try {
-                        retVal.getOptions().getOption(advName).setValue(value);
-                    } catch (Exception e) {
-                        MekHQ.getLogger().log(Person.class, METHOD_NAME, LogLevel.ERROR,
-                                "Error restoring available edge: " + adv); //$NON-NLS-1$
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
@@ -115,6 +115,7 @@ public class PersonAwardController {
         }
         person.setXp(person.getXp() + award.getXPReward());
         person.setEdge(person.getEdge() + award.getEdgeReward());
+        person.resetCurrentEdge(); //Reset the person's edge points
 
         award.addDate(date);
         logAward(award, date);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3291,8 +3291,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     if (engineer != null) {
                         if (engineer.getEdgeUsed() > 0) {
                             //Don't subtract an Edge if the individual has none left
-                            if (p.getEdge() > 0) {
-                                p.setEdge(p.getEdge() - 1);
+                            if (p.getCurrentEdge() > 0) {
+                                p.setCurrentEdge(p.getCurrentEdge() - 1);
                                 engineer.setEdgeUsed(engineer.getEdgeUsed() - 1);
                             }
                         }
@@ -3340,7 +3340,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     }
                     engineer.addSkill(SkillType.S_TECH_VESSEL, sumSkill/nCrew, sumBonus/nCrew);
                     engineer.setEdgeUsed(sumEdgeUsed);
-                    engineer.setEdge((sumEdge - sumEdgeUsed)/nCrew);
+                    engineer.setCurrentEdge((sumEdge - sumEdgeUsed)/nCrew);
                     engineer.setUnitId(this.getId());
                 } else {
                     engineer = null;

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -915,6 +915,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                 for (Person person : people) {
                     selectedPerson.setXp(selectedPerson.getXp() - cost);
                     person.setEdge(person.getEdge() + 1);
+                    //Make the new edge point available to support personnel, but don't reset until the week ends
+                    person.setCurrentEdge(person.getCurrentEdge() + 1);
                     gui.getCampaign().personUpdated(person);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
@@ -932,6 +934,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                 int i = pvcd.getValue();
                 for (Person person : people) {
                     person.setEdge(i);
+                    //Reset currentEdge for support people
+                    person.resetCurrentEdge();
                     gui.getCampaign().personUpdated(person);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -88,6 +88,8 @@ public class PersonViewPanel extends JPanel {
     private JLabel lblTough2;
     private JLabel lblEdge1;
     private JLabel lblEdge2;
+    private JLabel lblEdgeAvail1;
+    private JLabel lblEdgeAvail2;
     private JLabel lblAbility1;
     private JLabel lblAbility2;
     private JLabel lblImplants1;
@@ -725,6 +727,30 @@ public class PersonViewPanel extends JPanel {
             gridBagConstraints.fill = GridBagConstraints.NONE;
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
             pnlStats.add(lblEdge2, gridBagConstraints);
+            
+            if (person.isAdmin() || person.isDoctor() || person.isTech()) {
+                //Add the Edge Available field for support personnel only
+                secondy++;
+                lblEdgeAvail1.setName("lblEdgeAvail1"); // NOI18N //$NON-NLS-1$
+                lblEdgeAvail1.setText(resourceMap.getString("lblEdgeAvail1.text")); //$NON-NLS-1$
+                gridBagConstraints = new GridBagConstraints();
+                gridBagConstraints.gridx = 2;
+                gridBagConstraints.gridy = secondy;
+                gridBagConstraints.fill = GridBagConstraints.NONE;
+                gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+                pnlStats.add(lblEdgeAvail1, gridBagConstraints);
+
+                lblEdgeAvail2.setName("lblEdgeAvail2"); // NOI18N //$NON-NLS-1$
+                lblEdgeAvail2.setText(Integer.toString(person.getCurrentEdge()));
+                gridBagConstraints = new GridBagConstraints();
+                gridBagConstraints.gridx = 3;
+                gridBagConstraints.gridy = secondy;
+                gridBagConstraints.weightx = 0.5;
+                gridBagConstraints.insets = new Insets(0, 10, 0, 0);
+                gridBagConstraints.fill = GridBagConstraints.NONE;
+                gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+                pnlStats.add(lblEdgeAvail2, gridBagConstraints);
+            }
         }
 
         //special abilities and implants need to be three columns wide to handle their large width

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -469,6 +469,8 @@ public class PersonViewPanel extends JPanel {
         lblTough2 = new JLabel();
         lblEdge1 = new JLabel();
         lblEdge2 = new JLabel();
+        lblEdgeAvail1 = new JLabel();
+        lblEdgeAvail2 = new JLabel();
         lblAbility1 = new JLabel();
         lblAbility2 = new JLabel();
         lblImplants1 = new JLabel();


### PR DESCRIPTION
Refreshes the edge points available to support personnel each week. Combat personnel already get their edge points back at the start of each MM battle in which they are deployed. Available support edge points are displayed on the PersonViewPanel. 