### PR TITLE
Ensure the DateChooser dialog isn't hidden when you create a new campaign

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -113,6 +113,9 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         super(owner, "Date Chooser", true);
         date = d;
         workingDate = date;
+        
+        // Ensure the dialog isn't hidden
+        setAlwaysOnTop(true);
 
         Container contentPane = getContentPane();
         contentPane.setLayout(new BorderLayout());


### PR DESCRIPTION
On Mac OS X and Java 8 the DateChooser dialog becomes hidden behind the campaign loading splash screen when you create a new campaign. This makes it so that you no longer have to use Expose to find the date window.