### PR TITLE
Adds a GM hire button to new recruit dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/NewRecruitDialog.properties
+++ b/MekHQ/resources/mekhq/resources/NewRecruitDialog.properties
@@ -6,3 +6,5 @@ btnRandomPortrait.text=Randomize Portrait
 btnChoosePortrait.text=Choose Portrait
 btnEditPerson.text=Edit Statistics (GM)
 btnRegenerate.text=Regenerate (GM)
+btnRandomizeFaction.text=Randomize Faction
+btnAddGM.text=Add (GM)

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1265,6 +1265,36 @@ public class Campaign implements Serializable, ITechManager {
         return true;
     }
 
+    /** Adds a person to the campaign unconditionally, without paying for the person. */
+    public void addPerson(Person p) {
+        if (p == null) {
+            return;
+        }
+
+        UUID id = UUID.randomUUID();
+        while (null != personnel.get(id)) {
+            id = UUID.randomUUID();
+        }
+        p.setId(id);
+        personnel.put(id, p);
+
+        //TODO: implement a boolean check based on campaign options
+        addReport(p.getHyperlinkedName() + " has been added to the personnel roster.");
+        if (p.getPrimaryRole() == Person.T_ASTECH) {
+            astechPoolMinutes += 480;
+            astechPoolOvertime += 240;
+        }
+        if (p.getSecondaryRole() == Person.T_ASTECH) {
+            astechPoolMinutes += 240;
+            astechPoolOvertime += 120;
+        }
+        String rankEntry = LogEntryController.generateRankEntryString(p);
+    
+        p.setFreeMan();
+        ServiceLogger.joined(p, getDate(), getName(), rankEntry);
+        MekHQ.triggerEvent(new PersonNewEvent(p));
+    }
+
     /**
      * Imports a {@link Person} into a campaign.
      * @param p A {@link Person} to import into the campaign.

--- a/MekHQ/src/mekhq/gui/dialog/NewRecruitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewRecruitDialog.java
@@ -108,6 +108,15 @@ public class NewRecruitDialog extends javax.swing.JDialog {
         panButtons.add(button, gridBagConstraints);
         gridBagConstraints.gridx++;
 
+        if (hqView.getCampaign().isGM()) {
+            button = new JButton(resourceMap.getString("btnAddGM.text")); // NOI18N
+            button.setName("btnGM"); // NOI18N
+            button.addActionListener(e -> addGM());
+
+            panButtons.add(button, gridBagConstraints);
+            gridBagConstraints.gridx++;
+        }
+
         button = new JButton(resourceMap.getString("btnClose.text")); // NOI18N
         button.setName("btnClose"); // NOI18N
         button.addActionListener(e -> setVisible(false));
@@ -162,12 +171,29 @@ public class NewRecruitDialog extends javax.swing.JDialog {
                 GregorianCalendar rawrecruit = (GregorianCalendar) hqView.getCampaign().getCalendar().clone();
                 person.setRecruitment(rawrecruit);
             }
-            person = hqView.getCampaign().newPerson(person.getPrimaryRole());
-            refreshRanksCombo();
-            hqView.getCampaign().changeRank(person, hqView.getCampaign().getRanks().getRankNumericFromNameAndProfession(
-                    person.getProfession(), (String) choiceRanks.getSelectedItem()), false);
+
+            createNewRecruit();
         }
+
         refreshView();
+    }
+
+    private void addGM() {
+        hqView.getCampaign().addPerson(person);
+        if (hqView.getCampaign().getCampaignOptions().getUseTimeInService()) {
+            GregorianCalendar rawrecruit = (GregorianCalendar) hqView.getCampaign().getCalendar().clone();
+            person.setRecruitment(rawrecruit);
+        }
+
+        createNewRecruit();
+        refreshView();
+    }
+
+    private void createNewRecruit() {
+        person = hqView.getCampaign().newPerson(person.getPrimaryRole());
+        refreshRanksCombo();
+        hqView.getCampaign().changeRank(person, hqView.getCampaign().getRanks().getRankNumericFromNameAndProfession(
+                person.getProfession(), (String) choiceRanks.getSelectedItem()), false);
     }
 
     private void randomName() {


### PR DESCRIPTION
Adds a new "Add (GM)" button to the new recruit dialog.
![image](https://user-images.githubusercontent.com/8238690/50064325-888d9d00-017e-11e9-9d4c-a47eb4980df9.png)

I presume this was left out because Campaign did not have a means of doing so. I have added a function to unconditionally add a person.
