### PR TITLE
Bug: Do not recurse into getStickerPrice for Battle Armor

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -273,10 +273,8 @@ public class BattleArmorSuit extends Part {
         	if(null != p) {
         		if(p instanceof BaArmor) {
         			cost += p.getCurrentValue();
-        		} else {
-        			if(p instanceof BattleArmorSuit) {
-        			}
-        			cost += p.getStickerPrice();
+        		} else if (!(p instanceof BattleArmorSuit)) {
+                    cost += p.getStickerPrice();
         		}
         	}
         }


### PR DESCRIPTION
It looks like the old code was incomplete or perhaps cut/pasted wrong. Fixes #1010 