### PR TITLE
Bug: loan total value written as collateral value

### DIFF
--- a/MekHQ/src/mekhq/campaign/finances/Loan.java
+++ b/MekHQ/src/mekhq/campaign/finances/Loan.java
@@ -390,12 +390,16 @@ public class Loan implements MekHqXmlSerializable {
                 +"</payAmount>");
         pw1.println(MekHqXmlUtil.indentStr(indent+1)
                 +"<collateralValue>"
-                +totalValue
+                +collateralValue
                 +"</collateralValue>");
         pw1.println(MekHqXmlUtil.indentStr(indent+1)
                 +"<overdue>"
                 +overdue
                 +"</overdue>");
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<totalValue>"
+                +totalValue
+                +"</totalValue>");
         SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "nextPayment", df.format(nextPayment.getTime()));
         pw1.println(MekHqXmlUtil.indentStr(indent) + "</loan>");


### PR DESCRIPTION
A loan's collateral value was written out instead as its total value, and thus on subsequent save/load cycles the loan's properties would become incorrect. Fixes #991 