### PR TITLE
Bug: Default injury type wrong

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
@@ -94,26 +94,26 @@ public class EditInjuryEntryDialog extends JDialog {
             locations[i] = new BodyLocationChoice(loc);
             ++ i;
         }
-        types = InjuryType.getAllTypes().stream()
-            .map((type) -> new InjuryTypeChoice(type))
-            .collect(Collectors.toList()).toArray(new InjuryTypeChoice[0]);
-        String[] tf = { "True", "False" };
-        txtDays = new JTextArea();
-        ddLocation = new JComboBox<>(locations);
-        ddType = new JComboBox<>(types);
-        ddTypeModel = new FilterableComboBoxModel<InjuryTypeChoice>(ddType.getModel());
-        ddType.setModel(ddTypeModel);
-        ddTypeModel.setFilter(it -> {
-            BodyLocation loc = ((BodyLocationChoice) ddLocation.getSelectedItem()).loc;
-            return it.type.isValidInLocation(loc);
-        });
 
+        ddLocation = new JComboBox<>(locations);
         for (BodyLocationChoice choice : locations) {
             if (injury.getLocation() == choice.loc) {
                 ddLocation.setSelectedItem(choice);
                 break;
             }
         }
+
+        types = InjuryType.getAllTypes().stream()
+            .map((type) -> new InjuryTypeChoice(type))
+            .collect(Collectors.toList()).toArray(new InjuryTypeChoice[0]);
+
+        ddType = new JComboBox<>(types);
+        ddTypeModel = new FilterableComboBoxModel<InjuryTypeChoice>(ddType.getModel());
+        ddTypeModel.setFilter(it -> {
+            BodyLocation loc = ((BodyLocationChoice) ddLocation.getSelectedItem()).loc;
+            return it.type.isValidInLocation(loc);
+        });
+        ddType.setModel(ddTypeModel);
 
         for (InjuryTypeChoice choice : types) {
             if (injury.getType() == choice.type) {
@@ -122,8 +122,10 @@ public class EditInjuryEntryDialog extends JDialog {
             }
         }
         
+        txtDays = new JTextArea();
         txtFluff = new JTextArea();
         txtHits = new JTextArea();
+        String[] tf = { "True", "False" };
         ddPermanent = new JComboBox<String>(tf);
         ddWorkedOn = new JComboBox<String>(tf);
         ddExtended = new JComboBox<String>(tf);

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
@@ -182,6 +182,7 @@ public class EditPersonnelInjuriesDialog extends JDialog {
     
     private void addEntry() {
         EditInjuryEntryDialog eied = new EditInjuryEntryDialog(frame, true, new Injury());
+        eied.setAlwaysOnTop(true);
         eied.setVisible(true);
         if(null != eied.getEntry()) {
             person.addInjury(eied.getEntry());
@@ -193,6 +194,7 @@ public class EditPersonnelInjuriesDialog extends JDialog {
         Injury entry = injuryModel.getEntryAt(injuriesTable.getSelectedRow());
         if(null != entry) {
             EditInjuryEntryDialog eied = new EditInjuryEntryDialog(frame, true, entry);
+            eied.setAlwaysOnTop(true);
             eied.setVisible(true);
             refreshTable();
         }


### PR DESCRIPTION
The Edit Injury dialog defaulted to the wrong type due to the order of operations when setting up the master-detail combo boxes and their options. This also marks the dialog as modal before it is called to ensure it stays over top of the injury manager on Mac OS X. Fixes #1009 