### PR TITLE
Bug: Retirement/Defection dialog doesn't show first row details

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -246,7 +246,7 @@ public class RetirementDefectionDialog extends JDialog {
         	personnelTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
         		@Override
                 public void valueChanged(ListSelectionEvent ev) {
-        			if (personnelTable.getSelectedRow() <= 0) {
+        			if (personnelTable.getSelectedRow() < 0) {
         				return;
         			}
         			int row = personnelTable.convertRowIndexToModel(personnelTable.getSelectedRow());


### PR DESCRIPTION
Corrects an inequality in Retirement/Defection dialog, fixes #986.