### PR TITLE
Bug: techs without any minutes left may get stuck on overnight tasks

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2370,7 +2370,7 @@ public class Campaign implements Serializable, ITechManager {
             r.addTimeSpent(tech.getMinutesLeft());
             tech.setMinutesLeft(0);
             report = report + ", " + r.getTimeLeft() + " minutes left.";
-                } else {
+        } else {
             tech.setMinutesLeft(tech.getMinutesLeft() - minutes);
             r.addTimeSpent(minutes);
             if (r.hasFailedCheck()) {
@@ -2410,8 +2410,8 @@ public class Campaign implements Serializable, ITechManager {
                     }
                 }
                 report += wrongType;
-                    }
-                }
+            }
+        }
         MekHQ.triggerEvent(new PartWorkEvent(tech, r));
         addReport(report);
     }
@@ -2492,14 +2492,17 @@ public class Campaign implements Serializable, ITechManager {
             } else {
                 // we need to finish the task tomorrow
                 minutesUsed = tech.getMinutesLeft();
+                int overtimeUsed = 0;
                 if (isOvertimeAllowed()) {
-                    minutesUsed += tech.getOvertimeLeft();
+                    // Can't use more overtime than there are minutes remaining on the part
+                    overtimeUsed = Math.min(minutes, tech.getOvertimeLeft());
+                    minutesUsed += overtimeUsed;
                     partWork.setWorkedOvertime(true);
                     usedOvertime = true;
                 }
                 partWork.addTimeSpent(minutesUsed);
                 tech.setMinutesLeft(0);
-                tech.setOvertimeLeft(0);
+                tech.setOvertimeLeft(tech.getOvertimeLeft() - overtimeUsed);
                 int helpMod = getShorthandedMod(
                         getAvailableAstechs(minutesUsed, usedOvertime), false);
                 if (null != partWork.getUnit()
@@ -2516,7 +2519,15 @@ public class Campaign implements Serializable, ITechManager {
                 if (null != partWork.getUnit()) {
                     report += " on " + partWork.getUnit().getName();
                 }
-                report += " will be finished tomorrow.</b>";
+                if (minutesUsed > 0) {
+                    report += " will be finished tomorrow.</b>";
+                } else {
+                    report += " cannot be finished because there was no time left after maintenance tasks.</b>";
+                    partWork.resetTimeSpent();
+                    partWork.resetOvertime();
+                    partWork.setTeamId(null);
+                    partWork.cancelReservation();
+                }
                 MekHQ.triggerEvent(new PartWorkEvent(tech, partWork));
                 addReport(report);
                 return;
@@ -5277,15 +5288,9 @@ public class Campaign implements Serializable, ITechManager {
             isOvertime = true;
         }
 
-        int minutes = partWork.getTimeLeft();
-        if (minutes > tech.getMinutesLeft()) {
-            if (isOvertimeAllowed()) {
-                if (minutes > (tech.getMinutesLeft() + tech.getOvertimeLeft())) {
-                    minutes = tech.getMinutesLeft() + tech.getOvertimeLeft();
-                }
-            } else {
-                minutes = tech.getMinutesLeft();
-            }
+        int minutes = Math.min(partWork.getTimeLeft(), tech.getMinutesLeft());
+        if (isOvertimeAllowed()) {
+            minutes = Math.min(minutes, tech.getMinutesLeft() + tech.getOvertimeLeft());
         }
         int helpMod = 0;
         if (null != partWork.getUnit() && partWork.getUnit().isSelfCrewed()) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -822,7 +822,8 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
 	@Override
 	public int getTimeLeft() {
-		return getActualTime() - getTimeSpent();
+		// Cannot be less than 0 time left.
+		return Math.max(0, getActualTime() - getTimeSpent());
 	}
 
 	@Override


### PR DESCRIPTION
Addresses two bugs:

1. If a tech gets "stuck" on an overnight task when they have no minutes left after maintenance, remove them from the work and allow it to be reassigned (#976).
2. If `timeSpent` became greater than `actualTime` for a part, `getTimeLeft()` would underflow and give back time to techs.

This does not address the (currently unknown) root cause of why some techs can be assigned to overnight work when their maintenance tasks would prevent them from working on it.