### PR TITLE
Adds the list of missing units on campaign load to the log

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1573,6 +1573,8 @@ public class CampaignXmlParser {
             for (String s : unitList) {
                 unitListString += "\n" + s;
             }
+            MekHQ.getLogger().log(CampaignXmlParser.class, METHOD_NAME, LogLevel.ERROR,
+                String.format("Could not load the following units: %s", unitListString)); //$NON-NLS-1$
             return unitListString;
         }
     }


### PR DESCRIPTION
Purely a convenience feature to make it easier to copy/paste the missing units from a campaign file.