### PR TITLE
Bug: Do not raise UnitChangedEvent if there is no unit in GM Acquire Instantly

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
@@ -608,7 +608,10 @@ public class AcquisitionsDialog extends JDialog {
                     }
 
                     campaignGUI.getCampaign().addReport(actualWork.find(0));
-                    MekHQ.triggerEvent(new UnitChangedEvent(actualWork.getUnit()));
+                    Unit unit = actualWork.getUnit();
+                    if (null != unit) {
+                        MekHQ.triggerEvent(new UnitChangedEvent(unit));
+                    }
 
                     refresh();
                 });


### PR DESCRIPTION
Fixes NRE seen in #964 