### PR TITLE
Improved GM Tools Add RAT to clear the rolled unit each time

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -323,6 +323,7 @@ public class GMToolsDialog extends JDialog implements ActionListener {
                         person.setOriginalUnit(u);
                         setVisible(false);
                     }
+                    lastRolledUnit = null;
                 } catch (EntityLoadingException e1) {
                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                             "Failed to load entity " + lastRolledUnit.getName() + " from " //$NON-NLS-1$


### PR DESCRIPTION
This is a quick change to the GM Tools Add RAT Unit behavior to clear the last rolled unit after each add. Originally I had thought it best to have the user re-roll, but after using this in practice it wasn't that nice.