### PR TITLE
Fix bug where selected repair task moves when you change mode

### DIFF
--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -789,6 +789,8 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     }
 
     public void refreshTaskList() {
+        selectedRow = taskTable.getSelectedRow();
+        
         UUID uuid = null;
         if (null != getSelectedServicedUnit()) {
             uuid = getSelectedServicedUnit().getId();


### PR DESCRIPTION
Minor annoyance: whenever you changed the mode on a repair task (e.g. from normal to x4), the selected task moved to the next one.