### PR TITLE
Enable zero intensity level for AtB Scenario Generation

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2675,8 +2675,20 @@ public class Campaign implements Serializable, ITechManager {
     public int getDeploymentDeficit(AtBContract contract) {
         int total = -contract.getRequiredLances();
         int role = -Math.max(1, contract.getRequiredLances() / 2);
+        boolean hasScenarios = contract.getScenarios().size() > 0;
+
         for (Lance l : lances.values()) {
-            if (l.getMissionId() == contract.getId() && l.getRole() != Lance.ROLE_UNASSIGNED) {
+            if (hasScenarios) {
+                if (l.getMissionId() == contract.getId() && l.getRole() != Lance.ROLE_UNASSIGNED) {
+                    total++;
+                    if (l.getRole() == contract.getRequiredLanceType()) {
+                        role++;
+                    }
+                }
+            } else if (l.getMissionId() == Lance.NO_MISSION && l.getRole() != Lance.ROLE_UNASSIGNED) {
+                // We have no scenarios, so check by lance type. This isn't perfect,
+                // but prevents IRL players from getting nagged that they lack deployment
+                // levels when there are no scenarios into which they can deploy units
                 total++;
                 if (l.getRole() == contract.getRequiredLanceType()) {
                     role++;

--- a/MekHQ/src/mekhq/campaign/force/Lance.java
+++ b/MekHQ/src/mekhq/campaign/force/Lance.java
@@ -83,6 +83,9 @@ public class Lance implements Serializable, MekHqXmlSerializable {
     public static final long ETYPE_GROUND = Entity.ETYPE_MECH |
             Entity.ETYPE_TANK | Entity.ETYPE_INFANTRY | Entity.ETYPE_PROTOMECH;
 
+    /** Indicates a lance has no assigned mission */
+    public static final int NO_MISSION = -1;
+
     private int forceId;
     private int missionId;
     private int role;
@@ -133,7 +136,7 @@ public class Lance implements Serializable, MekHqXmlSerializable {
 
     public void setContract(AtBContract c) {
         if (null == c) {
-            missionId = -1;
+            missionId = NO_MISSION;
         } else {
             missionId = c.getId();
         }

--- a/MekHQ/src/mekhq/campaign/force/Lance.java
+++ b/MekHQ/src/mekhq/campaign/force/Lance.java
@@ -329,6 +329,12 @@ public class Lance implements Serializable, MekHqXmlSerializable {
     }
 
     public AtBScenario checkForBattle(Campaign c) {
+        double intensity = c.getCampaignOptions().getIntensity();
+        if (intensity < AtBContract.MINIMUM_INTENSITY) {
+            // AtB Battle Generation disabled
+            return null;
+        }
+
         int noBattle;
         int roll;
         //thresholds are coded from charts with 1-100 range, so we add 1 to mod to adjust 0-based random int
@@ -336,7 +342,7 @@ public class Lance implements Serializable, MekHqXmlSerializable {
         battleTypeMod += getContract(c).getBattleTypeMod();
         switch (role) {
         case ROLE_FIGHT:
-            noBattle = (int)(60.0 / c.getCampaignOptions().getIntensity() + 0.5);
+            noBattle = (int)(60.0 / intensity + 0.5);
             roll = Compute.randomInt(40 + noBattle) + battleTypeMod;
             if (roll < 1) {
                 return AtBScenarioFactory.createScenario(c, this,
@@ -370,7 +376,7 @@ public class Lance implements Serializable, MekHqXmlSerializable {
                         getBattleDate(c.getCalendar()));
             }
         case Lance.ROLE_SCOUT:
-            noBattle = (int)(40.0 / c.getCampaignOptions().getIntensity() + 0.5);
+            noBattle = (int)(40.0 / intensity + 0.5);
             roll = Compute.randomInt(60 + noBattle) + battleTypeMod;
             if (roll < 1) {
                 return AtBScenarioFactory.createScenario(c, this,
@@ -404,7 +410,7 @@ public class Lance implements Serializable, MekHqXmlSerializable {
                         getBattleDate(c.getCalendar()));
             }
         case Lance.ROLE_DEFEND:
-            noBattle = (int)(80.0 / c.getCampaignOptions().getIntensity() + 0.5);
+            noBattle = (int)(80.0 / intensity + 0.5);
             roll = Compute.randomInt(20 + noBattle) + battleTypeMod;
             if (roll < 1) {
                 return AtBScenarioFactory.createScenario(c, this,
@@ -434,7 +440,7 @@ public class Lance implements Serializable, MekHqXmlSerializable {
                         getBattleDate(c.getCalendar()));
             }
         case Lance.ROLE_TRAINING:
-            noBattle = (int)(90.0 / c.getCampaignOptions().getIntensity() + 0.5);
+            noBattle = (int)(90.0 / intensity + 0.5);
             roll = Compute.randomInt(10 + noBattle) + battleTypeMod;
             if (roll < 1) {
                 return AtBScenarioFactory.createScenario(c, this,

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -116,6 +116,9 @@ public class AtBContract extends Contract implements Serializable {
     public static final int EVT_SPECIALEVENTS = 9;
     public static final int EVT_BIGBATTLE = 10;
 
+    /** The minimum intensity below which no scenarios will be generated */
+    public static final double MINIMUM_INTENSITY = 0.01;
+
     /* null unless subcontract */
     protected AtBContract parentContract;
     /* hired by another mercenary unit on contract to a third-party employer */

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -5183,7 +5183,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
     private void updateBattleChances() {
         double intensity = (Double)spnIntensity.getValue();
-        if (intensity > AtBContract.MINIMUM_INTENSITY) {
+        if (intensity >= AtBContract.MINIMUM_INTENSITY) {
             lblFightPct.setText((int)(40.0 * intensity / (40.0 * intensity + 60.0) * 100.0 + 0.5) + "%");
             lblDefendPct.setText((int)(20.0 * intensity / (20.0 * intensity + 80.0) * 100.0 + 0.5) + "%");
             lblScoutPct.setText((int)(60.0 * intensity / (60.0 * intensity + 40.0) * 100.0 + 0.5) + "%");

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -104,6 +104,7 @@ import mekhq.campaign.GamePreset;
 import mekhq.campaign.RandomSkillPreferences;
 import mekhq.campaign.event.OptionsChangedEvent;
 import mekhq.campaign.market.PersonnelMarket;
+import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Ranks;
@@ -4061,7 +4062,7 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
         gridBagConstraints.gridy = 11;
         panSubAtBContract.add(lblIntensity, gridBagConstraints);
 
-        spnIntensity.setModel(new SpinnerNumberModel(options.getIntensity(), 0.1, 5.0, 0.1));
+        spnIntensity.setModel(new SpinnerNumberModel(options.getIntensity(), 0.0, 5.0, 0.1));
         spnIntensity.setToolTipText(resourceMap.getString("spnIntensity.toolTipText"));
         spnIntensity.setValue(options.getIntensity());
         gridBagConstraints.gridx = 1;
@@ -5181,11 +5182,18 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
     }
 
     private void updateBattleChances() {
-    	double intensity = (Double)spnIntensity.getValue();
-    	lblFightPct.setText((int)(40.0 * intensity / (40.0 * intensity + 60.0) * 100.0 + 0.5) + "%");
-    	lblDefendPct.setText((int)(20.0 * intensity / (20.0 * intensity + 80.0) * 100.0 + 0.5) + "%");
-    	lblScoutPct.setText((int)(60.0 * intensity / (60.0 * intensity + 40.0) * 100.0 + 0.5) + "%");
-    	lblTrainingPct.setText((int)(10.0 * intensity / (10.0 * intensity + 90.0) * 100.0 + 0.5) + "%");
+        double intensity = (Double)spnIntensity.getValue();
+        if (intensity > AtBContract.MINIMUM_INTENSITY) {
+            lblFightPct.setText((int)(40.0 * intensity / (40.0 * intensity + 60.0) * 100.0 + 0.5) + "%");
+            lblDefendPct.setText((int)(20.0 * intensity / (20.0 * intensity + 80.0) * 100.0 + 0.5) + "%");
+            lblScoutPct.setText((int)(60.0 * intensity / (60.0 * intensity + 40.0) * 100.0 + 0.5) + "%");
+            lblTrainingPct.setText((int)(10.0 * intensity / (10.0 * intensity + 90.0) * 100.0 + 0.5) + "%");            
+        } else {
+            lblFightPct.setText("Disabled");
+            lblDefendPct.setText("Disabled");
+            lblScoutPct.setText("Disabled");
+            lblTrainingPct.setText("Disabled");
+        }
     }
 
     /*


### PR DESCRIPTION
This implements enhancement request #1036 where 0% can be chosen for AtB scenario intensity levels.

![image](https://user-images.githubusercontent.com/8238690/50736793-b0758c80-118f-11e9-9b59-43269555ebbc.png)

This also removes a deployment nag if you have no possible scenarios to deploy into (this isn't perfect, but handles the most likely case).
