### PR TITLE
Fix bug where Mass Repair Options were not applied unless you clicked Save

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
@@ -1147,7 +1147,7 @@ public class MassRepairSalvageDialog extends JDialog {
 			MassRepairService.MassRepairConfiguredOptions configuredOptions = new MassRepairService.MassRepairConfiguredOptions();
 			configuredOptions.setup(this);
 
-			MassRepairService.massRepairSalvageUnits(campaignGUI, units);
+			MassRepairService.massRepairSalvageUnits(campaignGUI, units, activeMROs);
 
 			filterUnits();
 		} else if (isModeWarehouse()) {

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -192,7 +192,6 @@ public class MassRepairService {
 		List<Unit> units = new ArrayList<Unit>();
 
 		for (Unit unit : campaignGUI.getCampaign().getServiceableUnits()) {
-
 			if (!isValidMRMSUnit(unit)) {
 				continue;
 			}
@@ -217,12 +216,13 @@ public class MassRepairService {
 			}
 		});
 
-		massRepairSalvageUnits(campaignGUI, units);
+		List<MassRepairOption> activeMROs = createActiveMROsFromConfiguration(campaignGUI);
+
+		massRepairSalvageUnits(campaignGUI, units, activeMROs);
 	}
 
-	public static void massRepairSalvageUnits(CampaignGUI campaignGUI, List<Unit> units) {
+	public static void massRepairSalvageUnits(CampaignGUI campaignGUI, List<Unit> units, List<MassRepairOption> activeMROs) {
 		CampaignOptions options = campaignGUI.getCampaign().getCampaignOptions();
-		List<MassRepairOption> activeMROs = createActiveMROsFromConfiguration(campaignGUI);
 
 		Map<MassRepairUnitAction.STATUS, List<MassRepairUnitAction>> unitActionsByStatus = new HashMap<MassRepairUnitAction.STATUS, List<MassRepairUnitAction>>();
 


### PR DESCRIPTION
The active mass repair options were computed but not passed to the actual routine which does the work. This fixes bugs like #1028.