### PR TITLE
Allow fractional tons to be loaded in LargeCraftAmmoBins

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -304,7 +304,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
     @Override
     public boolean needsFixing() {
         return (shotsNeeded < 0)
-                || ((shotsNeeded > 0) && (type.getTonnage(null) <= bayAvailableCapacity())); 
+                || ((shotsNeeded > 0) && (type.getTonnage(null) <= Math.ceil(bayAvailableCapacity()))); 
     }
 
     /**


### PR DESCRIPTION
If less than a ton of ammo is needed a LargeCraftAmmoBin wasn't allowed to be reloaded. This fixes #1005.