### PR TITLE
Fix some unit/tech mismatches at CPNX load

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -892,8 +892,6 @@ public class Campaign implements Serializable, ITechManager {
             MekHQ.triggerEvent(new OrganizationChangedEvent(prevForce, u));
             if (null != prevForce.getTechID()) {
                 u.removeTech();
-                Person forceTech = getPerson(prevForce.getTechID());
-                forceTech.removeTechUnitId(u.getId());
             }
         }
         Force force = forceIds.get(id);
@@ -903,16 +901,13 @@ public class Campaign implements Serializable, ITechManager {
             u.setScenarioId(force.getScenarioId());
             MekHQ.triggerEvent(new OrganizationChangedEvent(force, u));
             if (null != force.getTechID()) {
-                if (null != u.getTech()) {
-                    Person oldTech = u.getTech();
-                    oldTech.removeTechUnitId(u.getId());
-                    MekHQ.triggerEvent(new PersonTechAssignmentEvent(oldTech, u));
-                }
                 Person forceTech = getPerson(force.getTechID());
                 if (forceTech.canTech(u.getEntity())) {
-                    u.setTech(force.getTechID());
-                    forceTech.addTechUnitID(u.getId());
-                    MekHQ.triggerEvent(new PersonTechAssignmentEvent(forceTech, u));
+                    if (null != u.getTech()) {
+                        u.removeTech();
+                    }
+
+                    u.setTech(forceTech);
                 } else {
                     String cantTech = forceTech.getName() + " cannot maintain " + u.getName() + "\n"
                             + "You will need to assign a tech manually.";

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -808,14 +808,13 @@ public class CampaignXmlParser {
     }
 
     /**
-     * This will fixup unit-tech problems seen in some save games,
-     * such as techs having been double-assigned or being assigned
-     * to mothballed units.
+     * This will fixup unit-tech problems seen in some save games, such as techs
+     * having been double-assigned or being assigned to mothballed units.
      */
-	private void fixupUnitTechProblems(Campaign retVal) {
+    private void fixupUnitTechProblems(Campaign retVal) {
         final String METHOD_NAME = "fixupUnitTechProblems(Campaign)";
 
-		// Cleanup problems with techs and units
+        // Cleanup problems with techs and units
         for (Person tech : retVal.getTechs()) {
             for (UUID id : new ArrayList<>(tech.getTechUnitIDs())) {
                 Unit u = retVal.getUnit(id);

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -721,6 +721,8 @@ public class CampaignXmlParser {
 
         //**EVERYTHING HAS BEEN LOADED. NOW FOR SANITY CHECKS**//
 
+        fixupUnitTechProblems(retVal);
+
         //unload any ammo bins in the warehouse
         ArrayList<AmmoBin> binsToUnload = new ArrayList<AmmoBin>();
         for(Part prt : retVal.getSpareParts()) {
@@ -804,17 +806,56 @@ public class CampaignXmlParser {
 
         return retVal;
     }
-    
+
     /**
-     * Pulled out purely for encapsulation. Makes the code neater and easier to read.
+     * This will fixup unit-tech problems seen in some save games,
+     * such as techs having been double-assigned or being assigned
+     * to mothballed units.
+     */
+	private void fixupUnitTechProblems(Campaign retVal) {
+        final String METHOD_NAME = "fixupUnitTechProblems(Campaign)";
+
+		// Cleanup problems with techs and units
+        for (Person tech : retVal.getTechs()) {
+            for (UUID id : new ArrayList<>(tech.getTechUnitIDs())) {
+                Unit u = retVal.getUnit(id);
+
+                String reason = null;
+                String unitDesc = id.toString();
+                if (null == u) {
+                    reason = "referenced missing unit";
+                    tech.removeTechUnitId(id);
+                } else if (null == u.getTechId()) {
+                    reason = "was not referenced by unit";
+                    u.setTech(tech);
+                } else if (u.isMothballed()) {
+                    reason = "referenced mothballed unit";
+                    unitDesc = u.getName();
+                    tech.removeTechUnitId(id);
+                } else if (!tech.getId().equals(u.getTechId())) {
+                    reason = String.format("referenced tech %s's maintained unit", u.getTech().getName());
+                    unitDesc = u.getName();
+                    tech.removeTechUnitId(id);
+                }
+                if (null != reason) {
+                    MekHQ.getLogger().log(CampaignXmlParser.class, METHOD_NAME, LogLevel.WARNING,
+                            String.format("Tech %s %s %s (fixed)", tech.getName(), reason, unitDesc));
+                }
+            }
+        }
+    }
+
+    /**
+     * Pulled out purely for encapsulation. Makes the code neater and easier to
+     * read.
      *
      * @param retVal The Campaign object that is being populated.
      * @param wni    The XML node we're working from.
      * @throws ParseException
      * @throws DOMException
      */
-    private static void processInfoNode(Campaign retVal, Node wni,
-            Version version) throws DOMException, CampaignXmlParseException {
+    private static void processInfoNode(Campaign retVal, Node wni, Version version)
+            throws DOMException, CampaignXmlParseException {
         NodeList nl = wni.getChildNodes();
 
         String rankNames = null;

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1727,8 +1727,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                                     "Unknown node type not loaded in techUnitIds nodes: " + wn3.getNodeName()); //$NON-NLS-1$
                             continue;
                         }
-                        retVal.techUnitIds.add(UUID.fromString(wn3.getTextContent()));
-
+                        retVal.addTechUnitID(UUID.fromString(wn3.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("personnelLog")) {
                     NodeList nl2 = wn2.getChildNodes();
@@ -3074,8 +3073,10 @@ public class Person implements Serializable, MekHqXmlSerializable {
         techUnitIds.remove(i);
     }
 
-    public void addTechUnitID(UUID i) {
-        techUnitIds.add(i);
+    public void addTechUnitID(UUID id) {
+        if (!techUnitIds.contains(id)) {
+            techUnitIds.add(id);
+        }
     }
 
     public void clearTechUnitIDs() {

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -857,7 +857,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         // If requested, switch to top entry
         if(getCampaign().getCampaignOptions().useResetToFirstTech() && techTable.getRowCount() > 0) {
             techTable.setRowSelectionInterval(0, 0);
-        } else {
+        } else if (selectedTech != null) {
             // Or get the selected tech back
             for (int i = 0; i < techTable.getRowCount(); i++) {
                 Person p = techsModel

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -256,14 +256,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                     }
                     // check for tech unit assignments
                     if (!person.getTechUnitIDs().isEmpty()) {
-                        // I need to create a new array list to avoid concurrent
-                        // problems
-                        ArrayList<UUID> temp = new ArrayList<UUID>();
-                        for (UUID i : person.getTechUnitIDs()) {
-                            temp.add(i);
-                        }
-                        for (UUID i : temp) {
-                            u = gui.getCampaign().getUnit(i);
+                        for (UUID id : new ArrayList<>(person.getTechUnitIDs())) {
+                            u = gui.getCampaign().getUnit(id);
                             if (null != u) {
                                 u.remove(person, true);
                                 u.resetEngineer();

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -128,15 +128,12 @@ ActionListener {
                         for (UUID uuid : singleForce.getAllUnits()) {
                             Unit u = gui.getCampaign().getUnit(uuid);
                             if (u != null) {
-                                if (null != u.getTech()) {
-                                    Person oldTech = u.getTech();
-                                    oldTech.removeTechUnitId(u.getId());
-                                    u.removeTech();
-                                }
                                 if (tech.canTech(u.getEntity())) {
-                                    u.setTech(tech.getId());
-                                    tech.addTechUnitID(u.getId());
-                                    MekHQ.triggerEvent(new PersonTechAssignmentEvent(tech, u));
+                                    if (null != u.getTech()) {
+                                        u.removeTech();
+                                    }
+                                    
+                                    u.setTech(tech);
                                 } else {
                                     cantTech += tech.getName() + " cannot maintain " + u.getName() + "\n";
                                 }
@@ -240,12 +237,7 @@ ActionListener {
                     for (UUID uuid : singleForce.getAllUnits()) {
                         Unit u = gui.getCampaign().getUnit(uuid);
                         if (null != u.getTech()) {
-                            oldTech = u.getTech();
-                            oldTech.removeTechUnitId(u.getId());
-                            MekHQ.triggerEvent(new PersonTechAssignmentEvent(oldTech, u));
-                        }
-                        if (u != null) {
-                            u.setTech((UUID)null);
+                            u.removeTech();
                         }
                     }
                 }
@@ -259,9 +251,6 @@ ActionListener {
                         gui.getCampaign().removeUnitFromForce(unit);
                         if (null != parentForce.getTechID()) {
                             unit.removeTech();
-                            Person forceTech = gui.getCampaign().getPerson(parentForce.getTechID());
-                            forceTech.removeTechUnitId(unit.getId());
-                            MekHQ.triggerEvent(new PersonTechAssignmentEvent(forceTech, unit));
                         }
                     }
                     MekHQ.triggerEvent(new OrganizationChangedEvent(parentForce, unit));

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -102,12 +102,6 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                     unit.remove(p, true);
                 }
                 
-                Person tech = unit.getTech();
-                
-                if (null != tech) {
-                	tech.removeTechUnitId(unit.getId());
-                }
-                
                 unit.removeTech();
                 
                 Person engineer = unit.getEngineer();


### PR DESCRIPTION
This fixes at CPNX load a few issues seen in a large CPNX:
1. A person techs a unit somebody else techs
2. A person techs a unit without a tech
3. A person techs a mothballed unit
4. A person techs a unit no longer in the campaign

This also cleans up setTech/removeTech usages.

This also fixes an NPE in RepairTab seen with the CPNX.