### PR TITLE
Allow recruiting if a valid prisoner is selected

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -710,7 +710,9 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                 break;
             case CMD_RECRUIT:
                 for(Person person : people) {
-                    gui.getCampaign().changePrisonerStatus(person, Person.PRISONER_NOT);
+                    if (StaticChecks.isWillingToDefect(person)) {
+                        gui.getCampaign().changePrisonerStatus(person, Person.PRISONER_NOT);
+                    }
                 }
                 break;
             case CMD_RANSOM:
@@ -1331,7 +1333,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                     && StaticChecks.areAllPrisoners(selected)) {
                 popup.add(newMenuItem(resourceMap.getString("ransom.text"), CMD_RANSOM));
                 popup.add(newMenuItem(resourceMap.getString("recruit.text"), CMD_RECRUIT, //$NON-NLS-1$
-                        StaticChecks.areAllWillingToDefect(selected)));
+                        StaticChecks.areAnyWillingToDefect(selected)));
             }
 
             menu = new JMenu(resourceMap.getString("changePrimaryRole.text")); //$NON-NLS-1$

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -306,14 +306,22 @@ public class StaticChecks {
         return true;
     }
 
-    public static boolean areAllWillingToDefect(Person[] people) {
-        for (Person person : people) {
-            if (!(person.isBondsman() || person.isWillingToDefect())) {
-                return false;
-            }
+    public static boolean isWillingToDefect(Person person) {
+        if (!(person.isBondsman() || person.isWillingToDefect())) {
+            return false;
         }
 
         return true;
+    }
+
+    public static boolean areAnyWillingToDefect(Person[] people) {
+        for (Person person : people) {
+            if (isWillingToDefect((person))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static boolean areAllWoB(Person[] people) {


### PR DESCRIPTION
Changing logic so Recruiting prisoners is enabled if at least one valid prisoner that can be recruited is selected. Only valid prisoners will be recruited.
Tested locally by creating a group of 4 prisoners, setting 2 to willing to defect and trying to recruit them all. Only 2 of them were actually recruited.