### PR TITLE
Fix two NRE's seen in warehouse tab

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -367,12 +367,14 @@ public class Armor extends Part implements IAcquisitionWork {
 	}
 
 	public int getBaseTimeFor(Entity entity) {
-		if(entity instanceof Tank) {
-			return 3;
-		}
-		//December 2017 errata, only large craft should return 15m/point.
-		else if(entity.hasETypeFlag(Entity.ETYPE_DROPSHIP) || entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
-			return 15;
+		if (null != entity) {
+			if (entity instanceof Tank) {
+				return 3;
+			}
+			//December 2017 errata, only large craft should return 15m/point.
+			else if (entity.hasETypeFlag(Entity.ETYPE_DROPSHIP) || entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+				return 15;
+			}
 		}
 		return 5;
 	}
@@ -395,10 +397,11 @@ public class Armor extends Part implements IAcquisitionWork {
 	
 	@Override 
 	public int getBaseTime() {
-		if(isSalvaging()) {
-			return getBaseTimeFor(unit.getEntity()) * amount;
+		Entity entity = unit != null ? unit.getEntity() : null;
+		if (isSalvaging()) {
+			return getBaseTimeFor(entity) * amount;
 		}
-		return getBaseTimeFor(unit.getEntity()) * Math.min(amountNeeded, getAmountAvailable());
+		return getBaseTimeFor(entity) * Math.min(amountNeeded, getAmountAvailable());
 	}
 	
 	@Override

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -862,7 +862,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
             for (int i = 0; i < techTable.getRowCount(); i++) {
                 Person p = techsModel
                         .getTechAt(techTable.convertRowIndexToModel(i));
-                if (selectedTech.getId().equals(p.getId())) {
+                if (p != null && selectedTech.getId().equals(p.getId())) {
                     techTable.setRowSelectionInterval(i, i);
                     break;
                 }


### PR DESCRIPTION
This resolves two NRE's seen in the warehouse tab in #1049. The first causes the tab to become unresponsive, and the second seems to occur when the tech list gets out of sync (unable to repro, but added a guard).