### PR TITLE
Don't let peacetime costs overflow

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8154,8 +8154,8 @@ public class Campaign implements Serializable, ITechManager {
         return unitRating;
     }
 
-    public int getPeacetimeCost() {
-        int cost = 0;
+    public long getPeacetimeCost() {
+        long cost = 0;
 
         cost += getPayRoll(getCampaignOptions().useInfantryDontCount());
         cost += getMonthlySpareParts();

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1210,7 +1210,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         // Only pay if option set and this isn't a prisoner or bondsman
         if (getCampaignOptions().payForRecruitment() && !prisoner) {
-            if (!getFinances().debit(2 * p.getSalary(), Transaction.C_SALARY,
+            if (!getFinances().debit(2L * p.getSalary(), Transaction.C_SALARY,
                     "recruitment of " + p.getFullName(), getCalendar().getTime())) {
                 addReport("<font color='red'><b>Insufficient funds to recruit "
                         + p.getFullName() + "</b></font>");
@@ -3171,8 +3171,8 @@ public class Campaign implements Serializable, ITechManager {
         // add in astechs from the astech pool
         // we will assume Mech Tech * able-bodied * enlisted (changed from vee mechanic)
         // 800 * 0.5 * 0.6 = 240
-        salaries += (240 * astechPool);
-        salaries += (320 * medicPool);
+        salaries += (240L * astechPool);
+        salaries += (320L * medicPool);
         return salaries;
     }
 
@@ -4936,7 +4936,7 @@ public class Campaign implements Serializable, ITechManager {
      */
     @SuppressWarnings("unused") // FIXME: Waiting for Dylan to finish re-writing
     public long calculateCostPerJump(boolean excludeOwnTransports, boolean campaignOpsCosts) {
-        int collarCost = (campaignOpsCosts ? 100000 : 50000);
+        long collarCost = (campaignOpsCosts ? 100000 : 50000);
 
         // first we need to get the total number of units by type
         int nMech = getNumberOfUnitsByType(Entity.ETYPE_MECH);

--- a/MekHQ/unittests/mekhq/campaign/mission/ContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/ContractTest.java
@@ -155,7 +155,7 @@ public class ContractTest {
         Mockito.when(mockCampaign.getOverheadExpenses()).thenReturn((long) 1);
         Mockito.when(mockCampaign.getContractBase()).thenReturn((long) 10);
         Mockito.when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Mockito.when(mockCampaign.getPeacetimeCost()).thenReturn(1);
+        Mockito.when(mockCampaign.getPeacetimeCost()).thenReturn(1L);
         Mockito.when(mockCampaign.getCalendar()).thenReturn(new GregorianCalendar(3067, Calendar.JANUARY, 1));
     }
 }


### PR DESCRIPTION
We were stuffing long's into int's. This fixes that (found via: https://lgtm.com/projects/g/MegaMek/mekhq/snapshot/82b2780e05bf73dec210033fc277da6a6e2cecf9/files/MekHQ/src/mekhq/campaign/Campaign.java?sort=name&dir=ASC&mode=heatmap#x110f0bc0b025a7ab:1)