### PR TITLE
Don't allow damage to go negative or use negative damages #1057

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Rotor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Rotor.java
@@ -72,7 +72,9 @@ public class Rotor extends TankLocation {
     @Override
     public void fix() {
         super.fix();
-        damage--;
+        if (damage > 0) {
+            damage--;
+        }
         if(null != unit && unit.getEntity() instanceof VTOL) {
             int currIsVal = unit.getEntity().getInternal(VTOL.LOC_ROTOR);
             int maxIsVal = unit.getEntity().getOInternal(VTOL.LOC_ROTOR);
@@ -129,7 +131,7 @@ public class Rotor extends TankLocation {
 
     @Override
     public void updateConditionFromPart() {
-        if(null != unit && unit.getEntity() instanceof VTOL) {
+        if(null != unit && damage > 0 && unit.getEntity() instanceof VTOL) {
             unit.getEntity().setInternal(unit.getEntity().getOInternal(VTOL.LOC_ROTOR) - damage, VTOL.LOC_ROTOR);
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -207,7 +207,8 @@ public class TankLocation extends Part {
             if(IArmorState.ARMOR_DESTROYED == unit.getEntity().getInternal(loc)) {
                 remove(false);
             } else {
-                damage = unit.getEntity().getOInternal(loc) - unit.getEntity().getInternal(loc);
+                int internal = unit.getEntity().getInternal(loc);
+                damage = unit.getEntity().getOInternal(loc) - Math.max(internal, 0);
                 if(unit.isLocationBreached(loc)) {
                     breached = true;
                 }

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -207,8 +207,9 @@ public class TankLocation extends Part {
             if(IArmorState.ARMOR_DESTROYED == unit.getEntity().getInternal(loc)) {
                 remove(false);
             } else {
+                int originalInternal = unit.getEntity().getOInternal(loc);
                 int internal = unit.getEntity().getInternal(loc);
-                damage = unit.getEntity().getOInternal(loc) - Math.max(internal, 0);
+                damage = originalInternal - Math.min(originalInternal, Math.max(internal, 0));
                 if(unit.isLocationBreached(loc)) {
                     breached = true;
                 }


### PR DESCRIPTION
This is a partial fix for #1057, keeps damages for rotors from rolling negative or using negative damages. Not 100% sure of the root cause, seems either `Rotor::fix` got called twice, or some calculation for the internals on the entity was incorrect in MM.