### PR TITLE
Tally the last part ID before checking for spares #1085

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1504,6 +1504,11 @@ public class Campaign implements Serializable, ITechManager {
             // a relic.
             return;
         }
+
+        // Update the lastPartId we've seen to avoid overwriting a part,
+        // which may occur if a replacement ID is assigned
+        lastPartId = Math.max(lastPartId, p.getId());
+
         // go ahead and check for existing parts because some version weren't
         // properly collecting parts
         if (!(p instanceof MissingPart) && null == p.getUnitId()) {
@@ -1528,7 +1533,6 @@ public class Campaign implements Serializable, ITechManager {
             }
         }
 
-        lastPartId = Math.max(lastPartId, p.getId());
         parts.put(p.getId(), p);
         MekHQ.triggerEvent(new PartNewEvent(p));
     }


### PR DESCRIPTION
This resolves (partially) #1085 by tallying the last part ID before spares are checked. Otherwise, if a part becomes a spare of a part with a lower ID, it may be skipped over on campaign load.

Still haven't located the source of the high part ID when a lower one would have done.