### PR TITLE
Fix damaged ams/masc tracking on load

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1702,15 +1702,12 @@ public class CampaignXmlParser {
 
             // deal with equipmentparts that are now subtyped
             int pid = p.getId();
-            if (p instanceof EquipmentPart
-                    && ((EquipmentPart) p).getType() instanceof MiscType
-                    && ((EquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && !(p instanceof MASC)) {
+            if (isLegacyMASC(p)) {
                 p = new MASC(p.getUnitTonnage(), ((EquipmentPart) p).getType(),
                         ((EquipmentPart) p).getEquipmentNum(), retVal, 0, p.isOmniPodded());
                 p.setId(pid);
             }
-            if (p instanceof MissingEquipmentPart
-                    && ((MissingEquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && !(p instanceof MASC)) {
+            if (isLegacyMissingMASC(p)) {
                 p = new MissingMASC(p.getUnitTonnage(),
                         ((MissingEquipmentPart) p).getType(), ((MissingEquipmentPart) p).getEquipmentNum(), retVal,
                         ((MissingEquipmentPart) p).getTonnage(), 0, p.isOmniPodded());
@@ -1774,6 +1771,30 @@ public class CampaignXmlParser {
 
         MekHQ.getLogger().log(CampaignXmlParser.class, METHOD_NAME, LogLevel.INFO,
                 "Load Part Nodes Complete!"); //$NON-NLS-1$
+    }
+    
+    /**
+     * Determines if the supplied part is a MASC from an older save. This means that it needs to be converted
+     * to an actual MASC part.
+     * @param p The part to check.
+     * @return Whether it's an old MASC.
+     */
+    private static boolean isLegacyMASC(Part p) {
+        return (p instanceof EquipmentPart) && 
+                ((EquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && 
+                (((EquipmentPart) p).getType() instanceof MiscType);
+    }
+    
+    /**
+     * Determines if the supplied part is a "missing" MASC from an older save. This means that it needs to be converted
+     * to an actual "missing" MASC part.
+     * @param p The part to check.
+     * @return Whether it's an old "missing" MASC.
+     */
+    private static boolean isLegacyMissingMASC(Part p) {
+        return (p instanceof MissingEquipmentPart) && 
+                ((EquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && 
+                (((EquipmentPart) p).getType() instanceof MiscType);
     }
     
     private static void updatePlanetaryEventsFromXML(Node wn) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1781,6 +1781,7 @@ public class CampaignXmlParser {
      */
     private static boolean isLegacyMASC(Part p) {
         return (p instanceof EquipmentPart) && 
+                !(p instanceof MASC) &&
                 ((EquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && 
                 (((EquipmentPart) p).getType() instanceof MiscType);
     }
@@ -1793,8 +1794,9 @@ public class CampaignXmlParser {
      */
     private static boolean isLegacyMissingMASC(Part p) {
         return (p instanceof MissingEquipmentPart) && 
-                ((EquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && 
-                (((EquipmentPart) p).getType() instanceof MiscType);
+                !(p instanceof MissingMASC) &&
+                ((MissingEquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && 
+                (((MissingEquipmentPart) p).getType() instanceof MiscType);
     }
     
     private static void updatePlanetaryEventsFromXML(Node wn) {

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -325,7 +325,7 @@ public class BattleArmorSuit extends Part {
         return part instanceof BattleArmorSuit
                 && chassis.equals(((BattleArmorSuit)part).getChassis())
                 && model.equals(((BattleArmorSuit)part).getModel())
-                && this.getStickerPrice() == part.getStickerPrice();
+                && getStickerPrice().equals(part.getStickerPrice());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -155,7 +155,7 @@ public class EquipmentPart extends Part {
     	return part instanceof EquipmentPart
         		&& getType().equals(((EquipmentPart)part).getType())
         		&& getTonnage() == part.getTonnage()
-        		&& getStickerPrice() == part.getStickerPrice()
+        		&& getStickerPrice().equals(part.getStickerPrice())
         		&& isOmniPodded() == part.isOmniPodded();
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -21,7 +21,6 @@
 package mekhq.campaign.parts.equipment;
 
 import java.io.PrintWriter;
-import java.math.RoundingMode;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
@@ -187,7 +187,7 @@ public class MissingEquipmentPart extends MissingPart {
 		if(part instanceof EquipmentPart) {
 			EquipmentPart eqpart = (EquipmentPart)part;
 			EquipmentType et = eqpart.getType();
-			return type.equals(et) && getTonnage() == part.getTonnage() && part.getStickerPrice() == newPart.getStickerPrice();
+			return type.equals(et) && getTonnage() == part.getTonnage() && part.getStickerPrice().equals(newPart.getStickerPrice());
 		}
 		return false;
 	}


### PR DESCRIPTION
Fixes #1125, #1127, and a few minor bugs introduced with the Joda money changeover (.equals is no longer the same as == for the Money data structure), which appears to fix #1121.