### PR TITLE
Ensure equipment parts don't chime in for parts not in their location #1109

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -130,11 +130,9 @@ public class CampaignXmlParser {
     /**
      * Designed to create a campaign object from an input stream containing an XML structure.
      *
-     * @param is The file holding the XML, in InputStream form.
      * @return The created Campaign object, or null if there was a problem.
-     * @throws ParseException
-     * @throws DOMException
-     * @throws NullEntityException
+     * @throws CampaignXmlParseException Thrown when there was a problem parsing the CPNX file
+     * @throws NullEntityException Thrown when an entity is referenced but cannot be loaded or found
      */
     public Campaign parse() throws CampaignXmlParseException, NullEntityException {
         final String METHOD_NAME = "parse()"; //$NON-NLS-1$

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -65,7 +65,8 @@ public class EnginePart extends Part {
     }
 
     public EnginePart clone() {
-        EnginePart clone = new EnginePart(getUnitTonnage(), new Engine(engine.getRating(), engine.getEngineType(), engine.getFlags()), campaign, forHover);
+        EnginePart clone = new EnginePart(getUnitTonnage(),
+                new Engine(engine.getRating(), engine.getEngineType(), engine.getFlags()), campaign, forHover);
         clone.copyBaseData(this);
         return clone;
     }
@@ -78,32 +79,32 @@ public class EnginePart extends Part {
     public double getTonnage() {
         double weight = Engine.ENGINE_RATINGS[(int) Math.ceil(engine.getRating() / 5.0)];
         switch (engine.getEngineType()) {
-            case Engine.COMBUSTION_ENGINE:
-                weight *= 2.0f;
-                break;
-            case Engine.NORMAL_ENGINE:
-                break;
-            case Engine.XL_ENGINE:
-                weight *= 0.5f;
-                break;
-            case Engine.LIGHT_ENGINE:
-                weight *= 0.75f;
-                break;
-            case Engine.XXL_ENGINE:
-                weight /= 3f;
-                break;
-            case Engine.COMPACT_ENGINE:
-                weight *= 1.5f;
-                break;
-            case Engine.FISSION:
-                weight *= 1.75;
-                weight = Math.max(5, weight);
-                break;
-            case Engine.FUEL_CELL:
-                weight *= 1.2;
-                break;
-            case Engine.NONE:
-                return 0;
+        case Engine.COMBUSTION_ENGINE:
+            weight *= 2.0f;
+            break;
+        case Engine.NORMAL_ENGINE:
+            break;
+        case Engine.XL_ENGINE:
+            weight *= 0.5f;
+            break;
+        case Engine.LIGHT_ENGINE:
+            weight *= 0.75f;
+            break;
+        case Engine.XXL_ENGINE:
+            weight /= 3f;
+            break;
+        case Engine.COMPACT_ENGINE:
+            weight *= 1.5f;
+            break;
+        case Engine.FISSION:
+            weight *= 1.75;
+            weight = Math.max(5, weight);
+            break;
+        case Engine.FUEL_CELL:
+            weight *= 1.2;
+            break;
+        case Engine.NONE:
+            return 0;
         }
         weight = TestEntity.ceilMaxHalf(weight, TestEntity.Ceil.HALFTON);
 
@@ -113,14 +114,14 @@ public class EnginePart extends Part {
         double toReturn = TestEntity.ceilMaxHalf(weight, TestEntity.Ceil.HALFTON);
         // hover have a minimum weight of 20%
         if (forHover) {
-            return Math.max(TestEntity.ceilMaxHalf(getUnitTonnage()/5.0, TestEntity.Ceil.HALFTON), toReturn);
+            return Math.max(TestEntity.ceilMaxHalf(getUnitTonnage() / 5.0, TestEntity.Ceil.HALFTON), toReturn);
         }
         return toReturn;
     }
 
     @Override
     public Money getStickerPrice() {
-        return Money.of((double)getEngine().getBaseCost() / 75.0 * getEngine().getRating() * getUnitTonnage());
+        return Money.of((double) getEngine().getBaseCost() / 75.0 * getEngine().getRating() * getUnitTonnage());
     }
 
     @Override
@@ -133,7 +134,7 @@ public class EnginePart extends Part {
 
     public void fixTankFlag(boolean hover) {
         int flags = engine.getFlags();
-        if(!engine.hasFlag(Engine.TANK_ENGINE)) {
+        if (!engine.hasFlag(Engine.TANK_ENGINE)) {
             flags |= Engine.TANK_ENGINE;
         }
         engine = new Engine(engine.getRating(), engine.getEngineType(), flags);
@@ -143,7 +144,7 @@ public class EnginePart extends Part {
 
     public void fixClanFlag() {
         int flags = engine.getFlags();
-        if(!engine.hasFlag(Engine.CLAN_ENGINE)) {
+        if (!engine.hasFlag(Engine.CLAN_ENGINE)) {
             flags |= Engine.CLAN_ENGINE;
         }
         engine = new Engine(engine.getRating(), engine.getEngineType(), flags);
@@ -153,17 +154,14 @@ public class EnginePart extends Part {
     @Override
     public boolean isSamePartType(Part part) {
         int year = campaign.getCalendar().get(GregorianCalendar.YEAR);
-        return part instanceof EnginePart
-                && getName().equals(part.getName())
-                && getEngine().getEngineType() == ((EnginePart) part)
-                        .getEngine().getEngineType()
-                && getEngine().getRating() == ((EnginePart) part).getEngine()
-                        .getRating()
-                && getEngine().getTechType(year) == ((EnginePart) part).getEngine()
-                        .getTechType(year)
-                && getEngine().hasFlag(Engine.TANK_ENGINE) == ((EnginePart) part).getEngine().hasFlag(Engine.TANK_ENGINE)
+        return part instanceof EnginePart && getName().equals(part.getName())
+                && getEngine().getEngineType() == ((EnginePart) part).getEngine().getEngineType()
+                && getEngine().getRating() == ((EnginePart) part).getEngine().getRating()
+                && getEngine().getTechType(year) == ((EnginePart) part).getEngine().getTechType(year)
+                && getEngine().hasFlag(Engine.TANK_ENGINE) == ((EnginePart) part).getEngine()
+                        .hasFlag(Engine.TANK_ENGINE)
                 && getUnitTonnage() == ((EnginePart) part).getUnitTonnage()
-                && getTonnage() == ((EnginePart)part).getTonnage();
+                && getTonnage() == ((EnginePart) part).getTonnage();
     }
 
     @Override
@@ -172,18 +170,10 @@ public class EnginePart extends Part {
         // The engine is a MM object...
         // And doesn't support XML serialization...
         // But it's defined by 3 ints. So we'll save those here.
-        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<engineType>"
-                + engine.getEngineType() + "</engineType>");
-        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<engineRating>"
-                + engine.getRating() + "</engineRating>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<engineFlags>"
-                +engine.getFlags()
-                +"</engineFlags>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<forHover>"
-                +forHover
-                +"</forHover>");
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<engineType>" + engine.getEngineType() + "</engineType>");
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<engineRating>" + engine.getRating() + "</engineRating>");
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<engineFlags>" + engine.getFlags() + "</engineFlags>");
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<forHover>" + forHover + "</forHover>");
         writeToXmlEnd(pw1, indent);
     }
 
@@ -194,7 +184,7 @@ public class EnginePart extends Part {
         int engineRating = -1;
         int engineFlags = 0;
 
-        for (int x=0; x<nl.getLength(); x++) {
+        for (int x = 0; x < nl.getLength(); x++) {
             Node wn2 = nl.item(x);
 
             if (wn2.getNodeName().equalsIgnoreCase("engineType")) {
@@ -214,46 +204,47 @@ public class EnginePart extends Part {
     @Override
     public void fix() {
         super.fix();
-        if(null != unit) {
-            if(unit.getEntity() instanceof Mech) {
+        if (null != unit) {
+            if (unit.getEntity() instanceof Mech) {
                 unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE);
             }
-            if(unit.getEntity() instanceof Aero) {
-                ((Aero)unit.getEntity()).setEngineHits(0);
+            if (unit.getEntity() instanceof Aero) {
+                ((Aero) unit.getEntity()).setEngineHits(0);
             }
-            if(unit.getEntity() instanceof Tank) {
-                ((Tank)unit.getEntity()).engineFix();
+            if (unit.getEntity() instanceof Tank) {
+                ((Tank) unit.getEntity()).engineFix();
             }
-            if(unit.getEntity() instanceof Protomech) {
-                ((Protomech)unit.getEntity()).setEngineHit(false);
+            if (unit.getEntity() instanceof Protomech) {
+                ((Protomech) unit.getEntity()).setEngineHit(false);
             }
         }
     }
 
     @Override
     public MissingPart getMissingPart() {
-        return new MissingEnginePart(getUnitTonnage(), new Engine(engine.getRating(), engine.getEngineType(), engine.getFlags()), campaign, forHover);
+        return new MissingEnginePart(getUnitTonnage(),
+                new Engine(engine.getRating(), engine.getEngineType(), engine.getFlags()), campaign, forHover);
     }
 
     @Override
     public void remove(boolean salvage) {
-        if(null != unit) {
-            if(unit.getEntity() instanceof Mech) {
+        if (null != unit) {
+            if (unit.getEntity() instanceof Mech) {
                 unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE);
             }
-            if(unit.getEntity() instanceof Aero) {
-                ((Aero)unit.getEntity()).setEngineHits(((Aero)unit.getEntity()).getMaxEngineHits());
+            if (unit.getEntity() instanceof Aero) {
+                ((Aero) unit.getEntity()).setEngineHits(((Aero) unit.getEntity()).getMaxEngineHits());
             }
-            if(unit.getEntity() instanceof Tank) {
-                ((Tank)unit.getEntity()).engineHit();
+            if (unit.getEntity() instanceof Tank) {
+                ((Tank) unit.getEntity()).engineHit();
             }
-            if(unit.getEntity() instanceof Protomech) {
-                ((Protomech)unit.getEntity()).setEngineHit(true);
+            if (unit.getEntity() instanceof Protomech) {
+                ((Protomech) unit.getEntity()).setEngineHit(true);
             }
             Part spare = campaign.checkForExistingSparePart(this);
-            if(!salvage) {
+            if (!salvage) {
                 campaign.removePart(this);
-            } else if(null != spare) {
+            } else if (null != spare) {
                 spare.incrementQuantity();
                 campaign.removePart(this);
             }
@@ -267,40 +258,37 @@ public class EnginePart extends Part {
 
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
-        if(null != unit) {
+        if (null != unit) {
             int engineHits = 0;
             int engineCrits = 0;
             Entity entity = unit.getEntity();
-            if(unit.getEntity() instanceof Mech) {
+            if (unit.getEntity() instanceof Mech) {
                 for (int i = 0; i < entity.locations(); i++) {
-                    engineHits += entity.getDamagedCriticals(CriticalSlot.TYPE_SYSTEM,
-                            Mech.SYSTEM_ENGINE, i);
-                    engineCrits += entity.getNumberOfCriticals(
-                            CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, i);
+                    engineHits += entity.getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, i);
+                    engineCrits += entity.getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, i);
                 }
             }
-            if(unit.getEntity() instanceof Aero) {
-                engineHits = ((Aero)unit.getEntity()).getEngineHits();
+            if (unit.getEntity() instanceof Aero) {
+                engineHits = ((Aero) unit.getEntity()).getEngineHits();
                 engineCrits = 3;
             }
-            if(unit.getEntity() instanceof Tank) {
+            if (unit.getEntity() instanceof Tank) {
                 engineCrits = 2;
-                if(((Tank)unit.getEntity()).isEngineHit()) {
+                if (((Tank) unit.getEntity()).isEngineHit()) {
                     engineHits = 1;
                 }
             }
-            if(unit.getEntity() instanceof Protomech) {
+            if (unit.getEntity() instanceof Protomech) {
                 engineCrits = 1;
-                if(unit.getEntity().getInternal(Protomech.LOC_TORSO) == IArmorState.ARMOR_DESTROYED) {
+                if (unit.getEntity().getInternal(Protomech.LOC_TORSO) == IArmorState.ARMOR_DESTROYED) {
                     engineHits = 1;
                 } else {
-                    engineHits = ((Protomech)unit.getEntity()).getEngineHits();
+                    engineHits = ((Protomech) unit.getEntity()).getEngineHits();
                 }
             }
-            if(engineHits >= engineCrits) {
+            if (engineHits >= engineCrits) {
                 remove(false);
-            }
-            else if(engineHits > 0) {
+            } else if (engineHits > 0) {
                 hits = engineHits;
             } else {
                 hits = 0;
@@ -310,11 +298,11 @@ public class EnginePart extends Part {
 
     @Override
     public int getBaseTime() {
-        //TODO: keep an aero flag here, so we dont need the unit
-        if(null != unit && unit.getEntity() instanceof Aero && hits > 0) {
+        // TODO: keep an aero flag here, so we dont need the unit
+        if (null != unit && unit.getEntity() instanceof Aero && hits > 0) {
             return 300;
         }
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             return 360;
         }
         if (hits == 1) {
@@ -329,11 +317,11 @@ public class EnginePart extends Part {
 
     @Override
     public int getDifficulty() {
-        //TODO: keep an aero flag here, so we dont need the unit
-        if(null != unit && unit.getEntity() instanceof Aero && hits > 0) {
+        // TODO: keep an aero flag here, so we dont need the unit
+        if (null != unit && unit.getEntity() instanceof Aero && hits > 0) {
             return 1;
         }
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             return -1;
         }
         if (hits == 1) {
@@ -346,7 +334,6 @@ public class EnginePart extends Part {
         return 0;
     }
 
-
     @Override
     public boolean needsFixing() {
         return hits > 0;
@@ -354,97 +341,96 @@ public class EnginePart extends Part {
 
     @Override
     public void updateConditionFromPart() {
-        if(null != unit) {
-            if(hits == 0) {
-                if(unit.getEntity() instanceof Mech) {
+        if (null != unit) {
+            if (hits == 0) {
+                if (unit.getEntity() instanceof Mech) {
                     unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE);
                 }
-                if(unit.getEntity() instanceof Aero) {
-                    ((Aero)unit.getEntity()).setEngineHits(0);
+                if (unit.getEntity() instanceof Aero) {
+                    ((Aero) unit.getEntity()).setEngineHits(0);
                 }
-                if(unit.getEntity() instanceof Tank) {
-                    ((Tank)unit.getEntity()).engineFix();
+                if (unit.getEntity() instanceof Tank) {
+                    ((Tank) unit.getEntity()).engineFix();
                 }
-                if(unit.getEntity() instanceof Protomech) {
-                    ((Protomech)unit.getEntity()).setEngineHit(false);
+                if (unit.getEntity() instanceof Protomech) {
+                    ((Protomech) unit.getEntity()).setEngineHit(false);
                 }
             } else {
-                if(unit.getEntity() instanceof Mech) {
+                if (unit.getEntity() instanceof Mech) {
                     unit.damageSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, hits);
                 }
-                if(unit.getEntity() instanceof Aero) {
-                    ((Aero)unit.getEntity()).setEngineHits(hits);
+                if (unit.getEntity() instanceof Aero) {
+                    ((Aero) unit.getEntity()).setEngineHits(hits);
                 }
-                if(unit.getEntity() instanceof Tank) {
-                    ((Tank)unit.getEntity()).engineHit();
+                if (unit.getEntity() instanceof Tank) {
+                    ((Tank) unit.getEntity()).engineHit();
                 }
-                if(unit.getEntity() instanceof Protomech) {
-                    ((Protomech)unit.getEntity()).setEngineHit(true);
+                if (unit.getEntity() instanceof Protomech) {
+                    ((Protomech) unit.getEntity()).setEngineHit(true);
                 }
             }
         }
     }
 
     @Override
-     public String checkFixable() {
-        if(null == unit) {
+    public String checkFixable() {
+        if (null == unit) {
             return null;
         }
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             return null;
         }
-        for(int i = 0; i < unit.getEntity().locations(); i++) {
-            if(unit.isLocationBreached(i)) {
+        for (int i = 0; i < unit.getEntity().locations(); i++) {
+            if (unit.isLocationBreached(i)) {
                 return unit.getEntity().getLocationName(i) + " is breached.";
             }
-            if(unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, i) > 0
+            if (unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, i) > 0
                     && unit.isLocationDestroyed(i)) {
                 return unit.getEntity().getLocationName(i) + " is destroyed.";
             }
         }
         return null;
-     }
+    }
 
     @Override
     public boolean isMountedOnDestroyedLocation() {
-        if(null == unit) {
+        if (null == unit) {
             return false;
         }
-        for(int i = 0; i < unit.getEntity().locations(); i++) {
-             if(unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, i) > 0
-                     && unit.isLocationDestroyed(i)) {
-                 return true;
-             }
-         }
+        for (int i = 0; i < unit.getEntity().locations(); i++) {
+            if (unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, i) > 0
+                    && unit.isLocationDestroyed(i)) {
+                return true;
+            }
+        }
         return false;
     }
 
-     @Override
-     public String getDetails() {
-         if(null != unit) {
-             return super.getDetails();
-         }
-         String hvrString = "";
-         if(forHover) {
-             hvrString = " (hover)";
-         }
-         return super.getDetails() + ", " + getUnitTonnage() + " tons" + hvrString;
-     }
-
-     @Override
-     public boolean isPartForEquipmentNum(int index, int loc) {
-         return Mech.SYSTEM_ENGINE == index && loc == getLocation();
-     }
-
-     @Override
-        public boolean isRightTechType(String skillType) {
-            if(getEngine().hasFlag(Engine.TANK_ENGINE)) {
-                return skillType.equals(SkillType.S_TECH_MECHANIC);
-            }
-            else {
-                return skillType.equals(SkillType.S_TECH_MECH) || skillType.equals(SkillType.S_TECH_AERO);
-            }
+    @Override
+    public String getDetails() {
+        if (null != unit) {
+            return super.getDetails();
         }
+        String hvrString = "";
+        if (forHover) {
+            hvrString = " (hover)";
+        }
+        return super.getDetails() + ", " + getUnitTonnage() + " tons" + hvrString;
+    }
+
+    @Override
+    public boolean isPartForEquipmentNum(int index, int loc) {
+        return Mech.SYSTEM_ENGINE == index && loc == getLocation();
+    }
+
+    @Override
+    public boolean isRightTechType(String skillType) {
+        if (getEngine().hasFlag(Engine.TANK_ENGINE)) {
+            return skillType.equals(SkillType.S_TECH_MECHANIC);
+        } else {
+            return skillType.equals(SkillType.S_TECH_MECH) || skillType.equals(SkillType.S_TECH_AERO);
+        }
+    }
 
     @Override
     public String getLocationName() {
@@ -464,26 +450,25 @@ public class EnginePart extends Part {
 
     @Override
     public boolean isInLocation(String loc) {
-         if(null == unit || null == unit.getEntity()) {
-             return false;
-         }
-         if (unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_CT) {
-             return true;
-         }
-         boolean needsSideTorso = false;
-         switch (getEngine().getEngineType()) {
-             case Engine.XL_ENGINE:
-             case Engine.LIGHT_ENGINE:
-             case Engine.XXL_ENGINE:
-                 needsSideTorso = true;
-                 break;
-         }
-         if (needsSideTorso
-                 && (unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_LT
-                         || unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_RT)) {
-             return true;
-         }
-         return false;
+        if (null == unit || null == unit.getEntity()) {
+            return false;
+        }
+        if (unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_CT) {
+            return true;
+        }
+        boolean needsSideTorso = false;
+        switch (getEngine().getEngineType()) {
+        case Engine.XL_ENGINE:
+        case Engine.LIGHT_ENGINE:
+        case Engine.XXL_ENGINE:
+            needsSideTorso = true;
+            break;
+        }
+        if (needsSideTorso && (unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_LT
+                || unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_RT)) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -433,7 +433,7 @@ public class EnginePart extends Part {
 
      @Override
      public boolean isPartForEquipmentNum(int index, int loc) {
-         return Mech.SYSTEM_ENGINE == index;
+         return Mech.SYSTEM_ENGINE == index && loc == getLocation();
      }
 
      @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekActuator.java
@@ -44,221 +44,211 @@ import mekhq.campaign.personnel.SkillType;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class MekActuator extends Part {
-	private static final long serialVersionUID = 719878556021696393L;
-	
-    static final TechAdvancement TA_STANDARD = new TechAdvancement(TECH_BASE_ALL)
-            .setAdvancement(2300, 2350, 2505).setApproximate(true, false, false)
-            .setPrototypeFactions(F_TA).setProductionFactions(F_TH)
-            .setStaticTechLevel(SimpleTechLevel.INTRO);
-    static final TechAdvancement TA_SUPERHEAVY = new TechAdvancement(TECH_BASE_IS)
-            .setAdvancement(2905, 2940, 3076).setApproximate(true, false, false)
-            .setPrototypeFactions(F_FW).setProductionFactions(F_FW)
-            .setStaticTechLevel(SimpleTechLevel.ADVANCED);
-    
-	protected int type;
-	protected int location;
+    private static final long serialVersionUID = 719878556021696393L;
 
-	public MekActuator() {
-		this(0, 0, null);
-	}
-	
-	public MekActuator clone() {
-		MekActuator clone = new MekActuator(getUnitTonnage(), type, location, campaign);
+    static final TechAdvancement TA_STANDARD = new TechAdvancement(TECH_BASE_ALL).setAdvancement(2300, 2350, 2505)
+            .setApproximate(true, false, false).setPrototypeFactions(F_TA).setProductionFactions(F_TH)
+            .setStaticTechLevel(SimpleTechLevel.INTRO);
+    static final TechAdvancement TA_SUPERHEAVY = new TechAdvancement(TECH_BASE_IS).setAdvancement(2905, 2940, 3076)
+            .setApproximate(true, false, false).setPrototypeFactions(F_FW).setProductionFactions(F_FW)
+            .setStaticTechLevel(SimpleTechLevel.ADVANCED);
+
+    protected int type;
+    protected int location;
+
+    public MekActuator() {
+        this(0, 0, null);
+    }
+
+    public MekActuator clone() {
+        MekActuator clone = new MekActuator(getUnitTonnage(), type, location, campaign);
         clone.copyBaseData(this);
-		return clone;
-	}
-	
+        return clone;
+    }
+
     public int getType() {
         return type;
     }
-    
+
     public void setLocation(int loc) {
-    	this.location = loc;
+        this.location = loc;
     }
-    
+
     public MekActuator(int tonnage, int type, Campaign c) {
         this(tonnage, type, -1, c);
     }
-    
+
     public MekActuator(int tonnage, int type, int loc, Campaign c) {
-    	super(tonnage, c);
+        super(tonnage, c);
         this.type = type;
         Mech m = new BipedMech();
-        this.name = m.getSystemName(type) + " Actuator" ;
+        this.name = m.getSystemName(type) + " Actuator";
         this.location = loc;
     }
 
     @Override
     public double getTonnage() {
-    	//TODO: how much do actuators weight?
-    	//apparently nothing
-    	return 0;
+        // TODO: how much do actuators weight?
+        // apparently nothing
+        return 0;
     }
-    
+
     @Override
     public Money getStickerPrice() {
         double unitCost = 0;
         switch (getType()) {
-            case (Mech.ACTUATOR_UPPER_ARM) : {
-                unitCost = 100;
-                break;
-            }
-            case (Mech.ACTUATOR_LOWER_ARM) : {
-                unitCost = 50;
-                break;
-            }
-            case (Mech.ACTUATOR_HAND) : {
-                unitCost = 80;
-                break;
-            }
-            case (Mech.ACTUATOR_UPPER_LEG) : {
-                unitCost = 150;
-                break;
-            }
-            case (Mech.ACTUATOR_LOWER_LEG) : {
-                unitCost = 80;
-                break;
-            }
-            case (Mech.ACTUATOR_FOOT) : {
-                unitCost = 120;
-                break;
-            }
-            case (Mech.ACTUATOR_HIP) : {
-                // not used
-                unitCost = 0;
-                break;
-            }
-            case (Mech.ACTUATOR_SHOULDER) : {
-                // not used
-                unitCost = 0;
-                break;
-            }
+        case (Mech.ACTUATOR_UPPER_ARM): {
+            unitCost = 100;
+            break;
+        }
+        case (Mech.ACTUATOR_LOWER_ARM): {
+            unitCost = 50;
+            break;
+        }
+        case (Mech.ACTUATOR_HAND): {
+            unitCost = 80;
+            break;
+        }
+        case (Mech.ACTUATOR_UPPER_LEG): {
+            unitCost = 150;
+            break;
+        }
+        case (Mech.ACTUATOR_LOWER_LEG): {
+            unitCost = 80;
+            break;
+        }
+        case (Mech.ACTUATOR_FOOT): {
+            unitCost = 120;
+            break;
+        }
+        case (Mech.ACTUATOR_HIP): {
+            // not used
+            unitCost = 0;
+            break;
+        }
+        case (Mech.ACTUATOR_SHOULDER): {
+            // not used
+            unitCost = 0;
+            break;
+        }
         }
         return Money.of(getUnitTonnage() * unitCost);
     }
 
     @Override
-    public boolean isSamePartType (Part part) {
-        return part instanceof MekActuator
-                && getType() == ((MekActuator)part).getType()
-                && getUnitTonnage() == ((MekActuator)part).getUnitTonnage();
+    public boolean isSamePartType(Part part) {
+        return part instanceof MekActuator && getType() == ((MekActuator) part).getType()
+                && getUnitTonnage() == ((MekActuator) part).getUnitTonnage();
     }
-    
+
     public int getLocation() {
-    	return location;
+        return location;
     }
-    
-	@Override
-	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<type>"
-				+type
-				+"</type>");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<location>"
-				+location
-				+"</location>");
-		writeToXmlEnd(pw1, indent);
-	}
 
-	@Override
-	protected void loadFieldsFromXmlNode(Node wn) {
-		NodeList nl = wn.getChildNodes();
-		
-		for (int x=0; x<nl.getLength(); x++) {
-			Node wn2 = nl.item(x);
-			
-			if (wn2.getNodeName().equalsIgnoreCase("type")) {
-				type = Integer.parseInt(wn2.getTextContent());
-			} else if (wn2.getNodeName().equalsIgnoreCase("location")) {
-				location = Integer.parseInt(wn2.getTextContent());
-			} 
-		}
-	}
+    @Override
+    public void writeToXml(PrintWriter pw1, int indent) {
+        writeToXmlBegin(pw1, indent);
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<type>" + type + "</type>");
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<location>" + location + "</location>");
+        writeToXmlEnd(pw1, indent);
+    }
 
-	@Override
-	public void fix() {
-		super.fix();
-		if(null != unit) {
-			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, type, location);
-		}
-	}
-	
-	@Override
-	public int getTechLevel() {
-		return TechConstants.T_ALLOWED_ALL;
-	}
+    @Override
+    protected void loadFieldsFromXmlNode(Node wn) {
+        NodeList nl = wn.getChildNodes();
 
-	@Override
-	public MissingPart getMissingPart() {
-		return new MissingMekActuator(getUnitTonnage(), type, location, campaign);
-	}
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn2 = nl.item(x);
 
-	@Override
-	public void remove(boolean salvage) {
-		if(null != unit) {
-			unit.destroySystem(CriticalSlot.TYPE_SYSTEM, type, location);
-			Part spare = campaign.checkForExistingSparePart(this);
-			if(!salvage) {
-				campaign.removePart(this);
-			} else if(null != spare) {
-				spare.incrementQuantity();
-				campaign.removePart(this);
-			}
-			unit.removePart(this);
-			Part missing = getMissingPart();
-			unit.addPart(missing);
-			campaign.addPart(missing, 0);
-		}	
-		setUnit(null);
-		updateConditionFromEntity(false);
-		location = -1;
-	}
+            if (wn2.getNodeName().equalsIgnoreCase("type")) {
+                type = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("location")) {
+                location = Integer.parseInt(wn2.getTextContent());
+            }
+        }
+    }
 
-	@Override
-	public void updateConditionFromEntity(boolean checkForDestruction) {
-		int priorHits = hits;
-		if(null != unit) {
-			//check for missing equipment
-			if(unit.isSystemMissing(type, location)) {
-				remove(false);
-				return;
-			}
-			hits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, type, location);
-			if(checkForDestruction 
-					&& hits > priorHits 
-					&& Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
-				remove(false);
-			}
-		}
-	}
-	
-	@Override 
-	public int getBaseTime() {
-		if(isSalvaging()) {
-			return isOmniPodded()? 30 : 90;
-		}
-		return 120;
-	}
-	
-	@Override
-	public int getDifficulty() {
-		if(isSalvaging()) {
-			return -3;
-		}
-		return 0;
-	}
+    @Override
+    public void fix() {
+        super.fix();
+        if (null != unit) {
+            unit.repairSystem(CriticalSlot.TYPE_SYSTEM, type, location);
+        }
+    }
 
-	@Override
-	public boolean needsFixing() {
-		return hits > 0;
-	}
-	
-	@Override
-	public String getDetails() {
-		if(null != unit) {
-		    StringJoiner sj = new StringJoiner(", ");
+    @Override
+    public int getTechLevel() {
+        return TechConstants.T_ALLOWED_ALL;
+    }
+
+    @Override
+    public MissingPart getMissingPart() {
+        return new MissingMekActuator(getUnitTonnage(), type, location, campaign);
+    }
+
+    @Override
+    public void remove(boolean salvage) {
+        if (null != unit) {
+            unit.destroySystem(CriticalSlot.TYPE_SYSTEM, type, location);
+            Part spare = campaign.checkForExistingSparePart(this);
+            if (!salvage) {
+                campaign.removePart(this);
+            } else if (null != spare) {
+                spare.incrementQuantity();
+                campaign.removePart(this);
+            }
+            unit.removePart(this);
+            Part missing = getMissingPart();
+            unit.addPart(missing);
+            campaign.addPart(missing, 0);
+        }
+        setUnit(null);
+        updateConditionFromEntity(false);
+        location = -1;
+    }
+
+    @Override
+    public void updateConditionFromEntity(boolean checkForDestruction) {
+        int priorHits = hits;
+        if (null != unit) {
+            // check for missing equipment
+            if (unit.isSystemMissing(type, location)) {
+                remove(false);
+                return;
+            }
+            hits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, type, location);
+            if (checkForDestruction && hits > priorHits
+                    && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
+                remove(false);
+            }
+        }
+    }
+
+    @Override
+    public int getBaseTime() {
+        if (isSalvaging()) {
+            return isOmniPodded() ? 30 : 90;
+        }
+        return 120;
+    }
+
+    @Override
+    public int getDifficulty() {
+        if (isSalvaging()) {
+            return -3;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean needsFixing() {
+        return hits > 0;
+    }
+
+    @Override
+    public String getDetails() {
+        if (null != unit) {
+            StringJoiner sj = new StringJoiner(", ");
             if (getLocationName() != null) {
                 sj.add(getLocationName());
             }
@@ -267,80 +257,80 @@ public class MekActuator extends Part {
                 sj.add(repairCost.toAmountAndSymbolString() + " to repair");
             }
             return sj.toString();
-		}
-		return getUnitTonnage() + " tons";
-	}
+        }
+        return getUnitTonnage() + " tons";
+    }
 
-	@Override
-	public void updateConditionFromPart() {
-		if(null != unit) {
-			if(hits > 0) {
-				unit.damageSystem(CriticalSlot.TYPE_SYSTEM, type, location, 1);
-			} else {
-				unit.repairSystem(CriticalSlot.TYPE_SYSTEM, type, location);
-			}
-		}	
-	}
-	
-	@Override
-	public String checkFixable() {
-		if(null == unit) {
-			return null;
-		}
-		if(isSalvaging()) {
-			return null;
-		}
-		if(unit.isLocationBreached(location)) {
-			return unit.getEntity().getLocationName(location) + " is breached.";
-		}
-		if(isMountedOnDestroyedLocation()) {
-			return unit.getEntity().getLocationName(location) + " is destroyed.";
-		}
-		return null;
-	}
-	
-	@Override
-	public boolean isMountedOnDestroyedLocation() {
-		return null != unit && unit.isLocationDestroyed(location);
-	}
-	
-	@Override
-	public boolean onBadHipOrShoulder() {
-		return null != unit && unit.hasBadHipOrShoulder(location);
-	}
-	
-	@Override
-	public boolean isPartForEquipmentNum(int index, int loc) {
-		return index == type && loc == location;
-	}
-	
-	@Override
-	public boolean isRightTechType(String skillType) {
-		return skillType.equals(SkillType.S_TECH_MECH);
-	}
-	
-	@Override
-	public boolean isOmniPoddable() {
-		return type == Mech.ACTUATOR_LOWER_ARM || type == Mech.ACTUATOR_HAND;
-	}
-	
-	@Override
-	public boolean isOmniPodded() {
-	    return isOmniPoddable() && getUnit() != null && getUnit().getEntity().isOmni();
-	}
+    @Override
+    public void updateConditionFromPart() {
+        if (null != unit) {
+            if (hits > 0) {
+                unit.damageSystem(CriticalSlot.TYPE_SYSTEM, type, location, 1);
+            } else {
+                unit.repairSystem(CriticalSlot.TYPE_SYSTEM, type, location);
+            }
+        }
+    }
 
-	@Override
-	public String getLocationName() {
-		return unit.getEntity().getLocationName(location);
-	}
-	
-	@Override
-	public TechAdvancement getTechAdvancement() {
-	    return (getUnitTonnage() <= 100)? TA_STANDARD : TA_SUPERHEAVY;
-	}
-	
-	@Override
-	public int getMassRepairOptionType() {
-    	return Part.REPAIR_PART_TYPE.ACTUATOR;
+    @Override
+    public String checkFixable() {
+        if (null == unit) {
+            return null;
+        }
+        if (isSalvaging()) {
+            return null;
+        }
+        if (unit.isLocationBreached(location)) {
+            return unit.getEntity().getLocationName(location) + " is breached.";
+        }
+        if (isMountedOnDestroyedLocation()) {
+            return unit.getEntity().getLocationName(location) + " is destroyed.";
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isMountedOnDestroyedLocation() {
+        return null != unit && unit.isLocationDestroyed(location);
+    }
+
+    @Override
+    public boolean onBadHipOrShoulder() {
+        return null != unit && unit.hasBadHipOrShoulder(location);
+    }
+
+    @Override
+    public boolean isPartForEquipmentNum(int index, int loc) {
+        return index == type && loc == location;
+    }
+
+    @Override
+    public boolean isRightTechType(String skillType) {
+        return skillType.equals(SkillType.S_TECH_MECH);
+    }
+
+    @Override
+    public boolean isOmniPoddable() {
+        return type == Mech.ACTUATOR_LOWER_ARM || type == Mech.ACTUATOR_HAND;
+    }
+
+    @Override
+    public boolean isOmniPodded() {
+        return isOmniPoddable() && getUnit() != null && getUnit().getEntity().isOmni();
+    }
+
+    @Override
+    public String getLocationName() {
+        return unit.getEntity().getLocationName(location);
+    }
+
+    @Override
+    public TechAdvancement getTechAdvancement() {
+        return (getUnitTonnage() <= 100) ? TA_STANDARD : TA_SUPERHEAVY;
+    }
+
+    @Override
+    public int getMassRepairOptionType() {
+        return Part.REPAIR_PART_TYPE.ACTUATOR;
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
@@ -113,21 +113,17 @@ public class MekCockpit extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof MekCockpit 
-                && ((MekCockpit)part).getType() == type;
+        return part instanceof MekCockpit && ((MekCockpit) part).getType() == type;
     }
-    
+
     public int getType() {
         return type;
     }
-    
+
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<type>"
-                +type
-                +"</type>");
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<type>" + type + "</type>");
         writeToXmlEnd(pw1, indent);
     }
 
@@ -135,7 +131,7 @@ public class MekCockpit extends Part {
     protected void loadFieldsFromXmlNode(Node wn) {
         NodeList nl = wn.getChildNodes();
 
-        for (int x=0; x<nl.getLength(); x++) {
+        for (int x = 0; x < nl.getLength(); x++) {
             Node wn2 = nl.item(x);
 
             if (wn2.getNodeName().equalsIgnoreCase("type")) {
@@ -147,7 +143,7 @@ public class MekCockpit extends Part {
     @Override
     public void fix() {
         super.fix();
-        if(null != unit) {
+        if (null != unit) {
             unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT);
         }
     }
@@ -159,12 +155,12 @@ public class MekCockpit extends Part {
 
     @Override
     public void remove(boolean salvage) {
-        if(null != unit) {
+        if (null != unit) {
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT);
             Part spare = campaign.checkForExistingSparePart(this);
-            if(!salvage) {
+            if (!salvage) {
                 campaign.removePart(this);
-            } else if(null != spare) {
+            } else if (null != spare) {
                 spare.incrementQuantity();
                 campaign.removePart(this);
             }
@@ -180,11 +176,11 @@ public class MekCockpit extends Part {
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         int priorHits = hits;
-        if(null != unit) {
+        if (null != unit) {
             Entity entity = unit.getEntity();
             for (int i = 0; i < entity.locations(); i++) {
                 if (entity.getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT, i) > 0) {
-                    //check for missing equipment as well
+                    // check for missing equipment as well
                     if (!unit.isSystemMissing(Mech.SYSTEM_COCKPIT, i)) {
                         hits = entity.getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT, i);
                         break;
@@ -194,8 +190,7 @@ public class MekCockpit extends Part {
                     }
                 }
             }
-            if(checkForDestruction
-                    && hits > priorHits
+            if (checkForDestruction && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
@@ -204,19 +199,19 @@ public class MekCockpit extends Part {
 
     @Override
     public int getBaseTime() {
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             return 300;
         }
-        //TODO: These are made up values until the errata establish them
+        // TODO: These are made up values until the errata establish them
         return 200;
     }
 
     @Override
     public int getDifficulty() {
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             return 0;
         }
-        //TODO: These are made up values until the errata establish them
+        // TODO: These are made up values until the errata establish them
         return 3;
     }
 
@@ -227,8 +222,8 @@ public class MekCockpit extends Part {
 
     @Override
     public void updateConditionFromPart() {
-        if(null != unit) {
-            if(hits == 0) {
+        if (null != unit) {
+            if (hits == 0) {
                 unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT);
             } else {
                 unit.damageSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT, hits);
@@ -238,18 +233,18 @@ public class MekCockpit extends Part {
 
     @Override
     public String checkFixable() {
-        if(null == unit) {
+        if (null == unit) {
             return null;
         }
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             return null;
         }
-        for(int i = 0; i < unit.getEntity().locations(); i++) {
-            if(unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT, i) > 0) {
-                if(unit.isLocationBreached(i)) {
+        for (int i = 0; i < unit.getEntity().locations(); i++) {
+            if (unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT, i) > 0) {
+                if (unit.isLocationBreached(i)) {
                     return unit.getEntity().getLocationName(i) + " is breached.";
                 }
-                if(unit.isLocationDestroyed(i)) {
+                if (unit.isLocationDestroyed(i)) {
                     return unit.getEntity().getLocationName(i) + " is destroyed.";
                 }
             }
@@ -259,27 +254,27 @@ public class MekCockpit extends Part {
 
     @Override
     public boolean isMountedOnDestroyedLocation() {
-        if(null == unit) {
+        if (null == unit) {
             return false;
         }
-        for(int i = 0; i < unit.getEntity().locations(); i++) {
-             if(unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT, i) > 0
-                     && unit.isLocationDestroyed(i)) {
-                 return true;
-             }
-         }
+        for (int i = 0; i < unit.getEntity().locations(); i++) {
+            if (unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT, i) > 0
+                    && unit.isLocationDestroyed(i)) {
+                return true;
+            }
+        }
         return false;
     }
 
-     @Override
-     public boolean isPartForEquipmentNum(int index, int loc) {
-         return Mech.SYSTEM_COCKPIT == index && loc == getLocation();
-     }
+    @Override
+    public boolean isPartForEquipmentNum(int index, int loc) {
+        return Mech.SYSTEM_COCKPIT == index && loc == getLocation();
+    }
 
-     @Override
-     public boolean isRightTechType(String skillType) {
-         return skillType.equals(SkillType.S_TECH_MECH);
-     }
+    @Override
+    public boolean isRightTechType(String skillType) {
+        return skillType.equals(SkillType.S_TECH_MECH);
+    }
 
     @Override
     public String getLocationName() {
@@ -289,7 +284,7 @@ public class MekCockpit extends Part {
 
     @Override
     public int getLocation() {
-        if(type == Mech.COCKPIT_TORSO_MOUNTED) {
+        if (type == Mech.COCKPIT_TORSO_MOUNTED) {
             return Mech.LOC_CT;
         } else {
             return Mech.LOC_HEAD;

--- a/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
@@ -273,7 +273,7 @@ public class MekCockpit extends Part {
 
      @Override
      public boolean isPartForEquipmentNum(int index, int loc) {
-         return Mech.SYSTEM_COCKPIT == index;
+         return Mech.SYSTEM_COCKPIT == index && loc == getLocation();
      }
 
      @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekGyro.java
@@ -252,7 +252,7 @@ public class MekGyro extends Part {
 
 	@Override
 	public boolean isPartForEquipmentNum(int index, int loc) {
-		return Mech.SYSTEM_GYRO == index;
+		return Mech.SYSTEM_GYRO == index && loc == getLocation();
 	}
 
 	 @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekGyro.java
@@ -40,23 +40,21 @@ import mekhq.campaign.personnel.SkillType;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class MekGyro extends Part {
-	private static final long serialVersionUID = 3420475726506139139L;
-	protected int type;
-	protected double gyroTonnage;
-	protected boolean isClan;
+    private static final long serialVersionUID = 3420475726506139139L;
+    protected int type;
+    protected double gyroTonnage;
+    protected boolean isClan;
 
     public MekGyro() {
-    	this(0, 0, 0, false, null);
+        this(0, 0, 0, false, null);
     }
 
     public MekGyro(int tonnage, int type, int walkMP, boolean isClan, Campaign c) {
-        this(tonnage, type, MekGyro.getGyroTonnage(walkMP, type, tonnage),
-                isClan, c);
+        this(tonnage, type, MekGyro.getGyroTonnage(walkMP, type, tonnage), isClan, c);
     }
 
-    public MekGyro(int tonnage, int type, double gyroTonnage, boolean isClan,
-            Campaign c) {
-    	super(tonnage, c);
+    public MekGyro(int tonnage, int type, double gyroTonnage, boolean isClan, Campaign c) {
+        super(tonnage, c);
         this.type = type;
         this.name = Mech.getGyroTypeString(type);
         this.gyroTonnage = gyroTonnage;
@@ -64,9 +62,9 @@ public class MekGyro extends Part {
     }
 
     public MekGyro clone() {
-    	MekGyro clone = new MekGyro(getUnitTonnage(), type, gyroTonnage, isClan, campaign);
+        MekGyro clone = new MekGyro(getUnitTonnage(), type, gyroTonnage, isClan, campaign);
         clone.copyBaseData(this);
-    	return clone;
+        return clone;
     }
 
     public int getType() {
@@ -74,17 +72,17 @@ public class MekGyro extends Part {
     }
 
     public static int getGyroBaseTonnage(int walkMP, int unitTonnage) {
-    	return (int) Math.ceil(walkMP * unitTonnage / 100f);
+        return (int) Math.ceil(walkMP * unitTonnage / 100f);
     }
 
     public static double getGyroTonnage(int walkMP, int gyroType, int unitTonnage) {
-    	int gyroBaseTonnage = MekGyro.getGyroBaseTonnage(walkMP, unitTonnage);
+        int gyroBaseTonnage = MekGyro.getGyroBaseTonnage(walkMP, unitTonnage);
         if (gyroType == Mech.GYRO_XL) {
             return gyroBaseTonnage * 0.5;
         } else if (gyroType == Mech.GYRO_COMPACT) {
-        	return gyroBaseTonnage * 1.5;
+            return gyroBaseTonnage * 1.5;
         } else if (gyroType == Mech.GYRO_HEAVY_DUTY) {
-        	return gyroBaseTonnage * 2;
+            return gyroBaseTonnage * 2;
         }
 
         return gyroBaseTonnage;
@@ -92,7 +90,7 @@ public class MekGyro extends Part {
 
     @Override
     public double getTonnage() {
-    	return gyroTonnage;
+        return gyroTonnage;
     }
 
     @Override
@@ -110,163 +108,155 @@ public class MekGyro extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof MekGyro
-                && getType() == ((MekGyro) part).getType()
+        return part instanceof MekGyro && getType() == ((MekGyro) part).getType()
                 && getTonnage() == ((MekGyro) part).getTonnage();
     }
 
-	@Override
-	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<type>"
-				+type
-				+"</type>");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<gyroTonnage>"
-				+gyroTonnage
-				+"</gyroTonnage>");
-		writeToXmlEnd(pw1, indent);
-	}
+    @Override
+    public void writeToXml(PrintWriter pw1, int indent) {
+        writeToXmlBegin(pw1, indent);
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<type>" + type + "</type>");
+        pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<gyroTonnage>" + gyroTonnage + "</gyroTonnage>");
+        writeToXmlEnd(pw1, indent);
+    }
 
-	@Override
-	protected void loadFieldsFromXmlNode(Node wn) {
-		NodeList nl = wn.getChildNodes();
+    @Override
+    protected void loadFieldsFromXmlNode(Node wn) {
+        NodeList nl = wn.getChildNodes();
 
-		int walkMP = -1;
-		int uTonnage = 0;
-		for (int x=0; x<nl.getLength(); x++) {
-			Node wn2 = nl.item(x);
+        int walkMP = -1;
+        int uTonnage = 0;
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn2 = nl.item(x);
 
-			if (wn2.getNodeName().equalsIgnoreCase("type")) {
-				type = Integer.parseInt(wn2.getTextContent());
-			} else if (wn2.getNodeName().equalsIgnoreCase("gyroTonnage")) {
-				gyroTonnage = Double.parseDouble(wn2.getTextContent());
-			} else if (wn2.getNodeName().equalsIgnoreCase("walkMP")) {
-				walkMP = Integer.parseInt(wn2.getTextContent());
-			} else if(wn2.getNodeName().equalsIgnoreCase("unitTonnage")) {
-				uTonnage = Integer.parseInt(wn2.getTextContent());
-			}
-		}
-		if(gyroTonnage == 0) {
-			//need to calculate gyroTonnage for reverse compatability
-	        gyroTonnage = MekGyro.getGyroTonnage(walkMP, type, uTonnage);
-		}
-	}
+            if (wn2.getNodeName().equalsIgnoreCase("type")) {
+                type = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("gyroTonnage")) {
+                gyroTonnage = Double.parseDouble(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("walkMP")) {
+                walkMP = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("unitTonnage")) {
+                uTonnage = Integer.parseInt(wn2.getTextContent());
+            }
+        }
+        if (gyroTonnage == 0) {
+            // need to calculate gyroTonnage for reverse compatability
+            gyroTonnage = MekGyro.getGyroTonnage(walkMP, type, uTonnage);
+        }
+    }
 
-	@Override
-	public void fix() {
-		super.fix();
-		if(null != unit) {
-			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
-		}
+    @Override
+    public void fix() {
+        super.fix();
+        if (null != unit) {
+            unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
+        }
 
-	}
+    }
 
-	@Override
-	public MissingPart getMissingPart() {
-		return new MissingMekGyro(getUnitTonnage(), getType(), getTonnage(), isClan, campaign);
-	}
+    @Override
+    public MissingPart getMissingPart() {
+        return new MissingMekGyro(getUnitTonnage(), getType(), getTonnage(), isClan, campaign);
+    }
 
-	@Override
-	public void remove(boolean salvage) {
-		if(null != unit) {
-			unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
-			Part spare = campaign.checkForExistingSparePart(this);
-			if(!salvage) {
-				campaign.removePart(this);
-			} else if(null != spare) {
-				spare.incrementQuantity();
-				campaign.removePart(this);
-			}
-			unit.removePart(this);
-			Part missing = getMissingPart();
-			unit.addPart(missing);
-			campaign.addPart(missing, 0);
-		}
-		setUnit(null);
-		updateConditionFromEntity(false);
-	}
+    @Override
+    public void remove(boolean salvage) {
+        if (null != unit) {
+            unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
+            Part spare = campaign.checkForExistingSparePart(this);
+            if (!salvage) {
+                campaign.removePart(this);
+            } else if (null != spare) {
+                spare.incrementQuantity();
+                campaign.removePart(this);
+            }
+            unit.removePart(this);
+            Part missing = getMissingPart();
+            unit.addPart(missing);
+            campaign.addPart(missing, 0);
+        }
+        setUnit(null);
+        updateConditionFromEntity(false);
+    }
 
-	@Override
-	public void updateConditionFromEntity(boolean checkForDestruction) {
-		if(null != unit) {
-			int priorHits = hits;
-			hits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_SYSTEM,Mech.SYSTEM_GYRO, Mech.LOC_CT);
-			if(checkForDestruction
-					&& hits > priorHits && hits >= 3
-					&& Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
-				remove(false);
-			}
-		}
-	}
+    @Override
+    public void updateConditionFromEntity(boolean checkForDestruction) {
+        if (null != unit) {
+            int priorHits = hits;
+            hits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
+            if (checkForDestruction && hits > priorHits && hits >= 3
+                    && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
+                remove(false);
+            }
+        }
+    }
 
-	@Override
-	public int getBaseTime() {
-		if(isSalvaging()) {
-			return 200;
-		}
-		if(hits >= 2) {
-			return 240;
-		}
-		return 120;
-	}
+    @Override
+    public int getBaseTime() {
+        if (isSalvaging()) {
+            return 200;
+        }
+        if (hits >= 2) {
+            return 240;
+        }
+        return 120;
+    }
 
-	@Override
-	public int getDifficulty() {
-		if(isSalvaging()) {
-			return 0;
-		}
-		if(hits >= 2) {
-			return 4;
-		}
-		return 1;
-	}
+    @Override
+    public int getDifficulty() {
+        if (isSalvaging()) {
+            return 0;
+        }
+        if (hits >= 2) {
+            return 4;
+        }
+        return 1;
+    }
 
-	@Override
-	public boolean needsFixing() {
-		return hits > 0;
-	}
+    @Override
+    public boolean needsFixing() {
+        return hits > 0;
+    }
 
-	@Override
-	public void updateConditionFromPart() {
-		if(null != unit) {
-			if(hits == 0) {
-				unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
-			} else {
-				unit.damageSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, hits);
-			}
-		}
-	}
+    @Override
+    public void updateConditionFromPart() {
+        if (null != unit) {
+            if (hits == 0) {
+                unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
+            } else {
+                unit.damageSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, hits);
+            }
+        }
+    }
 
-	@Override
-	public String checkFixable() {
-		if(null == unit) {
-			return null;
-		}
-		if(!isSalvaging() && unit.isLocationBreached(Mech.LOC_CT)) {
-    		return unit.getEntity().getLocationName(Mech.LOC_CT) + " is breached.";
-		}
-		return null;
-	}
+    @Override
+    public String checkFixable() {
+        if (null == unit) {
+            return null;
+        }
+        if (!isSalvaging() && unit.isLocationBreached(Mech.LOC_CT)) {
+            return unit.getEntity().getLocationName(Mech.LOC_CT) + " is breached.";
+        }
+        return null;
+    }
 
-	@Override
-	public boolean isPartForEquipmentNum(int index, int loc) {
-		return Mech.SYSTEM_GYRO == index && loc == getLocation();
-	}
+    @Override
+    public boolean isPartForEquipmentNum(int index, int loc) {
+        return Mech.SYSTEM_GYRO == index && loc == getLocation();
+    }
 
-	 @Override
-	 public boolean isRightTechType(String skillType) {
-		 return skillType.equals(SkillType.S_TECH_MECH);
-	 }
+    @Override
+    public boolean isRightTechType(String skillType) {
+        return skillType.equals(SkillType.S_TECH_MECH);
+    }
 
-	@Override
-	public String getLocationName() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public String getLocationName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	public static final int GYRO_STANDARD = Mech.GYRO_STANDARD;
+    public static final int GYRO_STANDARD = Mech.GYRO_STANDARD;
 
     public static final int GYRO_XL = Mech.GYRO_XL;
 
@@ -274,19 +264,18 @@ public class MekGyro extends Part {
 
     public static final int GYRO_HEAVY_DUTY = Mech.GYRO_HEAVY_DUTY;
 
+    @Override
+    public int getLocation() {
+        return Mech.LOC_CT;
+    }
 
-	@Override
-	public int getLocation() {
-		return Mech.LOC_CT;
-	}
-	
-	@Override
-	public TechAdvancement getTechAdvancement() {
-	    return Mech.getGyroTechAdvancement(type);
-	}
+    @Override
+    public TechAdvancement getTechAdvancement() {
+        return Mech.getGyroTechAdvancement(type);
+    }
 
-	@Override
-	public int getMassRepairOptionType() {
-    	return Part.REPAIR_PART_TYPE.GYRO;
+    @Override
+    public int getMassRepairOptionType() {
+        return Part.REPAIR_PART_TYPE.GYRO;
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
@@ -216,7 +216,7 @@ public class MekLifeSupport extends Part {
 	
 	@Override
 	public boolean isPartForEquipmentNum(int index, int loc) {
-		return Mech.SYSTEM_LIFE_SUPPORT == index;
+		return Mech.SYSTEM_LIFE_SUPPORT == index && loc == getLocation();
 	}
 	
 	@Override

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -40,239 +40,237 @@ import mekhq.campaign.personnel.SkillType;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class MekSensor extends Part {
-	private static final long serialVersionUID = 931907976883324097L;
+    private static final long serialVersionUID = 931907976883324097L;
 
-	public MekSensor() {
-		this(0, null);
-	}
+    public MekSensor() {
+        this(0, null);
+    }
 
-	public MekSensor(int tonnage, Campaign c) {
+    public MekSensor(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "Mech Sensors";
     }
 
-	public MekSensor clone() {
-		MekSensor clone = new MekSensor(getUnitTonnage(), campaign);
+    public MekSensor clone() {
+        MekSensor clone = new MekSensor(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
-		return clone;
-	}
-
-	@Override
-	public double getTonnage() {
-		//TODO: what should this tonnage be?
-		return 0;
-	}
-
-	@Override
-	public Money getStickerPrice() {
-		return Money.of(2000.0 * getUnitTonnage());
-	}
-
-    @Override
-    public boolean isSamePartType(Part part) {
-    	//the cost of sensors varies by tonnage, so according to
-    	//pg. 180 of StratOps that means they can only be exchanged
-    	//between meks of the same tonnage
-        return part instanceof MekSensor
-                && getUnitTonnage() == part.getUnitTonnage();
+        return clone;
     }
 
     @Override
-	public int getTechLevel() {
-		return TechConstants.T_ALLOWED_ALL;
-	}
+    public double getTonnage() {
+        // TODO: what should this tonnage be?
+        return 0;
+    }
 
-	@Override
-	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);
-		writeToXmlEnd(pw1, indent);
-	}
+    @Override
+    public Money getStickerPrice() {
+        return Money.of(2000.0 * getUnitTonnage());
+    }
 
-	@Override
-	protected void loadFieldsFromXmlNode(Node wn) {
-		// Do nothing - no fields to load.
-	}
+    @Override
+    public boolean isSamePartType(Part part) {
+        // the cost of sensors varies by tonnage, so according to
+        // pg. 180 of StratOps that means they can only be exchanged
+        // between meks of the same tonnage
+        return part instanceof MekSensor && getUnitTonnage() == part.getUnitTonnage();
+    }
 
-	@Override
-	public void fix() {
-		super.fix();
-		if(null != unit) {
-			unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
-		}
-	}
+    @Override
+    public int getTechLevel() {
+        return TechConstants.T_ALLOWED_ALL;
+    }
 
-	@Override
-	public MissingPart getMissingPart() {
-		return new MissingMekSensor(getUnitTonnage(), campaign);
-	}
+    @Override
+    public void writeToXml(PrintWriter pw1, int indent) {
+        writeToXmlBegin(pw1, indent);
+        writeToXmlEnd(pw1, indent);
+    }
 
-	@Override
-	public void remove(boolean salvage) {
-		if(null != unit) {
-			unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
-			Part spare = campaign.checkForExistingSparePart(this);
-			if(!salvage) {
-				campaign.removePart(this);
-			} else if(null != spare) {
-				spare.incrementQuantity();
-				campaign.removePart(this);
-			}
-			unit.removePart(this);
-			Part missing = getMissingPart();
-			unit.addPart(missing);
-			campaign.addPart(missing, 0);
-		}
-		setUnit(null);
-		updateConditionFromEntity(false);
-	}
+    @Override
+    protected void loadFieldsFromXmlNode(Node wn) {
+        // Do nothing - no fields to load.
+    }
 
-	@Override
-	public void updateConditionFromEntity(boolean checkForDestruction) {
-		if(null != unit) {
-			int priorHits = hits;
-			Entity entity = unit.getEntity();
-			for (int i = 0; i < entity.locations(); i++) {
-				if (entity.getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, i) > 0) {
-					if (!unit.isSystemMissing(Mech.SYSTEM_SENSORS, i)) {
-						hits = entity.getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, i);
-						break;
-					} else {
-						remove(false);
-						return;
-					}
-				}
-			}
-			if(checkForDestruction
-					&& hits > priorHits && hits >= 2
-					&& Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
-				remove(false);
-			}
-		}
-	}
+    @Override
+    public void fix() {
+        super.fix();
+        if (null != unit) {
+            unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
+        }
+    }
 
-	@Override
-	public int getBaseTime() {
-		if(isSalvaging()) {
-			return 260;
-		}
-		if(hits > 1) {
-			return 150;
-		}
-		return 75;
-	}
+    @Override
+    public MissingPart getMissingPart() {
+        return new MissingMekSensor(getUnitTonnage(), campaign);
+    }
 
-	@Override
-	public int getDifficulty() {
-		if(isSalvaging()) {
-			return 0;
-		}
-		if(hits > 1) {
-			return 3;
-		}
-		return 0;
-	}
+    @Override
+    public void remove(boolean salvage) {
+        if (null != unit) {
+            unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
+            Part spare = campaign.checkForExistingSparePart(this);
+            if (!salvage) {
+                campaign.removePart(this);
+            } else if (null != spare) {
+                spare.incrementQuantity();
+                campaign.removePart(this);
+            }
+            unit.removePart(this);
+            Part missing = getMissingPart();
+            unit.addPart(missing);
+            campaign.addPart(missing, 0);
+        }
+        setUnit(null);
+        updateConditionFromEntity(false);
+    }
 
-	@Override
-	public boolean needsFixing() {
-		return hits > 0;
-	}
+    @Override
+    public void updateConditionFromEntity(boolean checkForDestruction) {
+        if (null != unit) {
+            int priorHits = hits;
+            Entity entity = unit.getEntity();
+            for (int i = 0; i < entity.locations(); i++) {
+                if (entity.getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, i) > 0) {
+                    if (!unit.isSystemMissing(Mech.SYSTEM_SENSORS, i)) {
+                        hits = entity.getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, i);
+                        break;
+                    } else {
+                        remove(false);
+                        return;
+                    }
+                }
+            }
+            if (checkForDestruction && hits > priorHits && hits >= 2
+                    && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
+                remove(false);
+            }
+        }
+    }
 
-	@Override
-	public void updateConditionFromPart() {
-		if(null != unit) {
-			if(hits == 0) {
-				unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
-			} else {
-				unit.damageSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, hits);
-			}
-		}
-	}
+    @Override
+    public int getBaseTime() {
+        if (isSalvaging()) {
+            return 260;
+        }
+        if (hits > 1) {
+            return 150;
+        }
+        return 75;
+    }
 
-	@Override
+    @Override
+    public int getDifficulty() {
+        if (isSalvaging()) {
+            return 0;
+        }
+        if (hits > 1) {
+            return 3;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean needsFixing() {
+        return hits > 0;
+    }
+
+    @Override
+    public void updateConditionFromPart() {
+        if (null != unit) {
+            if (hits == 0) {
+                unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
+            } else {
+                unit.damageSystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, hits);
+            }
+        }
+    }
+
+    @Override
     public String checkFixable() {
-		if(null == unit) {
-			return null;
-		}
-		if(isSalvaging()) {
-			return null;
-		}
-        for(int i = 0; i < unit.getEntity().locations(); i++) {
-            if(unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, i) > 0) {
-            	if(unit.isLocationBreached(i)) {
-            		return unit.getEntity().getLocationName(i) + " is breached.";
-            	}
-            	if(unit.isLocationDestroyed(i)) {
-            		return unit.getEntity().getLocationName(i) + " is destroyed.";
-            	}
+        if (null == unit) {
+            return null;
+        }
+        if (isSalvaging()) {
+            return null;
+        }
+        for (int i = 0; i < unit.getEntity().locations(); i++) {
+            if (unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, i) > 0) {
+                if (unit.isLocationBreached(i)) {
+                    return unit.getEntity().getLocationName(i) + " is breached.";
+                }
+                if (unit.isLocationDestroyed(i)) {
+                    return unit.getEntity().getLocationName(i) + " is destroyed.";
+                }
 
             }
         }
         return null;
     }
 
-	@Override
-	public boolean isMountedOnDestroyedLocation() {
-		if(null == unit) {
-			return false;
-		}
-		for(int i = 0; i < unit.getEntity().locations(); i++) {
-			 if(unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, i) > 0
-					 && unit.isLocationDestroyed(i)) {
-				 return true;
-			 }
-		 }
-		return false;
-	}
+    @Override
+    public boolean isMountedOnDestroyedLocation() {
+        if (null == unit) {
+            return false;
+        }
+        for (int i = 0; i < unit.getEntity().locations(); i++) {
+            if (unit.getEntity().getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS, i) > 0
+                    && unit.isLocationDestroyed(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	@Override
+    @Override
     public String getDetails() {
-		return super.getDetails() + ", " + getUnitTonnage() + " tons";
+        return super.getDetails() + ", " + getUnitTonnage() + " tons";
     }
 
-	@Override
-	public boolean isPartForEquipmentNum(int index, int loc) {
-		return Mech.SYSTEM_SENSORS == index && loc == getLocation();
-	}
+    @Override
+    public boolean isPartForEquipmentNum(int index, int loc) {
+        return Mech.SYSTEM_SENSORS == index && loc == getLocation();
+    }
 
-	@Override
-	public boolean isRightTechType(String skillType) {
-		return skillType.equals(SkillType.S_TECH_MECH);
-	}
+    @Override
+    public boolean isRightTechType(String skillType) {
+        return skillType.equals(SkillType.S_TECH_MECH);
+    }
 
-	@Override
-	public String getLocationName() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public String getLocationName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	@Override
-	public int getLocation() {
-		return Entity.LOC_NONE;
-	}
-	
-	@Override
-	public TechAdvancement getTechAdvancement() {
-	    return TA_GENERIC;
-	}
+    @Override
+    public int getLocation() {
+        return Entity.LOC_NONE;
+    }
 
-	@Override
+    @Override
+    public TechAdvancement getTechAdvancement() {
+        return TA_GENERIC;
+    }
+
+    @Override
     public boolean isInLocation(String loc) {
-		 if(null == unit || null == unit.getEntity() || !(unit.getEntity() instanceof Mech)) {
-			 return false;
-		 }
-		 if (unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_HEAD) {
-             return true;
-         }
-		 if(((Mech)unit.getEntity()).getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED) {
-     		if(unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_CT) {
-     			return true;
-     		}
-		 }
-		 return false;
+        if (null == unit || null == unit.getEntity() || !(unit.getEntity() instanceof Mech)) {
+            return false;
+        }
+        if (unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_HEAD) {
+            return true;
+        }
+        if (((Mech) unit.getEntity()).getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED) {
+            if (unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_CT) {
+                return true;
+            }
+        }
+        return false;
     }
-	
-	@Override
-	public int getMassRepairOptionType() {
-    	return Part.REPAIR_PART_TYPE.ELECTRONICS;
+
+    @Override
+    public int getMassRepairOptionType() {
+        return Part.REPAIR_PART_TYPE.ELECTRONICS;
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -231,7 +231,7 @@ public class MekSensor extends Part {
 
 	@Override
 	public boolean isPartForEquipmentNum(int index, int loc) {
-		return Mech.SYSTEM_SENSORS == index;
+		return Mech.SYSTEM_SENSORS == index && loc == getLocation();
 	}
 
 	@Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -619,7 +619,7 @@ public class EquipmentPart extends Part {
 
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
-    	return equipmentNum == index;
+    	return equipmentNum == index && loc == getLocation();
     }
 
     @Override


### PR DESCRIPTION
This ~~isn't strictly~~ is required after #1129, ~~but~~ this fixes the upstream problem when evaluating equipment parts on campaign load. Basically these system level parts were chiming in for any matching equipment number, no matter the location. The combination of the prior pull request and this one should fix #1109.