### PR TITLE
Fix various logical bugs (found by error-prone)

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -1460,34 +1460,6 @@ public class Utilities {
         return roman;
     }
 
-    // TODO: Optionize this to allow user to choose roman or arabic numerals
-    public static int getArabicNumberFromRomanNumerals(String name) {
-        // If we're 0, then we just return an empty string
-        if (name.equals("")) { //$NON-NLS-1$
-            return 0;
-        }
-
-        // Roman numeral, prepended with a space for display purposes
-        int arabic = 0;
-        String roman = name;
-
-        for (int i = 0; i < roman.length(); i++) {
-            int num = romanNumerals.toString().indexOf(roman.charAt(i));
-            if (i < roman.length()) {
-                int temp = romanNumerals.toString().indexOf(roman.charAt(i+1));
-                // If this is a larger number, then we need to combine them
-                if (temp > num) {
-                    num = temp - num;
-                    i++;
-                }
-            }
-
-            arabic += num;
-        }
-
-        return arabic-1;
-    }
-
     public static Map<String, Integer> sortMapByValue(Map<String, Integer> unsortMap, boolean highFirst) {
 
         // Convert Map to List

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2578,7 +2578,7 @@ public class Campaign implements Serializable, ITechManager {
         if (roll >= target.getValue()) {
             report = report + partWork.succeed();
             if (getCampaignOptions().payForRepairs()
-                    && action == " fix "
+                    && action.equals(" fix ")
                     && !(partWork instanceof Armor)) {
                 Money cost = ((Part) partWork).getStickerPrice().multipliedBy(0.2);
                 report += "<br>Repairs cost " +

--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -161,10 +161,9 @@ public class Loot implements MekHqXmlSerializable {
                 +"</cash>");
         for(Entity e : units) {
             String lookupName = e.getChassis() + " " + e.getModel();
-            lookupName.replaceAll("\\s+$", "");
             pw1.println(MekHqXmlUtil.indentStr(indent+1)
                     +"<entityName>"
-                    +lookupName
+                    +lookupName.trim()
                     +"</entityName>");
         }
         for(Part p : parts) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
@@ -170,7 +170,7 @@ public class AtBScenarioModifier {
             Unmarshaller um = context.createUnmarshaller();
             File xmlFile = new File(fileName);
             if(!xmlFile.exists()) {
-                MekHQ.getLogger().warning(AtBScenarioModifier.class, "Deserialize", String.format("Specified file %d does not exist", fileName));
+                MekHQ.getLogger().warning(AtBScenarioModifier.class, "Deserialize", String.format("Specified file %s does not exist", fileName));
                 return null;
             }
 

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
@@ -92,7 +92,7 @@ public final class InjuryTypes {
             if(rand < 5) {
                 mod += (Compute.d6() < 4) ? rand : -rand;
             }
-            return  Math.round(time * mod * p.getAbilityTimeModifier() / 10000);
+            return (int)Math.round((time * mod * p.getAbilityTimeModifier()) / 10000.0);
         }
         
         @Override

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
@@ -242,7 +242,7 @@ public final class InjuryUtil {
             time += Compute.d6();
         }
 
-        time = Math.round(time * mod * p.getAbilityTimeModifier() / 10000);
+        time = (int)Math.round((time * mod * p.getAbilityTimeModifier()) / 10000.0);
         return time;
     }
     
@@ -269,7 +269,7 @@ public final class InjuryUtil {
                 if (roll < Math.max(1, fumbleLimit / 10)) {
                     mistakeXP += c.getCampaignOptions().getMistakeXP();
                     xpGained += mistakeXP;
-                } else if (roll > Math.min(98, 99 - Math.round(99 - critLimt) / 10)) {
+                } else if (roll > Math.min(98, 99 - (int)Math.round((99 - critLimt) / 10.0))) {
                     successXP += c.getCampaignOptions().getSuccessXP();
                     xpGained += successXP;
                 }

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
@@ -278,9 +278,8 @@ public final class InjuryUtil {
                 if (roll < fumbleLimit && c.getCampaignOptions().useSupportEdge()
                         && (doc.getOptions().booleanOption(PersonnelOptions.EDGE_MEDICAL) && doc.getCurrentEdge() > 0)) {
                     result.add(new GameEffect(
-                    String.format("%s made a mistake, but used Edge to reroll.",
-                            doc.getHyperlinkedFullTitle(), p.getHyperlinkedName(),
-                            p.getGenderPronoun(Person.PRONOUN_HISHER), i.getName())));
+                    String.format("%s made a mistake in the treatment of %s, but used Edge to reroll.",
+                            doc.getHyperlinkedFullTitle(), p.getHyperlinkedName())));
                     doc.setCurrentEdge(doc.getCurrentEdge() - 1);
                     roll = Compute.randomInt(100);
                 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -79,7 +79,7 @@ public class EquipmentPart extends Part {
     }
     
     public EquipmentPart(int tonnage, EquipmentType et, int equipNum, Campaign c) {
-        this(0, et, equipNum, false, c);
+        this(tonnage, et, equipNum, false, c);
     }
 
     public EquipmentPart(int tonnage, EquipmentType et, int equipNum, boolean omniPodded, Campaign c) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2988,7 +2988,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
      *         role
      */
     public boolean isCombat() {
-        return isCombatRole(primaryRole) || isCombatRole(primaryRole);
+        return isCombatRole(primaryRole) || isCombatRole(secondaryRole);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -482,7 +482,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
                 }
             }
             if (roll >= 6 && (p.getPrimaryRole() == Person.T_AERO_PILOT ||
-                    p.getPrimaryRole() == Person.T_AERO_PILOT)) {
+                    p.getSecondaryRole() == Person.T_AERO_PILOT)) {
                 stolenUnit = true;
             } else {
                 if (p.getProfession() == Ranks.RPROF_INF) {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1095,23 +1095,23 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             }
 
             if (isHeatSink) {
-                if (TechConstants.getTechName(etype.getTechLevel(year)).equals(
-                        "Inner Sphere"))
+                if (TechConstants.getTechName(etype.getTechLevel(year)).equals("Inner Sphere")) {
                     heatSinkIsClanTechBase = false;
-                else if (TechConstants.getTechName(etype.getTechLevel(year))
-                        .equals("Clan"))
+                } else if (TechConstants.getTechName(etype.getTechLevel(year)).equals("Clan")) {
                     heatSinkIsClanTechBase = true;
+                }
                 break;
             }
         }
 
         String heatSinkTypeString = heatSinkIsClanTechBase ? "(CL) " : "(IS) ";
-        if (heatSinkType == MiscType.F_LASER_HEAT_SINK)
+        if (heatSinkType.equals(MiscType.F_LASER_HEAT_SINK)) {
             heatSinkTypeString += "Laser Heat Sink";
-        else if (heatSinkType == MiscType.F_DOUBLE_HEAT_SINK)
+        } else if (heatSinkType.equals(MiscType.F_DOUBLE_HEAT_SINK)) {
             heatSinkTypeString += "Double Heat Sink";
-        else if (heatSinkType == MiscType.F_HEAT_SINK)
+        } else if (heatSinkType.equals(MiscType.F_HEAT_SINK)) {
             heatSinkTypeString += "Heat Sink";
+        }
 
         return heatSinkTypeString;
     }


### PR DESCRIPTION
This fixes a few logical bugs found while playing with [Google's error-prone](https://github.com/google/error-prone).

The only one that I'm not 100% sure of is the last commit, where `tonnage` was not passed to the other EquipmentPart ctor. It looks like it is used as if tonnage means the part's tonnage in some cases, and the unit's tonnage in other cases (or `0`).