### PR TITLE
Only remove duplicate parts if they are the same type on CPNX load #1109

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -413,7 +413,9 @@ public class CampaignXmlParser {
                         continue;
                     }
                     // Remove existing duplicate parts.
-                    if (u.getPartForEquipmentNum(((EquipmentPart) prt).getEquipmentNum(), ((EquipmentPart) prt).getLocation()) != null) {
+                    Part duplicatePart = u.getPartForEquipmentNum(((EquipmentPart) prt).getEquipmentNum(), ((EquipmentPart) prt).getLocation());
+                    if (duplicatePart instanceof EquipmentPart
+                        && ((EquipmentPart)prt).getType() == ((EquipmentPart)duplicatePart).getType()) {
                         removeParts.add(prt);
                         continue;
                     }
@@ -426,7 +428,10 @@ public class CampaignXmlParser {
                         continue;
                     }
                     // Remove existing duplicate parts.
-                    if (u.getPartForEquipmentNum(((MissingEquipmentPart) prt).getEquipmentNum(), ((MissingEquipmentPart) prt).getLocation()) != null) {
+                    Part duplicatePart = u.getPartForEquipmentNum(((MissingEquipmentPart) prt).getEquipmentNum(), 
+                        ((MissingEquipmentPart) prt).getLocation());
+                    if (duplicatePart instanceof EquipmentPart
+                        && ((MissingEquipmentPart)prt).getType() == ((EquipmentPart)duplicatePart).getType()) {
                         removeParts.add(prt);
                         continue;
                     }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -427,14 +427,6 @@ public class CampaignXmlParser {
                         removeParts.add(prt);
                         continue;
                     }
-                    // Remove existing duplicate parts.
-                    Part duplicatePart = u.getPartForEquipmentNum(((MissingEquipmentPart) prt).getEquipmentNum(), 
-                        ((MissingEquipmentPart) prt).getLocation());
-                    if (duplicatePart instanceof EquipmentPart
-                        && ((MissingEquipmentPart)prt).getType() == ((EquipmentPart)duplicatePart).getType()) {
-                        removeParts.add(prt);
-                        continue;
-                    }
                 }
                 //if the type is a BayWeapon, remove
                 if(prt instanceof EquipmentPart

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -420,7 +420,7 @@ public class EnginePart extends Part {
 
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
-        return Mech.SYSTEM_ENGINE == index && loc == getLocation();
+        return false;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekActuator.java
@@ -301,7 +301,7 @@ public class MekActuator extends Part {
 
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
-        return index == type && loc == location;
+        return false;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
@@ -268,7 +268,7 @@ public class MekCockpit extends Part {
 
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
-        return Mech.SYSTEM_COCKPIT == index && loc == getLocation();
+        return false;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekGyro.java
@@ -242,7 +242,7 @@ public class MekGyro extends Part {
 
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
-        return Mech.SYSTEM_GYRO == index && loc == getLocation();
+        return false;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
@@ -214,10 +214,10 @@ public class MekLifeSupport extends Part {
 		return false;
 	}
 	
-	@Override
-	public boolean isPartForEquipmentNum(int index, int loc) {
-		return Mech.SYSTEM_LIFE_SUPPORT == index && loc == getLocation();
-	}
+    @Override
+    public boolean isPartForEquipmentNum(int index, int loc) {
+        return false;
+    }
 	
 	@Override
 	public boolean isRightTechType(String skillType) {

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -229,7 +229,7 @@ public class MekSensor extends Part {
 
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
-        return Mech.SYSTEM_SENSORS == index && loc == getLocation();
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This is a follow-up to #1130 that adds a check for the actual part types, since it appears that MekActuators end up with the same equipment numbers as actual equipment parts (different bug?).