### PR TITLE
Don't expand/contract tab panels on right double click

### DIFF
--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -206,7 +206,7 @@ public final class HangarTab extends CampaignGuiTab {
                 unitTable, unitModel) {
             @Override
             public void mouseClicked(MouseEvent e) {
-                if (e.getClickCount() == 2) {
+                if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2) {
                     if ((splitUnit.getSize().width - splitUnit.getDividerLocation() + splitUnit
                             .getDividerSize()) < HangarTab.UNIT_VIEW_WIDTH) {
                         // expand
@@ -215,7 +215,6 @@ public final class HangarTab extends CampaignGuiTab {
                         // collapse
                         splitUnit.setDividerLocation(1.0);
                     }
-
                 }
             }            
         });

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -364,7 +364,6 @@ public class InterstellarMapPanel extends JPanel {
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (e.getButton() == MouseEvent.BUTTON1) {
-
                     if (e.getClickCount() >= 2) {
                         //center and zoom
                         changeSelectedPlanet(nearestNeighbour(scr2mapX(e.getX()), scr2mapY(e.getY())));

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -243,7 +243,7 @@ public final class PersonnelTab extends CampaignGuiTab {
                 personnelTable, personModel) {
             @Override
             public void mouseClicked(MouseEvent e) {
-                if (e.getClickCount() == 2) {
+                if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2) {
                     if ((splitPersonnel.getSize().width
                             - splitPersonnel.getDividerLocation() + splitPersonnel
                                 .getDividerSize()) < PersonnelTab.PERSONNEL_VIEW_WIDTH) {
@@ -253,7 +253,6 @@ public final class PersonnelTab extends CampaignGuiTab {
                         // collapse
                         splitPersonnel.setDividerLocation(1.0);
                     }
-
                 }
             }            
         });

--- a/MekHQ/src/mekhq/gui/dialog/CamoChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CamoChoiceDialog.java
@@ -351,8 +351,7 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
 
         @Override
         public void mouseClicked(MouseEvent e) {
-
-            if (e.getClickCount() == 2) {
+            if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2) {
                 int row = tableCamo.rowAtPoint(e.getPoint());
                 category = camoModel.getCategory();
                 if(category.equals(Player.NO_CAMO)) {

--- a/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
@@ -757,7 +757,7 @@ public class ImageChoiceDialog extends JDialog {
 
         @Override
         public void mouseClicked(MouseEvent evt) {
-            if (evt.getClickCount() == 2) {
+            if (evt.getButton() == MouseEvent.BUTTON1 && evt.getClickCount() == 2) {
                 if (tableImages.equals(evt.getSource())) {
                     int row = tableImages.rowAtPoint(evt.getPoint());
                     if(row < imageTableModel.getRowCount()) {


### PR DESCRIPTION
On my MacBook, when I use the right click gesture with my trackpad (two finger tap) the various panels expand or contract every time. This makes the expand/contract logic only occur with the left mouse button double clicking.