### PR TITLE
Fix issue where "Order One" on repair tab acquisition UI was only allowing one part to be ordered

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
@@ -299,7 +299,7 @@ public class AcquisitionsDialog extends JDialog {
             }
 
             if ((partCountInfo.getMissingCount() > 0) && partCountInfo.isCanBeAcquired()) {
-                campaignGUI.getCampaign().getShoppingList().addShoppingItem(targetWork, partCountInfo.getMissingCount(),
+                campaignGUI.getCampaign().getShoppingList().addShoppingItem(part.getAcquisitionWork(), partCountInfo.getMissingCount(),
                         campaignGUI.getCampaign());
 
                 refresh();
@@ -556,9 +556,9 @@ public class AcquisitionsDialog extends JDialog {
                 btnOrderOne.setToolTipText("Order one item");
                 btnOrderOne.setName("btnOrderOne"); // NOI18N
                 btnOrderOne.addActionListener(ev -> {
-                    campaignGUI.getCampaign().getShoppingList().addShoppingItem(targetWork, 1,
+                    campaignGUI.getCampaign().getShoppingList().addShoppingItem(part.getAcquisitionWork(), 1,
                             campaignGUI.getCampaign());
-
+                    
                     refresh();
                 });
 


### PR DESCRIPTION
Using "targetWork" for shopping for parts means that the quantity field gets decremented as part of the shopping process. Since the same targetWork object is re-used every time the user clicks "order one", the next time it's called, the internal quantity is 0, so...

Thus, we just generate a new shopping order each time instead.

