### PR TITLE
Do not throw if mounted is missing after refit #1138

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -813,7 +813,11 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
      */
     @Override
     public boolean isOmniPodded() {
-        return getUnit() != null && getUnit().getEntity().getEquipment(equipmentNum).isOmniPodMounted();
+        if (getUnit() == null || getUnit().getEntity() == null) {
+            return false;
+        }
+        Mounted m = getUnit().getEntity().getEquipment(equipmentNum);
+        return m != null && m.isOmniPodMounted();
     }
     
     @Override


### PR DESCRIPTION
It looks like after a refit there was an equipment number mismatch on an omnipodded ammobin. This avoids the NPE in this case.