### PR TITLE
Fix for MekHQ #1164

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/LootDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LootDialog.java
@@ -310,7 +310,7 @@ public class LootDialog extends javax.swing.JDialog {
 
     private void done() {
         loot.setName(txtName.getText());
-        loot.setCash(Money.of((Double)spnCash.getModel().getValue()));
+        loot.setCash(Money.of((Integer) spnCash.getModel().getValue()));
         cancelled = false;
         loot.clearUnits();
         loot.clearParts();


### PR DESCRIPTION
Fixes a behavior introduced in 45.4 where the user is unable to add loot to scenarios.