### PR TITLE
Adding autosave feature (#1171)

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -115,6 +115,7 @@ btnShowAllTechs.text=Show All Tech Types
 btnGMMode.text=GM Mode
 menuOptions.text=Campaign Options
 menuOptionsMM.text=MegaMek Options
+menuMekHqOptions.text=MekHQ Options
 btnRetrieveUnits.toolTipText=<html>Retrieve deployed units from a MUL file (including salvage)<br><b>NOTE:</b> This method will not load new pilots. Use Manage > Load Units from A MUL File to load new pilots.</html>
 btnRetrieveUnits.text=Retrieve Units
 menuManage.text=Manage

--- a/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
@@ -2,6 +2,7 @@ dialog.text=MekHQ Settings
 okButton.text=Ok
 cancelButton.text=Cancel
 labelSavedInfo.text=Auto save options
+optionNoSave.text=Don't save periodically
 optionSaveDaily.text=Save daily (before day starts)
 optionSaveWeekly.text=Save weekly (before week starts)
 checkSaveBeforeMissions.text=Save before attempting a mission?

--- a/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
@@ -1,4 +1,4 @@
-dialog.text=MekHQ Settings
+dialog.text=MekHQ Options
 okButton.text=Ok
 cancelButton.text=Cancel
 labelSavedInfo.text=Auto save options

--- a/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
@@ -1,2 +1,8 @@
 dialog.text=MekHQ Settings
-dialog.name=DialogMekHQOptions
+okButton.text=Ok
+cancelButton.text=Cancel
+labelSavedInfo.text=Auto save options
+optionSaveDaily.text=Save daily (before day starts)
+optionSaveWeekly.text=Save weekly (before week starts)
+checkSaveBeforeMissions.text=Save before attempting a mission?
+labelSavedGamesCount.text=Maximum number of auto-saved games

--- a/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
@@ -1,0 +1,2 @@
+dialog.text=MekHQ Settings
+dialog.name=DialogMekHQOptions

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -83,6 +83,8 @@ import mekhq.gui.preferences.StringPreference;
 import mekhq.gui.utilities.ObservableString;
 import mekhq.preferences.MekHqPreferences;
 import mekhq.preferences.PreferencesNode;
+import mekhq.service.AutosaveService;
+import mekhq.service.IAutosaveService;
 
 /**
  * The main class of the application.
@@ -126,6 +128,8 @@ public class MekHQ implements GameListener {
     private CampaignGUI campaigngui;
 
     private IconPackage iconPackage = new IconPackage();
+
+    private final IAutosaveService autosaveService;
 
 	/**
 	 * Converts the MekHQ {@link #VERBOSITY_LEVEL} to {@link LogLevel}.
@@ -274,7 +278,11 @@ public class MekHQ implements GameListener {
 	protected static MekHQ getInstance() {
 		return new MekHQ();
 	}
-	
+
+	private MekHQ() {
+	    this.autosaveService = new AutosaveService(getLogger());
+    }
+
     /**
      * At startup create and show the main frame of the application.
      */
@@ -476,6 +484,7 @@ public class MekHQ implements GameListener {
                 stopHost();
                 return;
             } else {
+                this.autosaveService.requestBeforeMissionAutosave(this.campaign);
                 port = lgd.port;
                 playerName = lgd.playerName;
             }

--- a/MekHQ/src/mekhq/MekHqConstants.java
+++ b/MekHQ/src/mekhq/MekHqConstants.java
@@ -1,0 +1,30 @@
+/*
+ * MekHqConstants.java
+ *
+ * Copyright (c) 2019 MekHQ Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq;
+
+public final class MekHqConstants {
+    public static final String AUTOSAVE_NODE = "mekhq/prefs/autosave";
+    public static final String SAVE_DAILY_KEY = "saveDaily";
+    public static final String SAVE_WEEKLY_KEY = "saveWeekly";
+    public static final String SAVE_BEFORE_MISSIONS_KEY = "saveBeforeMissions";
+    public static final String MAXIMUM_NUMBER_SAVES_KEY = "maximumNumberAutoSaves";
+}

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -35,6 +35,8 @@ import javax.swing.JOptionPane;
 import mekhq.*;
 import mekhq.campaign.finances.*;
 import mekhq.campaign.log.*;
+import mekhq.service.AutosaveService;
+import mekhq.service.IAutosaveService;
 import org.joda.time.DateTime;
 
 import megamek.client.RandomNameGenerator;
@@ -285,6 +287,8 @@ public class Campaign implements Serializable, ITechManager {
     private IUnitGenerator unitGenerator;
     private IUnitRating unitRating;
 
+    private final IAutosaveService autosaveService;
+
     public Campaign() {
         id = UUID.randomUUID();
         game = new Game();
@@ -312,8 +316,7 @@ public class Campaign implements Serializable, ITechManager {
         forceIds.put(0, forces);
         lances = new Hashtable<>();
         finances = new Finances();
-        location = new CurrentLocation(Planets.getInstance().getPlanets()
-                .get("Outreach"), 0);
+        location = new CurrentLocation(Planets.getInstance().getPlanets().get("Outreach"), 0);
         SkillType.initializeTypes();
         SpecialAbility.initializeSPA();
         astechPool = 0;
@@ -333,6 +336,7 @@ public class Campaign implements Serializable, ITechManager {
         retirementDefectionTracker = new RetirementDefectionTracker();
         fatigueLevel = 0;
         atbConfig = null;
+        autosaveService = new AutosaveService(MekHQ.getLogger());
     }
 
     /**
@@ -3062,11 +3066,11 @@ public class Campaign implements Serializable, ITechManager {
 
     /** @return <code>true</code> if the new day arrived */
     public boolean newDay() {
-        // AUTOSAVE HERE!
-
         if(MekHQ.triggerEvent(new DayEndingEvent(this))) {
             return false;
         }
+
+        this.autosaveService.requestDayAdvanceAutosave(this, this.calendar.get(Calendar.DAY_OF_WEEK));
 
         calendar.add(Calendar.DAY_OF_MONTH, 1);
         currentReport.clear();

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3062,6 +3062,8 @@ public class Campaign implements Serializable, ITechManager {
 
     /** @return <code>true</code> if the new day arrived */
     public boolean newDay() {
+        // AUTOSAVE HERE!
+
         if(MekHQ.triggerEvent(new DayEndingEvent(this))) {
             return false;
         }
@@ -3095,7 +3097,6 @@ public class Campaign implements Serializable, ITechManager {
         processNewDayPersonnel();
 
         resetAstechMinutes();
-
 
         processNewDayUnits();
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1722,7 +1722,7 @@ public class CampaignGUI extends JPanel {
     }// GEN-LAST:event_menuOptionsActionPerformed
 
     private void menuMekHqOptionsActionPerformed(ActionEvent evt) {
-        MekHqOptionsDialog dialog = new MekHqOptionsDialog(getFrame());
+        MekHqOptionsDialog dialog = new MekHqOptionsDialog(getFrame(), MekHQ.getLogger());
         dialog.setVisible(true);
     }
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -27,10 +27,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Toolkit;
 import java.awt.Window;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.event.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -55,6 +52,7 @@ import javax.swing.UIManager.LookAndFeelInfo;
 import javax.xml.parsers.DocumentBuilder;
 
 import mekhq.campaign.finances.Money;
+import mekhq.gui.dialog.*;
 import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
 import org.w3c.dom.Document;
@@ -119,33 +117,6 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.campaign.universe.Planets;
 import mekhq.campaign.universe.RandomFactionGenerator;
-import mekhq.gui.dialog.AdvanceDaysDialog;
-import mekhq.gui.dialog.BatchXPDialog;
-import mekhq.gui.dialog.BloodnameDialog;
-import mekhq.gui.dialog.CampaignOptionsDialog;
-import mekhq.gui.dialog.ContractMarketDialog;
-import mekhq.gui.dialog.DailyReportLogDialog;
-import mekhq.gui.dialog.DataLoadingDialog;
-import mekhq.gui.dialog.GMToolsDialog;
-import mekhq.gui.dialog.HireBulkPersonnelDialog;
-import mekhq.gui.dialog.HistoricalDailyReportDialog;
-import mekhq.gui.dialog.MaintenanceReportDialog;
-import mekhq.gui.dialog.MassMothballDialog;
-import mekhq.gui.dialog.MekHQAboutBox;
-import mekhq.gui.dialog.MercRosterDialog;
-import mekhq.gui.dialog.NewRecruitDialog;
-import mekhq.gui.dialog.NewsReportDialog;
-import mekhq.gui.dialog.PartsStoreDialog;
-import mekhq.gui.dialog.PersonnelMarketDialog;
-import mekhq.gui.dialog.PopupValueChoiceDialog;
-import mekhq.gui.dialog.RefitNameDialog;
-import mekhq.gui.dialog.ReportDialog;
-import mekhq.gui.dialog.RetirementDefectionDialog;
-import mekhq.gui.dialog.ScenarioTemplateEditorDialog;
-import mekhq.gui.dialog.ShipSearchDialog;
-import mekhq.gui.dialog.UnitCostReportDialog;
-import mekhq.gui.dialog.UnitMarketDialog;
-import mekhq.gui.dialog.UnitSelectorDialog;
 import mekhq.gui.model.PartsTableModel;
 import mekhq.io.FileType;
 
@@ -756,8 +727,12 @@ public class CampaignGUI extends JPanel {
                 menuOptionsMMActionPerformed(evt);
             }
         });
-
         menuFile.add(menuOptionsMM);
+
+        JMenuItem menuMekHqOptions = new JMenuItem(resourceMap.getString("menuMekHqOptions.text"));
+        menuMekHqOptions.setMnemonic(KeyEvent.VK_M);
+        menuMekHqOptions.addActionListener(this::menuMekHqOptionsActionPerformed);
+        menuFile.add(menuMekHqOptions);
 
         menuThemes = new JMenu("Themes");
 
@@ -1745,6 +1720,11 @@ public class CampaignGUI extends JPanel {
             refreshCalendar();
         }
     }// GEN-LAST:event_menuOptionsActionPerformed
+
+    private void menuMekHqOptionsActionPerformed(ActionEvent evt) {
+        MekHqOptionsDialog dialog = new MekHqOptionsDialog(getFrame());
+        dialog.setVisible(true);
+    }
 
     private void miLoadForcesActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_miLoadForcesActionPerformed
         try {

--- a/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
@@ -1,0 +1,215 @@
+/*
+ * BaseDialog.java
+ *
+ * Copyright (c) 2019 MekHQ Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.gui.dialog;
+
+import megamek.common.logging.MMLogger;
+import mekhq.MekHQ;
+import mekhq.gui.preferences.JWindowPreference;
+import mekhq.preferences.PreferencesNode;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.ResourceBundle;
+
+/*
+ * Base class for dialogs in MekHQ. This class handles setting the UI,
+ * managing the Ok/Cancel buttons, managing the X button, and saving the dialog preferences.
+ *
+ * A class that inherits from this class needs to at least implement the method
+ * setCustomUI which will create the custom UI dialog.
+ * The methods setCustomPreferences, okAction, and cancelAction allow to customize
+ * further the behavior of the dialog by child classes.
+ *
+ * The dialog will be constructed by the child class calling the initialize method.
+ *
+ * The resources associated with this dialog need to contain at least the following keys:
+ * - dialog.text -> title of the dialog
+ * - okButton.text -> text for the ok button
+ * - cancelButton.text -> text for the cancel button
+ */
+public abstract class BaseDialog extends JDialog implements WindowListener {
+    private final MMLogger logger;
+    private ResourceBundle resources;
+    private DialogResult result;
+
+    protected BaseDialog(JFrame parent, MMLogger logger) {
+        this(parent, logger, false);
+    }
+
+    protected BaseDialog(JFrame parent, MMLogger logger, boolean isModal) {
+        super(parent);
+        assert logger != null;
+
+        this.logger = logger;
+        this.addWindowListener(this);
+        this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        this.setModal(isModal);
+    }
+
+    /**
+     * Result of closing the dialog.
+     * @return
+     */
+    public DialogResult getResult() {
+        return this.result;
+    }
+
+    /**
+     * Initializes the dialog UI and preferences. Needs to be called by
+     * child classes for initial setup.
+     * @param resources the resources needed for this dialog
+     */
+    protected final void initialize(ResourceBundle resources) {
+        assert resources != null;
+
+        this.resources = resources;
+        this.createUI();
+        this.setPreferences();
+
+        this.pack();
+        this.setVisible(true);
+    }
+
+    /**
+     * Creates the custom UI (body) for the dialog.
+     * This custom UI will be placed in the BorderLayoutCENTER.
+     * @return
+     */
+    protected abstract Container createCustomUI();
+
+    /**
+     * Adds custom preferences to this dialog.
+     *
+     * By default, this dialog will track preferences related to the size
+     * and position of the dialog. Other preferences should be added by overriding
+     * this method.
+     * @param preferences
+     */
+    protected void setCustomPreferences(PreferencesNode preferences) {
+    }
+
+    /**
+     * Action performed when the ok button is clicked.
+     */
+    protected void okAction() {
+    }
+
+    /**
+     * Action performed when the cancel button is clicked or
+     * when the dialog is closed by the X button.
+     */
+    protected void cancelAction() {
+    }
+
+    private void createUI() {
+        this.setTitle(resources.getString("dialog.text"));
+
+        // Main body of the dialog
+        this.getContentPane().add(this.createCustomUI(), BorderLayout.CENTER);
+
+        // Ok/Cancel buttons
+        JButton okButton = new JButton(resources.getString("okButton.text"));
+        okButton.addActionListener(this::okButtonActionPerformed);
+        okButton.requestFocus();
+
+        JButton cancelButton = new JButton(resources.getString("cancelButton.text"));
+        cancelButton.addActionListener(this::cancelButtonActionPerformed);
+
+        // Layout buttons
+        JPanel buttonsPanel = new JPanel(new GridLayout(1, 2));
+        buttonsPanel.add(okButton);
+        buttonsPanel.add(cancelButton);
+        JPanel bottom = new JPanel(new GridBagLayout());
+        bottom.add(buttonsPanel);
+        this.getContentPane().add(bottom, BorderLayout.PAGE_END);
+    }
+
+    private final void setPreferences() {
+        PreferencesNode preferences = MekHQ.getPreferences().forClass(this.getClass());
+
+        preferences.manage(new JWindowPreference(this));
+        this.setCustomPreferences(preferences);
+    }
+
+    private void okButtonActionPerformed(ActionEvent evt) {
+        this.okAction();
+        this.result = DialogResult.OK;
+        this.dispose();
+    }
+
+    /**
+     * Notes: cancelling a dialog should always allow to close the dialog.
+     */
+    private void cancelButtonActionPerformed(ActionEvent evt) {
+        try {
+            this.cancelAction();
+        }
+        catch (Exception ex) {
+            this.logger.error(this.getClass(), "cancelButtonActionPerformed", ex);
+        }
+        finally {
+            this.result = DialogResult.CANCEL;
+            this.dispose();
+        }
+    }
+
+    /**
+     * Notes: closing the dialog should always allow to close the dialog.
+     */
+    @Override
+    public void windowClosing(WindowEvent e) {
+        try {
+            this.cancelAction();
+        }
+        catch (Exception ex) {
+            this.logger.error(this.getClass(), "windowClosing", ex);
+        }
+        finally {
+            this.result = DialogResult.CANCEL;
+        }
+    }
+
+    @Override
+    public void windowOpened(WindowEvent e) {
+    }
+
+    @Override
+    public void windowClosed(WindowEvent e) {
+    }
+
+    @Override
+    public void windowIconified(WindowEvent e){
+    }
+
+    @Override
+    public void windowDeiconified(WindowEvent e){
+    }
+
+    @Override
+    public void windowActivated(WindowEvent e) {
+    }
+
+    @Override
+    public void windowDeactivated(WindowEvent e) {
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
@@ -91,7 +91,7 @@ public abstract class BaseDialog extends JDialog implements WindowListener {
 
     /**
      * Creates the custom UI (body) for the dialog.
-     * This custom UI will be placed in the BorderLayoutCENTER.
+     * This custom UI will be placed in the BorderLayout.CENTER.
      * @return
      */
     protected abstract Container createCustomUI();

--- a/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
@@ -84,10 +84,9 @@ public abstract class BaseDialog extends JDialog implements WindowListener {
 
         this.resources = resources;
         this.createUI();
-        this.setPreferences();
 
         this.pack();
-        this.setVisible(true);
+        this.setPreferences();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/DialogResult.java
+++ b/MekHQ/src/mekhq/gui/dialog/DialogResult.java
@@ -1,0 +1,33 @@
+/*
+ * DialogResult.java
+ *
+ * Copyright (c) 2019 MekHQ Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.gui.dialog;
+
+public enum DialogResult {
+    OK(1),
+    CANCEL(-1);
+
+    private final int value;
+
+    DialogResult(int value) {
+        this.value = value;
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
@@ -1,0 +1,90 @@
+package mekhq.gui.dialog;
+
+import mekhq.MekHQ;
+import mekhq.gui.preferences.JWindowPreference;
+import mekhq.preferences.PreferencesNode;
+
+import javax.swing.*;
+import java.awt.event.KeyEvent;
+import java.util.ResourceBundle;
+
+public class MekHqOptionsDialog extends JDialog {
+    ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MekHqOptionsDialog");
+
+    public MekHqOptionsDialog(JFrame parent) {
+        super(parent);
+
+        initComponents();
+        setInitialState();
+        setUserPreferences();
+    }
+
+    private void initComponents() {
+        this.setTitle(resources.getString("dialog.text"));
+        this.setName("dialog.name");
+
+        JLabel labelSavedInfo = new JLabel("labelSavedInfo.text");
+        labelSavedInfo.setName("labelSavedInfo.name");
+
+        JRadioButton optionSaveDaily = new JRadioButton(resources.getString("optionSaveDaily.text"));
+        optionSaveDaily.setName("optionSaveDaily.name");
+        optionSaveDaily.setMnemonic(KeyEvent.VK_D);
+
+        JRadioButton optionSaveWeekly = new JRadioButton(resources.getString("optionSaveWeekly.text"));
+        optionSaveWeekly.setName("optionSaveWeekly.name");
+        optionSaveWeekly.setMnemonic(KeyEvent.VK_W);
+
+        ButtonGroup saveFrequencyGroup = new ButtonGroup();
+        saveFrequencyGroup.add(optionSaveDaily);
+        saveFrequencyGroup.add(optionSaveWeekly);
+
+        JCheckBox checkSaveBeforeMissions = new JCheckBox(resources.getString("checkSaveBeforeMissions.text"));
+        checkSaveBeforeMissions.setName("checkSaveBeforeMissions.name");
+        checkSaveBeforeMissions.setMnemonic(KeyEvent.VK_S);
+
+        JLabel labelSavedGamesCount = new JLabel("labelSavedGamesCount.text");
+        labelSavedGamesCount.setName("labelSavedGamesCount.name");
+
+        JSpinner spinnerSavedGamesCount = new JSpinner(new SpinnerNumberModel(1, 1, 10, 1));
+        spinnerSavedGamesCount.setName("spinnerSavedGamesCount.name");
+
+        GroupLayout layout = new GroupLayout(this);
+        this.setLayout(layout);
+
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setVerticalGroup(
+            layout.createSequentialGroup()
+                .addComponent(labelSavedInfo)
+                .addComponent(optionSaveDaily)
+                .addComponent(optionSaveWeekly)
+                .addComponent(checkSaveBeforeMissions)
+                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                    .addComponent(labelSavedGamesCount)
+                    .addComponent(spinnerSavedGamesCount, GroupLayout.Alignment.TRAILING))
+        );
+
+        layout.setHorizontalGroup(
+            layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addComponent(labelSavedInfo)
+                .addComponent(optionSaveDaily)
+                .addComponent(optionSaveWeekly)
+                .addComponent(checkSaveBeforeMissions)
+                .addGroup(layout.createSequentialGroup()
+                    .addComponent(labelSavedGamesCount)
+                    .addComponent(spinnerSavedGamesCount))
+        );
+    }
+
+    private void setInitialState() {
+
+    }
+
+    private void setUserPreferences() {
+        PreferencesNode preferences = MekHQ.getPreferences().forClass(MekHqOptionsDialog.class);
+
+        this.setName("dialog");
+        preferences.manage(new JWindowPreference(this));
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
@@ -1,37 +1,52 @@
+/*
+ * MekHqOptionsDialog.java
+ *
+ * Copyright (c) 2019 MekHQ Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package mekhq.gui.dialog;
 
-import mekhq.MekHQ;
-import mekhq.gui.preferences.JWindowPreference;
-import mekhq.preferences.PreferencesNode;
+import megamek.common.logging.MMLogger;
 
 import javax.swing.*;
+import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.util.ResourceBundle;
 
-public class MekHqOptionsDialog extends JDialog {
+public class MekHqOptionsDialog extends BaseDialog {
     ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MekHqOptionsDialog");
 
-    public MekHqOptionsDialog(JFrame parent) {
-        super(parent);
+    public MekHqOptionsDialog(JFrame parent, MMLogger logger) {
+        super(parent, logger);
 
-        initComponents();
-        setInitialState();
-        setUserPreferences();
+        this.initialize(resources);
+        this.setInitialState();
     }
 
-    private void initComponents() {
-        this.setTitle(resources.getString("dialog.text"));
-        this.setName("dialog.name");
-
-        JLabel labelSavedInfo = new JLabel("labelSavedInfo.text");
-        labelSavedInfo.setName("labelSavedInfo.name");
+    @Override
+    protected Container createCustomUI() {
+        // Create UI components
+        JLabel labelSavedInfo = new JLabel(resources.getString("labelSavedInfo.text"));
 
         JRadioButton optionSaveDaily = new JRadioButton(resources.getString("optionSaveDaily.text"));
-        optionSaveDaily.setName("optionSaveDaily.name");
         optionSaveDaily.setMnemonic(KeyEvent.VK_D);
 
         JRadioButton optionSaveWeekly = new JRadioButton(resources.getString("optionSaveWeekly.text"));
-        optionSaveWeekly.setName("optionSaveWeekly.name");
         optionSaveWeekly.setMnemonic(KeyEvent.VK_W);
 
         ButtonGroup saveFrequencyGroup = new ButtonGroup();
@@ -39,17 +54,16 @@ public class MekHqOptionsDialog extends JDialog {
         saveFrequencyGroup.add(optionSaveWeekly);
 
         JCheckBox checkSaveBeforeMissions = new JCheckBox(resources.getString("checkSaveBeforeMissions.text"));
-        checkSaveBeforeMissions.setName("checkSaveBeforeMissions.name");
         checkSaveBeforeMissions.setMnemonic(KeyEvent.VK_S);
 
-        JLabel labelSavedGamesCount = new JLabel("labelSavedGamesCount.text");
-        labelSavedGamesCount.setName("labelSavedGamesCount.name");
-
+        JLabel labelSavedGamesCount = new JLabel(resources.getString("labelSavedGamesCount.text"));
         JSpinner spinnerSavedGamesCount = new JSpinner(new SpinnerNumberModel(1, 1, 10, 1));
-        spinnerSavedGamesCount.setName("spinnerSavedGamesCount.name");
+        labelSavedGamesCount.setLabelFor(spinnerSavedGamesCount);
 
-        GroupLayout layout = new GroupLayout(this);
-        this.setLayout(layout);
+        // Layout the UI
+        JPanel body = new JPanel();
+        GroupLayout layout = new GroupLayout(body);
+        body.setLayout(layout);
 
         layout.setAutoCreateGaps(true);
         layout.setAutoCreateContainerGaps(true);
@@ -75,16 +89,14 @@ public class MekHqOptionsDialog extends JDialog {
                     .addComponent(labelSavedGamesCount)
                     .addComponent(spinnerSavedGamesCount))
         );
+
+        return body;
+    }
+
+    @Override
+    protected void okAction() {
     }
 
     private void setInitialState() {
-
-    }
-
-    private void setUserPreferences() {
-        PreferencesNode preferences = MekHQ.getPreferences().forClass(MekHqOptionsDialog.class);
-
-        this.setName("dialog");
-        preferences.manage(new JWindowPreference(this));
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
@@ -53,7 +53,7 @@ public class MekHqOptionsDialog extends BaseDialog {
         JLabel labelSavedInfo = new JLabel(resources.getString("labelSavedInfo.text"));
 
         optionNoSave = new JRadioButton(resources.getString("optionNoSave.text"));
-        optionNoSave.setMnemonic(KeyEvent.VK_D);
+        optionNoSave.setMnemonic(KeyEvent.VK_N);
 
         optionSaveDaily = new JRadioButton(resources.getString("optionSaveDaily.text"));
         optionSaveDaily.setMnemonic(KeyEvent.VK_D);

--- a/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
@@ -34,6 +34,7 @@ public class MekHqOptionsDialog extends BaseDialog {
     private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MekHqOptionsDialog");
     private final Preferences userPreferences = Preferences.userRoot().node(MekHqConstants.AUTOSAVE_NODE);
 
+    private JRadioButton optionNoSave;
     private JRadioButton optionSaveDaily;
     private JRadioButton optionSaveWeekly;
     private JCheckBox checkSaveBeforeMissions;
@@ -51,6 +52,9 @@ public class MekHqOptionsDialog extends BaseDialog {
         // Create UI components
         JLabel labelSavedInfo = new JLabel(resources.getString("labelSavedInfo.text"));
 
+        optionNoSave = new JRadioButton(resources.getString("optionNoSave.text"));
+        optionNoSave.setMnemonic(KeyEvent.VK_D);
+
         optionSaveDaily = new JRadioButton(resources.getString("optionSaveDaily.text"));
         optionSaveDaily.setMnemonic(KeyEvent.VK_D);
 
@@ -58,6 +62,7 @@ public class MekHqOptionsDialog extends BaseDialog {
         optionSaveWeekly.setMnemonic(KeyEvent.VK_W);
 
         ButtonGroup saveFrequencyGroup = new ButtonGroup();
+        saveFrequencyGroup.add(optionNoSave);
         saveFrequencyGroup.add(optionSaveDaily);
         saveFrequencyGroup.add(optionSaveWeekly);
 
@@ -79,6 +84,7 @@ public class MekHqOptionsDialog extends BaseDialog {
         layout.setVerticalGroup(
             layout.createSequentialGroup()
                 .addComponent(labelSavedInfo)
+                .addComponent(optionNoSave)
                 .addComponent(optionSaveDaily)
                 .addComponent(optionSaveWeekly)
                 .addComponent(checkSaveBeforeMissions)
@@ -90,6 +96,7 @@ public class MekHqOptionsDialog extends BaseDialog {
         layout.setHorizontalGroup(
             layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                 .addComponent(labelSavedInfo)
+                .addComponent(optionNoSave)
                 .addComponent(optionSaveDaily)
                 .addComponent(optionSaveWeekly)
                 .addComponent(checkSaveBeforeMissions)
@@ -103,6 +110,7 @@ public class MekHqOptionsDialog extends BaseDialog {
 
     @Override
     protected void okAction() {
+        this.userPreferences.putBoolean(MekHqConstants.NO_SAVE_KEY, this.optionNoSave.isSelected());
         this.userPreferences.putBoolean(MekHqConstants.SAVE_DAILY_KEY, this.optionSaveDaily.isSelected());
         this.userPreferences.putBoolean(MekHqConstants.SAVE_WEEKLY_KEY, this.optionSaveWeekly.isSelected());
         this.userPreferences.putBoolean(MekHqConstants.SAVE_BEFORE_MISSIONS_KEY, this.checkSaveBeforeMissions.isSelected());
@@ -110,9 +118,10 @@ public class MekHqOptionsDialog extends BaseDialog {
     }
 
     private void setInitialState() {
+        this.optionNoSave.setSelected(this.userPreferences.getBoolean(MekHqConstants.NO_SAVE_KEY, false));
         this.optionSaveDaily.setSelected(this.userPreferences.getBoolean(MekHqConstants.SAVE_DAILY_KEY, false));
         this.optionSaveWeekly.setSelected(this.userPreferences.getBoolean(MekHqConstants.SAVE_WEEKLY_KEY, true));
         this.checkSaveBeforeMissions.setSelected(this.userPreferences.getBoolean(MekHqConstants.SAVE_BEFORE_MISSIONS_KEY, false));
-        this.spinnerSavedGamesCount.setValue(this.userPreferences.getInt(MekHqConstants.MAXIMUM_NUMBER_SAVES_KEY, 5));
+        this.spinnerSavedGamesCount.setValue(this.userPreferences.getInt(MekHqConstants.MAXIMUM_NUMBER_SAVES_KEY, MekHqConstants.DEFAULT_NUMBER_SAVES));
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
@@ -22,14 +22,22 @@
 package mekhq.gui.dialog;
 
 import megamek.common.logging.MMLogger;
+import mekhq.MekHqConstants;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.util.ResourceBundle;
+import java.util.prefs.Preferences;
 
 public class MekHqOptionsDialog extends BaseDialog {
-    ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MekHqOptionsDialog");
+    private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MekHqOptionsDialog");
+    private final Preferences userPreferences = Preferences.userRoot().node(MekHqConstants.AUTOSAVE_NODE);
+
+    private JRadioButton optionSaveDaily;
+    private JRadioButton optionSaveWeekly;
+    private JCheckBox checkSaveBeforeMissions;
+    private JSpinner spinnerSavedGamesCount;
 
     public MekHqOptionsDialog(JFrame parent, MMLogger logger) {
         super(parent, logger);
@@ -43,21 +51,21 @@ public class MekHqOptionsDialog extends BaseDialog {
         // Create UI components
         JLabel labelSavedInfo = new JLabel(resources.getString("labelSavedInfo.text"));
 
-        JRadioButton optionSaveDaily = new JRadioButton(resources.getString("optionSaveDaily.text"));
+        optionSaveDaily = new JRadioButton(resources.getString("optionSaveDaily.text"));
         optionSaveDaily.setMnemonic(KeyEvent.VK_D);
 
-        JRadioButton optionSaveWeekly = new JRadioButton(resources.getString("optionSaveWeekly.text"));
+        optionSaveWeekly = new JRadioButton(resources.getString("optionSaveWeekly.text"));
         optionSaveWeekly.setMnemonic(KeyEvent.VK_W);
 
         ButtonGroup saveFrequencyGroup = new ButtonGroup();
         saveFrequencyGroup.add(optionSaveDaily);
         saveFrequencyGroup.add(optionSaveWeekly);
 
-        JCheckBox checkSaveBeforeMissions = new JCheckBox(resources.getString("checkSaveBeforeMissions.text"));
+        checkSaveBeforeMissions = new JCheckBox(resources.getString("checkSaveBeforeMissions.text"));
         checkSaveBeforeMissions.setMnemonic(KeyEvent.VK_S);
 
         JLabel labelSavedGamesCount = new JLabel(resources.getString("labelSavedGamesCount.text"));
-        JSpinner spinnerSavedGamesCount = new JSpinner(new SpinnerNumberModel(1, 1, 10, 1));
+        spinnerSavedGamesCount = new JSpinner(new SpinnerNumberModel(1, 1, 10, 1));
         labelSavedGamesCount.setLabelFor(spinnerSavedGamesCount);
 
         // Layout the UI
@@ -95,8 +103,16 @@ public class MekHqOptionsDialog extends BaseDialog {
 
     @Override
     protected void okAction() {
+        this.userPreferences.putBoolean(MekHqConstants.SAVE_DAILY_KEY, this.optionSaveDaily.isSelected());
+        this.userPreferences.putBoolean(MekHqConstants.SAVE_WEEKLY_KEY, this.optionSaveWeekly.isSelected());
+        this.userPreferences.putBoolean(MekHqConstants.SAVE_BEFORE_MISSIONS_KEY, this.checkSaveBeforeMissions.isSelected());
+        this.userPreferences.putInt(MekHqConstants.MAXIMUM_NUMBER_SAVES_KEY, (Integer)this.spinnerSavedGamesCount.getValue());
     }
 
     private void setInitialState() {
+        this.optionSaveDaily.setSelected(this.userPreferences.getBoolean(MekHqConstants.SAVE_DAILY_KEY, false));
+        this.optionSaveWeekly.setSelected(this.userPreferences.getBoolean(MekHqConstants.SAVE_WEEKLY_KEY, true));
+        this.checkSaveBeforeMissions.setSelected(this.userPreferences.getBoolean(MekHqConstants.SAVE_BEFORE_MISSIONS_KEY, false));
+        this.spinnerSavedGamesCount.setValue(this.userPreferences.getInt(MekHqConstants.MAXIMUM_NUMBER_SAVES_KEY, 5));
     }
 }

--- a/MekHQ/src/mekhq/service/AutosaveService.java
+++ b/MekHQ/src/mekhq/service/AutosaveService.java
@@ -1,0 +1,135 @@
+/*
+ * AutosaveService.java
+ *
+ * Copyright (c) 2019 MekHQ Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.service;
+
+import megamek.common.logging.MMLogger;
+import mekhq.MekHQ;
+import mekhq.MekHqConstants;
+import mekhq.campaign.Campaign;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.prefs.Preferences;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPOutputStream;
+
+public class AutosaveService implements IAutosaveService {
+    private final Preferences userPreferences = Preferences.userRoot().node(MekHqConstants.AUTOSAVE_NODE);
+    private final MMLogger logger;
+
+    public AutosaveService(MMLogger logger) {
+        assert logger != null;
+
+        this.logger = logger;
+    }
+
+    @Override
+    public void requestDayAdvanceAutosave(Campaign campaign, int dayOfTheWeek) {
+        assert campaign != null;
+
+        if (this.isDailyAutosaveEnabled()) {
+            this.performAutosave(campaign);
+        } else if (dayOfTheWeek == Calendar.SUNDAY && this.isWeeklyAutosaveEnabled()) {
+            this.performAutosave(campaign);
+        }
+    }
+
+    public void requestBeforeMissionAutosave(Campaign campaign) {
+        assert campaign != null;
+
+        if (this.isMissionAutosaveEnabled()) {
+            this.performAutosave(campaign);
+        }
+    }
+
+    private boolean isDailyAutosaveEnabled() {
+        return this.userPreferences.getBoolean(MekHqConstants.SAVE_DAILY_KEY, false);
+    }
+
+    private boolean isWeeklyAutosaveEnabled() {
+        return this.userPreferences.getBoolean(MekHqConstants.SAVE_WEEKLY_KEY, false);
+    }
+
+    private boolean isMissionAutosaveEnabled() {
+        return this.userPreferences.getBoolean(MekHqConstants.SAVE_BEFORE_MISSIONS_KEY, false);
+    }
+
+    private void performAutosave(Campaign campaign) {
+        try {
+            String fileName = this.getAutosaveFilename(campaign);
+
+            try (GZIPOutputStream output = new GZIPOutputStream(new FileOutputStream(fileName))) {
+                PrintWriter writer = new PrintWriter(new OutputStreamWriter(output, "UTF-8"));
+                campaign.writeToXml(writer);
+                writer.flush();
+                writer.close();
+            }
+        }
+        catch (Exception ex) {
+            this.logger.error(this.getClass(), "performAutosave", ex);
+        }
+    }
+
+    private String getAutosaveFilename(Campaign campaign) {
+        // Get all autosave files in ascending order of date creation
+        String savesDirectoryPath = MekHQ.getCampaignsDirectory().getValue();
+        File folder = new File(savesDirectoryPath);
+        List<File> autosaveFiles = Arrays.stream(folder.listFiles())
+                .filter(f -> f.getName().startsWith("Autosave-"))
+                .sorted(Comparator.comparing(f -> f.lastModified()))
+                .collect(Collectors.toList());
+
+        // Delete older autosave files if needed
+        int maxNumberAutosaves = this.userPreferences.getInt(MekHqConstants.MAXIMUM_NUMBER_SAVES_KEY, MekHqConstants.DEFAULT_NUMBER_SAVES);
+        while (autosaveFiles.size() >= maxNumberAutosaves && autosaveFiles.size() > 0) {
+            autosaveFiles.get(0).delete();
+            autosaveFiles.remove(0);
+        }
+
+        // Find a unique name for this autosave
+        String fileName = null;
+
+        boolean repeatedName = true;
+        int index = 0;
+        while (repeatedName) {
+            fileName = String.format(
+                    "Autosave-%d-%s-%s.cpnx.gz",
+                    index++,
+                    campaign.getName(),
+                    campaign.getShortDateAsString());
+
+            repeatedName = false;
+            for (File file : autosaveFiles) {
+                if (file.getName().compareToIgnoreCase(fileName) == 0) {
+                    repeatedName = true;
+                    break;
+                }
+            }
+        }
+
+        return Paths.get(savesDirectoryPath, fileName).toString();
+    }
+}

--- a/MekHQ/src/mekhq/service/AutosaveService.java
+++ b/MekHQ/src/mekhq/service/AutosaveService.java
@@ -81,7 +81,8 @@ public class AutosaveService implements IAutosaveService {
         try {
             String fileName = this.getAutosaveFilename(campaign);
 
-            try (GZIPOutputStream output = new GZIPOutputStream(new FileOutputStream(fileName))) {
+            try (FileOutputStream fos = new FileOutputStream(fileName);
+                 GZIPOutputStream output = new GZIPOutputStream(fos)) {
                 PrintWriter writer = new PrintWriter(new OutputStreamWriter(output, "UTF-8"));
                 campaign.writeToXml(writer);
                 writer.flush();

--- a/MekHQ/src/mekhq/service/IAutosaveService.java
+++ b/MekHQ/src/mekhq/service/IAutosaveService.java
@@ -1,5 +1,5 @@
 /*
- * MekHqConstants.java
+ * IAutosaveService.java
  *
  * Copyright (c) 2019 MekHQ Team. All rights reserved.
  *
@@ -19,15 +19,27 @@
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mekhq;
+package mekhq.service;
 
-public final class MekHqConstants {
-    public static final String AUTOSAVE_NODE = "mekhq/prefs/autosave";
-    public static final String NO_SAVE_KEY = "noSave";
-    public static final String SAVE_DAILY_KEY = "saveDaily";
-    public static final String SAVE_WEEKLY_KEY = "saveWeekly";
-    public static final String SAVE_BEFORE_MISSIONS_KEY = "saveBeforeMissions";
-    public static final String MAXIMUM_NUMBER_SAVES_KEY = "maximumNumberAutoSaves";
+import mekhq.campaign.Campaign;
 
-    public static final int DEFAULT_NUMBER_SAVES = 5;
+/**
+ * Handles the possible auto-save situations
+ * in MekHQ.
+ */
+public interface IAutosaveService {
+    /**
+     * Handles auto-saving when the day of the campaign advances.
+     *
+     * @param campaign Campaign to save
+     * @param dayOfTheWeek Day of the week when the auto-save is requested
+     */
+    void requestDayAdvanceAutosave(Campaign campaign, int dayOfTheWeek);
+
+    /**
+     * Handles auto-saving before a mission starts.
+     *
+     * @param campaign Campaign to save
+     */
+    void requestBeforeMissionAutosave(Campaign campaign);
 }


### PR DESCRIPTION
This PR adds several things:

- AutosaveService: which will handle creating and managing autosaves (per #1171).
- MekHqOptions: so the user can configure autosave (per day, week, no autosave, save before missions, number of saves). This can be access from the File menu, like the Megamek and Campaign options.
- BaseDialog: a base dialog class to unify the look and feel and functionality of our dialogs. Used for MekHqOptions, should be adopted little by little in the rest of our dialogs.

Missing from this PR:

- Autosave before a mission starts. I have to find where is that code and make the call to AutosaveService.requestBeforeMissionAutosave().

I'm putting this PR up to gather feedback while I finish the mission saves.