### PR TITLE
Set Battle Armor internals to 1 after repair

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -274,7 +274,7 @@ public class MissingBattleArmorSuit extends MissingPart {
         		}
             }
             replacement.decrementQuantity();
-            unit.getEntity().setInternal(0, trooper);
+            unit.getEntity().setInternal(1, trooper);
             remove(false);
         }
     }


### PR DESCRIPTION
This fixes the issue in #1197 where personnel could not be assigned to Battle Armor. The armor had 0 internals after repair, it is now set to 1 and allows personnel to be assigned to them. Previously repaired suits can have their internals manually set to 1 to be functional again.