### PR TITLE
Fixed missing ammo bin acquisition

### DIFF
--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -11,6 +11,7 @@ v0.45.5-SNAPSHOT
 + Issue #1171: Adds autosave feature (daily or weekly, and/or before missions).
 + Issue #1128: Player can now view stats for enemy personnel when resolving a scenario.
 + Issue #1197: Fix bug where personnel could not be assigned to Battle Armor after repair.
++ Issue #1185: Fix bug where ammo bins could not ordered for repair.
 
 v0.45.4 (2019-03-24 1700 UTC)
 + PR #1067: Switch to Joda Money library internally for financial math

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -115,11 +115,6 @@ public class ShoppingList implements MekHqXmlSerializable {
     }
 
     public void addShoppingItem(IAcquisitionWork newWork, int quantity, Campaign campaign) {
-        //ammo bins need a little extra work here
-        if(newWork instanceof AmmoBin) {
-            newWork = ((AmmoBin) newWork).getAcquisitionWork();
-        }
-        
         //check to see if this is already on the shopping list. If so, then add quantity to the list
         //and return
         for(IAcquisitionWork shoppingItem : shoppingList) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -780,11 +780,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public IAcquisitionWork getAcquisitionWork() {
-        int shots = 1;
-        if(type instanceof AmmoType) {
-            shots = ((AmmoType)type).getShots();
-        }
-        return new AmmoStorage(1,type,shots,campaign);
+        return this.getMissingPart();
     }
 
     @Override


### PR DESCRIPTION
This is a fix for #1185 which now allows the player to order ammo bins for repair. Previously, when attempting to order a new ammo bin, the player would instead receive ammunition.