### PR TITLE
Retirement null fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3246,6 +3246,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         removeAllPatientsFor(person);
         removeAllTechJobsFor(person);
+        getRetirementDefectionTracker().removePerson(person);
 
         if (log) {
             addReport(person.getFullTitle()

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -356,6 +356,18 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
     }
     
     /**
+     * Clears out an individual entirely from this tracker.
+     * @param person
+     */
+    public void removePerson(Person person) {
+        payouts.remove(person.getId());
+        
+        for(int contractID : unresolvedPersonnel.keySet()) {
+            unresolvedPersonnel.get(contractID).remove(person.getId());
+        }
+    }
+    
+    /**
      * Worker function that clears out any orphan retirement/defection records
      * @param id ID of the person in question
      * @param contract Contract in question, if any

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -25,10 +25,12 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -351,6 +353,34 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
     
     public void removePayout(Person person) {
         payouts.remove(person.getId());
+    }
+    
+    /**
+     * Worker function that clears out any orphan retirement/defection records
+     * @param id ID of the person in question
+     * @param contract Contract in question, if any
+     */
+    public void cleanupOrphans(Campaign campaign) {
+        Iterator<UUID> payoutIterator = payouts.keySet().iterator();
+        
+        while(payoutIterator.hasNext()) {
+            UUID personID = payoutIterator.next();
+            if(campaign.getPerson(personID) == null) {
+                payoutIterator.remove();
+            }
+        }
+        
+        for(int contractID : unresolvedPersonnel.keySet()) {
+            Iterator<UUID> personIterator = unresolvedPersonnel.get(contractID).iterator();
+            
+            while(personIterator.hasNext()) {
+                UUID personID = personIterator.next();
+                
+                if(campaign.getPerson(personID) == null) {
+                    personIterator.remove();
+                }
+            }
+        }
     }
     
     public boolean isOutstanding(AtBContract contract) {
@@ -731,6 +761,10 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
             MekHQ.getLogger().error(RetirementDefectionTracker.class, METHOD_NAME, ex);
         }
 
+        // sometimes, a campaign may be loaded with orphan records in the retirement/defection tracker
+        // let's clean those up here.
+        retVal.cleanupOrphans(c);
+        
         return retVal;
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -357,7 +357,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
     
     /**
      * Clears out an individual entirely from this tracker.
-     * @param person
+     * @param person The person to remove
      */
     public void removePerson(Person person) {
         payouts.remove(person.getId());
@@ -369,8 +369,6 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
     
     /**
      * Worker function that clears out any orphan retirement/defection records
-     * @param id ID of the person in question
-     * @param contract Contract in question, if any
      */
     public void cleanupOrphans(Campaign campaign) {
         Iterator<UUID> payoutIterator = payouts.keySet().iterator();
@@ -773,9 +771,11 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
             MekHQ.getLogger().error(RetirementDefectionTracker.class, METHOD_NAME, ex);
         }
 
-        // sometimes, a campaign may be loaded with orphan records in the retirement/defection tracker
-        // let's clean those up here.
-        retVal.cleanupOrphans(c);
+        if(retVal != null) {
+            // sometimes, a campaign may be loaded with orphan records in the retirement/defection tracker
+            // let's clean those up here.
+            retVal.cleanupOrphans(c);
+        }
         
         return retVal;
     }


### PR DESCRIPTION
Added functionality to the RetirementDefection tracker to clean up orphan person records when loading a save. Also made sure that the campaign removes orphan records when a person is gm-removed.

This fixes a behavior where, if you have an outstanding retirement/defection roll but then gm-remove that person, the player is unable to "advance day" due to an NPE in the retirement/defection UI.