### PR TITLE
Legacy atb goodies

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -39,6 +39,7 @@ import megamek.common.UnitType;
 import megamek.common.logging.LogLevel;
 import mekhq.campaign.force.Lance;
 import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.BotForce;
 import mekhq.campaign.unit.Unit;
@@ -265,8 +266,12 @@ public class AtBGameThread extends GameThread {
                     swingGui.getBots().put(name, botClient);
 
                     configureBot(botClient, bf);
+                    
+                    // we need to wait until the game has actually started to do transport loading
+                    if(scenario instanceof AtBScenario) {
+                        AtBDynamicScenarioFactory.loadTransports((AtBScenario) scenario, botClient);
+                    }
                 }
-
             }
 
             while(!stop) {

--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -19,6 +19,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Element;
@@ -48,7 +50,17 @@ public class MekHqXmlUtil {
     private static DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY;
     private static DocumentBuilderFactory UNSAFE_DOCUMENT_BUILDER_FACTORY;
     private static SAXParserFactory SAX_PARSER_FACTORY;
+    private static XPath XPATH_INSTANCE;
 
+    public static XPath getXPathInstance() {
+        if(XPATH_INSTANCE == null) {
+            XPathFactory xpf = XPathFactory.newInstance();
+            XPATH_INSTANCE = xpf.newXPath();
+        }
+        
+        return XPATH_INSTANCE;
+    }
+    
     /**
      * Creates a DocumentBuilder safe from XML external entities
      * attacks, and XML entity expansion attacks.

--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -40,6 +40,7 @@ import megamek.common.EntityListFile;
 import megamek.common.FighterSquadron;
 import megamek.common.IBomber;
 import megamek.common.IPlayer;
+import megamek.common.Infantry;
 import megamek.common.Jumpship;
 import megamek.common.MULParser;
 import megamek.common.Tank;
@@ -312,6 +313,14 @@ public class MekHqXmlUtil {
                  && !tgtEnt.getCamoFileName().isEmpty()) {
              retVal += "\" camoFileName=\"";
              retVal += String.valueOf(escape(tgtEnt.getCamoFileName()));
+         }
+         
+         if(tgtEnt.getDeployRound() > 0) {
+             retVal += String.format("\" %s=\"%d", MULParser.DEPLOYMENT, tgtEnt.getDeployRound());
+         }
+         
+         if(tgtEnt instanceof Infantry) {
+             retVal += String.format("\" %s=\"%d", MULParser.INF_SQUAD_NUM, ((Infantry) tgtEnt).getSquadN());
          }
 
         retVal += "\">\n";

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -7,10 +7,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import megamek.common.Entity;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Lance;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
@@ -30,6 +33,9 @@ public class AtBDynamicScenario extends AtBScenario {
      */
     private static final long serialVersionUID = 4671466413188687036L;
 
+    // by convention, this is the ID specified in the template for the primary player force
+    public static final String PRIMARY_PLAYER_FORCE_ID = "Player";
+    
     // derived fields used for various calculations
     private int effectivePlayerUnitCount;
     private int effectivePlayerBV;
@@ -42,6 +48,7 @@ public class AtBDynamicScenario extends AtBScenario {
     
     private Map<BotForce, ScenarioForceTemplate> botForceTemplates;
     private Map<Integer, ScenarioForceTemplate> playerForceTemplates;
+    private Map<UUID, ScenarioForceTemplate> playerUnitTemplates;
     
     private List<AtBScenarioModifier> scenarioModifiers;
     
@@ -50,6 +57,7 @@ public class AtBDynamicScenario extends AtBScenario {
         
         botForceTemplates = new HashMap<>();
         playerForceTemplates = new HashMap<>();
+        playerUnitTemplates = new HashMap<>();
         scenarioModifiers = new ArrayList<>();
     }
 
@@ -72,10 +80,40 @@ public class AtBDynamicScenario extends AtBScenario {
         playerForceTemplates.put(forceID, null);
     }
     
+    /**
+     * Add a force to the scenario, explicitly linked to the given template.
+     * @param forceID ID of the force to add.
+     * @param templateName Name of the force template.
+     */
+    public void addForce(int forceID, String templateName) {
+        // if we're not supplied a template name, fall back to trying to automatically place the force
+        if(StringUtils.isEmpty(templateName)) {
+            addForces(forceID);
+            return;
+        }
+        
+        super.addForces(forceID);
+        
+        ScenarioForceTemplate forceTemplate = template.scenarioForces.get(templateName);        
+        playerForceTemplates.put(forceID, forceTemplate);
+    }
+    
+    public void addUnit(UUID unitID, String templateName) {
+        super.addUnit(unitID);
+        ScenarioForceTemplate forceTemplate = template.scenarioForces.get(templateName);
+        playerUnitTemplates.put(unitID, forceTemplate);
+    }
+    
     @Override
     public void removeForce(int fid) {
         super.removeForce(fid);
         playerForceTemplates.remove(fid);
+    }
+    
+    @Override
+    public void removeUnit(UUID unitID) {
+        super.removeUnit(unitID);
+        playerUnitTemplates.remove(unitID);
     }
     
     @Override
@@ -111,9 +149,25 @@ public class AtBDynamicScenario extends AtBScenario {
         return getMapSizeY();
     }
     
+    /**
+     * Adds a bot force to this dynamic scenario.
+     * @param botForce
+     * @param forceTemplate
+     */
     public void addBotForce(BotForce botForce, ScenarioForceTemplate forceTemplate) {
         super.addBotForce(botForce);        
         botForceTemplates.put(botForce, forceTemplate);
+    }
+    
+    /**
+     * Removes a bot force from this dynamic scenario, and its associated template as well.
+     */
+    public void removeBotForce(int x) {
+        BotForce botToRemove = botForces.get(x);
+        
+        botForceTemplates.remove(botToRemove);
+        
+        super.removeBotForce(x);
     }
     
     public int getEffectivePlayerUnitCount() {
@@ -144,6 +198,10 @@ public class AtBDynamicScenario extends AtBScenario {
         return playerForceTemplates;
     }
     
+    public Map<UUID, ScenarioForceTemplate> getPlayerUnitTemplates() {
+        return playerUnitTemplates;
+    }
+    
     public Map<BotForce, ScenarioForceTemplate> getBotForceTemplates() {
         return botForceTemplates;
     }
@@ -162,6 +220,22 @@ public class AtBDynamicScenario extends AtBScenario {
     
     public void setEffectiveOpforQuality(int qualityLevel) {
         effectiveOpforQuality = qualityLevel;
+    }
+    
+    /**
+     * A list of all the force IDs associated with pre-defined scenario templates
+     * @return
+     */
+    public List<Integer> getPrimaryPlayerForceIDs() {
+        List<Integer> retval = new ArrayList<>();
+        
+        for(int forceID : getForceIDs()) {
+            if(getPlayerForceTemplates().containsKey(forceID)) {
+                retval.add(forceID);
+            }
+        }
+        
+        return retval;
     }
     
     /**
@@ -208,6 +282,10 @@ public class AtBDynamicScenario extends AtBScenario {
     
     public List<AtBScenarioModifier> getScenarioModifiers() {
         return scenarioModifiers;
+    }
+    
+    public void addScenarioModifier(AtBScenarioModifier modifier) {
+        scenarioModifiers.add(modifier);
     }
     
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -163,9 +163,12 @@ public class AtBDynamicScenario extends AtBScenario {
      * Removes a bot force from this dynamic scenario, and its associated template as well.
      */
     public void removeBotForce(int x) {
-        BotForce botToRemove = botForces.get(x);
-        
-        botForceTemplates.remove(botToRemove);
+        // safety check, just in case
+        if((x >= 0) && (x < botForces.size())) {
+            BotForce botToRemove = botForces.get(x);
+            
+            botForceTemplates.remove(botToRemove);
+        }
         
         super.removeBotForce(x);
     }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -647,9 +647,7 @@ public class AtBDynamicScenarioFactory {
         int numMods = Compute.randomInt(2);
         
         for(int x = 0; x < numMods; x++) {
-            int scenarioIndex = Compute.randomInt(AtBScenarioModifier.getScenarioModifiers().size());
-            
-            AtBScenarioModifier scenarioMod = (AtBScenarioModifier) AtBScenarioModifier.getScenarioModifiers().values().toArray()[scenarioIndex];
+            AtBScenarioModifier scenarioMod = AtBScenarioModifier.getRandomScenarioModifier();
          
             if((scenarioMod.getAllowedMapLocations() == null) ||
                     scenarioMod.getAllowedMapLocations().contains(scenario.getTemplate().mapParameters.getMapLocation())) {
@@ -833,6 +831,11 @@ public class AtBDynamicScenarioFactory {
                 while(infantry.getWeight() > bayCapacity) {
                     ((Infantry) infantry).setSquadN(((Infantry) infantry).getSquadN() - 1);
                     infantry.autoSetInternal();
+                }
+                
+                // unlikely but theoretically possible
+                if(((Infantry) infantry).getSquadN() == 0) {
+                    continue;
                 }
                 
                 // sometimes something crazy will happen and we will not be able to load the unit into the transport

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -873,7 +873,9 @@ public class AtBDynamicScenarioFactory {
         Map<String, Integer> idMap = new HashMap<>();
         // this is a bit inefficient, should really give the client/game the ability to look up an entity by external ID
         for(Entity entity : client.getEntitiesVector()) {
-            idMap.put(entity.getExternalIdAsString(), entity.getId());
+            if(entity.getOwnerId() == client.getLocalPlayerNumber()) {
+                idMap.put(entity.getExternalIdAsString(), entity.getId());
+            }
         }
         
         for(int x = 0; x < scenario.getNumBots(); x++) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -748,10 +748,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             });
             
             if(campaign.getCampaignOptions().getAllowOpforLocalUnits()) {
-                AtBDynamicScenarioFactory.fillTransports(this, reinforcements, 
+                reinforcements.addAll(AtBDynamicScenarioFactory.fillTransports(this, reinforcements, 
                         getContract(campaign).getEnemyCode(),
                         getContract(campaign).getEnemySkill(), getContract(campaign).getEnemyQuality(), 
-                        campaign);
+                        campaign));
                 
             }
             
@@ -1733,8 +1733,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         }
         crew += MekHqXmlUtil.indentStr(indentLvl+1) + "</crew>\n";
         
-        return retVal.replaceFirst(">", " deployment=\"" +
-            tgtEnt.getDeployRound() + "\">\n" + crew + "\n");
+        return retVal.replaceFirst(">", ">\n" + crew + "\n");
     }
 
     @Override
@@ -1788,10 +1787,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                         Entity en = null;
                         try {
                             en = MekHqXmlUtil.getEntityFromXmlString(wn3);
-                            if (wn3.getAttributes().getNamedItem("deployment") != null) {
+                            /*if (wn3.getAttributes().getNamedItem("deployment") != null) {
                                 en.setDeployRound(Math.max(0,
                                         Integer.parseInt(wn3.getAttributes().getNamedItem("deployment").getTextContent())));
-                            }
+                            }*/
                         } catch (Exception e) {
                             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                     "Error loading allied unit in scenario"); //$NON-NLS-1$

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -25,22 +25,21 @@ package mekhq.campaign.mission;
 import java.io.PrintWriter;
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Calendar;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.UUID;
 import java.util.Vector;
-import java.util.stream.Collectors;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import megamek.client.RandomNameGenerator;
 import megamek.client.RandomSkillsGenerator;
-import megamek.client.RandomUnitGenerator;
 import megamek.common.Board;
 import megamek.common.Compute;
 import megamek.common.Crew;
@@ -65,12 +64,10 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.force.Lance;
 import mekhq.campaign.market.UnitMarket;
 import mekhq.campaign.mission.atb.IAtBScenario;
-import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.IUnitGenerator;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.Planets;
 
@@ -223,6 +220,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
     HashMap<UUID, Entity> entityIds;
 
+    // key-value pairs linking transports and the units loaded onto them.
+    private Map<String, List<String>> transportLinkages;
+    private Map<String, Entity> externalIDLookup;
+    
     private static ResourceBundle defaultResourceBundle = ResourceBundle.getBundle("mekhq.resources.AtBScenarioBuiltIn", new EncodeControl()); //$NON-NLS-1$
     
     public AtBScenario () {
@@ -236,6 +237,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         attachedUnitIds = new ArrayList<UUID>();
         survivalBonus = new ArrayList<UUID>();
         entityIds = new HashMap<UUID, Entity>();
+        transportLinkages = new HashMap<>();
+        externalIDLookup = new HashMap<>();
 
         light = PlanetaryConditions.L_DAY;
         weather = PlanetaryConditions.WE_NONE;
@@ -731,12 +734,22 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                         getContract(campaign).getEnemySkill(), getContract(campaign).getEnemyQuality(),
                         EntityWeightClass.WEIGHT_LIGHT, EntityWeightClass.WEIGHT_ASSAULT, campaign, 6);
             }
+            
             /* Must set per-entity start pos for units after start of scenarios. Reinforcements
              * arrive from the enemy home edge, which is not necessarily the start pos. */
             final int enemyDir = enemyHome;
             reinforcements.stream().filter(Objects::nonNull).forEach(en -> {
                 en.setStartingPos(enemyDir);
             });
+            
+            if(campaign.getCampaignOptions().getAllowOpforLocalUnits()) {
+                AtBDynamicScenarioFactory.fillTransports(this, reinforcements, 
+                        getContract(campaign).getEnemyCode(),
+                        getContract(campaign).getEnemySkill(), getContract(campaign).getEnemyQuality(), 
+                        campaign);
+                
+            }
+            
             BotForce bf = getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, reinforcements);
             bf.setName(bf.getName() + " (Reinforcements)");
             addBotForce(bf);
@@ -755,10 +768,11 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                     }
                 }
                 if (!dropshipFound) {
-                    Entity dropship = getEntityByName("Leopard (2537)",
-                            getContract(campaign).getEmployerCode(),
-                            getContract(campaign).getAllySkill(),
-                            campaign);
+                    Entity dropship = AtBDynamicScenarioFactory.getEntity(getContract(campaign).getEmployerCode(), 
+                            getContract(campaign).getAllySkill(), 
+                            getContract(campaign).getAllyQuality(), 
+                            UnitType.DROPSHIP, AtBDynamicScenarioFactory.UNIT_WEIGHT_UNSPECIFIED, campaign);
+                    
                     alliesPlayer.add(dropship);
                     attachedUnitIds.add(UUID.fromString(dropship.getExternalIdAsString()));
                 }
@@ -891,6 +905,14 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             addEnemyLance(list, AtBConfiguration.decodeWeightStr(lances, i) + weightMod,
                     maxWeight, campaign);
         }
+        
+        if(campaign.getCampaignOptions().getAllowOpforLocalUnits()) {
+            list.addAll(AtBDynamicScenarioFactory.fillTransports(this, list, 
+                    getContract(campaign).getEnemyCode(),
+                    getContract(campaign).getEnemySkill(), getContract(campaign).getEnemyQuality(), 
+                    campaign));
+            
+        }
     }
 
     /**
@@ -926,102 +948,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      * @return                A new Entity with crew.
      */
     protected Entity getEntity(String faction, int skill, int quality, int unitType, int weightClass, Campaign campaign) {
-        MechSummary ms = null;
-        if (unitType == UnitType.TANK) {
-            if (campaign.getCampaignOptions().getOpforUsesVTOLs()) {
-                ms = campaign.getUnitGenerator()
-                        .generate(faction, unitType, weightClass, campaign.getCalendar()
-                                .get(Calendar.YEAR), quality, IUnitGenerator.MIXED_TANK_VTOL, null);            
-            } else {
-                ms = campaign.getUnitGenerator()
-                        .generate(faction, unitType, weightClass, campaign.getCalendar()
-                                .get(Calendar.YEAR), quality, v -> !v.getUnitType().equals("VTOL"));
-            }
-        } else {
-            ms = campaign.getUnitGenerator()
-                    .generate(faction, unitType, weightClass, campaign.getCalendar()
-                            .get(Calendar.YEAR), quality);
-        }
-
-        if (ms == null) {
-            return null;
-        }
-        return createEntityWithCrew(faction, skill, campaign, ms);
-    }
-
-    /**
-     * @param faction Faction to use for name generation
-     * @param skill Skill rating of the crew
-     * @param campaign The campaign instance
-     * @param ms Which entity to generate
-     * @return An crewed entity
-     */
-    protected Entity createEntityWithCrew(String faction, int skill, Campaign campaign, MechSummary ms) {
-        final String METHOD_NAME = "createEntityWithCrew(String,int,Campaign,MechSummary)"; //$NON-NLS-1$
-        Entity en = null;
-        try {
-            en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
-        } catch (Exception ex) {
-            en = null;
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
-                    "Unable to load entity: " + ms.getSourceFile() + ": " + ms.getEntryName() + ": " + ex.getMessage()); //$NON-NLS-1$
-            MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
-            return null;
-        }
-
-        en.setOwner(campaign.getPlayer());
-        en.setGame(campaign.getGame());
-
-        Faction f = Faction.getFaction(faction);
-
-        RandomNameGenerator rng = RandomNameGenerator.getInstance();
-        rng.setChosenFaction(f.getNameGenerator());
-        String crewName = rng.generate();
-
-        RandomSkillsGenerator rsg = new RandomSkillsGenerator();
-        rsg.setMethod(RandomSkillsGenerator.M_TAHARQA);
-        rsg.setLevel(skill);
-
-        if (f.isClan()) {
-            rsg.setType(RandomSkillsGenerator.T_CLAN);
-        }
-        int[] skills = rsg.getRandomSkills(en);
-
-        if (f.isClan() && Compute.d6(2) > 8 - skill + skills[0] + skills[1]) {
-            int phenotype;
-            switch (en.getUnitType()) {
-            case UnitType.MEK:
-                phenotype = Bloodname.P_MECHWARRIOR;
-                break;
-            case UnitType.BATTLE_ARMOR:
-                phenotype = Bloodname.P_ELEMENTAL;
-                break;
-            case UnitType.AERO:
-                phenotype = Bloodname.P_AEROSPACE;
-                break;
-            case UnitType.PROTOMEK:
-                phenotype = Bloodname.P_PROTOMECH;
-                break;
-            default:
-                phenotype = -1;
-            }
-            if (phenotype >= 0) {
-                crewName += " " + Bloodname.randomBloodname(faction, phenotype, campaign.getCalendar().get(Calendar.YEAR)).getName();
-            }
-        }
-
-        en.setCrew(new Crew(en.getCrew().getCrewType(), crewName,
-                            Compute.getFullCrewSize(en),
-                            skills[0], skills[1]));
-
-        UUID id = UUID.randomUUID();
-        while (null != entityIds.get(id)) {
-            id = UUID.randomUUID();
-        }
-        en.setExternalIdAsString(id.toString());
-        entityIds.put(id, en);
-        
-        return en;
+        return AtBDynamicScenarioFactory.getEntity(faction, skill, quality, unitType, weightClass, false, campaign);
     }
 
     /**
@@ -1403,13 +1330,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      * @param campaign
      */
     protected void addCivilianUnits(ArrayList<Entity> list, int num, Campaign campaign) {
-        RandomUnitGenerator.getInstance().setChosenRAT("CivilianUnits");
-        ArrayList<MechSummary> msl = RandomUnitGenerator.getInstance().generate(num);
-        
-        List<Entity> entities = msl.stream().map(ms -> createEntityWithCrew("IND",
-                RandomSkillsGenerator.L_GREEN, campaign, ms))
-                .collect(Collectors.<Entity>toList());
-        list.addAll(entities);
+        list.addAll(AtBDynamicScenarioFactory.generateCivilianUnits(num, campaign));
     }
     
     /**
@@ -1422,13 +1343,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      * @param campaign  The campaign for which the turrets are being generated.
      */
     protected void addTurrets(ArrayList<Entity> list, int num, int skill, int quality, Campaign campaign) {
-        int currentYear = campaign.getCalendar().get(Calendar.YEAR);
-        
-        List<MechSummary> msl = campaign.getUnitGenerator().generateTurrets(num, skill, quality, currentYear);
-        List<Entity> entities = msl.stream().map(ms -> createEntityWithCrew("IND",
-                skill, campaign, ms))
-                .collect(Collectors.<Entity>toList());
-        list.addAll(entities);
+        list.addAll(AtBDynamicScenarioFactory.generateTurrets(num, skill, quality, campaign));
     }
 
     /**
@@ -1490,6 +1405,9 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 en.setStartingPos(enemyHome);
                 en.setDeployRound(deployRound);
             });
+            
+            AtBDynamicScenarioFactory.populateAeroBombs(aircraft, campaign);
+            
             BotForce bf = getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, aircraft);
             bf.setName(bf.getName() + " (Air Support)");
             addBotForce(bf);
@@ -1742,6 +1660,21 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             }
             pw1.println(MekHqXmlUtil.indentStr(indent+1) + "</specMissionEnemies>");
         }
+        
+        if(transportLinkages.size() > 0) {
+            pw1.println(MekHqXmlUtil.indentStr(indent+1) + "<transportLinkages>");
+            
+            for(String key : transportLinkages.keySet()) {
+                pw1.println(MekHqXmlUtil.indentStr(indent+2) + "<transportLinkage>");
+                pw1.println(MekHqXmlUtil.indentStr(indent+3) + "<transportID>" + key + "</transportID>");
+                pw1.println(MekHqXmlUtil.indentStr(indent+3) + "<transportedUnits>" +
+                        String.join(",", transportLinkages.get(key)) + "</transportedUnits>");
+                
+                pw1.println(MekHqXmlUtil.indentStr(indent+2) + "</transportLinkage>");
+            }
+            
+            pw1.println(MekHqXmlUtil.indentStr(indent+1) + "</transportLinkages>");
+        }
 
         super.writeToXmlEnd(pw1, indent);
     }
@@ -1954,6 +1887,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 for (String s : ids) {
                     survivalBonus.add(UUID.fromString(s));
                 }
+            } else if (wn2.getNodeName().equalsIgnoreCase("transportLinkages")) {
+                loadTransportLinkages(wn2);
             }
         }
         /* In the event a discrepancy occurs between a RAT entry and the unit lookup name,
@@ -1969,6 +1904,15 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         survivalBonus.removeAll(toRemove);
     }
 
+    private void loadTransportLinkages(Node wn) {
+        for(int x = 0; x < wn.getChildNodes().getLength(); x++) {
+            String transportID = wn.getChildNodes().item(x).getChildNodes().item(0).getNodeValue();
+            List<String> transporteeIDs = Arrays.asList(wn.getChildNodes().item(x).getChildNodes().item(1).getNodeValue().split(","));
+            
+            transportLinkages.put(transportID, transporteeIDs);
+        }
+    }
+    
     private ArrayList<String> getEntityStub(Node wn) {
         ArrayList<String> stub = new ArrayList<String>();
         NodeList nl = wn.getChildNodes();
@@ -2038,6 +1982,11 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
     public void addBotForce(BotForce botForce) {
         botForces.add(botForce);
+        
+        // put all bot units into the external ID lookup.
+        for(Entity entity : botForce.getEntityList()) {
+            getExternalIDLookup().put(entity.getExternalIdAsString(), entity);
+        }
     }
     
     public BotForce getBotForce(int i) {
@@ -2186,5 +2135,34 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
     public void setEnemyHome(int enemyHome) {
         this.enemyHome = enemyHome;
+    }
+    
+    public Map<String, List<String>> getTransportLinkages() {
+        return transportLinkages;
+    }
+
+    public void setTransportLinkages(HashMap<String, List<String>> transportLinkages) {
+        this.transportLinkages = transportLinkages;
+    }
+    
+    /**
+     * Adds a transport-cargo pair to the internal transport relationship store.
+     * @param transport
+     * @param cargo
+     */
+    public void addTransportRelationship(String transport, String cargo) {
+        if(!transportLinkages.containsKey(transport)) {
+            transportLinkages.put(transport, new ArrayList<>());
+        }
+        
+        transportLinkages.get(transport).add(cargo);
+    }
+    
+    public Map<String, Entity> getExternalIDLookup() {
+        return externalIDLookup;
+    }
+
+    public void setExternalIDLookup(HashMap<String, Entity> externalIDLookup) {
+        this.externalIDLookup = externalIDLookup;
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -1787,10 +1787,6 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                         Entity en = null;
                         try {
                             en = MekHqXmlUtil.getEntityFromXmlString(wn3);
-                            /*if (wn3.getAttributes().getNamedItem("deployment") != null) {
-                                en.setDeployRound(Math.max(0,
-                                        Integer.parseInt(wn3.getAttributes().getNamedItem("deployment").getTextContent())));
-                            }*/
                         } catch (Exception e) {
                             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                     "Error loading allied unit in scenario"); //$NON-NLS-1$
@@ -1811,10 +1807,6 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                         Entity en = null;
                         try {
                             en = MekHqXmlUtil.getEntityFromXmlString(wn3);
-                            if (wn3.getAttributes().getNamedItem("deployment") != null) {
-                                en.setDeployRound(Math.max(0,
-                                        Integer.parseInt(wn3.getAttributes().getNamedItem("deployment").getTextContent())));
-                            }
                         } catch (Exception e) {
                             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                     "Error loading allied unit in scenario"); //$NON-NLS-1$
@@ -1843,10 +1835,6 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                                 Entity en = null;
                                 try {
                                     en = MekHqXmlUtil.getEntityFromXmlString(wn4);
-                                    if (wn4.getAttributes().getNamedItem("deployment") != null) {
-                                        en.setDeployRound(Math.max(0,
-                                                Integer.parseInt(wn4.getAttributes().getNamedItem("deployment").getTextContent())));
-                                    }
                                 } catch (Exception e) {
                                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                             "Error loading allied unit in scenario"); //$NON-NLS-1$

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -778,8 +778,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                             getContract(campaign).getAllyQuality(), 
                             UnitType.DROPSHIP, AtBDynamicScenarioFactory.UNIT_WEIGHT_UNSPECIFIED, campaign);
                     
-                    alliesPlayer.add(dropship);
-                    attachedUnitIds.add(UUID.fromString(dropship.getExternalIdAsString()));
+                    if(dropship != null) {
+                        alliesPlayer.add(dropship);
+                        attachedUnitIds.add(UUID.fromString(dropship.getExternalIdAsString()));
+                    }
                 }
                 for (int i = 0; i < Compute.d6() - 3; i++) {
                     addLance(enemyEntities, getContract(campaign).getEnemyCode(),

--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -252,10 +252,6 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
                         Entity en = null;
                         try {
                             en = MekHqXmlUtil.getEntityFromXmlString(wn3);
-                            if (wn3.getAttributes().getNamedItem("deployment") != null) {
-                                en.setDeployRound(Math.max(0,
-                                        Integer.parseInt(wn3.getAttributes().getNamedItem("deployment").getTextContent())));
-                            }
                         } catch (Exception e) {
                             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                                     "Error loading allied unit in scenario"); //$NON-NLS-1$

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
@@ -28,7 +28,7 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
     // 6) Allowed unit types - This is a set of unit types of which the force may consist
     
     public static final String[] FORCE_ALIGNMENTS = { "Player", "Allied", "Opposing", "Third", "Planet Owner" };
-    public static final String[] FORCE_GENERATION_METHODS = { "Player Supplied", "BV Scaled", "Unit Count Scaled", "Fixed Unit Count" };
+    public static final String[] FORCE_GENERATION_METHODS = { "Player Supplied", "BV Scaled", "Unit Count Scaled", "Fixed Unit Count", "Player/Fixed Unit Count" };
     public static final String[] FORCE_DEPLOYMENT_SYNC_TYPES = { "None", "Same Edge", "Same Arc", "Opposite Edge", "Opposite Arc" };
     public static final String[] DEPLOYMENT_ZONES = { "Any", "Northwest", "North", "Northeast", "East", "Southeast", "South", "Southwest", "West", "Edge", "Center", "Narrow Edge" };
     public static final String[] BOT_DESTINATION_ZONES = { "North", "East", "South", "West", "None", "Opposite Deployment Edge", "Random" };
@@ -40,21 +40,24 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
     public static final Map<Integer, Integer> TEAM_IDS;
     public static final Map<Integer, String> SPECIAL_ARRIVAL_TURNS;
     
-    public static int SPECIAL_UNIT_TYPE_ATB_AERO_MIX = -3;
-    public static int SPECIAL_UNIT_TYPE_ATB_MIX = -2;
-    public static int SPECIAL_UNIT_TYPE_ATB_CIVILIANS = -1;
+    public static final int SPECIAL_UNIT_TYPE_ATB_AERO_MIX = -3;
+    public static final int SPECIAL_UNIT_TYPE_ATB_MIX = -2;
+    public static final int SPECIAL_UNIT_TYPE_ATB_CIVILIANS = -1;
     
-    public static int ARRIVAL_TURN_STAGGERED = -1;
-    public static int ARRIVAL_TURN_STAGGERED_BY_LANCE = -2;
-    public static int ARRIVAL_TURN_AS_REINFORCEMENTS = -3;
+    public static final int ARRIVAL_TURN_STAGGERED = -1;
+    public static final int ARRIVAL_TURN_STAGGERED_BY_LANCE = -2;
+    public static final int ARRIVAL_TURN_AS_REINFORCEMENTS = -3;
     
-    public static int DEPLOYMENT_ZONE_NARROW_EDGE = DEPLOYMENT_ZONES.length - 1;
+    public static final int DEPLOYMENT_ZONE_NARROW_EDGE = DEPLOYMENT_ZONES.length - 1;
     
-    public static int DESTINATION_EDGE_OPPOSITE_DEPLOYMENT = 5;
-    public static int DESTINATION_EDGE_RANDOM = 6;    
+    public static final int DESTINATION_EDGE_OPPOSITE_DEPLOYMENT = 5;
+    public static final int DESTINATION_EDGE_RANDOM = 6;    
     
     // this is used to indicate that a "fixed" size unit should deploy as a lance 
-    public static int FIXED_UNIT_SIZE_LANCE = -1;
+    public static final int FIXED_UNIT_SIZE_LANCE = -1;
+    
+    public static final String PRIMARY_FORCE_TEMPLATE_ID = "Player";
+    public static final String REINFORCEMENT_TEMPLATE_ID = "Reinforcements";
     
     public enum ForceAlignment {
         Player,
@@ -77,7 +80,8 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
         PlayerSupplied,
         BVScaled,
         UnitCountScaled,
-        FixedUnitCount
+        FixedUnitCount,
+        PlayerOrFixedUnitCount
     }
     
     public enum SynchronizedDeploymentType {
@@ -97,6 +101,7 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
         SPECIAL_ARRIVAL_TURNS = new HashMap<>();
         SPECIAL_ARRIVAL_TURNS.put(ARRIVAL_TURN_STAGGERED, "Staggered");
         SPECIAL_ARRIVAL_TURNS.put(ARRIVAL_TURN_STAGGERED_BY_LANCE, "Staggered By Lance");
+        SPECIAL_ARRIVAL_TURNS.put(ARRIVAL_TURN_AS_REINFORCEMENTS, "Reinforcements");
         
         TEAM_IDS = new HashMap<>();
         TEAM_IDS.put(ForceAlignment.Player.ordinal(), 1);

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
@@ -103,12 +103,6 @@ public class ScenarioTemplate {
         }
         
         return retVal;
-        /*return scenarioForces.values().stream().filter(forceTemplate -> 
-            (forceTemplate.getForceAlignment() == ForceAlignment.Player.ordinal()) &&
-            (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS) &&
-                ((forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerSupplied.ordinal()) ||
-                 (forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerOrFixedUnitCount.ordinal())))  
-                .collect(Collectors.toList());*/
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
@@ -3,6 +3,7 @@ package mekhq.campaign.mission;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,26 +34,29 @@ import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
 @XmlRootElement(name="ScenarioTemplate")
 public class ScenarioTemplate {
     public static final String ROOT_XML_ELEMENT_NAME = "ScenarioTemplate";
-    
+    public static final String PRIMARY_PLAYER_FORCE_ID = "Player";
     
     public String name;
     public String shortBriefing;
     public String detailedBriefing;
     
     public ScenarioMapParameters mapParameters = new ScenarioMapParameters();
+    public List<String> scenarioModifiers = new ArrayList<>(); 
     
     @XmlElementWrapper(name="scenarioForces")
     @XmlElement(name="scenarioForce")
     public Map<String, ScenarioForceTemplate> scenarioForces = new HashMap<>();
     
-    public List<ScenarioForceTemplate> getAllScenarioForces() {
-        return scenarioForces.values().stream().collect(Collectors.toList());
+    /**
+     * Returns the "primary" player force. This is always the force with the name "Player".
+     * @return Primary player force.
+     */
+    public ScenarioForceTemplate getPrimaryPlayerForce() {
+        return scenarioForces.get(PRIMARY_PLAYER_FORCE_ID);
     }
     
-    public List<ScenarioForceTemplate> getAllPlayerControlledAllies() {
-        return scenarioForces.values().stream().filter(forceTemplate -> 
-            (forceTemplate.getForceAlignment() == ForceAlignment.Player.ordinal()))
-                .collect(Collectors.toList());
+    public List<ScenarioForceTemplate> getAllScenarioForces() {
+        return scenarioForces.values().stream().collect(Collectors.toList());
     }
     
     public List<ScenarioForceTemplate> getAllBotControlledAllies() {
@@ -67,6 +71,44 @@ public class ScenarioTemplate {
             (forceTemplate.getForceAlignment() == ForceAlignment.Opposing.ordinal()) ||
             (forceTemplate.getForceAlignment() == ForceAlignment.Third.ordinal()))
                 .collect(Collectors.toList());
+    }
+    
+    /**
+     * All force templates that are controlled and supplied, or potentially supplied, by the player, that are not reinforcements
+     * @return List of scenario force templates
+     */
+    public List<ScenarioForceTemplate> getAllPrimaryPlayerForces() {
+        return scenarioForces.values().stream().filter(forceTemplate -> 
+            (forceTemplate.getForceAlignment() == ForceAlignment.Player.ordinal()) &&
+            (forceTemplate.getArrivalTurn() != ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS) &&
+                ((forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerSupplied.ordinal()) ||
+                 (forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerOrFixedUnitCount.ordinal())))  
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * All force templates that are controlled and supplied, or potentially supplied, by the player, that are not reinforcements
+     * @return List of scenario force templates
+     */
+    public List<ScenarioForceTemplate> getAllPlayerReinforcementForces() {
+        List<ScenarioForceTemplate> retVal = new ArrayList<>();
+        
+        for(ScenarioForceTemplate forceTemplate : scenarioForces.values()) {
+            if((forceTemplate.getForceAlignment() == ForceAlignment.Player.ordinal()) &&
+                    (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS) &&
+                    ((forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerSupplied.ordinal()) ||
+                     (forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerOrFixedUnitCount.ordinal()))) {
+                retVal.add(forceTemplate);
+            }
+        }
+        
+        return retVal;
+        /*return scenarioForces.values().stream().filter(forceTemplate -> 
+            (forceTemplate.getForceAlignment() == ForceAlignment.Player.ordinal()) &&
+            (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS) &&
+                ((forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerSupplied.ordinal()) ||
+                 (forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerOrFixedUnitCount.ordinal())))  
+                .collect(Collectors.toList());*/
     }
     
     /**
@@ -100,6 +142,21 @@ public class ScenarioTemplate {
         } catch(Exception e) {
             MekHQ.getLogger().error(ScenarioTemplate.class, "Serialize", e.getMessage());
         }
+    }
+    
+    /**
+     * Attempt to deserialize a file at the given path.
+     * @param filePath The location of the file
+     * @return Possibly an instance of a scenario template.
+     */
+    public static ScenarioTemplate Deserialize(String filePath) {
+        File inputFile = new File(filePath);
+        if(!inputFile.exists()) {
+            MekHQ.getLogger().error(ScenarioTemplate.class, "Deserialize", String.format("Cannot deserialize file %s, does not exist", filePath));
+            return null;
+        }
+        
+        return Deserialize(inputFile);
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
@@ -3,6 +3,7 @@ package mekhq.campaign.mission.atb;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.transform.Source;
 
+import megamek.common.Compute;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
@@ -108,9 +110,15 @@ public class AtBScenarioModifier {
     }
     
     private static Map<String, AtBScenarioModifier> scenarioModifiers;
+    private static List<String> scenarioModifierKeys;
     
     public static Map<String, AtBScenarioModifier> getScenarioModifiers() {
         return scenarioModifiers;
+    }
+    
+    public static AtBScenarioModifier getRandomScenarioModifier() {
+        int modIndex = Compute.randomInt(scenarioModifierKeys.size());
+        return scenarioModifiers.get(scenarioModifierKeys.get(modIndex));
     }
     
     /**
@@ -150,6 +158,7 @@ public class AtBScenarioModifier {
      */
     private static void loadScenarioModifiers() {
         scenarioModifiers = new HashMap<>();
+        scenarioModifierKeys = new ArrayList<String>();
         
         for(String fileName : scenarioModifierManifest.fileNameList) {
             String filePath = String.format("./data/scenariomodifiers/%s", fileName);
@@ -163,6 +172,7 @@ public class AtBScenarioModifier {
                     }
                     
                     scenarioModifiers.put(modifier.getModifierName(), modifier);
+                    scenarioModifierKeys.add(modifier.getModifierName());
                 }
             }
             catch(Exception e) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
@@ -3,7 +3,9 @@ package mekhq.campaign.mission.atb;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -48,6 +50,7 @@ public class AtBScenarioModifier {
     private Integer unitRemovalCount = null;
     private List<MapLocation> allowedMapLocations = null;
     private Boolean useAmbushLogic = null; 
+    private Boolean switchSides = null;
     
     /**
      * Process this scenario modifier for a particular scenario, given a particular timing indicator.
@@ -88,6 +91,10 @@ public class AtBScenarioModifier {
             if(getUseAmbushLogic() != null && getEventRecipient() != null) {
                 AtBScenarioModifierApplicator.setupAmbush(scenario, campaign, getEventRecipient());
             }
+            
+            if(getSwitchSides() != null && getEventRecipient() != null) {
+                AtBScenarioModifierApplicator.switchSides(scenario, getEventRecipient());
+            }
         }
     }
     
@@ -100,10 +107,19 @@ public class AtBScenarioModifier {
         return scenarioModifierManifest.fileNameList;
     }
     
-    private static List<AtBScenarioModifier> scenarioModifiers;
+    private static Map<String, AtBScenarioModifier> scenarioModifiers;
     
-    public static List<AtBScenarioModifier> getScenarioModifiers() {
+    public static Map<String, AtBScenarioModifier> getScenarioModifiers() {
         return scenarioModifiers;
+    }
+    
+    /**
+     * Convenience method to get a scenario modifier with the specified key.
+     * @param key The key
+     * @return The scenario modifier, if any.
+     */
+    public static AtBScenarioModifier getScenarioModifier(String key) {
+        return scenarioModifiers.get(key);
     }
     
     static {
@@ -133,7 +149,7 @@ public class AtBScenarioModifier {
      * Loads the defined scenario modifiers from the manifest.
      */
     private static void loadScenarioModifiers() {
-        scenarioModifiers = new ArrayList<>();
+        scenarioModifiers = new HashMap<>();
         
         for(String fileName : scenarioModifierManifest.fileNameList) {
             String filePath = String.format("./data/scenariomodifiers/%s", fileName);
@@ -143,11 +159,10 @@ public class AtBScenarioModifier {
                 
                 if(modifier != null) {
                     if(modifier.getModifierName() == null) {
-                        modifier.setModifierName(String.format("%s (%s)", fileName,
-                                modifier.getEventTiming() == EventTiming.PreForceGeneration ? "Pre" : "Post"));
+                        modifier.setModifierName(fileName);
                     }
                     
-                    scenarioModifiers.add(modifier);
+                    scenarioModifiers.put(modifier.getModifierName(), modifier);
                 }
             }
             catch(Exception e) {
@@ -301,6 +316,14 @@ public class AtBScenarioModifier {
 
     public void setUseAmbushLogic(Boolean useAmbushLogic) {
         this.useAmbushLogic = useAmbushLogic;
+    }
+    
+    public Boolean getSwitchSides() {
+        return switchSides;
+    }
+    
+    public void setSwitchSides(Boolean switchSides) {
+        this.switchSides = switchSides;
     }
 }
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -280,6 +280,35 @@ public class AtBScenarioModifierApplicator {
         }
     }
     
+    /**
+     * Worker method that turns all your allies into treacherous enemies
+     * Look into a variant of this where some hostiles defect or go rogue?
+     * @param scenario The scenario to process.
+     * @param recipient Who's switching sides. Only valid recipient is Allied currently.
+     */
+    public static void switchSides(AtBDynamicScenario scenario, ForceAlignment recipient) {
+        // this operation is only meaningful for the allied forces currently
+        if(recipient != ForceAlignment.Allied) {
+            return;
+        }
+
+        int team = ScenarioForceTemplate.TEAM_IDS.get(recipient.ordinal());
+        int oppositeTeam = ScenarioForceTemplate.TEAM_IDS.get(ForceAlignment.Opposing);
+        
+        for(int x = 0; x < scenario.getNumBots(); x++) {
+            BotForce bf = scenario.getBotForce(x);
+            if(bf.getTeam() == team) {
+                bf.setTeam(oppositeTeam);
+            }
+        }
+    }
+    
+    
+    /**
+     * Appends the given text to the scenario briefing.
+     * @param scenario The scenario to modify.
+     * @param additionalBriefingText The additional briefing text.
+     */
     public static void appendScenarioBriefingText(AtBDynamicScenario scenario, String additionalBriefingText) {
         scenario.setDesc(String.format("%s\n\n%s", scenario.getDescription(), additionalBriefingText));
     }

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
@@ -10,6 +10,7 @@ import megamek.common.MechSummary;
 import megamek.common.UnitType;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.market.UnitMarket;
+import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.BotForce;
 import mekhq.campaign.mission.Loot;
@@ -105,7 +106,7 @@ public class StarLeagueCache1BuiltInScenario extends AtBScenario {
 					(roll == 6) ? IUnitRating.DRAGOON_A : IUnitRating.DRAGOON_D);
 		}
 		Entity en = (ms == null) ? null
-				: createEntityWithCrew(campaign.getFactionCode(), RandomSkillsGenerator.L_GREEN, campaign, ms);
+				: AtBDynamicScenarioFactory.createEntityWithCrew(campaign.getFactionCode(), RandomSkillsGenerator.L_GREEN, campaign, ms);
 		otherForce.add(en);
 
 		// TODO: During SW offer a choice between an employer exchange or a

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache2BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache2BuiltInScenario.java
@@ -9,6 +9,7 @@ import megamek.common.EntityWeightClass;
 import megamek.common.MechSummary;
 import megamek.common.UnitType;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
 import mekhq.campaign.rating.IUnitRating;
 
@@ -43,7 +44,7 @@ public class StarLeagueCache2BuiltInScenario extends StarLeagueCache1BuiltInScen
 					(Compute.d6() == 6) ? IUnitRating.DRAGOON_A : IUnitRating.DRAGOON_D);
 
 			if (ms != null) {
-				enemyEntities.add(createEntityWithCrew(getContract(campaign).getEnemyCode(),
+				enemyEntities.add(AtBDynamicScenarioFactory.createEntityWithCrew(getContract(campaign).getEnemyCode(),
 						getContract(campaign).getEnemySkill(), campaign, ms));
 			} else {
 				enemyEntities.add(null);

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -357,7 +357,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
     
     /**
      * Clears out an individual entirely from this tracker.
-     * @param person
+     * @param person The person to remove
      */
     public void removePerson(Person person) {
         payouts.remove(person.getId());
@@ -369,8 +369,6 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
     
     /**
      * Worker function that clears out any orphan retirement/defection records
-     * @param id ID of the person in question
-     * @param contract Contract in question, if any
      */
     public void cleanupOrphans(Campaign campaign) {
         Iterator<UUID> payoutIterator = payouts.keySet().iterator();
@@ -773,9 +771,11 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
             MekHQ.getLogger().error(RetirementDefectionTracker.class, METHOD_NAME, ex);
         }
 
-        // sometimes, a campaign may be loaded with orphan records in the retirement/defection tracker
-        // let's clean those up here.
-        retVal.cleanupOrphans(c);
+        if(retVal != null) {
+            // sometimes, a campaign may be loaded with orphan records in the retirement/defection tracker
+            // let's clean those up here.
+            retVal.cleanupOrphans(c);
+        }
         
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/universe/IUnitGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/IUnitGenerator.java
@@ -52,6 +52,10 @@ public interface IUnitGenerator {
             EntityMovementMode.INF_LEG, EntityMovementMode.INF_MOTORIZED, EntityMovementMode.INF_UMU,
             EntityMovementMode.TRACKED, EntityMovementMode.WHEELED, EntityMovementMode.HOVER);
 
+    /**
+     * For convenience in generating infantry units, the maximum tonnage of a foot infantry platoon.
+     */
+    final static double FOOT_PLATOON_INFANTRY_WEIGHT = 3.0;
 
     /**
      * Convenience function to let us know whether a unit type supports weight class selection.

--- a/MekHQ/src/mekhq/campaign/universe/UnitGeneratorParameters.java
+++ b/MekHQ/src/mekhq/campaign/universe/UnitGeneratorParameters.java
@@ -35,6 +35,34 @@ public class UnitGeneratorParameters {
     }
     
     /**
+     * Thorough deep clone of this generator parameters object.
+     */
+    @Override
+    public UnitGeneratorParameters clone() {
+        UnitGeneratorParameters newParams = new UnitGeneratorParameters();
+        
+        newParams.setFaction(faction);
+        newParams.setUnitType(unitType);
+        newParams.setWeightClass(weightClass);
+        newParams.setYear(year);
+        newParams.setQuality(quality);
+        newParams.setFilter(filter);
+        
+        Collection<EntityMovementMode> newModes = new ArrayList<>();
+        for(EntityMovementMode movementMode : movementModes) {
+            newModes.add(movementMode);
+        }
+        
+        newParams.setMovementModes(newModes);
+        
+        for(MissionRole missionRole : missionRoles) {
+            newParams.addMissionRole(missionRole);
+        }
+        
+        return newParams;
+    }
+    
+    /**
      * Translate the contents of this data structure into a megamek.client.ratgenerator.Parameters object
      * @return
      */

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -260,7 +260,7 @@ public class CustomizeScenarioDialog extends javax.swing.JDialog {
             gridBagConstraints.gridwidth = 1;
             
             modifierBox = new JComboBox<>();
-            for(AtBScenarioModifier modifier : AtBScenarioModifier.getScenarioModifiers()) {
+            for(AtBScenarioModifier modifier : AtBScenarioModifier.getScenarioModifiers().values()) {
                 modifierBox.addItem(modifier);
             }
             panMain.add(modifierBox, gridBagConstraints);


### PR DESCRIPTION
Ported some of my work on AtB-StratCon back to legacy AtB just to give some of the mechanisms I've worked on a better workout.

Major changes for legacy AtB:
- APC type units will now come loaded with infantry
- Infantry may now be field gunners
- VTOLs are always on (the bot has gotten good enough at them that they're no longer useless)
- Aircraft may be loaded with bombs
- allied dropships aren't all just Leopards

Changes for Scenario Template system:
- can specify fixed modifiers for a scenario template
- capability for a scenario modifier to turn allied bot units against you. Surprise!

