### PR TITLE
Track part ID moves during campaign loads that may affect refits

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1554,13 +1554,36 @@ public class Campaign implements Serializable, ITechManager {
             for (Unit u : getUnits()) {
                 Refit r = u.getRefit();
                 // If there is a refit and this part matches the new armor, update the ID
-                if (null != r && r.getNewArmorSuppliesId() == p.getId()
-                    && mergedWith instanceof Armor) {
-                    MekHQ.getLogger().info(Campaign.class, "addPartWithoutId",
-                        String.format("%s (%d) was merged with %s (%d) used in a refit for %s", p.getName(),
-                            p.getId(), mergedWith.getName(), mergedWith.getId(), u.getName()));
-                    Armor mergedArmor = (Armor)mergedWith;
-                    r.setNewArmorSupplies(mergedArmor);
+                if (null != r) {
+                    if (mergedWith instanceof Armor
+                        && r.getNewArmorSuppliesId() == p.getId()) {
+                        MekHQ.getLogger().info(Campaign.class, "addPartWithoutId",
+                            String.format("%s (%d) was merged with %s (%d) used in a refit for %s", p.getName(),
+                                p.getId(), mergedWith.getName(), mergedWith.getId(), u.getName()));
+                        Armor mergedArmor = (Armor)mergedWith;
+                        r.setNewArmorSupplies(mergedArmor);
+                    } else {
+                        List<Integer> ids = r.getOldUnitPartIds();
+                        for (int ii = 0; ii < ids.size(); ++ii) {
+                            int oid = (int)ids.get(ii);
+                            if (p.getId() == oid) {
+                                MekHQ.getLogger().info(Campaign.class, "addPartWithoutId",
+                                String.format("%s (%d) was merged with %s (%d) used in the old unit in a refit for %s", p.getName(),
+                                    p.getId(), mergedWith.getName(), mergedWith.getId(), u.getName()));
+                                ids.set(ii, mergedWith.getId());
+                            }
+                        }
+                        ids = r.getNewUnitPartIds();
+                        for (int ii = 0; ii < ids.size(); ++ii) {
+                            int nid = (int)ids.get(ii);
+                            if (p.getId() == nid) {
+                                MekHQ.getLogger().info(Campaign.class, "addPartWithoutId",
+                                String.format("%s (%d) was merged with %s (%d) used in the new unit in a refit for %s", p.getName(),
+                                    p.getId(), mergedWith.getName(), mergedWith.getId(), u.getName()));
+                                ids.set(ii, mergedWith.getId());
+                            }
+                        }
+                    }
                 }
             }
             MekHQ.triggerEvent(new PartRemovedEvent(p));

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2018 - The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -587,11 +587,17 @@ public class CampaignXmlParser {
                 unit.getRefit().reCalc();
                 if (null == unit.getRefit().getNewArmorSupplies()
                         && unit.getRefit().getNewArmorSuppliesId() > 0) {
-                    Armor armorSupplies = (Armor) retVal.getPart(
-                            unit.getRefit().getNewArmorSuppliesId());
-                    unit.getRefit().setNewArmorSupplies(armorSupplies);
-                    if (null == armorSupplies.getUnit()) {
-                        armorSupplies.setUnit(unit);
+                    Part armorPart = retVal.getPart(unit.getRefit().getNewArmorSuppliesId());
+                    if (armorPart instanceof Armor) {
+                        Armor armorSupplies = (Armor) armorPart;
+                        unit.getRefit().setNewArmorSupplies(armorSupplies);
+                        if (null == armorSupplies.getUnit()) {
+                            armorSupplies.setUnit(unit);
+                        }
+                    } else {
+                        MekHQ.getLogger().error(CampaignXmlParser.class, METHOD_NAME,
+                            String.format("[Campain Load] Refit for unit %s (%s) references armor supplies that are incorrect; ignoring.",
+                                unit.getName(), unit.getId().toString()));
                     }
                 }
                 if (!unit.getRefit().isCustomJob()
@@ -667,7 +673,7 @@ public class CampaignXmlParser {
         List<Unit> removeUnits = new ArrayList<>();
         for (Unit unit : retVal.getUnits()) {
             // just in case parts are missing (i.e. because they weren't tracked
-            // in previous versions)            
+            // in previous versions)
             unit.initializeParts(true);
             unit.runDiagnostic(false);
             if (!unit.isRepairable()) {
@@ -1767,7 +1773,7 @@ public class CampaignXmlParser {
         MekHQ.getLogger().log(CampaignXmlParser.class, METHOD_NAME, LogLevel.INFO,
                 "Load Part Nodes Complete!"); //$NON-NLS-1$
     }
-    
+
     /**
      * Determines if the supplied part is a MASC from an older save. This means that it needs to be converted
      * to an actual MASC part.
@@ -1775,12 +1781,12 @@ public class CampaignXmlParser {
      * @return Whether it's an old MASC.
      */
     private static boolean isLegacyMASC(Part p) {
-        return (p instanceof EquipmentPart) && 
+        return (p instanceof EquipmentPart) &&
                 !(p instanceof MASC) &&
-                ((EquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && 
+                ((EquipmentPart) p).getType().hasFlag(MiscType.F_MASC) &&
                 (((EquipmentPart) p).getType() instanceof MiscType);
     }
-    
+
     /**
      * Determines if the supplied part is a "missing" MASC from an older save. This means that it needs to be converted
      * to an actual "missing" MASC part.
@@ -1788,12 +1794,12 @@ public class CampaignXmlParser {
      * @return Whether it's an old "missing" MASC.
      */
     private static boolean isLegacyMissingMASC(Part p) {
-        return (p instanceof MissingEquipmentPart) && 
+        return (p instanceof MissingEquipmentPart) &&
                 !(p instanceof MissingMASC) &&
-                ((MissingEquipmentPart) p).getType().hasFlag(MiscType.F_MASC) && 
+                ((MissingEquipmentPart) p).getType().hasFlag(MiscType.F_MASC) &&
                 (((MissingEquipmentPart) p).getType() instanceof MiscType);
     }
-    
+
     private static void updatePlanetaryEventsFromXML(Node wn) {
         // TODO: make Planets a member of Campaign
         Planets.reload(true);

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -210,6 +210,26 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         return cost;
     }
 
+    /**
+     * Returns a mutable list of part IDs for the old unit in the refit.
+     * This is intended to be mutated only be {@link Campaign} when merging
+     * parts.
+     * @return A mutable {@link List} of old part IDs in the refit.
+     */
+    public List<Integer> getOldUnitPartIds() {
+        return oldUnitParts;
+    }
+
+    /**
+     * Returns a mutable list of part IDs for the new unit in the refit.
+     * This is intended to be mutated only be {@link Campaign} when merging
+     * parts.
+     * @return A mutable {@link List} of new part IDs in the refit.
+     */
+    public List<Integer> getNewUnitPartIds() {
+        return newUnitParts;
+    }
+
     public List<Part> getShoppingList() {
         return shoppingList;
     }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -137,7 +137,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
     private Armor newArmorSupplies;
     private int newArmorSuppliesId;
     private boolean sameArmorType;
-    
+
     private int oldLargeCraftHeatSinks;
     private int oldLargeCraftSinkType;
     private int newLargeCraftHeatSinks;
@@ -1771,7 +1771,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         }
         pw1.println(MekHqXmlUtil.indentStr(indentLvl + 1) + "</shoppingList>");
         if(null != newArmorSupplies) {
-            if(newArmorSupplies.getId() == 0) {
+            if(newArmorSupplies.getId() <= 0) {
                 pw1.println(MekHqXmlUtil.indentStr(indentLvl + 1) + "<newArmorSupplies>");
                 newArmorSupplies.writeToXml(pw1, indentLvl+2);
                 pw1.println(MekHqXmlUtil.indentStr(indentLvl + 1) + "</newArmorSupplies>");
@@ -1876,19 +1876,19 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                 // Errr, what should we do here?
                 MekHQ.getLogger().log(Refit.class, "processShoppingList(Refit,Node,Unit,Version)", LogLevel.ERROR, //$NON-NLS-1$
                         "Unknown node type not loaded in Part nodes: " + wn2.getNodeName()); //$NON-NLS-1$
-                continue;
-            }
+				continue;
+			}
 
-            Part p = Part.generateInstanceFromXML(wn2, version);
-            if (p != null) {
-                p.setUnit(u);
-                retVal.shoppingList.add(p);
-            } else {
-                MekHQ.getLogger().error(Refit.class, "processShoppingList()", 
-                    u != null ? String.format("Unit %s has invalid parts in its refit shopping list", u.getId()) : "Invalid parts in shopping list");
-            }
-        }
-    }
+			Part p = Part.generateInstanceFromXML(wn2, version);
+			if (p != null) {
+				p.setUnit(u);
+				retVal.shoppingList.add(p);
+			} else {
+				MekHQ.getLogger().error(Refit.class, "processShoppingList()",
+					u != null ? String.format("Unit %s has invalid parts in its refit shopping list", u.getId()) : "Invalid parts in shopping list");
+			}
+		}
+	}
 
     private static void processArmorSupplies(Refit retVal, Node wn, Version version) {
 
@@ -2056,6 +2056,9 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 
     public void setNewArmorSupplies(Armor a) {
         newArmorSupplies = a;
+        if (null != a) {
+            newArmorSuppliesId = a.getId();
+        }
     }
 
     public int getNewArmorSuppliesId() {


### PR DESCRIPTION
This is an experimental change that may fix the tough to track down part ID changes affecting refits at CPNX load #1193 #1180 #1138 #1123 (to name a few).

*note: best compared with whitespace ignored*