### PR TITLE
Revert "Merge pull request #1203 from Krashner/ammo-bin-repair"

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -115,6 +115,11 @@ public class ShoppingList implements MekHqXmlSerializable {
     }
 
     public void addShoppingItem(IAcquisitionWork newWork, int quantity, Campaign campaign) {
+        //ammo bins need a little extra work here
+        if(newWork instanceof AmmoBin) {
+            newWork = ((AmmoBin) newWork).getAcquisitionWork();
+        }
+        
         //check to see if this is already on the shopping list. If so, then add quantity to the list
         //and return
         for(IAcquisitionWork shoppingItem : shoppingList) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -780,7 +780,11 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public IAcquisitionWork getAcquisitionWork() {
-        return getMissingPart();
+        int shots = 1;
+        if(type instanceof AmmoType) {
+            shots = ((AmmoType)type).getShots();
+        }
+        return new AmmoStorage(1,type,shots,campaign);
     }
 
     @Override


### PR DESCRIPTION
PR #1203 introduced a regression in the Parts in Use dialog (#1219). This reverts commit 9e600312c6d63946e8a1d771804e7bc2e7fcbf5c, reversing
changes made to 5ea5a4fc55ea48773fc2533145f21afdd41248bb.

The ammo bin issue should be addressed, but not in a manner that regresses ammunition purchases.