### PR TITLE
Additional Fix for #1193

### DIFF
--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -296,7 +296,7 @@ public class MekHqXmlUtil {
                 .getEntity(tgtEnt.getC3Master().getId())
                 .getC3UUIDAsString();
         }
-        if (tgtEnt.hasC3() || tgtEnt.hasC3i()) {
+        if (tgtEnt.hasC3() || tgtEnt.hasC3i() || tgtEnt.hasNavalC3()) {
             retVal += "\" c3UUID=\"";
             retVal += tgtEnt.getC3UUIDAsString();
         }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -619,7 +619,8 @@ public class CampaignXmlParser {
             // possible that these might have changed if changes were made to
             // the
             // ordering of equipment in the underlying data file for the unit
-            Utilities.unscrambleEquipmentNumbers(unit);
+            // We're not checking for refit here.
+            Utilities.unscrambleEquipmentNumbers(unit, false);
 
             // some units might need to be assigned to scenarios
             Scenario s = retVal.getScenario(unit.getScenarioId());

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1360,7 +1360,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             }
         }
         oldUnit.setParts(newParts);
-        Utilities.unscrambleEquipmentNumbers(oldUnit);
+        Utilities.unscrambleEquipmentNumbers(oldUnit, true);
         assignArmActuators();
         assignBayParts();
         for (Part p : newParts) {


### PR DESCRIPTION
This fixes an additional refit bug as seen in SilverSword's campaign posted under #1193 
If a refit changed the munition type of an ammo bin part (which happens a lot with updates that add ArtemisIV FCS and compatible missiles), UnscrambleEquipment was failing to update the equipment number of the AmmoBin part because it saw the munition mismatch as a complete part mismatch. This led to class cast exceptions when a refit was completed, the campaign saved, and then reloaded as ammo bin parts from the old entity were matched up with non-ammo bin Mounteds on the new entity.

I was also pointed to a piece of code that had never been updated to allow saving of NavalC3 networks in addition to C3/C3i networks.

+ Fix  NavalC3 networks can now be saved to MHQ campaign files
+ Fix Ammo bins that change munitions during refits are no longer skipped when unscrambling equipment numbers, causing class cast exception on load of saved campaign