### PR TITLE
Check for crew before calculating special abilities.

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3132,6 +3132,10 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     || entity.hasETypeFlag(Entity.ETYPE_TRIPOD_MECH)) {
                 //Find the unit commander
                 Person commander = getCommander();
+                // If there is no crew, there's nothing left to do here.
+                if (null == commander) {
+                    return;
+                }
                 //Combine drivers and gunners into a single list
                 List<UUID> combatCrew = new ArrayList<UUID>();
 


### PR DESCRIPTION
There is a path through Unit#resetPilotAndEntity that dereferences the
value returned by getCommander() without checking for null, which
indicates no crew assigned.

Fixes #1230: Tripod mech breaking campaign save