### PR TITLE
Campaign subset export update

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -199,7 +199,6 @@ public class Campaign implements Serializable, ITechManager {
     private TreeMap<Integer, Force> forceIds = new TreeMap<>();
     private TreeMap<Integer, Mission> missions = new TreeMap<>();
     private TreeMap<Integer, Scenario> scenarios = new TreeMap<>();
-    //private List<Kill> kills = new ArrayList<>();
     private Map<UUID, ArrayList<Kill>> kills = new HashMap<>();
 
     private Map<String, Integer> duplicateNameHash = new HashMap<>();

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -199,7 +199,7 @@ public class Campaign implements Serializable, ITechManager {
     private TreeMap<Integer, Force> forceIds = new TreeMap<>();
     private TreeMap<Integer, Mission> missions = new TreeMap<>();
     private TreeMap<Integer, Scenario> scenarios = new TreeMap<>();
-    private Map<UUID, ArrayList<Kill>> kills = new HashMap<>();
+    private Map<UUID, List<Kill>> kills = new HashMap<>();
 
     private Map<String, Integer> duplicateNameHash = new HashMap<>();
 
@@ -4042,7 +4042,7 @@ public class Campaign implements Serializable, ITechManager {
         location.writeToXml(pw1, 1);
         shoppingList.writeToXml(pw1, 1);
         pw1.println("\t<kills>");
-        for (ArrayList<Kill> kills : kills.values()) {
+        for (List<Kill> kills : kills.values()) {
             for(Kill k : kills) {
                 k.writeToXml(pw1, 2);
             }
@@ -5998,19 +5998,19 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public List<Kill> getKills() {
-        List<Kill> flattenedKills = new ArrayList<Kill>();
-        for(ArrayList<Kill> personKills : kills.values()) {
+        List<Kill> flattenedKills = new ArrayList<>();
+        for(List<Kill> personKills : kills.values()) {
             flattenedKills.addAll(personKills);
         }
         
         return Collections.unmodifiableList(flattenedKills);
     }
 
-    public ArrayList<Kill> getKillsFor(UUID pid) {
-        ArrayList<Kill> personalKills = kills.get(pid);
+    public List<Kill> getKillsFor(UUID pid) {
+        List<Kill> personalKills = kills.get(pid);
         
         if(personalKills == null) {
-            return new ArrayList<Kill>();
+            return Collections.emptyList();
         }
         
         Collections.sort(personalKills, new Comparator<Kill>() {

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -528,6 +528,7 @@ public class CampaignExportWizard extends JDialog {
             }
             
             destinationCampaign.importUnit(unit);
+            destinationCampaign.getUnit(unit.getId()).setForceId(Force.FORCE_NONE);
         }
         
         // overwrite any people with the same ID.
@@ -537,6 +538,7 @@ public class CampaignExportWizard extends JDialog {
             }
             
             destinationCampaign.importPerson(person);
+
             for(Kill kill : sourceCampaign.getKillsFor(person.getId())) {
                 destinationCampaign.importKill(kill);
             }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1063,7 +1063,7 @@ public class PersonViewPanel extends JPanel {
     }
 
     private void fillKillRecord() {
-        ArrayList<Kill> kills = campaign.getKillsFor(person.getId());
+        List<Kill> kills = campaign.getKillsFor(person.getId());
         pnlKills.setLayout(new GridBagLayout());
 
         JLabel lblRecord = new JLabel(String.format(resourceMap.getString("format.kills"), kills.size())); //$NON-NLS-1$


### PR DESCRIPTION
Fixed an issue where, if exporting a person into a campaign where their ID already exists, their kills would duplicate. 

Clear an exported unit's force ID to avoid phantom irreversible force assignments on export.

Optimization to the kills mechanism, where they are now stored in memory in a hashmap keyed by person ID, rather than re-scanning every kill in the campaign every time (this could probably lead to some hairy performance for longer campaigns).