### PR TITLE
Update 'Mech location repair and salvage times to match StratOps #1075

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -395,18 +395,16 @@ public class MekLocation extends Part {
 			}
         }
 
-        int time = getRepairOrSalvageTime();
-
 		if (isBreached()) {
             // StratOps p177 - 'Mech Hull Breach
             // "Once this time is spent [fixing the breach], the components
             // in the damaged location work normally. Other damage suffered
             // by that location prior to and after the breach must be
             // repaired normally."
-			return time + 60;
+			return 60;
         }
 
-		return time;
+		return getRepairOrSalvageTime();
     }
 
     /**
@@ -455,14 +453,12 @@ public class MekLocation extends Part {
 			}
         }
 
-        int difficulty = getRepairOrSalvageDifficulty();
 		if (isBreached()) {
-            // 'Mech hull breach is at least +0, but may be higher
-            // if there are also other repairs needed.
-			return Math.max(0, difficulty);
+            // 'Mech hull breach is +0
+			return 0;
 		}
 
-		return difficulty;
+		return getRepairOrSalvageDifficulty();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -420,12 +420,10 @@ public class MekLocation extends Part {
 			return 180;
 		} else if (percent < 0.75) {
 			return 135;
-		} else if (percent < 1.0) {
+		} else {
+            // <25% damage
             return 90;
         }
-
-        // No damage, may just have been breached.
-        return 0;
     }
 
 	@Override
@@ -474,8 +472,10 @@ public class MekLocation extends Part {
 			return 1;
 		} else if (percent < 0.75) {
 			return 0;
+        } else {
+            // <25% damage
+            return -1;
         }
-		return -1;
     }
 
 	public boolean isBreached() {


### PR DESCRIPTION
This fixes #1075 and updates 'Mech location repair/salvage times and difficulties based on StratOps p191. It also updates our logic for breached locations to include costs for any other repairs required per StratOps p177.

Best to review this with [whitespace off](https://github.com/MegaMek/mekhq/pull/1233/files?w=1).