### PR TITLE
Add feature to GM Mothball/Activate units

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4071,12 +4071,6 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         } else {
             //start maintenance cycle over again
             resetDaysSinceMaintenance();
-
-            // if we previously mothballed this unit, attempt to restore its pre-mothball state
-            if(mothballInfo != null) {
-                mothballInfo.restorePreMothballInfo(this, getCampaign());
-                mothballInfo = null;
-            }
         }
     }
 
@@ -4144,6 +4138,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             return;
         }
 
+        // if we previously mothballed this unit, attempt to restore its pre-mothball state
+        if(mothballInfo != null) {
+            mothballInfo.restorePreMothballInfo(this, getCampaign());
+            mothballInfo = null;
+        }
+
         //set this person as tech
         if(!isSelfCrewed() && null != tech && !tech.equals(id)) {
             if(null != getTech()) {
@@ -4176,6 +4176,25 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         } else {
             return TECH_WORK_DAY * 2;
         }
+    }
+
+    /**
+     * Cancels a pending mothball or activation work order.
+     */
+    public void cancelMothballOrActivation() {
+        if (!isMothballing()) {
+            return;
+        }
+
+        setMothballTime(0);
+
+        // ...if we were activating, save our crew
+        if (isMothballed()) {
+            mothballInfo = new MothballInfo(this);
+        }
+
+        // reset our mothball status
+        setMothballed(isMothballed());
     }
 
     public ArrayList<Person> getActiveCrew() {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2067,7 +2067,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 driveCoil = part;
             //For Small Craft and larger, add this as a container for all their heatsinks instead of adding hundreds
             //of individual heatsink parts.
-            } else if(part instanceof SpacecraftCoolingSystem 
+            } else if(part instanceof SpacecraftCoolingSystem
                     && (entity instanceof SmallCraft || entity instanceof Jumpship)) {
                 coolingSystem = part;
             } else if(part instanceof AeroSensor || part instanceof MissingAeroSensor) {
@@ -2366,7 +2366,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 partsToAdd.add(engine);
             }
         }
-        
+
         // Transport Bays
         for (Bay bay : entity.getTransportBays()) {
             bayPartsToAdd.put(bay.getBayNumber(), new ArrayList<>());
@@ -2583,7 +2583,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 addPart(heliumTank);
                 partsToAdd.add(heliumTank);
             }
-            if(null == lfBattery 
+            if(null == lfBattery
                     && (entity instanceof Jumpship) && !(entity instanceof SpaceStation) && ((Jumpship) entity).hasLF()) {
                 lfBattery = new LFBattery((int)entity.getWeight(), ((Jumpship)entity).getDriveCoreType(), entity.getDocks(), getCampaign());
                 addPart(lfBattery);
@@ -4014,22 +4014,48 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         return null;
     }
 
+    /**
+     * Gets a value indicating whether or not the unit is being mothballed
+     * or activated.
+     * @return True if the unit is undergoing mothballing or activation,
+     *         otherwise false.
+     */
     public boolean isMothballing() {
         return mothballTime > 0;
     }
 
+    /**
+     * Gets the time (in minutes) remaining to mothball or activate the unit.
+     * @return The time (in minutes) remaining to mothboll or activate the unit.
+     */
     public int getMothballTime() {
         return mothballTime;
     }
 
+    /**
+     * Sets the time (in minutes) remaining to mothball or activate the unit.
+     * @param t The time (in minutes) remaining to mothboll or activate the unit.
+     */
     public void setMothballTime(int t) {
-        mothballTime = t;
+        mothballTime = Math.max(t, 0);
     }
 
+    /**
+     * Gets a value indicating whether or not this unit is mothballed.
+     * @return True if the unit is mothballed, otherwise false.
+     */
     public boolean isMothballed() {
         return mothballed;
     }
 
+    /**
+     * Sets a value indicating whether or not this unit is mothballed.
+     *
+     * If the unit is being mothballed, all of its personnel will be removed.
+     * If the unit is being activated, all of its personnel will be restored (if applicable)
+     * and its maintenance cycle will be reset.
+     * @param b True if the unit is now mothballed, or false if the unit is now activated.
+     */
     public void setMothballed(boolean b) {
         this.mothballed = b;
         // Tech gets removed either way bug [#488]
@@ -4054,7 +4080,21 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         }
     }
 
+    /**
+     * Begins mothballing a unit.
+     * @param id The ID of the tech performing the mothball.
+     */
     public void startMothballing(UUID id) {
+        startMothballing(id, false);
+    }
+
+    /**
+     * Begins mothballing a unit, optionally as a GM action.
+     * @param id The ID of the tech performing the mothball.
+     * @param isGM A value indicating if the mothball action should
+     *             be performed immediately by the GM.
+     */
+    public void startMothballing(UUID id, boolean isGM) {
         if(!isMothballed()) {
             mothballInfo = new MothballInfo(this);
         }
@@ -4066,26 +4106,76 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             }
         }
         tech = id;
+
         //dont remove personnel yet, because self crewed units need their crews to mothball
         getCampaign().removeUnitFromForce(this);
+
         //clear any assigned tasks
         for(Part p : getParts()) {
             p.cancelAssignment();
         }
-        //set mothballing time
-        if(getEntity() instanceof Infantry) {
-            mothballTime = TECH_WORK_DAY;
-        }
-        else if(getEntity() instanceof Dropship || getEntity() instanceof Jumpship) {
-            mothballTime = TECH_WORK_DAY * (int)Math.ceil(getEntity().getWeight()/500.0);
+
+        if (!isGM) {
+            setMothballTime(getMothballOrActivationTime());
+            getCampaign().mothball(this);
         } else {
-            if(isMothballed()) {
-                mothballTime = TECH_WORK_DAY;
-            } else {
-                mothballTime = TECH_WORK_DAY * 2;
+            getCampaign().completeMothball(this);
+            getCampaign().addReport(getHyperlinkedName() + " has been mothballed (GM)");
+        }
+    }
+
+    /**
+     * Begins activating a unit which has been mothballed.
+     * @param id The ID of the tech performing the activation.
+     */
+    public void startActivating(UUID id) {
+        startActivating(id, false);
+    }
+
+    /**
+     * Begins activating a unit which has been mothballed,
+     * optionally as a GM action.
+     * @param id The ID of the tech performing the activation.
+     * @param isGM A value indicating if the activation action should
+     *             be performed immediately by the GM.
+     */
+    public void startActivating(UUID id, boolean isGM) {
+        if (!isMothballed()) {
+            return;
+        }
+
+        //set this person as tech
+        if(!isSelfCrewed() && null != tech && !tech.equals(id)) {
+            if(null != getTech()) {
+                remove(getTech(), true);
             }
         }
-        getCampaign().mothball(this);
+        tech = id;
+
+        if (!isGM) {
+            setMothballTime(getMothballOrActivationTime());
+            getCampaign().activate(this);
+        } else {
+            getCampaign().completeActivation(this);
+            getCampaign().addReport(getHyperlinkedName() + " has been activated (GM)");
+        }
+    }
+
+    /**
+     * Gets the time required to mothball or activate this unit.
+     * @return The time in minutes required to mothball or activate this unit.
+     */
+    private int getMothballOrActivationTime() {
+        //set mothballing time
+        if(getEntity() instanceof Infantry) {
+            return TECH_WORK_DAY;
+        } else if(getEntity() instanceof Dropship || getEntity() instanceof Jumpship) {
+            return TECH_WORK_DAY * (int)Math.ceil(getEntity().getWeight()/500.0);
+        } else if(isMothballed()) {
+            return TECH_WORK_DAY;
+        } else {
+            return TECH_WORK_DAY * 2;
+        }
     }
 
     public ArrayList<Person> getActiveCrew() {

--- a/MekHQ/src/mekhq/campaign/unit/actions/ActivateUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/ActivateUnitAction.java
@@ -1,0 +1,63 @@
+/*
+ * ActivateUnitAction.java
+ *
+ * Copyright (c) 2019 Megamek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.unit.actions;
+
+import java.util.UUID;
+
+import megamek.common.annotations.Nullable;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+
+/**
+ * Activates a unit.
+ */
+public class ActivateUnitAction implements IUnitAction {
+
+    private final UUID techId;
+    private final boolean isGM;
+
+    /**
+     * Initializes a new instance of the ActivateUnitAction class.
+     * @param techId The ID of the technician performing the work, or null
+     *               if noone is needed to perform the work (self crewed or GM).
+     * @param isGM A boolean value indicating whether or not GM mode should be used
+     *             to complete the action.
+     */
+    public ActivateUnitAction(@Nullable UUID techId, boolean isGM) {
+        this.techId = techId;
+        this.isGM = isGM;
+    }
+
+    @Override
+	public void Execute(Campaign campaign, Unit unit) {
+        if (isGM) {
+            unit.startActivating(null, true);
+        }
+        else {
+            if (!unit.isSelfCrewed() && null == techId) {
+                return;
+            }
+
+            unit.startActivating(techId);
+        }
+	}
+}

--- a/MekHQ/src/mekhq/campaign/unit/actions/ActivateUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/ActivateUnitAction.java
@@ -48,7 +48,7 @@ public class ActivateUnitAction implements IUnitAction {
     }
 
     @Override
-	public void Execute(Campaign campaign, Unit unit) {
+    public void Execute(Campaign campaign, Unit unit) {
         if (isGM) {
             unit.startActivating(null, true);
         }
@@ -59,5 +59,5 @@ public class ActivateUnitAction implements IUnitAction {
 
             unit.startActivating(techId);
         }
-	}
+    }
 }

--- a/MekHQ/src/mekhq/campaign/unit/actions/CancelMothballUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/CancelMothballUnitAction.java
@@ -30,8 +30,8 @@ import mekhq.campaign.unit.Unit;
 public class CancelMothballUnitAction implements IUnitAction {
 
     @Override
-	public void Execute(Campaign campaign, Unit unit) {
+    public void Execute(Campaign campaign, Unit unit) {
         unit.cancelMothballOrActivation();
-	}
+    }
 
 }

--- a/MekHQ/src/mekhq/campaign/unit/actions/CancelMothballUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/CancelMothballUnitAction.java
@@ -1,0 +1,37 @@
+/*
+ * CancelMothballUnitAction.java
+ *
+ * Copyright (c) 2019 Megamek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.unit.actions;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+
+/**
+ * A unit action which cancels a pending mothball or activation work order.
+ */
+public class CancelMothballUnitAction implements IUnitAction {
+
+    @Override
+	public void Execute(Campaign campaign, Unit unit) {
+        unit.cancelMothballOrActivation();
+	}
+
+}

--- a/MekHQ/src/mekhq/campaign/unit/actions/MothballUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/MothballUnitAction.java
@@ -48,7 +48,7 @@ public class MothballUnitAction implements IUnitAction {
     }
 
     @Override
-	public void Execute(Campaign campaign, Unit unit) {
+    public void Execute(Campaign campaign, Unit unit) {
         if (isGM) {
             unit.startMothballing(null, true);
         }
@@ -59,5 +59,5 @@ public class MothballUnitAction implements IUnitAction {
 
             unit.startMothballing(techId);
         }
-	}
+    }
 }

--- a/MekHQ/src/mekhq/campaign/unit/actions/MothballUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/MothballUnitAction.java
@@ -1,0 +1,63 @@
+/*
+ * MothballUnitAction.java
+ *
+ * Copyright (c) 2019 Megamek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.unit.actions;
+
+import java.util.UUID;
+
+import megamek.common.annotations.Nullable;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+
+/**
+ * Mothballs a unit.
+ */
+public class MothballUnitAction implements IUnitAction {
+
+    private final UUID techId;
+    private final boolean isGM;
+
+    /**
+     * Initializes a new instance of the MothballUnitAction class.
+     * @param techId The ID of the technician performing the work, or null
+     *               if noone is needed to perform the work (self crewed or GM).
+     * @param isGM A boolean value indicating whether or not GM mode should be used
+     *             to complete the action.
+     */
+    public MothballUnitAction(@Nullable UUID techId, boolean isGM) {
+        this.techId = techId;
+        this.isGM = isGM;
+    }
+
+    @Override
+	public void Execute(Campaign campaign, Unit unit) {
+        if (isGM) {
+            unit.startMothballing(null, true);
+        }
+        else {
+            if (!unit.isSelfCrewed() && null == techId) {
+                return;
+            }
+
+            unit.startMothballing(techId);
+        }
+	}
+}

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -52,6 +52,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.actions.StripUnitAction;
 import mekhq.campaign.unit.actions.ActivateUnitAction;
+import mekhq.campaign.unit.actions.CancelMothballUnitAction;
 import mekhq.campaign.unit.actions.IUnitAction;
 import mekhq.campaign.unit.actions.MothballUnitAction;
 import mekhq.gui.CampaignGUI;
@@ -76,6 +77,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
 
     public final static String COMMAND_MOTHBALL = "MOTHBALL";
     public final static String COMMAND_ACTIVATE = "ACTIVATE";
+    public final static String COMMAND_CANCEL_MOTHBALL = "CANCEL_MOTHBALL";
     public final static String COMMAND_GM_MOTHBALL = "GM_MOTHBALL";
     public final static String COMMAND_GM_ACTIVATE = "GM_ACTIVATE";
 
@@ -447,9 +449,10 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                 activateUnitAction.Execute(gui.getCampaign(), selectedUnit);
                 MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }
-        } else if (command.equalsIgnoreCase("CANCEL_MOTHBALL")) {
+        } else if (command.equalsIgnoreCase(COMMAND_CANCEL_MOTHBALL)) {
             if (null != selectedUnit) {
-                selectedUnit.setMothballTime(0);
+                CancelMothballUnitAction cancelAction = new CancelMothballUnitAction();
+                cancelAction.Execute(gui.getCampaign(), selectedUnit);
                 MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }
         } else if (command.equalsIgnoreCase("BOMBS")) {
@@ -740,7 +743,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                 if (unit.isMothballing()) {
                     menuItem = new JMenuItem(
                             "Cancel Mothballing/Activation");
-                    menuItem.setActionCommand("CANCEL_MOTHBALL");
+                    menuItem.setActionCommand(COMMAND_CANCEL_MOTHBALL);
                     menuItem.addActionListener(this);
                     menuItem.setEnabled(true);
                     popup.add(menuItem);
@@ -748,8 +751,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                     menuItem = new JMenuItem("Activate Unit");
                     menuItem.setActionCommand(COMMAND_ACTIVATE);
                     menuItem.addActionListener(this);
-                    menuItem.setEnabled(!unit.isSelfCrewed()
-                            || null != unit.getEngineer());
+                    menuItem.setEnabled(true);
                     popup.add(menuItem);
                 } else {
                     menuItem = new JMenuItem("Mothball Unit");

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -6,7 +6,6 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -52,7 +51,9 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.actions.StripUnitAction;
+import mekhq.campaign.unit.actions.ActivateUnitAction;
 import mekhq.campaign.unit.actions.IUnitAction;
+import mekhq.campaign.unit.actions.MothballUnitAction;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.GuiTabType;
 import mekhq.gui.MekLabTab;
@@ -72,8 +73,11 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
     private JTable unitTable;
     private UnitTableModel unitModel;
     private ResourceBundle resourceMap;
+
     public final static String COMMAND_MOTHBALL = "MOTHBALL";
     public final static String COMMAND_ACTIVATE = "ACTIVATE";
+    public final static String COMMAND_GM_MOTHBALL = "GM_MOTHBALL";
+    public final static String COMMAND_GM_ACTIVATE = "GM_ACTIVATE";
 
     public UnitTableMouseAdapter(CampaignGUI gui, JTable unitTable,
             UnitTableModel unitModel) {
@@ -174,8 +178,6 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
             for (Unit unit : units) {
                 if (!unit.isDeployed()) {
                     Money sellValue = unit.getSellValue();
-                    NumberFormat numberFormat = NumberFormat
-                            .getNumberInstance();
                     String text = sellValue.toAmountAndSymbolString();
                     if (0 == JOptionPane.showConfirmDialog(null,
                             "Do you really want to sell " + unit.getName()
@@ -427,27 +429,10 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                 return;
             }
 
-            UUID id = null;
-            if (!selectedUnit.isSelfCrewed()) {
-                id = gui.selectTech(selectedUnit, "mothball", true);
-                if (null != id) {
-                    Person tech = gui.getCampaign().getPerson(id);
-                    if (tech.getTechUnitIDs().size() > 0) {
-                        if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(gui.getFrame(),
-                                tech.getName() + " will not be able to perform maintenance on "
-                                        + tech.getTechUnitIDs().size() + " assigned units. Proceed?",
-                                        "Unmaintained unit warning",
-                                        JOptionPane.YES_NO_OPTION)) {
-                            id = null;
-                        }
-                    }
-                }
-                if (null == id) {
-                    return;
-                }
-            }
             if (null != selectedUnit) {
-                selectedUnit.startMothballing(id);
+                UUID techId = pickTechForMothballOrActivation(selectedUnit);
+                MothballUnitAction mothballUnitAction = new MothballUnitAction(techId, false);
+                mothballUnitAction.Execute(gui.getCampaign(), selectedUnit);
                 MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }
         } else if (command.equalsIgnoreCase(COMMAND_ACTIVATE)) {
@@ -456,27 +441,10 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                 return;
             }
 
-            UUID id = null;
-            if (!selectedUnit.isSelfCrewed()) {
-                id = gui.selectTech(selectedUnit, "activation", true);
-                if (null != id) {
-                    Person tech = gui.getCampaign().getPerson(id);
-                    if (tech.getTechUnitIDs().size() > 0) {
-                        if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(gui.getFrame(),
-                                tech.getName() + " will not be able to perform maintenance on "
-                                        + tech.getTechUnitIDs().size() + " assigned units. Proceed?",
-                                        "Unmaintained unit warning",
-                                        JOptionPane.YES_NO_OPTION)) {
-                            id = null;
-                        }
-                    }
-                }
-                if (null == id) {
-                    return;
-                }
-            }
             if (null != selectedUnit) {
-                selectedUnit.startMothballing(id);
+                UUID techId = pickTechForMothballOrActivation(selectedUnit);
+                ActivateUnitAction activateUnitAction = new ActivateUnitAction(techId, false);
+                activateUnitAction.Execute(gui.getCampaign(), selectedUnit);
                 MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }
         } else if (command.equalsIgnoreCase("CANCEL_MOTHBALL")) {
@@ -597,7 +565,39 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
             for (Unit unit : units) {
                 stripUnitAction.Execute(gui.getCampaign(), unit);
             }
+        } else if (command.equalsIgnoreCase(COMMAND_GM_MOTHBALL)) {
+            if (null != selectedUnit) {
+                MothballUnitAction mothballUnitAction = new MothballUnitAction(null, true);
+                mothballUnitAction.Execute(gui.getCampaign(), selectedUnit);
+                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
+            }
+        } else if (command.equalsIgnoreCase(COMMAND_GM_ACTIVATE)) {
+            if (null != selectedUnit) {
+                ActivateUnitAction activateUnitAction = new ActivateUnitAction(null, true);
+                activateUnitAction.Execute(gui.getCampaign(), selectedUnit);
+                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
+            }
         }
+    }
+
+    private UUID pickTechForMothballOrActivation(Unit unit) {
+        UUID id = null;
+        if (!unit.isSelfCrewed()) {
+            id = gui.selectTech(unit, "activation", true);
+            if (null != id) {
+                Person tech = gui.getCampaign().getPerson(id);
+                if (tech.getTechUnitIDs().size() > 0) {
+                    if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(gui.getFrame(),
+                            tech.getName() + " will not be able to perform maintenance on "
+                                    + tech.getTechUnitIDs().size() + " assigned units. Proceed?",
+                                    "Unmaintained unit warning",
+                                    JOptionPane.YES_NO_OPTION)) {
+                        id = null;
+                    }
+                }
+            }
+        }
+        return id;
     }
 
     @Override
@@ -996,6 +996,13 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
             menuItem.addActionListener(this);
             menuItem.setEnabled(gui.getCampaign().isGM());
             menu.add(menuItem);
+            if (oneSelected) {
+                menuItem = new JMenuItem(unit.isMothballed() ? "Activate Unit" : "Mothball Unit");
+                menuItem.setActionCommand(unit.isMothballed() ? COMMAND_GM_ACTIVATE : COMMAND_GM_MOTHBALL);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(gui.getCampaign().isGM());
+                menu.add(menuItem);
+            }
             menuItem = new JMenuItem("Undeploy Unit");
             menuItem.setActionCommand("UNDEPLOY");
             menuItem.addActionListener(this);

--- a/MekHQ/src/mekhq/gui/dialog/MassMothballDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassMothballDialog.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
@@ -65,19 +66,19 @@ import mekhq.preferences.PreferencesNode;
  */
 public class MassMothballDialog extends JDialog implements ActionListener, ListSelectionListener {
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -7435381378836891774L;
-    
+
     Map<Integer, List<Unit>> unitsByType = new HashMap<>();
-    Map<Integer, JList<Person>> techListsByUnitType = new HashMap<>(); 
+    Map<Integer, JList<Person>> techListsByUnitType = new HashMap<>();
     Map<Integer, JLabel> timeLabelsByUnitType = new HashMap<>();
     Campaign campaign;
     boolean activating;
-    
+
     JScrollPane scrollPane = new JScrollPane();
     JPanel contentPanel = new JPanel();
-    
+
     /**
      * Constructor
      * @param parent MekHQ frame
@@ -88,12 +89,12 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
     public MassMothballDialog(Frame parent, Unit[] units, Campaign campaign, boolean activate) {
         super(parent, "Mass Mothball/Activate");
         setLocationRelativeTo(parent);
-        
+
         sortUnitsByType(units);
         this.campaign = campaign;
 
         contentPanel.setLayout(new GridBagLayout());
-        
+
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridwidth = 3;
         gbc.gridx = 0;
@@ -101,31 +102,31 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
         gbc.ipadx = 4;
         gbc.ipady = 4;
         gbc.insets = new Insets(2, 2, 2, 2);
-        
+
         gbc.weightx = 3;
         JLabel instructionLabel = new JLabel();
         instructionLabel.setBorder(new LineBorder(Color.BLUE));
         instructionLabel.setText("<html>Choose the techs to carry out mothball/reactivation operations on the displayed units. <br/>A * indicates that the tech is currently maintaining units.</html>");
         contentPanel.add(instructionLabel, gbc);
-        
+
         gbc.weightx = 1;
         gbc.gridy++;
         addTableHeaders(gbc);
-        
+
         for(int unitType : unitsByType.keySet()) {
             gbc.gridy++;
             addUnitTypePanel(unitType, gbc);
         }
-        
+
         gbc.gridy++;
         addExecuteButton(activate, gbc);
-        
+
         scrollPane.setViewportView(contentPanel);
         scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
         scrollPane.setMaximumSize(new Dimension(600, 600));
         scrollPane.setPreferredSize(new Dimension(600, 600));
         getContentPane().add(scrollPane);
-        
+
         this.setResizable(true);
         this.pack();
         this.validate();
@@ -141,23 +142,23 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
         gbc.weightx = .3;
         gbc.anchor = GridBagConstraints.WEST;
         gbc.fill = GridBagConstraints.BOTH;
-        
+
         gbc.gridx = 0;
         JLabel labelUnitNames = new JLabel();
         labelUnitNames.setText("Units to Process");
         contentPanel.add(labelUnitNames, gbc);
-        
+
         gbc.gridx = 1;
         JLabel labelTechs = new JLabel();
         labelTechs.setText("Available Techs");
         contentPanel.add(labelTechs, gbc);
-        
+
         gbc.gridx = 2;
         JLabel labelPlaceHolder = new JLabel();
         labelPlaceHolder.setText(" ");
         contentPanel.add(labelPlaceHolder, gbc);
     }
-    
+
     /**
      * Adds a row of units, techs and time summary to the content pane
      * @param unitType
@@ -169,43 +170,43 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
         gbc.gridx = 0;
         gbc.fill = GridBagConstraints.BOTH;
         gbc.anchor = GridBagConstraints.NORTHWEST;
-        
+
         JPanel unitPanel = new JPanel();
         unitPanel.setLayout(new GridLayout(unitsByType.get(unitType).size(), 1, 1, 0));
-        
+
         for(Unit unit : unitsByType.get(unitType)) {
             JLabel unitLabel = new JLabel();
             unitLabel.setText(unit.getName());
             unitPanel.add(unitLabel);
         }
-        
-        unitPanel.setBorder(new LineBorder(Color.GRAY, 1));   
+
+        unitPanel.setBorder(new LineBorder(Color.GRAY, 1));
         contentPanel.add(unitPanel, gbc);
-        
+
         gbc.gridx = 1;
 
         JList<Person> techList = new JList<Person>();
         DefaultListModel<Person> listModel = new DefaultListModel<Person>();
-        
+
         for(Person tech : campaign.getTechs()) {
             if(tech.canTech(unitsByType.get(unitType).get(0).getEntity())) {
                 listModel.addElement(tech);
             }
         }
-        
+
         techList.setModel(listModel);
         techList.addListSelectionListener(this);
         techList.setBorder(new LineBorder(Color.GRAY, 1));
         techList.setCellRenderer(new TechListCellRenderer());
-        
+
         JScrollPane techListPane = new JScrollPane();
         techListPane.setViewportView(techList);
         techListPane.setMaximumSize(new Dimension(200, 100));
         techListPane.setPreferredSize(new Dimension(200, 50));
-        
+
         contentPanel.add(techListPane, gbc);
         techListsByUnitType.put(unitType, techList);
-        
+
         gbc.gridx = 2;
         gbc.weightx = 1;
         gbc.fill = GridBagConstraints.HORIZONTAL;
@@ -215,14 +216,14 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
         timeLabelsByUnitType.put(unitType, labelTotalTime);
         contentPanel.add(labelTotalTime, gbc);
     }
-    
+
     /**
-     * Renders the mothball/activate button on the content pane 
+     * Renders the mothball/activate button on the content pane
      * @param activate Whether the button is "mothball" or "activate"
      * @param gbc
      */
     private void addExecuteButton(boolean activate, GridBagConstraints gbc) {
-        gbc.gridx = 1; 
+        gbc.gridx = 1;
         gbc.weightx = .8;
         gbc.weighty = .8;
         gbc.anchor = GridBagConstraints.CENTER;
@@ -247,11 +248,11 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
     private void sortUnitsByType(Unit[] units) {
         for(int x = 0; x < units.length; x++) {
             int unitType = units[x].getEntity().getUnitType();
-            
+
             if(!unitsByType.containsKey(unitType)) {
                 unitsByType.put(unitType, new ArrayList<>());
             }
-            
+
             unitsByType.get(unitType).add(units[x]);
         }
     }
@@ -261,22 +262,29 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
      */
     @Override
     public void actionPerformed(ActionEvent e) {
-        
+
         if(e.getActionCommand() != UnitTableMouseAdapter.COMMAND_MOTHBALL &&
                 e.getActionCommand() != UnitTableMouseAdapter.COMMAND_ACTIVATE) {
             return;
         }
-        
+
+        boolean isMothballing = e.getActionCommand() == UnitTableMouseAdapter.COMMAND_MOTHBALL;
+
         for(int unitType : unitsByType.keySet()) {
             List<Person> selectedTechs = techListsByUnitType.get(unitType).getSelectedValuesList();
             int techIndex = 0;
-            
+
             // this is a "naive" approach, where we assign each of the selected techs
             // to approximately # units / # techs in mothball/reactivation tasks
-            for(Unit unit : unitsByType.get(unitType)) {                
-                unit.startMothballing(selectedTechs.get(techIndex).getId());
+            for(Unit unit : unitsByType.get(unitType)) {
+                UUID id = selectedTechs.get(techIndex).getId();
+                if (isMothballing) {
+                    unit.startMothballing(id);
+                } else {
+                    unit.startActivating(id);
+                }
                 MekHQ.triggerEvent(new UnitChangedEvent(unit));
-                
+
                 if(techIndex == selectedTechs.size() - 1) {
                     techIndex = 0;
                 } else {
@@ -284,7 +292,7 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
                 }
             }
         }
-        
+
         this.setVisible(false);
     }
 
@@ -295,7 +303,7 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
     public void valueChanged(ListSelectionEvent e) {
         @SuppressWarnings("unchecked")
         JList<Person> techList = (JList<Person>) e.getSource();
-        
+
         int unitType = -1;
         // this is mildly kludgy:
         // we scan the 'tech lists by unit type' dictionary to determine the unit type
@@ -306,16 +314,16 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
                 break;
             }
         }
-        
+
         // time to do the work is # units * 2 if mothballing * work day in minutes;
         int workTime = unitsByType.get(unitType).size() * (activating ? 1 : 2) * Unit.TECH_WORK_DAY;
         // a unit can only be mothballed by one tech, so it's pointless to assign more techs to the task
         int numTechs = Math.min(techList.getSelectedValuesList().size(), unitsByType.get(unitType).size());
-        
+
         timeLabelsByUnitType.get(unitType).setText(getCompletionTimeText(workTime / numTechs));
         pack();
     }
-    
+
     /**
      * Worker function that determines the "completion time" text based on the passed-in number.
      * @param completionTime How many minutes to complete the work.
@@ -337,7 +345,7 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
     class TechListCellRenderer extends DefaultListCellRenderer {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = -1552997620131149101L;
 
@@ -345,14 +353,14 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
         public Component getListCellRendererComponent(JList<?> list, Object value, int index,
                 boolean isSelected, boolean cellHasFocus) {
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-            
+
             Person person = (Person) value;
-            
+
             boolean maintainsUnits = person.getTechUnitIDs().size() > 0;
             setText(person.getFullName() + (maintainsUnits ? " (*)" : ""));
-            
+
             return this;
         }
-        
+
     }
 }


### PR DESCRIPTION
This adds GM Mothball and Activate to units in the hangar, contributing to #1238. This also splits out mothballing and activation to make it easier to do both as a GM action.