### PR TITLE
fix immortality in certain cases

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -1068,6 +1068,7 @@ public class ResolveScenarioTracker {
             if(null == person || null == status) {
                 continue;
             }
+            
             MekHQ.triggerEvent(new PersonBattleFinishedEvent(person, status));
             if(status.getHits() > person.getHits()) {
                 person.setHits(status.getHits());

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -418,9 +418,12 @@ public class ResolveScenarioWizardDialog extends JDialog {
             if(status.isMissing()) {
                 miaCheck.setSelected(true);
             }
+            
+            kiaCheck.addItemListener(new CheckBoxKIAListener(hitSlider, miaCheck, null));            
             if(status.isDead()) {
                 kiaCheck.setSelected(true);
             }
+            
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = i;
@@ -440,8 +443,6 @@ public class ResolveScenarioWizardDialog extends JDialog {
             gridBagConstraints.weightx = 1.0;
             pnlPilotStatus.add(kiaCheck, gridBagConstraints);
             i++;
-            
-            kiaCheck.addItemListener(new CheckBoxKIAListener(hitSlider, miaCheck, null));
         }
         pnlMain.add(pnlPilotStatus, PILOTPANEL);
 
@@ -480,7 +481,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
             j++;
             prstatuses.add(status);
             nameLbl = new JLabel("<html>" + status.getName() + "<br><i> " + status.getUnitName() + "</i></html>");
-            miaCheck = new JCheckBox("");
+
             hitSlider = new JSlider(JSlider.HORIZONTAL, 0, 5, Math.min(status.getHits(),5));
             hitSlider.setMajorTickSpacing(1);
             hitSlider.setPaintTicks(true);
@@ -492,7 +493,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
                 hitSlider.setEnabled(false);
             }
             pr_hitSliders.add(hitSlider);
-            miaCheck.setSelected(status.isMissing());
+
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = i;
@@ -1220,21 +1221,23 @@ public class ResolveScenarioWizardDialog extends JDialog {
         //now personnel
         for(int i = 0; i < pstatuses.size(); i++) {
             PersonStatus status = pstatuses.get(i);
-            status.setMissing(miaBtns.get(i).isSelected());
-            status.setDead(kiaBtns.get(i).isSelected());
+            
             if (hitSliders.get(i).isEnabled()) {
                 status.setHits(hitSliders.get(i).getValue());
             }
+            status.setMissing(miaBtns.get(i).isSelected());
+            status.setDead(kiaBtns.get(i).isSelected());
         }
 
         //now prisoners
         for(int i = 0; i < prstatuses.size(); i++) {
             PrisonerStatus status = prstatuses.get(i);
-            status.setDead(prisonerKiaBtns.get(i).isSelected());
+            
             if (pr_hitSliders.get(i).isEnabled()) {
                 status.setHits(pr_hitSliders.get(i).getValue());
             }
             status.setCaptured(prisonerBtns.get(i).isSelected());
+            status.setDead(prisonerKiaBtns.get(i).isSelected());
         }
 
         //now salvage


### PR DESCRIPTION
A couple of minor changes to the scenario resolution wizard:

- Let event handler handle setting enabled/disabled status for personnel MIA checkbox/hit slider
- When finishing up, make sure "dead" status is set last, as "set hits" overrides being dead if the # of hits < 6
- Removed unnecessary checkbox initialization