### PR TITLE
re-organize skill data structure

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -160,7 +160,10 @@ public class AtBDynamicScenarioFactory {
         
         setDeploymentTurns(scenario, campaign);
         translatePlayerNPCsToAttached(scenario, campaign);
-        upgradeBotCrews(scenario);
+        
+        if(campaign.getCampaignOptions().useAbilities()) {
+        	upgradeBotCrews(scenario);
+        }
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -820,7 +820,9 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         }
         
         // aaand for fun, run everyone through the crew upgrader
-        AtBDynamicScenarioFactory.upgradeBotCrews(this);
+        if(campaign.getCampaignOptions().useAbilities()) {
+        	AtBDynamicScenarioFactory.upgradeBotCrews(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR fixes an observed behavior where, if a unit being upgraded is not eligible for any SPAs with a cost below the SPA cap, the spa upgrader code goes into an endless loop.

Also, check if the user has SPAs enabled before giving bot units SPAs.