### PR TITLE
Allow salvage at 100% salvage terms

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -407,7 +407,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
             miaBtns.add(miaCheck);
             kiaCheck = new JCheckBox("");
             kiaBtns.add(kiaCheck);
-            
+
             hitSlider = new JSlider(JSlider.HORIZONTAL, 0, 5, Math.min(status.getHits(),5));
             hitSlider.setMajorTickSpacing(1);
             hitSlider.setPaintTicks(true);
@@ -418,12 +418,12 @@ public class ResolveScenarioWizardDialog extends JDialog {
             if(status.isMissing()) {
                 miaCheck.setSelected(true);
             }
-            
-            kiaCheck.addItemListener(new CheckBoxKIAListener(hitSlider, miaCheck, null));            
+
+            kiaCheck.addItemListener(new CheckBoxKIAListener(hitSlider, miaCheck, null));
             if(status.isDead()) {
                 kiaCheck.setSelected(true);
             }
-            
+
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = i;
@@ -523,9 +523,9 @@ public class ResolveScenarioWizardDialog extends JDialog {
             gridBagConstraints.weightx = 1.0;
             pnlPrisonerStatus.add(btnViewPrisoner, gridBagConstraints);
             i++;
-            
+
             kiaCheck.addItemListener(new CheckBoxKIAListener(hitSlider, prisonerCheck, btnViewPrisoner));
-            
+
             // if the person is dead, set the checkbox and skip all this captured stuff
             if(status.getHits() > 5 || status.isDead()) {
                 kiaCheck.setSelected(true);
@@ -1221,7 +1221,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
         //now personnel
         for(int i = 0; i < pstatuses.size(); i++) {
             PersonStatus status = pstatuses.get(i);
-            
+
             if (hitSliders.get(i).isEnabled()) {
                 status.setHits(hitSliders.get(i).getValue());
             }
@@ -1232,7 +1232,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
         //now prisoners
         for(int i = 0; i < prstatuses.size(); i++) {
             PrisonerStatus status = prstatuses.get(i);
-            
+
             if (pr_hitSliders.get(i).isEnabled()) {
                 status.setHits(pr_hitSliders.get(i).getValue());
             }
@@ -1357,7 +1357,10 @@ public class ResolveScenarioWizardDialog extends JDialog {
         }
 
         for(JCheckBox box : salvageBoxes) {
-            if(!box.isSelected() && currentSalvagePct >= maxSalvagePct) {
+
+            if(!box.isSelected() && currentSalvagePct >= maxSalvagePct
+                    // always eligible with 100% salvage rights even when current == max
+                    && maxSalvagePct < 100) {
                 box.setEnabled(false);
             } else {
                 box.setEnabled(true);
@@ -1564,26 +1567,26 @@ public class ResolveScenarioWizardDialog extends JDialog {
         private JSlider slider;
         private JCheckBox checkbox;
         private JButton button;
-        
+
         public CheckBoxKIAListener(JSlider slider, JCheckBox checkBox, JButton button) {
             this.slider = slider;
             this.checkbox = checkBox;
             this.button = button;
         }
-        
+
         @Override
         public void itemStateChanged(ItemEvent e) {
             JCheckBox kiaChk = (JCheckBox)e.getSource();
             boolean enable = !kiaChk.isSelected();
-            
+
             if(slider != null) {
                 slider.setEnabled(enable);
             }
-            
+
             if(checkbox != null) {
                 checkbox.setEnabled(enable);
             }
-            
+
             if(button != null) {
                 button.setEnabled(enable);
             }


### PR DESCRIPTION
Current behavior is to disallow salvage unless the current % is less than the max. This prevents salvaging any units at 100% salvage rights if the current salvage level is at 100%.

Fixes #1240