### PR TITLE
Restore tech action description

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2596,6 +2596,8 @@ public class Campaign implements Serializable, ITechManager {
                 return;
             }
         }
+        report += tech.getHyperlinkedFullTitle() + " attempts to" + action
+                    + partWork.getPartName();
         if (null != partWork.getUnit()) {
             report += " on " + partWork.getUnit().getName();
         }


### PR DESCRIPTION
Note that this is for merge into stable and not master.
This restores "[techname] attempts to [action] [partname]" in the daily report. It was left out while manually merging the mothball fix into the stable branch, which does not have the large craft parts feature. There is a conditional that changes the name to heat sink for large craft cooling system. I left out the entire if/else block, instead of including just the else block.

Fixes #1249: Tech Names Missing in Event Log