### PR TITLE
fix map size display

### DIFF
--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -543,7 +543,7 @@ public class AtBScenarioViewPanel extends JPanel {
             chkReroll[REROLL_MAPSIZE].addItemListener(checkBoxListener);
         }
 
-        lblMapSizeDesc.setText(scenario.getMapSizeX() + "x" + scenario.getMapSizeY());
+        lblMapSizeDesc.setText(scenario.getMapX() + "x" + scenario.getMapY());
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = y++;
         panStats.add(lblMapSizeDesc, gridBagConstraints);


### PR DESCRIPTION
Relevant to both the stable and dev versions, this fixes the map size displayed in the briefing tab for standard AtB scenarios.