### PR TITLE
Don't double up salaries in peacetime costs #1257

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8330,12 +8330,33 @@ public class Campaign implements Serializable, ITechManager {
         return unitRating;
     }
 
+    /**
+     * Gets peacetime costs including salaries.
+     * @return The peacetime costs of the campaign including salaries.
+     */
     public Money getPeacetimeCost() {
-        return Money.zero()
-                .plus(getPayRoll(getCampaignOptions().useInfantryDontCount()))
-                .plus(getMonthlySpareParts())
-                .plus(getMonthlyFuel())
-                .plus(getMonthlyAmmo());
+        return getPeacetimeCost(true);
+    }
+
+    /**
+     * Gets peacetime costs, optionally including salaries.
+     *
+     * This can be used to ensure salaries are not double counted.
+     *
+     * @param includeSalaries A value indicating whether or not salaries
+     *                        should be included in peacetime cost calculations.
+     * @return The peacetime costs of the campaign, optionally including salaries.
+     */
+    public Money getPeacetimeCost(boolean includeSalaries) {
+        Money peaceTimeCosts = Money.zero()
+                                .plus(getMonthlySpareParts())
+                                .plus(getMonthlyFuel())
+                                .plus(getMonthlyAmmo());
+        if (includeSalaries) {
+            peaceTimeCosts = peaceTimeCosts.plus(getPayRoll(getCampaignOptions().useInfantryDontCount()));
+        }
+
+        return peaceTimeCosts;
     }
 
     public Money getMonthlySpareParts() {

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -301,8 +301,9 @@ public class Finances implements Serializable {
         if (calendar.get(Calendar.DAY_OF_MONTH) == 1) {
             if (campaignOptions.usePeacetimeCost()) {
                 if (!campaignOptions.showPeacetimeCost()) {
-                    Money peacetimeCost = campaign.getPeacetimeCost();
-                    
+                    // Do not include salaries as that will be tracked below
+                    Money peacetimeCost = campaign.getPeacetimeCost(/*includeSalaries:*/false);
+
                     if (debit(peacetimeCost, Transaction.C_MAINTAIN,
                             resourceMap.getString("PeacetimeCosts.title"), calendar.getTime())) {
                         campaign.addReport(String.format(
@@ -316,7 +317,7 @@ public class Finances implements Serializable {
                     Money sparePartsCost = campaign.getMonthlySpareParts();
                     Money ammoCost = campaign.getMonthlyAmmo();
                     Money fuelCost = campaign.getMonthlyFuel();
-                    
+
                     if (debit(sparePartsCost, Transaction.C_MAINTAIN,
                             resourceMap.getString("PeacetimeCostsParts.title"), calendar.getTime())) {
                         campaign.addReport(String.format(
@@ -345,9 +346,10 @@ public class Finances implements Serializable {
                     }
                 }
             }
+
             if (campaignOptions.payForSalaries()) {
                 Money payrollCost = campaign.getPayRoll();
-                
+
                 if (debit(payrollCost, Transaction.C_SALARY, resourceMap.getString("Salaries.title"),
                         calendar.getTime())) {
                     campaign.addReport(
@@ -362,7 +364,7 @@ public class Finances implements Serializable {
             // Handle overhead expenses
             if (campaignOptions.payForOverhead()) {
                 Money overheadCost = campaign.getOverheadExpenses();
-                
+
                 if (debit(overheadCost, Transaction.C_OVERHEAD,
                         resourceMap.getString("Overhead.title"),
                         calendar.getTime())) {
@@ -479,7 +481,7 @@ public class Finances implements Serializable {
                 .plus(getTotalAssetValue())
                 .minus(getTotalLoanCollateral());
     }
-    
+
     public String exportFinances(String path, String format) {
         String report;
 


### PR DESCRIPTION
This resolves bug (1) in #1257 where salaries are applied twice when peacetime costs are used. Salaries are excluded when reporting peacetime costs, but not showing them, on the first of the month. Effectively this means `payForSalaries` is the single source of truth for salary payments.