### PR TITLE
Track important dates for units

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -24,6 +24,7 @@ package mekhq.campaign.unit;
 
 import java.io.PrintWriter;
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -263,9 +264,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     private int mothballTime;
     private boolean mothballed;
 
+    private LocalDate dateAcquired;
+
     private int daysSinceMaintenance;
     private int daysActivelyMaintained;
     private int astechDaysMaintained;
+    private LocalDate lastMaintenanceDate;
 
     //old ids for reverse compatibility
     private ArrayList<Integer> oldDrivers;
@@ -1498,10 +1502,22 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 +"<daysToArrival>"
                 +daysToArrival
                 +"</daysToArrival>");
+        if (null != dateAcquired) {
+            pw1.println(MekHqXmlUtil.indentStr(indentLvl+1)
+                    +"<dateAcquired>"
+                    +dateAcquired
+                    +"</dateAcquired>");
+        }
         pw1.println(MekHqXmlUtil.indentStr(indentLvl+1)
                 +"<daysSinceMaintenance>"
                 +daysSinceMaintenance
                 +"</daysSinceMaintenance>");
+        if (null != lastMaintenanceDate) {
+            pw1.println(MekHqXmlUtil.indentStr(indentLvl+1)
+                    +"<lastMaintenanceDate>"
+                    +lastMaintenanceDate
+                    +"</lastMaintenanceDate>");
+        }
         pw1.println(MekHqXmlUtil.indentStr(indentLvl+1)
                 +"<daysActivelyMaintained>"
                 +daysActivelyMaintained
@@ -1566,12 +1582,16 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     retVal.site = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("pilotId")) {
                     retVal.pilotId = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("dateAcquired")) {
+                    retVal.dateAcquired = LocalDate.parse(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("daysToArrival")) {
                     retVal.daysToArrival = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("daysActivelyMaintained")) {
                     retVal.daysActivelyMaintained = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("daysSinceMaintenance")) {
                     retVal.daysSinceMaintenance = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("lastMaintenanceDate")) {
+                    retVal.lastMaintenanceDate = LocalDate.parse(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("mothballTime")) {
                     retVal.mothballTime = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("astechDaysMaintained")) {
@@ -4396,6 +4416,22 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         return availability;
     }
 
+    /**
+     * Gets the date the unit was acquired.
+     * @return The date the unit was acquired.
+     */
+    public @Nullable LocalDate getDateAcquired() {
+        return dateAcquired;
+    }
+
+    /**
+     * Sets the date the unit was acquired.
+     * @param date The date the unit was acquired.
+     */
+    public void setDateAcquired(LocalDate date) {
+        dateAcquired = date;
+    }
+
     public void setDaysToArrival(int days) {
         daysToArrival = days;
     }
@@ -4506,6 +4542,24 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
     public int getDaysSinceMaintenance() {
         return daysSinceMaintenance;
+    }
+
+    /**
+     * Gets the last day the unit was maintained, or null if the unit
+     * has never had maintenance performed.
+     * @return The last day the unit was maintained, otherwise null if the
+     *         unit has never had maintenance.
+     */
+    public @Nullable LocalDate getLastMaintenanceDate() {
+        return lastMaintenanceDate;
+    }
+
+    /**
+     * Sets the last date the unit was maintained.
+     * @param date The last day the unit was maintained.
+     */
+    public void setLastMaintenanceDate(LocalDate date) {
+        lastMaintenanceDate = date;
     }
 
     //there are no official rules about partial maintenance

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -97,6 +97,10 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
         String command = action.getActionCommand();
         Unit selectedUnit = unitModel.getUnit(unitTable
                 .convertRowIndexToModel(unitTable.getSelectedRow()));
+        if (selectedUnit == null) {
+            return;
+        }
+
         int[] rows = unitTable.getSelectedRows();
         Unit[] units = new Unit[rows.length];
         for (int i = 0; i < rows.length; i++) {
@@ -384,14 +388,12 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                     gui.getCampaign(), selectedUnit, gui);
             crd.setVisible(true);
         } else if (command.contains("CHANGE_HISTORY")) {
-            if (null != selectedUnit) {
-                TextAreaDialog tad = new TextAreaDialog(gui.getFrame(), true,
-                        "Edit Unit History", selectedUnit.getHistory());
-                tad.setVisible(true);
-                if (tad.wasChanged()) {
-                    selectedUnit.setHistory(tad.getText());
-                    MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-                }
+            TextAreaDialog tad = new TextAreaDialog(gui.getFrame(), true,
+                    "Edit Unit History", selectedUnit.getHistory());
+            tad.setVisible(true);
+            if (tad.wasChanged()) {
+                selectedUnit.setHistory(tad.getText());
+                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }
         } else if (command.contains("REMOVE_INDI_CAMO")) {
             selectedUnit.getEntity().setCamoCategory(null);
@@ -415,52 +417,41 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
         } else if (command.equalsIgnoreCase("CANCEL_ORDER")) {
             double refund = gui.getCampaign().getCampaignOptions()
                     .GetCanceledOrderReimbursement();
-            if (null != selectedUnit) {
-                Money refundAmount = selectedUnit.getBuyCost().multipliedBy(refund);
-                gui.getCampaign().removeUnit(selectedUnit.getId());
-                gui.getCampaign().getFinances().credit(
-                        refundAmount,
-                        Transaction.C_EQUIP,
-                        "refund for cancelled equipment sale",
-                        gui.getCampaign().getDate());
-            }
+            Money refundAmount = selectedUnit.getBuyCost().multipliedBy(refund);
+            gui.getCampaign().removeUnit(selectedUnit.getId());
+            gui.getCampaign().getFinances().credit(
+                    refundAmount,
+                    Transaction.C_EQUIP,
+                    "refund for cancelled equipment sale",
+                    gui.getCampaign().getDate());
         } else if (command.equalsIgnoreCase("ARRIVE")) {
-            if (null != selectedUnit) {
-                selectedUnit.setDaysToArrival(0);
-            }
+            selectedUnit.setDaysToArrival(0);
         } else if (command.equalsIgnoreCase(COMMAND_MOTHBALL)) {
             if(units.length > 1) {
                 gui.showMassMothballDialog(units, false);
                 return;
             }
 
-            if (null != selectedUnit) {
-                UUID techId = pickTechForMothballOrActivation(selectedUnit);
-                MothballUnitAction mothballUnitAction = new MothballUnitAction(techId, false);
-                mothballUnitAction.Execute(gui.getCampaign(), selectedUnit);
-                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-            }
+            UUID techId = pickTechForMothballOrActivation(selectedUnit);
+            MothballUnitAction mothballUnitAction = new MothballUnitAction(techId, false);
+            mothballUnitAction.Execute(gui.getCampaign(), selectedUnit);
+            MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
         } else if (command.equalsIgnoreCase(COMMAND_ACTIVATE)) {
             if(units.length > 1) {
                 gui.showMassMothballDialog(units, true);
                 return;
             }
 
-            if (null != selectedUnit) {
-                UUID techId = pickTechForMothballOrActivation(selectedUnit);
-                ActivateUnitAction activateUnitAction = new ActivateUnitAction(techId, false);
-                activateUnitAction.Execute(gui.getCampaign(), selectedUnit);
-                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-            }
+            UUID techId = pickTechForMothballOrActivation(selectedUnit);
+            ActivateUnitAction activateUnitAction = new ActivateUnitAction(techId, false);
+            activateUnitAction.Execute(gui.getCampaign(), selectedUnit);
+            MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
         } else if (command.equalsIgnoreCase(COMMAND_CANCEL_MOTHBALL)) {
-            if (null != selectedUnit) {
-                CancelMothballUnitAction cancelAction = new CancelMothballUnitAction();
-                cancelAction.Execute(gui.getCampaign(), selectedUnit);
-                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-            }
+            CancelMothballUnitAction cancelAction = new CancelMothballUnitAction();
+            cancelAction.Execute(gui.getCampaign(), selectedUnit);
+            MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
         } else if (command.equalsIgnoreCase("BOMBS")) {
-            if (null != selectedUnit
-                    && selectedUnit.getEntity().isBomber()) {
+            if (selectedUnit.getEntity().isBomber()) {
                 BombsDialog dialog = new BombsDialog(
                         (IBomber)selectedUnit.getEntity(), gui.getCampaign(),
                         gui.getFrame());
@@ -468,30 +459,24 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                 MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }
         } else if (command.equalsIgnoreCase("QUIRKS")) {
-            if (null != selectedUnit) {
-                QuirksDialog dialog = new QuirksDialog(
-                        selectedUnit.getEntity(), gui.getFrame());
-                dialog.setVisible(true);
-                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-            }
+            QuirksDialog dialog = new QuirksDialog(
+                    selectedUnit.getEntity(), gui.getFrame());
+            dialog.setVisible(true);
+            MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
         } else if (command.equalsIgnoreCase("EDIT_DAMAGE")) {
-            if (null != selectedUnit) {
-                Entity entity = selectedUnit.getEntity();
-                UnitEditorDialog med = new UnitEditorDialog(gui.getFrame(), entity);
-                med.setVisible(true);
-                selectedUnit.runDiagnostic(false);
-                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-            }
+            Entity entity = selectedUnit.getEntity();
+            UnitEditorDialog med = new UnitEditorDialog(gui.getFrame(), entity);
+            med.setVisible(true);
+            selectedUnit.runDiagnostic(false);
+            MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
         } else if (command.equalsIgnoreCase("FLUFF_NAME")) {
-            if (selectedUnit != null) {
-                String fluffName = (String) JOptionPane.showInputDialog(
-                        gui.getFrame(), "Name for this unit?", "Unit Name",
-                        JOptionPane.QUESTION_MESSAGE, null, null,
-                        selectedUnit.getFluffName() == null ? ""
-                                : selectedUnit.getFluffName());
-                selectedUnit.setFluffName(fluffName);
-                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-            }
+            String fluffName = (String) JOptionPane.showInputDialog(
+                    gui.getFrame(), "Name for this unit?", "Unit Name",
+                    JOptionPane.QUESTION_MESSAGE, null, null,
+                    selectedUnit.getFluffName() == null ? ""
+                            : selectedUnit.getFluffName());
+            selectedUnit.setFluffName(fluffName);
+            MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
         } else if(command.equalsIgnoreCase("RESTORE_UNIT")) {
             for (Unit unit : units) {
                 unit.setSalvage(false);
@@ -572,17 +557,13 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                 stripUnitAction.Execute(gui.getCampaign(), unit);
             }
         } else if (command.equalsIgnoreCase(COMMAND_GM_MOTHBALL)) {
-            if (null != selectedUnit) {
-                MothballUnitAction mothballUnitAction = new MothballUnitAction(null, true);
-                mothballUnitAction.Execute(gui.getCampaign(), selectedUnit);
-                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-            }
+            MothballUnitAction mothballUnitAction = new MothballUnitAction(null, true);
+            mothballUnitAction.Execute(gui.getCampaign(), selectedUnit);
+            MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
         } else if (command.equalsIgnoreCase(COMMAND_GM_ACTIVATE)) {
-            if (null != selectedUnit) {
-                ActivateUnitAction activateUnitAction = new ActivateUnitAction(null, true);
-                activateUnitAction.Execute(gui.getCampaign(), selectedUnit);
-                MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
-            }
+            ActivateUnitAction activateUnitAction = new ActivateUnitAction(null, true);
+            activateUnitAction.Execute(gui.getCampaign(), selectedUnit);
+            MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
         } else if (command.equalsIgnoreCase(COMMAND_SET_DATE_ACQUIRED)) {
             LocalDate today = gui.getCampaign().getLocalDate();
             LocalDate dateAcquired = selectedUnit.getDateAcquired();

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -6,6 +6,7 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -61,6 +62,7 @@ import mekhq.gui.MekLabTab;
 import mekhq.gui.dialog.BombsDialog;
 import mekhq.gui.dialog.CamoChoiceDialog;
 import mekhq.gui.dialog.ChooseRefitDialog;
+import mekhq.gui.dialog.DateChooser;
 import mekhq.gui.dialog.LargeCraftAmmoSwapDialog;
 import mekhq.gui.dialog.QuirksDialog;
 import mekhq.gui.dialog.TextAreaDialog;
@@ -80,6 +82,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
     public final static String COMMAND_CANCEL_MOTHBALL = "CANCEL_MOTHBALL";
     public final static String COMMAND_GM_MOTHBALL = "GM_MOTHBALL";
     public final static String COMMAND_GM_ACTIVATE = "GM_ACTIVATE";
+    public final static String COMMAND_SET_DATE_ACQUIRED = "SET_DATE_ACQUIRED";
 
     public UnitTableMouseAdapter(CampaignGUI gui, JTable unitTable,
             UnitTableModel unitModel) {
@@ -580,6 +583,26 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                 activateUnitAction.Execute(gui.getCampaign(), selectedUnit);
                 MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }
+        } else if (command.equalsIgnoreCase(COMMAND_SET_DATE_ACQUIRED)) {
+            LocalDate today = gui.getCampaign().getLocalDate();
+            LocalDate dateAcquired = selectedUnit.getDateAcquired();
+            if (null == dateAcquired) {
+                dateAcquired = today;
+            }
+
+            // show the date chooser
+            DateChooser dc = new DateChooser(gui.getFrame(), dateAcquired);
+
+            // user can either choose a date or cancel by closing
+            if (dc.showDateChooser() == DateChooser.OK_OPTION) {
+                LocalDate newDate = dc.getLocalDate();
+                if (newDate.isAfter(today)) {
+                    newDate = today;
+                }
+                for (Unit unit : units) {
+                    unit.setDateAcquired(newDate);
+                }
+            }
         }
     }
 
@@ -960,6 +983,12 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                 menuItem.setEnabled(true);
                 popup.add(menuItem);
             }
+
+            menuItem = new JMenuItem("Set Date Acquired...");
+            menuItem.setActionCommand(COMMAND_SET_DATE_ACQUIRED);
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(true);
+            popup.add(menuItem);
 
             // remove all personnel
             popup.addSeparator();

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -324,7 +324,9 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
     /**
      * Updates the dialog's controls with the passed in date.
      *
-     * @param cal The date to be displayed.
+     * @param d The date to be displayed.
+     * @param fromDateField A value indicating whether the date is being change
+     *                      from the date text field itself.
      */
     private void setDate(LocalDate d, boolean fromDateField) {
         date = workingDate = d;


### PR DESCRIPTION
In order to add better accounting for some things, we would need to track two dates for units:
- The date the unit was acquired.
- The date the unit was last maintained.

This adds both of those fields, and starts moving Campaign (etc) to `java.time.LocalDate` rather than `GregorianCalendar`.