### PR TITLE
Only call dispose if the dialog is modal #1274

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -188,12 +188,14 @@ public class CampaignGUI extends JPanel {
     public void showAboutBox() {
         MekHQAboutBox aboutBox = new MekHQAboutBox(getFrame());
         aboutBox.setLocationRelativeTo(getFrame());
+        aboutBox.setModal(true);
         aboutBox.setVisible(true);
         aboutBox.dispose();
     }
 
     private void showHistoricalDailyReportDialog() {
         HistoricalDailyReportDialog histDailyReportDialog = new HistoricalDailyReportDialog(getFrame(), this);
+        histDailyReportDialog.setModal(true);
         histDailyReportDialog.setVisible(true);
         histDailyReportDialog.dispose();
     }
@@ -261,6 +263,7 @@ public class CampaignGUI extends JPanel {
 
     public void showAdvanceDaysDialog() {
         AdvanceDaysDialog advanceDaysDialog = new AdvanceDaysDialog(getFrame(), this, reportHLL);
+        advanceDaysDialog.setModal(true);
         advanceDaysDialog.setVisible(true);
         advanceDaysDialog.dispose();
     }

--- a/MekHQ/src/mekhq/gui/dialog/MekHQAboutBox.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQAboutBox.java
@@ -171,7 +171,6 @@ public class MekHQAboutBox extends javax.swing.JDialog {
     private void setUserPreferences() {
         PreferencesNode preferences = MekHQ.getPreferences().forClass(MekHQAboutBox.class);
 
-        this.setName("dialog");
         preferences.manage(new JWindowPreference(this));
     }
 }


### PR DESCRIPTION
If you call `setVisible(true)` on a non-modal dialog, it returns instantly. And if you then call `dispose`, well...you will definitely close that brand new window. This fixes the problem by explicitly calling `setModal(true)` before our calls to `setVisible` when we'd like to dispose of the dialog.

Fixes #1274 