### PR TITLE
Update edge cost for AtB preset to match current rules #1273

### DIFF
--- a/MekHQ/mmconf/mhqPresets/AgainstTheBot.xml
+++ b/MekHQ/mmconf/mhqPresets/AgainstTheBot.xml
@@ -17,6 +17,7 @@
 		<useArtillery>true</useArtillery>
 		<useAbilities>true</useAbilities>
 		<useEdge>true</useEdge>
+		<edgeCost>10</edgeCost>
 		<useImplants>true</useImplants>
 		<altQualityAveraging>true</altQualityAveraging>
 		<useAdvancedMedical>true</useAdvancedMedical>


### PR DESCRIPTION
This addresses #1273 by making the preset edge cost 10 XP for AtB.

(apparently my editor also fixed some whitespace issues as well)