### PR TITLE
Large Craft Ammo Swap Fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -260,7 +260,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
     public void remove(boolean salvage) {
         // The bin represents capacity rather than an actual part, and cannot be
         // removed or damaged.
-        unload();
+        unloadSingle();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -260,7 +260,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
     public void remove(boolean salvage) {
         // The bin represents capacity rather than an actual part, and cannot be
         // removed or damaged.
-        unloadSingle();
+        unload();
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
@@ -85,18 +85,20 @@ public class LargeCraftAmmoSwapDialog extends JDialog {
     }
     
     private void apply() {
-        mainPanel.apply();
         // Save the current number of shots by bay and ammo type
         Map<Mounted, Map<String, Integer>> shotsByBay = new HashMap<>();
         for (Part p : unit.getParts()) {
             if (p instanceof LargeCraftAmmoBin) {
                 LargeCraftAmmoBin bin = (LargeCraftAmmoBin) p;
+                Mounted m = unit.getEntity().getEquipment(bin.getEquipmentNum());
                 shotsByBay.putIfAbsent(bin.getBay(), new HashMap<>());
                 shotsByBay.get(bin.getBay()).merge(bin.getType().getInternalName(),
-                        bin.getFullShots() - bin.getShotsNeeded(),
+                        m.getBaseShotsLeft(),
                         Integer::sum);
             }
         }
+        // Actually apply the ammo change
+        mainPanel.apply();
         // Rebuild bin parts as necessary
         unit.adjustLargeCraftAmmo();
         // Update the parts and set the number of shots needed based on the current size and the number

--- a/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
@@ -29,6 +29,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import megamek.client.ui.swing.BayMunitionsChoicePanel;
+import megamek.common.AmmoType;
 import megamek.common.Mounted;
 import mekhq.MekHQ;
 import mekhq.campaign.parts.Part;
@@ -104,9 +105,14 @@ public class LargeCraftAmmoSwapDialog extends JDialog {
             if (p instanceof LargeCraftAmmoBin) {
                 LargeCraftAmmoBin bin = (LargeCraftAmmoBin) p;
                 bin.updateConditionFromEntity(false);
+                int oldShots = shotsByBay.get(bin.getBay()).getOrDefault(bin.getType().getInternalName(), 0);
+                // If we're using the swap dialog to unload some ammo, make sure it gets added to the warehouse
+                int shotsToRemove = oldShots - unit.getEntity().getEquipment(bin.getEquipmentNum()).getBaseShotsLeft();
+                if (shotsToRemove > 0) {
+                    bin.changeAmountAvailable(shotsToRemove, (AmmoType) bin.getType()); 
+                }
                 if (shotsByBay.containsKey(bin.getBay())) {
-                    bin.setShotsNeeded(bin.getFullShots()
-                            - shotsByBay.get(bin.getBay()).getOrDefault(bin.getType().getInternalName(), 0));
+                    bin.setShotsNeeded(bin.getShotsNeeded());
                 } else {
                     bin.setShotsNeeded(bin.getFullShots());
                 }

--- a/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
@@ -114,8 +114,17 @@ public class LargeCraftAmmoSwapDialog extends JDialog {
                     bin.changeAmountAvailable(shotsToRemove, (AmmoType) bin.getType()); 
                 }
                 if (shotsByBay.containsKey(bin.getBay())) {
-                    bin.setShotsNeeded(bin.getShotsNeeded());
+                    Map<String,Integer> oldAmmo = shotsByBay.get(bin.getBay());
+                    if (oldAmmo.containsKey(bin.getType().getInternalName())) {
+                        //We've found the matching ammo bin, even though they've moved around.
+                        //Don't do anything else.
+                        continue;
+                    } else {
+                        //We've got a new bin for a new ammo type. It needs loading.
+                        bin.setShotsNeeded(bin.getFullShots());
+                    }
                 } else {
+                    //This bin isn't on our original ammo list at all. It needs loading.
                     bin.setShotsNeeded(bin.getFullShots());
                 }
                 bin.updateConditionFromPart();


### PR DESCRIPTION
+ BugFix  Allow the large craft ammo swap dialog to switch AR10, missile and artillery munitions properly