### PR TITLE
Large Craft Ammo Bin Improvements

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1821,6 +1821,12 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                     + "</pid>");
         }
         pw1.println(MekHqXmlUtil.indentStr(indentLvl + 1) + "</newUnitParts>");
+        pw1.println(MekHqXmlUtil.indentStr(indentLvl + 1) + "<lcBinsToChange>");
+        for(int pid : lcBinsToChange) {
+            pw1.println(MekHqXmlUtil.indentStr(indentLvl + 2) + "<pid>" + pid
+                    + "</pid>");
+        }
+        pw1.println(MekHqXmlUtil.indentStr(indentLvl + 1) + "</lcBinsToChange>");
         pw1.println(MekHqXmlUtil.indentStr(indentLvl + 1) + "<shoppingList>");
         for(Part p : shoppingList) {
             p.writeToXml(pw1, indentLvl+2);
@@ -1899,6 +1905,14 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                         Node wn3 = nl2.item(y);
                         if (wn3.getNodeName().equalsIgnoreCase("pid")) {
                             retVal.newUnitParts.add(Integer.parseInt(wn3.getTextContent()));
+                        }
+                    }
+                } else if (wn2.getNodeName().equalsIgnoreCase("lcBinsToChange")) {
+                    NodeList nl2 = wn2.getChildNodes();
+                    for (int y=0; y<nl2.getLength(); y++) {
+                        Node wn3 = nl2.item(y);
+                        if (wn3.getNodeName().equalsIgnoreCase("pid")) {
+                            retVal.lcBinsToChange.add(Integer.parseInt(wn3.getTextContent()));
                         }
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("shoppingList")) {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -785,7 +785,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                         if (type.hasFlag(AmmoType.F_CAP_MISSILE) || type.hasFlag(AmmoType.F_CRUISE_MISSILE) || type.hasFlag(AmmoType.F_SCREEN)) {
                             time += 60 * ((LargeCraftAmmoBin)oPart).getFullShots();
                         } else {
-                            time += 15 * Math.max(1, oPart.getTonnage());
+                            time += 15 * Math.max(1, (int) oPart.getTonnage());
                         }
                     } else {
                         time += 120;

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -343,8 +343,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                 // the old parts list here.
                 if (oPart instanceof LargeCraftAmmoBin
                         && part instanceof LargeCraftAmmoBin
-                        && ((LargeCraftAmmoBin)oPart).getType() == ((LargeCraftAmmoBin)part).getType()
-                        && ((LargeCraftAmmoBin)oPart).getCapacity() != ((LargeCraftAmmoBin)part).getCapacity()) {
+                        && ((LargeCraftAmmoBin)oPart).getType() == ((LargeCraftAmmoBin)part).getType()) {
                     lcBinsToChange.add(oPart.getId());
                 }
                 //FIXME: There have been instances of null oParts here. Save/load will fix these, but

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -152,6 +152,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         shoppingList = new ArrayList<>();
         oldIntegratedHS = new ArrayList<>();
         newIntegratedHS = new ArrayList<>();
+        lcBinsToChange = new ArrayList<>();
         fixableString = null;
         cost = Money.zero();
     }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -353,6 +353,15 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                             && (oPart.getLocation() != part.getLocation())) {
                         continue;
                     }
+                    // If we're changing the size but not type of an LC ammo bin, we want to ensure that the ammo
+                    // gets tracked appropriately - it should unload to the warehouse later in the process and then
+                    // reload in the correct quantity. For that we must make sure the bin doesn't get dropped off
+                    // the old parts list here.
+                    if (oPart instanceof LargeCraftAmmoBin
+                            && part instanceof LargeCraftAmmoBin
+                            && ((LargeCraftAmmoBin)oPart).getCapacity() == ((LargeCraftAmmoBin)part).getCapacity()) {
+                        continue;
+                    }
                     if(part instanceof EquipmentPart) {
                         //check the location to see if this moved. If so, then don't break, but
                         //save this in case we fail to find equipment in the same location.

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -134,7 +134,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
     private List<Part> shoppingList;
     private List<Part> oldIntegratedHS;
     private List<Part> newIntegratedHS;
-    private Set<Part> lcBinsToChange;
+    private Set<Integer> lcBinsToChange;
 
     private int armorNeeded;
     private Armor newArmorSupplies;
@@ -343,8 +343,9 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                 // the old parts list here.
                 if (oPart instanceof LargeCraftAmmoBin
                         && part instanceof LargeCraftAmmoBin
+                        && ((LargeCraftAmmoBin)oPart).getType() == ((LargeCraftAmmoBin)part).getType()
                         && ((LargeCraftAmmoBin)oPart).getCapacity() != ((LargeCraftAmmoBin)part).getCapacity()) {
-                    lcBinsToChange.add(oPart);
+                    lcBinsToChange.add(oPart.getId());
                 }
                 //FIXME: There have been instances of null oParts here. Save/load will fix these, but
                 //I would like to figure out the source. From experimentation, I think it has to do with
@@ -1350,8 +1351,12 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         }
         // Unload any large craft ammo bins to ensure ammo isn't lost
         // when we're changing the amount but not the type of ammo
-        for (Part bin : lcBinsToChange) {
-            ((AmmoBin) bin).unload();
+        for (int pid : lcBinsToChange) {
+            Part part = oldUnit.getCampaign().getPart(pid);
+            if (part instanceof AmmoBin) {
+                ((AmmoBin)part).unload();
+            }
+            
         }
         // add leftover untracked heat sinks to the warehouse
         for(Part part : oldIntegratedHS) {

--- a/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
@@ -111,6 +111,10 @@ public class LargeCraftAmmoSwapDialog extends JDialog {
                 int oldShots = shotsByBay.get(bin.getBay()).getOrDefault(bin.getType().getInternalName(), 0);
                 // If we're removing ammo, add it the warehouse
                 int shotsToChange = oldShots - ammo.getBaseShotsLeft();
+                if (bin.getCapacity() == 0) {
+                    // Then we've got a valid bin for which the ammo's out
+                    shotsToChange = oldShots;
+                }
                 if (shotsToChange > 0) {
                     bin.changeAmountAvailable(shotsToChange, (AmmoType) bin.getType()); 
                 }


### PR DESCRIPTION
A couple of extra improvements after my last PR on the subject


+ Enhancement:  Properly removes ammo from large craft bins when ammo swap dialog reduces a bin to 0 shots
+ Enhancement: Refits return large craft ammo to the warehouse when the refit changes the count but not the type of ammo (AR10s, MMLs...)