### PR TITLE
Subset export fixes

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3658,6 +3658,8 @@ public class Campaign implements Serializable, ITechManager {
                     unitsToCheck.add(unit.getId());
                 }
             }
+            
+            unit.resetEngineer();
         }
 
         for(UUID uid : unitsToCheck) {

--- a/MekHQ/src/mekhq/campaign/personnel/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillType.java
@@ -132,6 +132,10 @@ public class SkillType implements Serializable {
         }
     }
     
+    public static Hashtable<String, SkillType> getSkillHash() {
+        return lookupHash;
+    }
+    
     public static String[] getSkillList() {
         return skillList;
     }    
@@ -304,26 +308,6 @@ public class SkillType implements Serializable {
         lookupHash.put(S_LEADER, createLeadership());
         lookupHash.put(S_NEG, createNegotiation());
         lookupHash.put(S_SCROUNGE, createScrounge());
-
-        /*
-        abilityCosts = new HashMap<String, Integer>();
-        abilityCosts.put("hot_dog", 4);
-        abilityCosts.put("jumping_jack", 12);
-        abilityCosts.put("melee_master", 12);
-        abilityCosts.put("multi_tasker", 4);
-        abilityCosts.put("oblique_attacker", 4);
-        abilityCosts.put("pain_resistance", 4);
-        abilityCosts.put("sniper", 12);
-        abilityCosts.put("weapon_specialist", 1);
-        abilityCosts.put("specialist", 4);
-        abilityCosts.put("tactical_genius", 12);
-        abilityCosts.put("aptitude_gunnery", 40);
-        abilityCosts.put("gunnery_laser", 4);
-        abilityCosts.put("gunnery_ballistic", 4);
-        abilityCosts.put("gunnery_missile", 4);
-        abilityCosts.put("ei_implant", 0);
-        abilityCosts.put("clan_pilot_training", 0);
-        */
     }
     
     public static SkillType getType(String t) {

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -532,9 +532,6 @@ public class CampaignExportWizard extends JDialog {
         // forces aren't moved/copied over, we just use the force selection to pre-populate the list of people and units 
         // to be exported
         
-        // we keep track of "engineers" for self-maintained units, key is the person ID, value is the unit ID.
-        Map<UUID, UUID> selfMaintainedUnitTechMap = new HashMap<>();
-        
         for(Unit unit : unitList.getSelectedValuesList()) {
             if(destinationCampaign.getUnit(unit.getId()) != null) {
                 destinationCampaign.removeUnit(unit.getId());
@@ -542,10 +539,6 @@ public class CampaignExportWizard extends JDialog {
             
             destinationCampaign.importUnit(unit);
             destinationCampaign.getUnit(unit.getId()).setForceId(Force.FORCE_NONE);
-            
-            if(unit.getEngineer() != null) {
-                selfMaintainedUnitTechMap.put(unit.getEngineer().getId(), unit.getId());
-            }
         }
         
         // overwrite any people with the same ID.


### PR DESCRIPTION
Fixes behaviors reported in #1290:
- part counts properly export
- source campaign skill and ability settings don't get clobbered
- "techs" for crew-maintained units properly register upon export campaign load rather than having to wait a day