### PR TITLE
Rescalable images for unit view panel when fluff image exists

### DIFF
--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -93,7 +93,7 @@ public final class HangarTab extends CampaignGuiTab {
 
     private static final long serialVersionUID = -5636638711420905602L;
 
-    public static final int UNIT_VIEW_WIDTH = 450;
+    public static final int UNIT_VIEW_WIDTH = 600;
 
     // unit views
     private static final int UV_GRAPHIC = 0;

--- a/MekHQ/src/mekhq/gui/utilities/ImgLabel.java
+++ b/MekHQ/src/mekhq/gui/utilities/ImgLabel.java
@@ -1,0 +1,81 @@
+/*
+ * MekHQ - Copyright (C) 2019 - The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+package mekhq.gui.utilities;
+
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Image;
+
+import javax.swing.JLabel;
+
+/**
+ * A custom label that paints an image to the label that resizes based on the size of the label while
+ * maintaining the aspect ratio of the original image.
+ * 
+ * Code borrowed from:
+ * https://stackoverflow.com/questions/10245220/java-image-resize-maintain-aspect-ratio
+ * 
+ * @author Taharqa
+ *
+ */
+public class ImgLabel extends JLabel {
+     /**
+     * 
+     */
+    private static final long serialVersionUID = 2805687715274055318L;
+    Image image;
+    
+    public ImgLabel(Image i) {
+        super();
+        this.image = i;
+    }
+    
+    /**
+     * Get the scaled dimensions for the image that allow it to fit into the label's current size
+     * @return <code>Dimension</code> giving the new scaled dimensions 
+     */
+    private Dimension getScaledDimension() {
+        int original_width = image.getWidth(this);
+        int original_height = image.getHeight(this);
+        int bound_width = getWidth();
+        int bound_height = getHeight();
+        int new_width = original_width;
+        int new_height = original_height;
+
+        // first check if we need to scale width
+        if (original_width > bound_width) {
+            //scale width to fit
+            new_width = bound_width;
+            //scale height to maintain aspect ratio
+            new_height = (new_width * original_height) / original_width;
+        }
+
+        // then check if we need to scale even with the new height
+        if (new_height > bound_height) {
+            //scale height to fit instead
+            new_height = bound_height;
+            //scale width to maintain aspect ratio
+            new_width = (new_height * original_width) / original_height;
+        }
+        return new Dimension(new_width, new_height);
+    }
+        
+    @Override
+    public void paintComponent(Graphics g)
+    {
+        super.paintComponent(g);
+        Dimension dims = getScaledDimension();
+        g.drawImage(image, 0, 0, (int) dims.getWidth(), (int) dims.getHeight(), this);
+    }
+}

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -8,13 +8,15 @@ package mekhq.gui.view;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.Graphics;
 import java.awt.Image;
 import java.util.ResourceBundle;
 
 import javax.swing.BorderFactory;
-import javax.swing.Icon;
 import javax.swing.ImageIcon;
+import javax.swing.JLabel;
 
 import megamek.client.ui.swing.MechTileset;
 import megamek.client.ui.swing.util.FluffImageHelper;
@@ -28,6 +30,7 @@ import megamek.common.util.EncodeControl;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.EntityImage;
+import mekhq.gui.utilities.ImgLabel;
 import mekhq.gui.utilities.MarkdownRenderer;
 
 /**
@@ -48,7 +51,7 @@ public class UnitViewPanel extends ScrollablePanel {
 	private MechTileset mt;
     private DirectoryItems camos;
 	
-	private javax.swing.JLabel lblImage;
+	private JLabel lblImage;
 	//private javax.swing.JPanel pnlStats;
 	private javax.swing.JTextPane txtReadout;
 	private javax.swing.JTextPane txtFluff;	
@@ -79,7 +82,6 @@ public class UnitViewPanel extends ScrollablePanel {
 	private void initComponents() {
 		java.awt.GridBagConstraints gridBagConstraints;
 
-		lblImage = new javax.swing.JLabel();
 		txtReadout = new javax.swing.JTextPane();
 		txtFluff = new javax.swing.JTextPane();
 		pnlStats = new javax.swing.JPanel();
@@ -89,36 +91,50 @@ public class UnitViewPanel extends ScrollablePanel {
 		setLayout(new java.awt.GridBagLayout());
 
 		setBackground(Color.WHITE);
-		
-		lblImage.setName("lblImage"); // NOI18N
-		lblImage.setBackground(Color.WHITE);
-		Image image = FluffImageHelper.getFluffImage(entity);
-		if(null == image) {
-			image = getImageFor(unit, lblImage);     
-		}
-        Icon icon;
-		if(null != image) {
-			if(image.getWidth(lblImage) > 200) {
-                image = image.getScaledInstance(200, -1, Image.SCALE_DEFAULT);               
+
+        int compWidth = 1;
+        Image image = FluffImageHelper.getFluffImage(entity);
+        if(null != image) {
+            //fluff image exists so use custom ImgLabel to get full mech porn
+            lblImage = new  ImgLabel(image);
+            gridBagConstraints = new java.awt.GridBagConstraints();
+            gridBagConstraints.gridx = 1;
+            gridBagConstraints.gridy = 0;
+            gridBagConstraints.gridheight = 3;
+            gridBagConstraints.weightx = 1.0;
+            gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
+            gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+            gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+            add(lblImage, gridBagConstraints);
+        } else {
+            //no fluff image, so just use image icon from top-down view
+            compWidth=2;
+            lblImage = new JLabel();
+            lblImage.setBackground(Color.WHITE);
+            image = getImageFor(unit, lblImage);
+            if(null != image) {
+                ImageIcon icon = new ImageIcon(image);
+                lblImage.setIcon(icon);
+                gridBagConstraints = new java.awt.GridBagConstraints();
+                gridBagConstraints.gridx = 1;
+                gridBagConstraints.gridy = 0;
+                gridBagConstraints.gridheight = 1;
+                gridBagConstraints.weightx = 1.0;
+                gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+                gridBagConstraints.anchor = java.awt.GridBagConstraints.CENTER;
+                add(lblImage, gridBagConstraints);
             }
-            icon = new ImageIcon(image);
-            lblImage.setIcon(icon);
         }
-		gridBagConstraints = new java.awt.GridBagConstraints();
-		gridBagConstraints.gridx = 0;
-		gridBagConstraints.gridy = 0;
-		gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
-		gridBagConstraints.anchor = java.awt.GridBagConstraints.CENTER;
-		add(lblImage, gridBagConstraints);
-	
+        
 		pnlStats.setName("pnlBasic");
 		pnlStats.setBorder(BorderFactory.createTitledBorder(unit.getName()));
 		pnlStats.setBackground(Color.WHITE);
 		fillStats(resourceMap);
 		gridBagConstraints = new java.awt.GridBagConstraints();
-		gridBagConstraints.gridx = 1;
+		gridBagConstraints.gridx = 0;
 		gridBagConstraints.gridy = 0;
-		gridBagConstraints.weightx = 1.0;
+		gridBagConstraints.weightx = 0.0;
+		gridBagConstraints.gridwidth = 1;
 		gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
 		gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;	
@@ -137,8 +153,8 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints = new java.awt.GridBagConstraints();
 		gridBagConstraints.gridx = 0;
 		gridBagConstraints.gridy = 1;
-		gridBagConstraints.gridwidth = 2;
-		gridBagConstraints.weightx = 1.0;
+		gridBagConstraints.weightx = 0.0;
+		gridBagConstraints.gridwidth = compWidth;
 		if(unit.getHistory().length() == 0) {
 			gridBagConstraints.weighty = 1.0;
 		}
@@ -158,9 +174,9 @@ public class UnitViewPanel extends ScrollablePanel {
 			gridBagConstraints = new java.awt.GridBagConstraints();
 			gridBagConstraints.gridx = 0;
 			gridBagConstraints.gridy = 2;
-			gridBagConstraints.gridwidth = 2;
-			gridBagConstraints.weightx = 1.0;
+			gridBagConstraints.weightx = 0.0;
 			gridBagConstraints.weighty = 1.0;
+			gridBagConstraints.gridwidth = compWidth;
 			gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
 			gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
 			gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
@@ -331,4 +347,48 @@ public class UnitViewPanel extends ScrollablePanel {
         }
         return camo;
     }
+    
+ /*   private class ImgLabel extends JLabel {
+        Image image;
+        
+        public ImgLabel(Image i)
+        {
+            super();
+            this.image = i;
+        }
+        
+        private Dimension getScaledDimension() {
+            int original_width = image.getWidth(this);
+            int original_height = image.getHeight(this);
+            int bound_width = getWidth();
+            int bound_height = getHeight();
+            int new_width = original_width;
+            int new_height = original_height;
+
+            // first check if we need to scale width
+            if (original_width > bound_width) {
+                //scale width to fit
+                new_width = bound_width;
+                //scale height to maintain aspect ratio
+                new_height = (new_width * original_height) / original_width;
+            }
+
+            // then check if we need to scale even with the new height
+            if (new_height > bound_height) {
+                //scale height to fit instead
+                new_height = bound_height;
+                //scale width to maintain aspect ratio
+                new_width = (new_height * original_width) / original_height;
+            }
+            return new Dimension(new_width, new_height);
+        }
+        
+        @Override
+        public void paintComponent(Graphics g)
+        {
+            super.paintComponent(g);
+            Dimension dims = getScaledDimension();
+            g.drawImage(image, 0, 0, (int) dims.getWidth(), (int) dims.getHeight(), this);
+        }
+    }*/
 }

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -347,48 +347,4 @@ public class UnitViewPanel extends ScrollablePanel {
         }
         return camo;
     }
-    
- /*   private class ImgLabel extends JLabel {
-        Image image;
-        
-        public ImgLabel(Image i)
-        {
-            super();
-            this.image = i;
-        }
-        
-        private Dimension getScaledDimension() {
-            int original_width = image.getWidth(this);
-            int original_height = image.getHeight(this);
-            int bound_width = getWidth();
-            int bound_height = getHeight();
-            int new_width = original_width;
-            int new_height = original_height;
-
-            // first check if we need to scale width
-            if (original_width > bound_width) {
-                //scale width to fit
-                new_width = bound_width;
-                //scale height to maintain aspect ratio
-                new_height = (new_width * original_height) / original_width;
-            }
-
-            // then check if we need to scale even with the new height
-            if (new_height > bound_height) {
-                //scale height to fit instead
-                new_height = bound_height;
-                //scale width to maintain aspect ratio
-                new_width = (new_height * original_width) / original_height;
-            }
-            return new Dimension(new_width, new_height);
-        }
-        
-        @Override
-        public void paintComponent(Graphics g)
-        {
-            super.paintComponent(g);
-            Dimension dims = getScaledDimension();
-            g.drawImage(image, 0, 0, (int) dims.getWidth(), (int) dims.getHeight(), this);
-        }
-    }*/
 }


### PR DESCRIPTION
On the twin premises that:

1. Battletech is first and foremost about mech porn
2. Players are so into mech images (see premise 1) that they are willing to commission [great works of art](https://bg.battletech.com/forums/index.php?topic=37902.0;topicseen) to see their personal units in action

I have therefore concluded that our UnitViewPanel could use some work to better show off fluff images when players have them. In order to do that I have moved things around a little bit when a fluff image exists and put an image which automatically adjusts to fit the space (up to its size) when it has the room. Here is an example of it in action;

![Screen Shot 2019-10-23 at 9 57 39 AM](https://user-images.githubusercontent.com/16107446/67436404-2b832480-f5a3-11e9-9ef8-4fc214c8b970.png)

In order to do this, I created a custom ImgLabel.java object that uses the paintComponent method to paint a properly sized image. This could be used in other places as well. There is already a method similar to this in ImageUtils for rescaling images but (a) it uses getScaledImage which I have been reading is not a great way to do this, and (b) I couldn't get it to work right. 

I also increased the default of the unit view scrollbar in the hangar tab to accomodate the larger images from the get-go. 

If the player does not have a fluff image the display looks more or less as it did before except that I moved the image to the right of the text:

![Screen Shot 2019-10-23 at 2 45 05 PM](https://user-images.githubusercontent.com/16107446/67436637-ba903c80-f5a3-11e9-92db-686a1f4fad29.png)
