### PR TITLE
detect units given to other players

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjective.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjective.java
@@ -314,7 +314,8 @@ public class ScenarioObjective {
      */
     public String toShortString() {
         String timeLimitString = getTimeLimitString();
-        String edgeString = getDestinationEdge() != OffBoardDirection.NONE ? getDestinationEdge().toString() : "";
+        String edgeString = ((getDestinationEdge() != OffBoardDirection.NONE) &&
+                (getDestinationEdge() != null)) ? getDestinationEdge().toString() : "";
         String amountString = fixedAmount != null ? fixedAmount.toString() : String.format("%d%%", percentage);
         
         switch(getObjectiveCriterion()) {


### PR DESCRIPTION
This fixes a long-standing complaint about MekHQ: if you give some of your units to a buddy, they show up as totaled during scenario resolution. Turns out, it's pretty easy to detect if a unit that you gave to an ally actually came from your campaign.