### PR TITLE
SV parts and customization

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -234,7 +234,7 @@ public class Armor extends Part implements IAcquisitionWork {
     public TechAdvancement getTechAdvancement() {
         return EquipmentType.getArmorTechAdvancement(type, clan);
     }
-    
+
     public double getArmorWeight(int points) {
         // from megamek.common.Entity.getArmorWeight()
 
@@ -278,7 +278,18 @@ public class Armor extends Part implements IAcquisitionWork {
                 +"<clan>"
                 +clan
                 +"</clan>");
+        writeAdditionalFields(pw1, indent + 1);
         writeToXmlEnd(pw1, indent);
+    }
+
+    /**
+     * This should be overridden by subclasses that need to write additional fields
+     *
+     * @param pw      The writer instance
+     * @param indent  The amount to indent the xml output
+     */
+    protected void writeAdditionalFields(PrintWriter pw, int indent) {
+        // do nothing
     }
 
     @Override
@@ -310,7 +321,7 @@ public class Armor extends Part implements IAcquisitionWork {
             amountNeeded *= 10;
         }
         int amountFound = Math.min(getAmountAvailable(), amountNeeded);
-        int fixAmount = Math.min(amount + 
+        int fixAmount = Math.min(amount +
                 // Make sure that we handle the capital scale conversion when setting the fix amount
                 (unit.getEntity().isCapitalScale() ? (amountFound / 10) : amountFound), unit.getEntity().getOArmor(location, rear));
         unit.getEntity().setArmor(fixAmount, location, rear);
@@ -472,7 +483,7 @@ public class Armor extends Part implements IAcquisitionWork {
     @Override
     public String getAcquisitionDisplayName() {
         return getName();
-    }    
+    }
 
     @Override
     public String getAcquisitionExtraDesc() {

--- a/MekHQ/src/mekhq/campaign/parts/MissingSVEngine.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingSVEngine.java
@@ -56,7 +56,9 @@ public class MissingSVEngine extends MissingPart {
         this.baseEngineFactor = baseEngineFactor;
         this.fuelType = fuelType;
 
-        techAdvancement = new Engine(10, etype, Engine.SUPPORT_VEE_ENGINE).getTechAdvancement();
+        Engine engine = new Engine(10, etype, Engine.SUPPORT_VEE_ENGINE);
+        techAdvancement = engine.getTechAdvancement();
+        name = String.format("%s (%s) Engine", engine.getEngineName(), ITechnology.getRatingName(techRating));
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingSVEngine.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingSVEngine.java
@@ -1,20 +1,20 @@
 /*
- * MekBuilder - unit design companion of MegaMek
- * Copyright (C) 2017 The MegaMek Team
+ * Copyright (c) 2019 - The MegaMek Team
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This file is part of MekHQ.
  *
- * This program is distributed in the hope that it will be useful,
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.parts;
 
@@ -30,6 +30,7 @@ import java.io.PrintWriter;
  * Place holder for an engine that has been destroyed or removed from a support vehicle
  */
 public class MissingSVEngine extends MissingPart {
+    private static final long serialVersionUID = -1388693773192376347L;
 
     private double engineTonnage;
     private int etype;

--- a/MekHQ/src/mekhq/campaign/parts/MissingSVEngine.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingSVEngine.java
@@ -1,0 +1,199 @@
+/*
+ * MekBuilder - unit design companion of MegaMek
+ * Copyright (C) 2017 The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package mekhq.campaign.parts;
+
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.GregorianCalendar;
+
+/**
+ * Place holder for an engine that has been destroyed or removed from a support vehicle
+ */
+public class MissingSVEngine extends MissingPart {
+
+    // Part stores unit tonnage as an int. Support vees can come in fractions of a ton.
+    private double actualTonnage;
+    private int etype;
+    private int techRating;
+    private int movementFactor;
+    private double baseEngineFactor;
+    private FuelType fuelType;
+
+    private TechAdvancement techAdvancement;
+
+    public MissingSVEngine() {
+        this(0.0, Engine.COMBUSTION_ENGINE, RATING_D, 1, 0.0, FuelType.PETROCHEMICALS, null);
+    }
+
+    public MissingSVEngine(double unitTonnage, int etype, int techRating, int movementFactor,
+                           double baseEngineFactor, FuelType fuelType, Campaign campaign) {
+        super((int) unitTonnage, campaign);
+        this.actualTonnage = unitTonnage;
+        this.etype = etype;
+        this.techRating = techRating;
+        this.movementFactor = movementFactor;
+        this.baseEngineFactor = baseEngineFactor;
+        this.fuelType = fuelType;
+
+        techAdvancement = new Engine(10, etype, Engine.SUPPORT_VEE_ENGINE).getTechAdvancement();
+    }
+
+    @Override
+    public int getBaseTime() {
+        return 360;
+    }
+
+    @Override
+    public int getDifficulty() {
+        return -1;
+    }
+
+    @Override
+    public double getTonnage() {
+        if (null != getUnit()) {
+            return RoundWeight.standard(actualTonnage * baseEngineFactor * movementFactor
+                    * Engine.getSVEngineFactor(etype, techRating), getUnit().getEntity());
+        } else {
+            return RoundWeight.nextKg(actualTonnage * baseEngineFactor * movementFactor
+                    * Engine.getSVEngineFactor(etype, techRating));
+        }
+    }
+
+    private static final String NODE_UNIT_TONNAGE = "actualUnitTonnage";
+    private static final String NODE_ETYPE = "etype";
+    private static final String NODE_TECH_RATING = "techRating";
+    private static final String NODE_MOVEMENT_FACTOR = "movementFactor";
+    private static final String NODE_BASE_ENGINE_FACTOR = "baseEngineFactor";
+    private static final String NODE_FUEL_TYPE = "fuelType";
+    @Override
+    public void writeToXml(PrintWriter pw, int indent) {
+        writeToXmlBegin(pw, indent);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_UNIT_TONNAGE, actualTonnage);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_ETYPE, etype);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_TECH_RATING, ITechnology.getRatingName(techRating));
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_MOVEMENT_FACTOR, movementFactor);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_BASE_ENGINE_FACTOR, baseEngineFactor);
+        if (etype == Engine.COMBUSTION_ENGINE) {
+            MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_FUEL_TYPE, fuelType.name());
+        }
+        writeToXmlEnd(pw, indent);
+    }
+
+    @Override
+    public void loadFieldsFromXmlNode(Node node) {
+        NodeList nl = node.getChildNodes();
+        for (int x = 0; x < nl.getLength(); x++) {
+            final Node wn = nl.item(x);
+            switch (wn.getNodeName()) {
+                case NODE_UNIT_TONNAGE:
+                    actualTonnage = Double.parseDouble(wn.getTextContent());
+                    break;
+                case NODE_ETYPE:
+                    etype = Integer.parseInt(wn.getTextContent());
+                    break;
+                case NODE_TECH_RATING:
+                    for (int i = 0; i < ratingNames.length; i++) {
+                        if (ratingNames[i].equals(wn.getTextContent())) {
+                            techRating = i;
+                            break;
+                        }
+                    }
+                    break;
+                case NODE_MOVEMENT_FACTOR:
+                    movementFactor = Integer.parseInt(wn.getTextContent());
+                    break;
+                case NODE_BASE_ENGINE_FACTOR:
+                    baseEngineFactor = Double.parseDouble(wn.getTextContent());
+                    break;
+                case NODE_FUEL_TYPE:
+                    fuelType = FuelType.valueOf(wn.getTextContent());
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public boolean isAcceptableReplacement(Part other, boolean refit) {
+        return other instanceof SVEnginePart
+                && (etype == ((SVEnginePart) other).getEType())
+                && (techRating == ((SVEnginePart) other).getTechRating())
+                && (movementFactor == ((SVEnginePart) other).getMovementFactor())
+                && (baseEngineFactor == ((SVEnginePart) other).getBaseEngineFactor())
+                && ((etype != Engine.COMBUSTION_ENGINE) || (fuelType == ((SVEnginePart) other).getFuelType()));
+    }
+
+    @Override
+    public String checkFixable() {
+        // If the engine location is destroyed, the unit is destroyed
+        return null;
+    }
+
+    @Override
+    public Part getNewPart() {
+        return new SVEnginePart(actualTonnage, etype, techRating, movementFactor,
+                baseEngineFactor, fuelType, getCampaign());
+    }
+
+    @Override
+    public void updateConditionFromPart() {
+        if(null != unit) {
+            if(unit.getEntity() instanceof Tank) {
+                ((Tank) unit.getEntity()).engineHit();
+            } else if(unit.getEntity() instanceof Aero) {
+                ((Aero) unit.getEntity()).setEngineHits(((Aero) unit.getEntity()).getMaxEngineHits());
+            }
+        }
+    }
+
+    @Override
+    public String getAcquisitionName() {
+        return getPartName() + ",  " + getTonnage() + " tons";
+    }
+
+    @Override
+    public String getLocationName() {
+        return null;
+    }
+
+    @Override
+    public int getLocation() {
+        return Entity.LOC_NONE;
+    }
+
+    @Override
+    public TechAdvancement getTechAdvancement() {
+        return techAdvancement;
+    }
+
+    @Override
+    public boolean isInLocation(String loc) {
+        return false;
+    }
+
+    @Override
+    public int getMassRepairOptionType() {
+        return Part.REPAIR_PART_TYPE.ENGINE;
+    }
+
+}

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -290,7 +290,15 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             return;
         }
         time = 0;
-        sameArmorType = newEntity.getArmorType(0) == oldUnit.getEntity().getArmorType(0);
+        sameArmorType = newEntity.getArmorType(newEntity.firstArmorIndex())
+                == oldUnit.getEntity().getArmorType(oldUnit.getEntity().firstArmorIndex());
+        // SVs with standard SV armor need to check for change in BAR/tech rating
+        if (newEntity.isSupportVehicle()
+                && (newEntity.getArmorType(newEntity.firstArmorIndex()) == EquipmentType.T_ARMOR_STANDARD)) {
+            sameArmorType = newEntity.getBARRating(newEntity.firstArmorIndex())
+                        == oldUnit.getEntity().getArmorType(oldUnit.getEntity().firstArmorIndex())
+                    && (newEntity.getArmorTechRating() == oldUnit.getEntity().getArmorTechRating());
+        }
         int recycledArmorPoints = 0;
         boolean replacingLocations = false;
         boolean[] locationHasNewStuff = new boolean[Math.max(newEntity.locations(), oldUnit.getEntity().locations())];

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -22,9 +22,13 @@ import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.ITechnology;
 import megamek.common.TechAdvancement;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.work.IAcquisitionWork;
+import org.w3c.dom.Node;
+
+import java.io.PrintWriter;
 
 /**
  * Standard support vehicle armor, which can differ by BAR and tech rating.
@@ -98,11 +102,6 @@ public class SVArmor extends Armor {
     }
 
     @Override
-    public Money getBuyCost() {
-        return getStickerPrice();
-    }
-
-    @Override
     public boolean isSamePartType(Part part) {
         return part instanceof SVArmor
                 && bar == ((SVArmor) part).bar
@@ -116,11 +115,6 @@ public class SVArmor extends Armor {
     @Override
     public IAcquisitionWork getAcquisitionWork() {
         return new SVArmor(bar, techRating, (int) Math.round(5.0 / getArmorPointsPerTon()), -1, campaign);
-    }
-
-    @Override
-    public int getDifficulty() {
-        return -2;
     }
 
     @Override
@@ -154,6 +148,35 @@ public class SVArmor extends Armor {
             campaign.removePart(a);
         } else if(null == a && amount > 0) {
             campaign.addPart(new SVArmor(bar, techRating, amount, -1, campaign), 0);
+        }
+    }
+
+    private static final String NODE_BAR = "bar";
+    private static final String NODE_TECH_RATING = "techRating";
+
+    @Override
+    protected void writeAdditionalFields(PrintWriter pw, int indent) {
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent, NODE_BAR, bar);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent, NODE_TECH_RATING, ITechnology.getRatingName(techRating));
+    }
+
+    @Override
+    protected void loadFieldsFromXmlNode(Node node) {
+        for (int x = 0; x < node.getChildNodes().getLength(); x++) {
+            final Node wn = node.getChildNodes().item(x);
+            switch (wn.getNodeName()) {
+                case NODE_BAR:
+                    bar = Integer.parseInt(wn.getTextContent());
+                    break;
+                case NODE_TECH_RATING:
+                    for (int r = 0; r < ratingNames.length; r++) {
+                        if (ratingNames[r].equals(wn.getTextContent())) {
+                            techRating = r;
+                            break;
+                        }
+                    }
+                    break;
+            }
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
@@ -1,0 +1,387 @@
+/*
+ * MekBuilder - unit design companion of MegaMek
+ * Copyright (C) 2017 The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package mekhq.campaign.parts;
+
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.personnel.SkillType;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+
+/**
+ * Engine for a support vehicle. An identical support vehicle engine will have the same engine type,
+ * unit tonnage, tech rating, and movement factor. The movement factor is the vehicle's (cruise/safe thrust)^2 + 4.
+ * ICEs will also have the same fuel type.
+ */
+public class SVEnginePart extends Part {
+
+    // Part stores unit tonnage as an int. Support vees can come in fractions of a ton.
+    private double actualTonnage;
+    private int etype;
+    private int techRating;
+    private int movementFactor;
+    private double baseEngineFactor;
+    private FuelType fuelType;
+
+    private TechAdvancement techAdvancement;
+
+    /**
+     * Constructor used during campaign deserialization
+     */
+    @SuppressWarnings("unused")
+    private SVEnginePart() {
+        this(0.0, Engine.COMBUSTION_ENGINE, RATING_D, 1, 0.0, FuelType.PETROCHEMICALS, null);
+    }
+
+    /**
+     * Creates a support vehicle engine part.
+     *
+     * @param unitTonnage      The mass of the unit it is installed on/intended for, in tons.
+     * @param etype            An {@link Engine} type constant
+     * @param techRating       The engine's tech rating, {@code RATING_A} through {@code RATING_F}
+     * @param movementFactor   The movement factor of the unit this engine is installed on/intended for. The movement
+     *                         factor is the square of the cruise/safe thrust squared, plus four. Rail support
+     *                         vehicles subtract two from the cruise speed for use in this calculation. The rules
+     *                         don't say what to do with a theoretical mp of 1, but presumably it would not be
+     *                         larger than a unit with mp 2, despite the formula.
+     * @param baseEngineFactor A factor based on the vehicle size class and motive type. See {@link megamek.common.Entity#getBaseEngineValue()}
+     * @param fuelType         Needed to distinguish different types of internal combustion engines.
+     * @param campaign         The campaign instance
+     */
+    public SVEnginePart(double unitTonnage, int etype, int techRating, int movementFactor, double baseEngineFactor,
+                        FuelType fuelType, Campaign campaign) {
+        super((int) unitTonnage, campaign);
+        this.actualTonnage = unitTonnage;
+        this.etype = etype;
+        this.techRating = techRating;
+        this.movementFactor = movementFactor;
+        this.baseEngineFactor = baseEngineFactor;
+        this.fuelType = fuelType;
+
+        techAdvancement = new Engine(10, etype, Engine.SUPPORT_VEE_ENGINE).getTechAdvancement();
+    }
+
+    /**
+     * {@link Part#getUnitTonnage()} returns an {@code int}. Support vehicle weights don't necessarily
+     * come in full tons.
+     *
+     * @return The weight of the support vehicle the engine belongs in.
+     */
+    public double getActualUnitTonnage() {
+        return actualTonnage;
+    }
+
+    /**
+     * @return The {@link Engine} type flag
+     */
+    public int getEType() {
+        return etype;
+    }
+
+    /**
+     * @return The engine tech rating (A-F)
+     */
+    public int getTechRating() {
+        return techRating;
+    }
+
+    /**
+     * @return The unit's movement factor, used to calculate engine weight.
+     */
+    public int getMovementFactor() {
+        return movementFactor;
+    }
+
+    /**
+     * The base engine factor is determined by motive type and size class.
+     *
+     * @return The base engine factor, used to calculate engine weight.
+     * @see Entity#getBaseEngineValue()
+     */
+    public double getBaseEngineFactor() {
+        return baseEngineFactor;
+    }
+
+    /**
+     * Internal combustion engines differ by the type of fuel they are designed for.
+     *
+     * @return The type of fuel used by the engine.
+     */
+    public FuelType getFuelType() {
+        return fuelType;
+    }
+
+    @Override
+    public SVEnginePart clone() {
+        SVEnginePart engine = new SVEnginePart(actualTonnage, etype, techRating, movementFactor,
+                baseEngineFactor, fuelType, getCampaign());
+        engine.copyBaseData(this);
+        return engine;
+    }
+
+    @Override
+    public double getTonnage() {
+        if (null != getUnit()) {
+            return RoundWeight.standard(actualTonnage * baseEngineFactor * movementFactor
+                    * Engine.getSVEngineFactor(etype, techRating), getUnit().getEntity());
+        } else {
+            return RoundWeight.nextKg(actualTonnage * baseEngineFactor * movementFactor
+                    * Engine.getSVEngineFactor(etype, techRating));
+        }
+    }
+
+    @Override
+    public Money getStickerPrice() {
+        return Money.of(5000 * getTonnage() * Engine.getSVCostMultiplier(etype));
+    }
+
+    @Override
+    public boolean isSamePartType(Part other) {
+        return other instanceof SVEnginePart
+                && (etype == ((SVEnginePart) other).etype)
+                && (techRating == ((SVEnginePart) other).techRating)
+                && (movementFactor == ((SVEnginePart) other).movementFactor)
+                && (baseEngineFactor == ((SVEnginePart) other).baseEngineFactor)
+                && ((etype != Engine.COMBUSTION_ENGINE) || (fuelType == ((SVEnginePart) other).fuelType));
+    }
+
+    @Override
+    public int getTechLevel() {
+        return TechConstants.T_IS_TW_NON_BOX;
+    }
+
+    private static final String NODE_UNIT_TONNAGE = "actualUnitTonnage";
+    private static final String NODE_ETYPE = "etype";
+    private static final String NODE_TECH_RATING = "techRating";
+    private static final String NODE_MOVEMENT_FACTOR = "movementFactor";
+    private static final String NODE_BASE_ENGINE_FACTOR = "baseEngineFactor";
+    private static final String NODE_FUEL_TYPE = "fuelType";
+    @Override
+    public void writeToXml(PrintWriter pw, int indent) {
+        writeToXmlBegin(pw, indent);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_UNIT_TONNAGE, actualTonnage);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_ETYPE, etype);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_TECH_RATING, ITechnology.getRatingName(techRating));
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_MOVEMENT_FACTOR, movementFactor);
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_BASE_ENGINE_FACTOR, baseEngineFactor);
+        if (etype == Engine.COMBUSTION_ENGINE) {
+            MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, NODE_FUEL_TYPE, fuelType.name());
+        }
+        writeToXmlEnd(pw, indent);
+    }
+
+    @Override
+    public void loadFieldsFromXmlNode(Node node) {
+        NodeList nl = node.getChildNodes();
+        for (int x = 0; x < nl.getLength(); x++) {
+            final Node wn = nl.item(x);
+            switch (wn.getNodeName()) {
+                case NODE_UNIT_TONNAGE:
+                    actualTonnage = Double.parseDouble(wn.getTextContent());
+                    break;
+                case NODE_ETYPE:
+                    etype = Integer.parseInt(wn.getTextContent());
+                    break;
+                case NODE_TECH_RATING:
+                    for (int i = 0; i < ratingNames.length; i++) {
+                        if (ratingNames[i].equals(wn.getTextContent())) {
+                            techRating = i;
+                            break;
+                        }
+                    }
+                    break;
+                case NODE_MOVEMENT_FACTOR:
+                    movementFactor = Integer.parseInt(wn.getTextContent());
+                    break;
+                case NODE_BASE_ENGINE_FACTOR:
+                    baseEngineFactor = Double.parseDouble(wn.getTextContent());
+                    break;
+                case NODE_FUEL_TYPE:
+                    fuelType = FuelType.valueOf(wn.getTextContent());
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public void fix() {
+        super.fix();
+        if (null != unit) {
+            if (unit.getEntity() instanceof Tank) {
+                ((Tank) unit.getEntity()).engineFix();
+            } else if (unit.getEntity() instanceof Aero) {
+                ((Aero) unit.getEntity()).setEngineHits(0);
+            }
+        }
+    }
+
+    @Override
+    public MissingPart getMissingPart() {
+        return new MissingSVEngine(actualTonnage, etype, techRating, movementFactor,
+                baseEngineFactor, fuelType, getCampaign());
+    }
+
+    @Override
+    public void remove(boolean salvage) {
+        if (null != unit) {
+            if (unit.getEntity() instanceof Tank) {
+                ((Tank) unit.getEntity()).engineHit();
+            } else if (unit.getEntity() instanceof Aero) {
+                ((Aero) unit.getEntity()).setEngineHits(((Aero) unit.getEntity()).getMaxEngineHits());
+            }
+            Part spare = campaign.checkForExistingSparePart(this);
+            if(!salvage) {
+                campaign.removePart(this);
+            } else if(null != spare) {
+                spare.incrementQuantity();
+                campaign.removePart(this);
+            }
+            unit.removePart(this);
+            Part missing = getMissingPart();
+            unit.addPart(missing);
+            campaign.addPart(missing, 0);
+        }
+        setUnit(null);
+        updateConditionFromEntity(false);
+    }
+
+    @Override
+    public void updateConditionFromEntity(boolean checkForDestruction) {
+        if(null != unit) {
+            int engineHits = 0;
+            int engineCrits = 0;
+            if (unit.getEntity() instanceof Tank) {
+                engineCrits = 2;
+                if (((Tank) unit.getEntity()).isEngineHit()) {
+                    engineHits = 1;
+                }
+            } else if (unit.getEntity() instanceof Aero) {
+                engineHits = unit.getEntity().getEngineHits();
+                engineCrits = 3;
+            }
+            if(engineHits >= engineCrits) {
+                remove(false);
+            } else {
+                hits = Math.max(engineHits, 0);
+            }
+        }
+    }
+
+    @Override
+    public int getBaseTime() {
+        if (isSalvaging()) {
+            return 360;
+        }
+        // 100 minutes per hit, to a maximum of 300 minutes
+        return Math.min(300, hits * 100);
+    }
+
+    @Override
+    public int getDifficulty() {
+        if (isSalvaging()) {
+            return -1;
+        }
+        if (hits == 1) {
+            return -1;
+        } else if (hits == 2) {
+            return 0;
+        } else if (hits > 2) {
+            return 2;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean needsFixing() {
+        return hits > 0;
+    }
+
+    @Override
+    public void updateConditionFromPart() {
+        if (null != unit) {
+            if (hits == 0) {
+                if (unit.getEntity() instanceof Tank) {
+                    ((Tank) unit.getEntity()).engineFix();
+                } else if (unit.getEntity() instanceof Aero) {
+                    ((Aero) unit.getEntity()).setEngineHits(0);
+                }
+            } else {
+                if (unit.getEntity() instanceof Tank) {
+                    ((Tank) unit.getEntity()).engineHit();
+                } else if (unit.getEntity() instanceof Aero) {
+                    ((Aero) unit.getEntity()).setEngineHits(hits);
+                }
+            }
+        }
+    }
+
+    @Override
+    public String checkFixable() {
+        return null;
+    }
+
+    @Override
+    public boolean isMountedOnDestroyedLocation() {
+        return false;
+    }
+
+    @Override
+    public boolean isRightTechType(String skillType) {
+        if (null != getUnit()) {
+            if (getUnit().getEntity() instanceof Aero) {
+                return skillType.equals(SkillType.S_TECH_AERO);
+            } else {
+                return skillType.equals(SkillType.S_TECH_MECHANIC);
+            }
+        }
+        // We're not tracking whether parts in the warehouse came from ground or fixed-wing/airships,
+        // so let either tech repair it.
+        return (skillType.equals(SkillType.S_TECH_AERO) || skillType.equals(SkillType.S_TECH_MECHANIC));
+    }
+
+    @Override
+    public String getLocationName() {
+        if (null != unit) {
+            return unit.getEntity().getLocationName(unit.getEntity().getBodyLocation());
+        }
+        return null;
+    }
+
+    @Override
+    public int getLocation() {
+        if (null != unit) {
+            return unit.getEntity().getBodyLocation();
+        }
+        return Entity.LOC_NONE;
+    }
+
+    @Override
+    public TechAdvancement getTechAdvancement() {
+        return techAdvancement;
+    }
+
+    @Override
+    public int getMassRepairOptionType() {
+        return Part.REPAIR_PART_TYPE.ENGINE;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
@@ -78,7 +78,9 @@ public class SVEnginePart extends Part {
         this.baseEngineFactor = baseEngineFactor;
         this.fuelType = fuelType;
 
-        techAdvancement = new Engine(10, etype, Engine.SUPPORT_VEE_ENGINE).getTechAdvancement();
+        Engine engine = new Engine(10, etype, Engine.SUPPORT_VEE_ENGINE);
+        techAdvancement = engine.getTechAdvancement();
+        name = String.format("%s (%s) Engine", engine.getEngineName(), ITechnology.getRatingName(techRating));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
@@ -1,20 +1,20 @@
 /*
- * MekBuilder - unit design companion of MegaMek
- * Copyright (C) 2017 The MegaMek Team
+ * Copyright (c) 2019 - The MegaMek Team
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This file is part of MekHQ.
  *
- * This program is distributed in the hope that it will be useful,
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.parts;
 
@@ -34,6 +34,7 @@ import java.io.PrintWriter;
  * ICEs will also have the same fuel type.
  */
 public class SVEnginePart extends Part {
+    private static final long serialVersionUID = -5207004566629089937L;
 
     private double engineTonnage;
     private int etype;

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2238,7 +2238,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                         fuel = ((Tank) entity).getICEFuelType();
                     }
                     engine = new SVEnginePart(entity.getWeight(), entity.getEngine().getEngineType(),
-                            entity.getTechRating(), mf, entity.getBaseEngineValue(),
+                            entity.getEngineTechRating(), mf, entity.getBaseEngineValue(),
                             fuel, getCampaign());
                     addPart(engine);
                     partsToAdd.add(engine);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2079,8 +2079,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     BaArmor a = new BaArmor((int) getEntity().getWeight(), getEntity().getOArmor(i, false), entity.getArmorType(1), i, entity.isClan(), getCampaign());
                     addPart(a);
                     partsToAdd.add(a);
-                }
-                else {
+                } else if (entity.isSupportVehicle() && entity.getArmorType(i) == EquipmentType.T_ARMOR_STANDARD) {
+                    Armor a = new SVArmor(entity.getBARRating(i), entity.getArmorTechRating(),
+                            getEntity().getOArmor(i, false), i, getCampaign());
+                    addPart(a);
+                    partsToAdd.add(a);
+                } else {
                     Armor a = new Armor((int) getEntity().getWeight(), getEntity().getArmorType(i), getEntity().getOArmor(i, false), i, false, entity.isClanArmor(i), getCampaign());
                     addPart(a);
                     partsToAdd.add(a);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -28,69 +28,14 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import megamek.common.*;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.ServiceLogger;
+import mekhq.campaign.parts.*;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.ASFBay;
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.BattleArmorBay;
-import megamek.common.Bay;
-import megamek.common.BayType;
-import megamek.common.CargoBay;
-import megamek.common.Compute;
-import megamek.common.ConvFighter;
-import megamek.common.CriticalSlot;
-import megamek.common.DockingCollar;
-import megamek.common.Dropship;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityWeightClass;
-import megamek.common.EquipmentType;
-import megamek.common.FighterSquadron;
-import megamek.common.HeavyVehicleBay;
-import megamek.common.IArmorState;
-import megamek.common.ILocationExposureStatus;
-import megamek.common.IPlayer;
-import megamek.common.ITechnology;
-import megamek.common.Infantry;
-import megamek.common.InfantryBay;
-import megamek.common.InsulatedCargoBay;
-import megamek.common.Jumpship;
-import megamek.common.LAMPilot;
-import megamek.common.LandAirMech;
-import megamek.common.LightVehicleBay;
-import megamek.common.LiquidCargoBay;
-import megamek.common.LivestockCargoBay;
-import megamek.common.LocationFullException;
-import megamek.common.Mech;
-import megamek.common.MechBay;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.PillionSeatCargoBay;
-import megamek.common.Player;
-import megamek.common.Protomech;
-import megamek.common.ProtomechBay;
-import megamek.common.QuadMech;
-import megamek.common.QuadVee;
-import megamek.common.RefrigeratedCargoBay;
-import megamek.common.SimpleTechLevel;
-import megamek.common.SmallCraft;
-import megamek.common.SmallCraftBay;
-import megamek.common.SpaceStation;
-import megamek.common.StandardSeatCargoBay;
-import megamek.common.SupportTank;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.TechConstants;
-import megamek.common.VTOL;
-import megamek.common.Warship;
-import megamek.common.WeaponType;
 import megamek.common.annotations.Nullable;
 import megamek.common.logging.LogLevel;
 import megamek.common.options.IOption;
@@ -109,97 +54,6 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PersonCrewAssignmentEvent;
 import mekhq.campaign.event.PersonTechAssignmentEvent;
 import mekhq.campaign.event.UnitArrivedEvent;
-import mekhq.campaign.parts.AeroHeatSink;
-import mekhq.campaign.parts.AeroLifeSupport;
-import mekhq.campaign.parts.AeroSensor;
-import mekhq.campaign.parts.Armor;
-import mekhq.campaign.parts.Avionics;
-import mekhq.campaign.parts.BaArmor;
-import mekhq.campaign.parts.BattleArmorSuit;
-import mekhq.campaign.parts.BayDoor;
-import mekhq.campaign.parts.CombatInformationCenter;
-import mekhq.campaign.parts.Cubicle;
-import mekhq.campaign.parts.DropshipDockingCollar;
-import mekhq.campaign.parts.EnginePart;
-import mekhq.campaign.parts.FireControlSystem;
-import mekhq.campaign.parts.GravDeck;
-import mekhq.campaign.parts.InfantryArmorPart;
-import mekhq.campaign.parts.InfantryMotiveType;
-import mekhq.campaign.parts.JumpshipDockingCollar;
-import mekhq.campaign.parts.KFChargingSystem;
-import mekhq.campaign.parts.KFDriveCoil;
-import mekhq.campaign.parts.KFDriveController;
-import mekhq.campaign.parts.KFFieldInitiator;
-import mekhq.campaign.parts.KFHeliumTank;
-import mekhq.campaign.parts.KfBoom;
-import mekhq.campaign.parts.LFBattery;
-import mekhq.campaign.parts.LandingGear;
-import mekhq.campaign.parts.MekActuator;
-import mekhq.campaign.parts.MekCockpit;
-import mekhq.campaign.parts.MekGyro;
-import mekhq.campaign.parts.MekLifeSupport;
-import mekhq.campaign.parts.MekLocation;
-import mekhq.campaign.parts.MekSensor;
-import mekhq.campaign.parts.MissingAeroHeatSink;
-import mekhq.campaign.parts.MissingAeroLifeSupport;
-import mekhq.campaign.parts.MissingAeroSensor;
-import mekhq.campaign.parts.MissingAvionics;
-import mekhq.campaign.parts.MissingBattleArmorSuit;
-import mekhq.campaign.parts.MissingBayDoor;
-import mekhq.campaign.parts.MissingCIC;
-import mekhq.campaign.parts.MissingCubicle;
-import mekhq.campaign.parts.MissingDropshipDockingCollar;
-import mekhq.campaign.parts.MissingEnginePart;
-import mekhq.campaign.parts.MissingFireControlSystem;
-import mekhq.campaign.parts.MissingKFBoom;
-import mekhq.campaign.parts.MissingKFChargingSystem;
-import mekhq.campaign.parts.MissingKFDriveCoil;
-import mekhq.campaign.parts.MissingKFDriveController;
-import mekhq.campaign.parts.MissingKFFieldInitiator;
-import mekhq.campaign.parts.MissingKFHeliumTank;
-import mekhq.campaign.parts.MissingLFBattery;
-import mekhq.campaign.parts.MissingLandingGear;
-import mekhq.campaign.parts.MissingMekActuator;
-import mekhq.campaign.parts.MissingMekCockpit;
-import mekhq.campaign.parts.MissingMekGyro;
-import mekhq.campaign.parts.MissingMekLifeSupport;
-import mekhq.campaign.parts.MissingMekLocation;
-import mekhq.campaign.parts.MissingMekSensor;
-import mekhq.campaign.parts.MissingPart;
-import mekhq.campaign.parts.MissingProtomekArmActuator;
-import mekhq.campaign.parts.MissingProtomekJumpJet;
-import mekhq.campaign.parts.MissingProtomekLegActuator;
-import mekhq.campaign.parts.MissingProtomekLocation;
-import mekhq.campaign.parts.MissingProtomekSensor;
-import mekhq.campaign.parts.MissingQuadVeeGear;
-import mekhq.campaign.parts.MissingRotor;
-import mekhq.campaign.parts.MissingSpacecraftEngine;
-import mekhq.campaign.parts.MissingThrusters;
-import mekhq.campaign.parts.MissingTurret;
-import mekhq.campaign.parts.MissingVeeSensor;
-import mekhq.campaign.parts.MissingVeeStabiliser;
-import mekhq.campaign.parts.MotiveSystem;
-import mekhq.campaign.parts.Part;
-import mekhq.campaign.parts.PodSpace;
-import mekhq.campaign.parts.ProtomekArmActuator;
-import mekhq.campaign.parts.ProtomekArmor;
-import mekhq.campaign.parts.ProtomekJumpJet;
-import mekhq.campaign.parts.ProtomekLegActuator;
-import mekhq.campaign.parts.ProtomekLocation;
-import mekhq.campaign.parts.ProtomekSensor;
-import mekhq.campaign.parts.QuadVeeGear;
-import mekhq.campaign.parts.Refit;
-import mekhq.campaign.parts.Rotor;
-import mekhq.campaign.parts.SpacecraftCoolingSystem;
-import mekhq.campaign.parts.SpacecraftEngine;
-import mekhq.campaign.parts.StructuralIntegrity;
-import mekhq.campaign.parts.TankLocation;
-import mekhq.campaign.parts.Thrusters;
-import mekhq.campaign.parts.TransportBayPart;
-import mekhq.campaign.parts.Turret;
-import mekhq.campaign.parts.TurretLock;
-import mekhq.campaign.parts.VeeSensor;
-import mekhq.campaign.parts.VeeStabiliser;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.BattleArmorAmmoBin;
 import mekhq.campaign.parts.equipment.BattleArmorEquipmentPart;
@@ -1879,7 +1733,10 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 if(!(entity instanceof SmallCraft || entity instanceof Jumpship)) {
                     engine = part;
                 }
-            } else if(part instanceof SpacecraftEngine || part instanceof MissingSpacecraftEngine) {
+            } else if (part instanceof SpacecraftEngine
+                    || part instanceof MissingSpacecraftEngine
+                    || part instanceof SVEnginePart
+                    || part instanceof MissingSVEngine) {
                 engine = part;
             } else if(part instanceof MekLifeSupport  || part instanceof MissingMekLifeSupport) {
                 lifeSupport = part;
@@ -2359,7 +2216,33 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 engine = new SpacecraftEngine((int) entity.getWeight(), 0, getCampaign(), entity.isClan());
                 addPart(engine);
                 partsToAdd.add(engine);
-                ((SpacecraftEngine)engine).calculateTonnage();
+                ((SpacecraftEngine) engine).calculateTonnage();
+            } else if (entity.isSupportVehicle()) {
+                // Check for trailer with no engine
+                if (entity.hasEngine() && entity.getEngine().getEngineType() != Engine.NONE) {
+                    int mf;
+                    // Rail support gets a -2 mp boost to the move factor calculation
+                    if (entity.getMovementMode().equals(EntityMovementMode.RAIL)
+                            || entity.getMovementMode().equals(EntityMovementMode.MAGLEV)) {
+                        int mp = Math.max(0, entity.getOriginalWalkMP() - 2);
+                        mf = mp * mp + 4;
+                    } else if (entity.getMovementMode().equals(EntityMovementMode.STATION_KEEPING)) {
+                        // satellite support vees have a flat 1 for move factor
+                        mf = 1;
+                    } else {
+                        int mp = entity.getOriginalWalkMP();
+                        mf = mp * mp + 4;
+                    }
+                    FuelType fuel = FuelType.NONE;
+                    if (entity instanceof Tank) {
+                        fuel = ((Tank) entity).getICEFuelType();
+                    }
+                    engine = new SVEnginePart(entity.getWeight(), entity.getEngine().getEngineType(),
+                            entity.getTechRating(), mf, entity.getBaseEngineValue(),
+                            fuel, getCampaign());
+                    addPart(engine);
+                    partsToAdd.add(engine);
+                }
             } else if(null != entity.getEngine()) {
                 engine = new EnginePart((int) entity.getWeight(), new Engine(entity.getEngine().getRating(), entity.getEngine().getEngineType(), entity.getEngine().getFlags()), getCampaign(), entity.getMovementMode() == EntityMovementMode.HOVER && entity instanceof Tank);
                 addPart(engine);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2220,25 +2220,15 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             } else if (entity.isSupportVehicle()) {
                 // Check for trailer with no engine
                 if (entity.hasEngine() && entity.getEngine().getEngineType() != Engine.NONE) {
-                    int mf;
-                    // Rail support gets a -2 mp boost to the move factor calculation
-                    if (entity.getMovementMode().equals(EntityMovementMode.RAIL)
-                            || entity.getMovementMode().equals(EntityMovementMode.MAGLEV)) {
-                        int mp = Math.max(0, entity.getOriginalWalkMP() - 2);
-                        mf = mp * mp + 4;
-                    } else if (entity.getMovementMode().equals(EntityMovementMode.STATION_KEEPING)) {
-                        // satellite support vees have a flat 1 for move factor
-                        mf = 1;
-                    } else {
-                        int mp = entity.getOriginalWalkMP();
-                        mf = mp * mp + 4;
-                    }
+                    // Surface vehicles (including vehicles) have to choose the fuel type for a combustion engine.
+                    // Fixed wing with an ICE will have the fuel type set to NONE, which is technically
+                    // not correct but does the job of distinguishing the turbine from other ICE types.
                     FuelType fuel = FuelType.NONE;
                     if (entity instanceof Tank) {
                         fuel = ((Tank) entity).getICEFuelType();
                     }
-                    engine = new SVEnginePart(entity.getWeight(), entity.getEngine().getEngineType(),
-                            entity.getEngineTechRating(), mf, entity.getBaseEngineValue(),
+                    engine = new SVEnginePart((int) entity.getWeight(), entity.getEngine().getWeightEngine(entity),
+                            entity.getEngine().getEngineType(), entity.getEngineTechRating(),
                             fuel, getCampaign());
                     addPart(engine);
                     partsToAdd.add(engine);

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -54,14 +54,7 @@ import megamek.common.Tank;
 import megamek.common.WeaponType;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.logging.LogLevel;
-import megamek.common.verifier.EntityVerifier;
-import megamek.common.verifier.TestAero;
-import megamek.common.verifier.TestBattleArmor;
-import megamek.common.verifier.TestEntity;
-import megamek.common.verifier.TestInfantry;
-import megamek.common.verifier.TestMech;
-import megamek.common.verifier.TestSmallCraft;
-import megamek.common.verifier.TestTank;
+import megamek.common.verifier.*;
 import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CConfig;
@@ -274,6 +267,8 @@ public class MekLabTab extends CampaignGuiTab {
         testEntity = null;
         if (entity instanceof SmallCraft) {
             testEntity = new TestSmallCraft((SmallCraft) entity, entityVerifier.aeroOption, null);
+        } else if (entity.isSupportVehicle()) {
+            testEntity = new TestSupportVehicle(entity, entityVerifier.tankOption, null);
         } else if (entity instanceof Aero) {
             testEntity = new TestAero((Aero) entity, entityVerifier.aeroOption, null);
         } else if (entity instanceof Mech) {
@@ -435,6 +430,8 @@ public class MekLabTab extends CampaignGuiTab {
     private EntityPanel getCorrectLab(Entity en) {
         if (en instanceof SmallCraft) {
             return new DropshipPanel((SmallCraft) en);
+        } else if (en.isSupportVehicle()) {
+            return new SupportVehiclePanel(en);
         } else if (en instanceof Aero) {
             return new AeroPanel((Aero) en);
         } else if (en instanceof Mech) {
@@ -977,11 +974,138 @@ public class MekLabTab extends CampaignGuiTab {
         }
     }
 
+    private class SupportVehiclePanel extends EntityPanel {
+
+        private static final long serialVersionUID = -2209864752115049947L;
+
+        private Entity entity;
+        private megameklab.com.ui.supportvehicle.SVStructureTab structureTab;
+        private megameklab.com.ui.supportvehicle.SVArmorTab armorTab;
+        private megameklab.com.ui.tabs.EquipmentTab equipmentTab;
+        private megameklab.com.ui.supportvehicle.SVBuildTab buildTab;
+        private megameklab.com.ui.tabs.TransportTab transportTab;
+
+        SupportVehiclePanel(Entity en) {
+            entity = en;
+            reloadTabs();
+        }
+
+        @Override
+        public Entity getEntity() {
+            return entity;
+        }
+
+        void reloadTabs() {
+            removeAll();
+
+            structureTab = new megameklab.com.ui.supportvehicle.SVStructureTab(this);
+            armorTab = new megameklab.com.ui.supportvehicle.SVArmorTab(this, getTechManager());
+            equipmentTab = new megameklab.com.ui.tabs.EquipmentTab(this);
+            buildTab = new megameklab.com.ui.supportvehicle.SVBuildTab(this, equipmentTab);
+            transportTab = new megameklab.com.ui.tabs.TransportTab(this);
+            structureTab.addRefreshedListener(this);
+            armorTab.addRefreshedListener(this);
+            equipmentTab.addRefreshedListener(this);
+            buildTab.addRefreshedListener(this);
+            transportTab.addRefreshedListener(this);
+
+            addTab("Structure", new JScrollPane(structureTab));
+            addTab("Armor", new JScrollPane(armorTab));
+            addTab("Equipment", new JScrollPane(equipmentTab));
+            addTab("Build", new JScrollPane(buildTab));
+            addTab("Transport", new JScrollPane(transportTab));
+            this.repaint();
+        }
+
+        @Override
+        public void refreshAll() {
+            structureTab.refresh();
+            armorTab.refresh();
+            equipmentTab.refresh();
+            buildTab.refresh();
+            transportTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshArmor() {
+            armorTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshBuild() {
+            buildTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshEquipment() {
+            equipmentTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshTransport() {
+            transportTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshStatus() {
+            refreshRefitSummary();
+        }
+
+        @Override
+        public void refreshStructure() {
+            structureTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshWeapons() {
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshHeader() {
+        }
+
+        @Override
+        public void refreshPreview() {
+        }
+
+        @Override
+        public void refreshSummary() {
+            structureTab.refreshSummary();
+        }
+
+        @Override
+        public void refreshEquipmentTable() {
+            equipmentTab.refreshTable();
+        }
+
+        @Override
+        public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
+            // not used by MekHQ
+        }
+
+        @Override
+        public ITechManager getTechManager() {
+            if (null != structureTab) {
+                return structureTab.getTechManager();
+            }
+            return null;
+        }
+
+        @Override
+        void setTechFaction(int techFaction) {
+            structureTab.setTechFaction(techFaction);
+        }
+    }
+
     private class BattleArmorPanel extends EntityPanel {
 
-        /**
-         *
-         */
         private static final long serialVersionUID = 6894731868670529166L;
 
         private BattleArmor entity;

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -261,7 +261,7 @@ public class MekLabTab extends CampaignGuiTab {
         add(labPanel, BorderLayout.CENTER);
         labPanel.refreshAll();
     }
-    
+
     public void refreshRefitSummary() {
         if (null == labPanel) {
             return;
@@ -452,20 +452,20 @@ public class MekLabTab extends CampaignGuiTab {
     private abstract class EntityPanel extends JTabbedPane implements RefreshListener, EntitySource {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = 6886946112861955446L;
 
         @Override
         public abstract Entity getEntity();
-        
+
         abstract void setTechFaction(int techFaction);
     }
 
     private class AeroPanel extends EntityPanel {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = 6894731868670529166L;
 
@@ -574,7 +574,7 @@ public class MekLabTab extends CampaignGuiTab {
         @Override
         public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
@@ -584,26 +584,26 @@ public class MekLabTab extends CampaignGuiTab {
             }
             return null;
         }
-        
+
         @Override
         void setTechFaction(int techFaction) {
             structureTab.setTechFaction(techFaction);
         }
-        
+
     }
 
     private class DropshipPanel extends EntityPanel {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = 4348862352101110686L;
-        
+
         private SmallCraft entity;
         private megameklab.com.ui.aerospace.DropshipStructureTab structureTab;
         private megameklab.com.ui.Aero.tabs.EquipmentTab equipmentTab;
         private megameklab.com.ui.Aero.tabs.BuildTab buildTab;
-        private megameklab.com.ui.aerospace.TransportTab transportTab;
+        private megameklab.com.ui.tabs.TransportTab transportTab;
         private megameklab.com.ui.tabs.PreviewTab previewTab;
 
         public DropshipPanel(SmallCraft a) {
@@ -624,7 +624,7 @@ public class MekLabTab extends CampaignGuiTab {
             previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
             equipmentTab = new megameklab.com.ui.Aero.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.Aero.tabs.BuildTab(this, equipmentTab);
-            transportTab = new megameklab.com.ui.aerospace.TransportTab(this);
+            transportTab = new megameklab.com.ui.tabs.TransportTab(this);
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
@@ -709,7 +709,7 @@ public class MekLabTab extends CampaignGuiTab {
         @Override
         public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
@@ -719,18 +719,18 @@ public class MekLabTab extends CampaignGuiTab {
             }
             return null;
         }
-        
+
         @Override
         void setTechFaction(int techFaction) {
             structureTab.setTechFaction(techFaction);
         }
-        
+
     }
 
     private class MekPanel extends EntityPanel {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = 6894731868670529166L;
 
@@ -838,7 +838,7 @@ public class MekLabTab extends CampaignGuiTab {
         @Override
         public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
@@ -858,7 +858,7 @@ public class MekLabTab extends CampaignGuiTab {
     private class TankPanel extends EntityPanel {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = 6894731868670529166L;
 
@@ -882,7 +882,7 @@ public class MekLabTab extends CampaignGuiTab {
 
             structureTab = new megameklab.com.ui.Vehicle.tabs.StructureTab(this);
             equipmentTab = new megameklab.com.ui.Vehicle.tabs.EquipmentTab(this);
-            buildTab = new megameklab.com.ui.Vehicle.tabs.BuildTab(this, equipmentTab);
+            buildTab = new megameklab.com.ui.Vehicle.tabs.BuildTab(this, equipmentTab.getEquipmentList());
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
@@ -960,7 +960,7 @@ public class MekLabTab extends CampaignGuiTab {
         @Override
         public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
@@ -980,7 +980,7 @@ public class MekLabTab extends CampaignGuiTab {
     private class BattleArmorPanel extends EntityPanel {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = 6894731868670529166L;
 
@@ -1074,7 +1074,7 @@ public class MekLabTab extends CampaignGuiTab {
         @Override
         public void refreshSummary() {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
@@ -1085,7 +1085,7 @@ public class MekLabTab extends CampaignGuiTab {
         @Override
         public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
@@ -1105,7 +1105,7 @@ public class MekLabTab extends CampaignGuiTab {
     private class InfantryPanel extends EntityPanel {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = 6894731868670529166L;
 
@@ -1191,19 +1191,19 @@ public class MekLabTab extends CampaignGuiTab {
         @Override
         public void refreshSummary() {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
         public void refreshEquipmentTable() {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
         public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -878,6 +878,7 @@ public class MekLabTab extends CampaignGuiTab {
             removeAll();
 
             structureTab = new megameklab.com.ui.Vehicle.tabs.StructureTab(this);
+            structureTab.setAsCustomization();
             equipmentTab = new megameklab.com.ui.Vehicle.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.Vehicle.tabs.BuildTab(this, equipmentTab.getEquipmentList());
             structureTab.addRefreshedListener(this);
@@ -999,6 +1000,7 @@ public class MekLabTab extends CampaignGuiTab {
             removeAll();
 
             structureTab = new megameklab.com.ui.supportvehicle.SVStructureTab(this);
+            structureTab.setAsCustomization();
             armorTab = new megameklab.com.ui.supportvehicle.SVArmorTab(this, getTechManager());
             equipmentTab = new megameklab.com.ui.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.supportvehicle.SVBuildTab(this, equipmentTab);

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -888,10 +888,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                     menuItem.addActionListener(this);
                     menuItem.setEnabled(unit.isAvailable()
                             && ((unit.getEntity().getEntityType() &
-                                    (Entity.ETYPE_FIXED_WING_SUPPORT
-                                            | Entity.ETYPE_JUMPSHIP
-                                            | Entity.ETYPE_SUPPORT_TANK
-                                            | Entity.ETYPE_SUPPORT_VTOL
+                                    (Entity.ETYPE_JUMPSHIP
                                             | Entity.ETYPE_PROTOMECH
                                             | Entity.ETYPE_GUN_EMPLACEMENT)) == 0));
                     menu.add(menuItem);


### PR DESCRIPTION
Adds support vehicle support to MekHQ, including two SV-specific part types and the ability to configure SVs in the MekLab tab. It also fixes errors in the MekLab tab introduced by API changes in MML.

The new parts are SVEnginePart (and MissingSVEngine) and SVArmor. Though support vehicles in MM use the Engine class, there are some additional characteristics of the engine that are contained in the Entity itself and need to be tracked separately in a MekHQ part. SVArmor likewise tracks the BAR and tech rating of the armor. Under advanced rules SVs with the armored chassis mod can use armor types used by other units or patchwork. The constant EquipmentType.T_ARMOR_STANDARD is used to indicate that the SV uses standard SV armor.

This branch depends on the sv_customize branches in MM and MML.