### PR TITLE
Customize protomechs and advanced aero

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -110,7 +110,7 @@ public class PartsStore implements Serializable {
 	private static final long serialVersionUID = 1686222527383868364L;
 
 	private static int EXPECTED_SIZE = 50000;
-	
+
 	private ArrayList<Part> parts;
 	private Map<String, Part> nameAndDetailMap;
 
@@ -123,7 +123,7 @@ public class PartsStore implements Serializable {
 	public ArrayList<Part> getInventory() {
 		return parts;
 	}
-	
+
 	public Part getByNameAndDetails(String nameAndDetails) {
 		return nameAndDetailMap.get(nameAndDetails);
 	}
@@ -141,7 +141,7 @@ public class PartsStore implements Serializable {
 		stockProtomekLocations(c);
 		stockProtomekComponents(c);
 		stockBattleArmorSuits(c);
-		
+
 		Pattern cleanUp1 = Pattern.compile("\\d+\\shit\\(s\\),\\s"); //$NON-NLS-1$
 		Pattern cleanUp2 = Pattern.compile("\\d+\\shit\\(s\\)"); //$NON-NLS-1$
 		StringBuilder sb = new StringBuilder();
@@ -269,7 +269,7 @@ public class PartsStore implements Serializable {
 			        poddable &= (et.hasFlag(WeaponType.F_MECH_WEAPON)
 			                || et.hasFlag(Weapon.F_TANK_WEAPON)
 			                || et.hasFlag(WeaponType.F_AERO_WEAPON))
-			                && !((WeaponType) et).isCapital(); 
+			                && !((WeaponType) et).isCapital();
 			    }
 				if(EquipmentPart.hasVariableTonnage(et)) {
 					EquipmentPart epart;
@@ -300,12 +300,12 @@ public class PartsStore implements Serializable {
         parts.add(hs);
         parts.add(new OmniPod(hs, c));
         parts.add(new AeroHeatSink(0, Aero.HEAT_SINGLE, true, c));
-        
+
         hs = new AeroHeatSink(0, Aero.HEAT_DOUBLE, false, c);
         parts.add(hs);
         parts.add(new OmniPod(hs, c));
         parts.add(new AeroHeatSink(0, Aero.HEAT_DOUBLE, true, c));
-        
+
         hs = new AeroHeatSink(0, AeroHeatSink.CLAN_HEAT_DOUBLE, false, c);
         parts.add(hs);
         parts.add(new OmniPod(hs, c));
@@ -511,7 +511,8 @@ public class PartsStore implements Serializable {
 		/*
 		 * Protomek Armor
 		 */
-		parts.add(new ProtomekArmor(0, 100, -1, true, c));
+        parts.add(new ProtomekArmor(0, EquipmentType.T_ARMOR_STANDARD, 100, -1, true, c));
+        parts.add(new ProtomekArmor(0, EquipmentType.T_ARMOR_EDP, 66, -1, true, c));
 	}
 
 	private void stockMekLocations(Campaign c) {

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
@@ -1,26 +1,28 @@
 /*
  * ProtomechArmor.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq.campaign.parts;
 
+import megamek.common.EquipmentType;
+import megamek.common.Protomech;
 import megamek.common.TechAdvancement;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -32,49 +34,50 @@ import mekhq.campaign.work.IAcquisitionWork;
  */
 public class ProtomekArmor extends Armor implements IAcquisitionWork {
     private static final long serialVersionUID = 5275226057484468868L;
-    
+
     public ProtomekArmor() {
-        this(0, 0, -1, false, null);
+        this(0, EquipmentType.T_ARMOR_STANDARD, 0, -1, false, null);
     }
-    
-    public ProtomekArmor(int tonnage, int points, int loc, boolean clan, Campaign c) {
+
+    public ProtomekArmor(int tonnage, int type, int points, int loc, boolean clan, Campaign c) {
         // Amount is used for armor quantity, not tonnage
-        super(tonnage, -1, points, loc, false, clan, c);
+        super(tonnage, type, points, loc, false, clan, c);
         this.name = "Protomech Armor";
     }
-    
+
     @Override
     public ProtomekArmor clone() {
-        ProtomekArmor clone = new ProtomekArmor(0, 0, amount, clan, campaign);
+        ProtomekArmor clone = new ProtomekArmor(0, type, 0, amount, clan, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     @Override
     public double getTonnage() {
-        return 50 * amount/1000.0;
+        return EquipmentType.getProtomechArmorWeightPerPoint(type) * amount;
     }
-    
+
     @Override
     public Money getCurrentValue() {
-        return Money.of(amount * 625);
+        return Money.of(amount * EquipmentType.getProtomechArmorCostPerPoint(type));
     }
-    
+
     public double getTonnageNeeded() {
-        double armorPerTon = 20;
-        return amountNeeded / armorPerTon;
+        return amountNeeded / EquipmentType.getProtomechArmorWeightPerPoint(type);
     }
-    
+
     public Money getValueNeeded() {
-        return adjustCostsForCampaignOptions(Money.of(amountNeeded * 625));
+        return adjustCostsForCampaignOptions(
+                Money.of(amountNeeded * EquipmentType.getProtomechArmorCostPerPoint(type)));
     }
-    
+
     @Override
     public Money getStickerPrice() {
         //always in 5-ton increments
-        return Money.of(5 * 20 * 625);
+        return Money.of(5.0 / EquipmentType.getProtomechArmorWeightPerPoint(type) * getArmorPointsPerTon()
+                * EquipmentType.getProtomechArmorCostPerPoint(type));
     }
-    
+
     @Override
     public Money getBuyCost() {
         return getStickerPrice();
@@ -83,6 +86,7 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
     @Override
     public boolean isSamePartType(Part part) {
         return part instanceof ProtomekArmor
+                && type == ((ProtomekArmor) part).type
                 && isClanTechBase() == part.isClanTechBase()
                 && getRefitId() == part.getRefitId();
     }
@@ -91,70 +95,76 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
     protected boolean isClanTechBase() {
         return clan;
     }
-    
+
     public double getArmorWeight(int points) {
         return points * 50/1000.0;
     }
 
     @Override
     public IAcquisitionWork getAcquisitionWork() {
-        return new ProtomekArmor(0, (int)Math.round(5 * getArmorPointsPerTon()), -1, clan, campaign);
+        return new ProtomekArmor(0, type, (int) Math.round(5.0 * getArmorPointsPerTon()),
+                -1, clan, campaign);
     }
-	
+
 	@Override
 	public int getDifficulty() {
 		return -2;
 	}
 
     public double getArmorPointsPerTon() {
-        return 20;
+        return 1.0 / EquipmentType.getProtomechArmorWeightPerPoint(type);
     }
-    
+
     public Part getNewPart() {
-        return new ProtomekArmor(0, (int)Math.round(5 * getArmorPointsPerTon()), -1, clan, campaign);
+        return new ProtomekArmor(0, type, (int) Math.round(5 * getArmorPointsPerTon()),
+                -1, clan, campaign);
     }
-    
+
     public int getAmountAvailable() {
         for(Part part : campaign.getSpareParts()) {
             if(part instanceof ProtomekArmor) {
-                ProtomekArmor a = (ProtomekArmor)part;
-                if(a.isClanTechBase() == clan && !a.isReservedForRefit() && a.isPresent()) {
+                ProtomekArmor a = (ProtomekArmor) part;
+                if(a.isClanTechBase() == clan
+                        && a.type == type
+                        && !a.isReservedForRefit() && a.isPresent()) {
                     return a.getAmount();
                 }
             }
         }
         return 0;
     }
-    
+
     public void changeAmountAvailable(int amount) {
         ProtomekArmor a = null;
         for(Part part : campaign.getSpareParts()) {
-            if(part instanceof ProtomekArmor 
-                    && ((ProtomekArmor)part).isClanTechBase() == clan 
+            if(part instanceof ProtomekArmor
+                    && part.isClanTechBase() == clan
+                    && ((ProtomekArmor) part).type == type
                     && getRefitId() == part.getRefitId()
                     && part.isPresent()) {
-                a = (ProtomekArmor)part;                
+                a = (ProtomekArmor)part;
                 a.setAmount(a.getAmount() + amount);
                 break;
             }
         }
         if(null != a && a.getAmount() <= 0) {
             campaign.removePart(a);
-        } else if(null == a && amount > 0) {            
-            campaign.addPart(new ProtomekArmor(getUnitTonnage(), amount, -1, isClanTechBase(), campaign), 0);
+        } else if(null == a && amount > 0) {
+            campaign.addPart(new ProtomekArmor(getUnitTonnage(), type, amount, -1, isClanTechBase(), campaign), 0);
         }
     }
-    
-    @Override
-    public int getTechRating() {
-        return RATING_F;
-    }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
-        // This is for standard armor, which does not currently have a separate entry in MM.
-        // TODO: EDP armor (which does have an entry in MM)
-        return ProtomekLocation.TECH_ADVANCEMENT;
+        if (type != EquipmentType.T_ARMOR_STANDARD) {
+            final EquipmentType eq = EquipmentType.get(EquipmentType.getArmorTypeName(type, clan));
+            if (null != eq) {
+                return eq.getTechAdvancement();
+            }
+        }
+        // Standard Protomech armor is not the same as Standard armor, but does not have an associated
+        // type entry so we can just use the base protomech advancement
+        return Protomech.TA_STANDARD_PROTOMECH;
     }
 
 }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2121,8 +2121,9 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     continue;
                 }
                 if(!(m.getType().hasFlag(MiscType.F_BA_MANIPULATOR) ||
-                     m.getType().hasFlag(MiscType.F_BA_MEA) ||
-                     m.getType().hasFlag(MiscType.F_AP_MOUNT))) {
+                        m.getType().hasFlag(MiscType.F_BA_MEA) ||
+                        m.getType().hasFlag(MiscType.F_AP_MOUNT) ||
+                        m.getType().hasFlag(MiscType.F_MAGNETIC_CLAMP))) {
                     continue;
                 }
             }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2071,7 +2071,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             }
             if(null == armor[i]) {
                 if(entity instanceof Protomech) {
-                    ProtomekArmor a = new ProtomekArmor((int) getEntity().getWeight(), getEntity().getOArmor(i, false), i, true, getCampaign());
+                    ProtomekArmor a = new ProtomekArmor((int) getEntity().getWeight(), getEntity().getArmorType(i),
+                            getEntity().getOArmor(i, false), i, true, getCampaign());
                     addPart(a);
                     partsToAdd.add(a);
                 }

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -1393,6 +1393,8 @@ public class MekLabTab extends CampaignGuiTab {
         public void refreshBuild() {
             buildTab.refresh();
             refreshSummary();
+            // trick to catch toggling the main gun location, which does not affect the status bar
+            refreshRefitSummary();
         }
 
         @Override

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -254,6 +254,8 @@ public class MekLabTab extends CampaignGuiTab {
         testEntity = null;
         if (entity instanceof SmallCraft) {
             testEntity = new TestSmallCraft((SmallCraft) entity, entityVerifier.aeroOption, null);
+        } else if (entity instanceof Jumpship) {
+            testEntity = new TestAdvancedAerospace((Jumpship) entity, entityVerifier.aeroOption, null);
         } else if (entity.isSupportVehicle()) {
             testEntity = new TestSupportVehicle(entity, entityVerifier.tankOption, null);
         } else if (entity instanceof Aero) {
@@ -419,6 +421,8 @@ public class MekLabTab extends CampaignGuiTab {
     private EntityPanel getCorrectLab(Entity en) {
         if (en instanceof SmallCraft) {
             return new DropshipPanel((SmallCraft) en);
+        } else if (en instanceof Jumpship) {
+            return new AdvancedAeroPanel((Jumpship) en);
         } else if (en.isSupportVehicle()) {
             return new SupportVehiclePanel(en);
         } else if (en instanceof Aero) {
@@ -1461,4 +1465,136 @@ public class MekLabTab extends CampaignGuiTab {
             structureTab.setTechFaction(techFaction);
         }
     }
+
+    private class AdvancedAeroPanel extends EntityPanel {
+
+        private static final long serialVersionUID = 4031380495472570820L;
+
+        private Jumpship entity;
+        private megameklab.com.ui.aerospace.AdvancedAeroStructureTab structureTab;
+        private megameklab.com.ui.Aero.tabs.EquipmentTab equipmentTab;
+        private megameklab.com.ui.Aero.tabs.BuildTab buildTab;
+        private megameklab.com.ui.tabs.TransportTab transportTab;
+        private megameklab.com.ui.tabs.PreviewTab previewTab;
+
+        public AdvancedAeroPanel(Jumpship a) {
+            entity = a;
+            reloadTabs();
+        }
+
+        @Override
+        public Entity getEntity() {
+            return entity;
+        }
+
+        public void reloadTabs() {
+            removeAll();
+
+            structureTab = new megameklab.com.ui.aerospace.AdvancedAeroStructureTab(this);
+            structureTab.setAsCustomization();
+            previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
+            equipmentTab = new megameklab.com.ui.Aero.tabs.EquipmentTab(this);
+            buildTab = new megameklab.com.ui.Aero.tabs.BuildTab(this, equipmentTab);
+            transportTab = new megameklab.com.ui.tabs.TransportTab(this);
+            structureTab.addRefreshedListener(this);
+            equipmentTab.addRefreshedListener(this);
+            buildTab.addRefreshedListener(this);
+            transportTab.addRefreshedListener(this);
+
+            addTab("Structure/Armor", new JScrollPane(structureTab));
+            addTab("Equipment", new JScrollPane(equipmentTab));
+            addTab("Assign Criticals", new JScrollPane(buildTab));
+            addTab("Transport Bays", new JScrollPane(transportTab));
+            addTab("Preview", new JScrollPane(previewTab));
+            this.repaint();
+        }
+
+        @Override
+        public void refreshAll() {
+            structureTab.refresh();
+            equipmentTab.refresh();
+            buildTab.refresh();
+            transportTab.refresh();
+            previewTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshArmor() {
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshBuild() {
+            buildTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshEquipment() {
+            equipmentTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshTransport() {
+            transportTab.refresh();
+        }
+
+        @Override
+        public void refreshStatus() {
+            refreshRefitSummary();
+        }
+
+        @Override
+        public void refreshStructure() {
+            structureTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshWeapons() {
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshHeader() {
+
+        }
+
+        @Override
+        public void refreshPreview() {
+            previewTab.refresh();
+        }
+
+        @Override
+        public void refreshSummary() {
+            structureTab.refreshSummary();
+        }
+
+        @Override
+        public void refreshEquipmentTable() {
+            equipmentTab.refreshTable();
+        }
+
+        @Override
+        public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
+            // Not used by MekHQ
+        }
+
+        @Override
+        public ITechManager getTechManager() {
+            if (null != structureTab) {
+                return structureTab.getTechManager();
+            }
+            return null;
+        }
+
+        @Override
+        void setTechFaction(int techFaction) {
+            structureTab.setTechFaction(techFaction);
+        }
+
+    }
+
 }

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -37,26 +37,13 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.ITechManager;
-import megamek.common.Infantry;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.Mounted;
-import megamek.common.SmallCraft;
-import megamek.common.Tank;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.logging.LogLevel;
 import megamek.common.verifier.*;
 import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.protomek.ProtomekBuildTab;
 import megameklab.com.util.CConfig;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
@@ -279,6 +266,8 @@ public class MekLabTab extends CampaignGuiTab {
             testEntity = new TestBattleArmor((BattleArmor) entity, entityVerifier.baOption, null);
         } else if (entity instanceof Infantry) {
             testEntity = new TestInfantry((Infantry) entity, entityVerifier.tankOption, null);
+        } else if (entity instanceof Protomech) {
+            testEntity = new TestProtomech((Protomech) entity, entityVerifier.protomechOption, null);
         }
         if (null == testEntity) {
             return;
@@ -442,7 +431,8 @@ public class MekLabTab extends CampaignGuiTab {
             return new BattleArmorPanel((BattleArmor) en);
         } else if (en instanceof Infantry) {
             return new InfantryPanel((Infantry) en);
-        }
+        } else if (en instanceof Protomech)
+            return new ProtomechPanel((Protomech) en);
         return null;
     }
 
@@ -1330,6 +1320,130 @@ public class MekLabTab extends CampaignGuiTab {
         public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
             // TODO Auto-generated method stub
 
+        }
+
+        @Override
+        public ITechManager getTechManager() {
+            if (null != structureTab) {
+                return structureTab.getTechManager();
+            }
+            return null;
+        }
+
+        @Override
+        void setTechFaction(int techFaction) {
+            structureTab.setTechFaction(techFaction);
+        }
+    }
+
+    private class ProtomechPanel extends EntityPanel {
+
+        private static final long serialVersionUID = -4649180495358483182L;
+
+        private Protomech entity;
+        private megameklab.com.ui.protomek.ProtomekStructureTab structureTab;
+        private megameklab.com.ui.tabs.EquipmentTab equipmentTab;
+        private megameklab.com.ui.protomek.ProtomekBuildTab buildTab;
+        private megameklab.com.ui.tabs.PreviewTab previewTab;
+
+        ProtomechPanel(Protomech m) {
+            entity = m;
+            reloadTabs();
+        }
+
+        @Override
+        public Entity getEntity() {
+            return entity;
+        }
+
+        void reloadTabs() {
+            removeAll();
+
+            structureTab = new megameklab.com.ui.protomek.ProtomekStructureTab(this);
+            structureTab.setAsCustomization();
+            equipmentTab = new megameklab.com.ui.tabs.EquipmentTab(this);
+            previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
+            buildTab = new megameklab.com.ui.protomek.ProtomekBuildTab(this, equipmentTab, this);
+            structureTab.addRefreshedListener(this);
+            equipmentTab.addRefreshedListener(this);
+            buildTab.addRefreshedListener(this);
+
+            addTab("Structure/Armor", new JScrollPane(structureTab));
+            addTab("Equipment", new JScrollPane(equipmentTab));
+            addTab("Assign Critical", new JScrollPane(buildTab));
+            addTab("Preview", new JScrollPane(previewTab));
+            this.repaint();
+        }
+
+        @Override
+        public void refreshAll() {
+            structureTab.refresh();
+            equipmentTab.refresh();
+            buildTab.refresh();
+            previewTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshArmor() {
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshBuild() {
+            buildTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshEquipment() {
+            equipmentTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshTransport() {
+        }
+
+        @Override
+        public void refreshStatus() {
+            refreshRefitSummary();
+        }
+
+        @Override
+        public void refreshStructure() {
+            structureTab.refresh();
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshWeapons() {
+            refreshSummary();
+        }
+
+        @Override
+        public void refreshHeader() {
+
+        }
+
+        @Override
+        public void refreshPreview() {
+            previewTab.refresh();
+        }
+
+        @Override
+        public void refreshSummary() {
+            structureTab.refreshSummary();
+        }
+
+        @Override
+        public void refreshEquipmentTable() {
+            equipmentTab.refreshTable();
+        }
+
+        @Override
+        public void createNewUnit(long entitytype, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
+            // Not needed for MekHQ
         }
 
         @Override

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -44,6 +44,7 @@ import megamek.common.verifier.*;
 import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.protomek.ProtomekBuildTab;
+import megameklab.com.ui.tabs.FluffTab;
 import megameklab.com.util.CConfig;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
@@ -484,13 +485,16 @@ public class MekLabTab extends CampaignGuiTab {
             previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
             equipmentTab = new megameklab.com.ui.Aero.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.Aero.tabs.BuildTab(this, equipmentTab);
+            FluffTab fluffTab = new FluffTab(this);
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Structure/Armor", new JScrollPane(structureTab));
             addTab("Equipment", new JScrollPane(equipmentTab));
             addTab("Assign Criticals", new JScrollPane(buildTab));
+            addTab("Fluff", new JScrollPane(fluffTab));
             addTab("Preview", new JScrollPane(previewTab));
             this.repaint();
         }
@@ -615,16 +619,19 @@ public class MekLabTab extends CampaignGuiTab {
             previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
             equipmentTab = new megameklab.com.ui.Aero.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.Aero.tabs.BuildTab(this, equipmentTab);
+            FluffTab fluffTab = new FluffTab(this);
             transportTab = new megameklab.com.ui.tabs.TransportTab(this);
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
             transportTab.addRefreshedListener(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Structure/Armor", new JScrollPane(structureTab));
             addTab("Equipment", new JScrollPane(equipmentTab));
             addTab("Assign Criticals", new JScrollPane(buildTab));
             addTab("Transport Bays", new JScrollPane(transportTab));
+            addTab("Fluff", new JScrollPane(fluffTab));
             addTab("Preview", new JScrollPane(previewTab));
             this.repaint();
         }
@@ -749,13 +756,16 @@ public class MekLabTab extends CampaignGuiTab {
             equipmentTab = new megameklab.com.ui.Mek.tabs.EquipmentTab(this);
             previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
             buildTab = new megameklab.com.ui.Mek.tabs.BuildTab(this, equipmentTab);
+            FluffTab fluffTab = new FluffTab(this);
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Structure/Armor", new JScrollPane(structureTab));
             addTab("Equipment", new JScrollPane(equipmentTab));
             addTab("Assign Critical", new JScrollPane(buildTab));
+            addTab("Fluff", new JScrollPane(fluffTab));
             addTab("Preview", new JScrollPane(previewTab));
             this.repaint();
         }
@@ -857,6 +867,7 @@ public class MekLabTab extends CampaignGuiTab {
         private megameklab.com.ui.Vehicle.tabs.StructureTab structureTab;
         private megameklab.com.ui.Vehicle.tabs.EquipmentTab equipmentTab;
         private megameklab.com.ui.Vehicle.tabs.BuildTab buildTab;
+        private megameklab.com.ui.tabs.PreviewTab previewTab;
 
         public TankPanel(Tank t) {
             entity = t;
@@ -875,13 +886,18 @@ public class MekLabTab extends CampaignGuiTab {
             structureTab.setAsCustomization();
             equipmentTab = new megameklab.com.ui.Vehicle.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.Vehicle.tabs.BuildTab(this, equipmentTab.getEquipmentList());
+            previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
+            FluffTab fluffTab = new FluffTab(this);
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Structure", new JScrollPane(structureTab));
             addTab("Equipment", new JScrollPane(equipmentTab));
             addTab("Build", new JScrollPane(buildTab));
+            addTab("Fluff", new JScrollPane(fluffTab));
+            addTab("Preview", new JScrollPane(previewTab));
             this.repaint();
         }
 
@@ -890,6 +906,7 @@ public class MekLabTab extends CampaignGuiTab {
             structureTab.refresh();
             equipmentTab.refresh();
             buildTab.refresh();
+            previewTab.refresh();
             refreshSummary();
         }
 
@@ -937,6 +954,7 @@ public class MekLabTab extends CampaignGuiTab {
 
         @Override
         public void refreshPreview() {
+            previewTab.refresh();
         }
 
         @Override
@@ -979,6 +997,7 @@ public class MekLabTab extends CampaignGuiTab {
         private megameklab.com.ui.tabs.EquipmentTab equipmentTab;
         private megameklab.com.ui.supportvehicle.SVBuildTab buildTab;
         private megameklab.com.ui.tabs.TransportTab transportTab;
+        private megameklab.com.ui.tabs.PreviewTab previewTab;
 
         SupportVehiclePanel(Entity en) {
             entity = en;
@@ -999,17 +1018,22 @@ public class MekLabTab extends CampaignGuiTab {
             equipmentTab = new megameklab.com.ui.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.supportvehicle.SVBuildTab(this, equipmentTab);
             transportTab = new megameklab.com.ui.tabs.TransportTab(this);
+            previewTab = new megameklab.com.ui.tabs.PreviewTab((this));
+            FluffTab fluffTab = new FluffTab(this);
             structureTab.addRefreshedListener(this);
             armorTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
             transportTab.addRefreshedListener(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Structure", new JScrollPane(structureTab));
             addTab("Armor", new JScrollPane(armorTab));
             addTab("Equipment", new JScrollPane(equipmentTab));
             addTab("Build", new JScrollPane(buildTab));
             addTab("Transport", new JScrollPane(transportTab));
+            addTab("Fluff", new JScrollPane(fluffTab));
+            addTab("Preview", new JScrollPane(previewTab));
             this.repaint();
         }
 
@@ -1020,6 +1044,7 @@ public class MekLabTab extends CampaignGuiTab {
             equipmentTab.refresh();
             buildTab.refresh();
             transportTab.refresh();
+            previewTab.refresh();
             refreshSummary();
         }
 
@@ -1069,6 +1094,7 @@ public class MekLabTab extends CampaignGuiTab {
 
         @Override
         public void refreshPreview() {
+            previewTab.refresh();
         }
 
         @Override
@@ -1126,13 +1152,16 @@ public class MekLabTab extends CampaignGuiTab {
             structureTab.setAsCustomization();
             equipmentTab = new megameklab.com.ui.BattleArmor.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.BattleArmor.tabs.BuildTab(this);
+            FluffTab fluffTab = new FluffTab(this);
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Structure", new JScrollPane(structureTab));
             addTab("Equipment", new JScrollPane(equipmentTab));
             addTab("Assign Criticals", new JScrollPane(buildTab));
+            addTab("Fluff", new JScrollPane(fluffTab));
             this.repaint();
         }
 
@@ -1250,8 +1279,11 @@ public class MekLabTab extends CampaignGuiTab {
             structureTab.setAsCustomization();
             structureTab.addRefreshedListener(this);
             previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
+            FluffTab fluffTab = new FluffTab(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Build", new JScrollPane(structureTab));
+            addTab("Fluff", new JScrollPane(fluffTab));
             addTab("Preview", new JScrollPane(previewTab));
             this.repaint();
         }
@@ -1368,13 +1400,16 @@ public class MekLabTab extends CampaignGuiTab {
             equipmentTab = new megameklab.com.ui.tabs.EquipmentTab(this);
             previewTab = new megameklab.com.ui.tabs.PreviewTab(this);
             buildTab = new megameklab.com.ui.protomek.ProtomekBuildTab(this, equipmentTab, this);
+            FluffTab fluffTab = new FluffTab(this);
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Structure/Armor", new JScrollPane(structureTab));
             addTab("Equipment", new JScrollPane(equipmentTab));
             addTab("Assign Critical", new JScrollPane(buildTab));
+            addTab("FluffTab", new JScrollPane(fluffTab));
             addTab("Preview", new JScrollPane(previewTab));
             this.repaint();
         }
@@ -1477,7 +1512,7 @@ public class MekLabTab extends CampaignGuiTab {
         private megameklab.com.ui.tabs.TransportTab transportTab;
         private megameklab.com.ui.tabs.PreviewTab previewTab;
 
-        public AdvancedAeroPanel(Jumpship a) {
+        AdvancedAeroPanel(Jumpship a) {
             entity = a;
             reloadTabs();
         }
@@ -1487,7 +1522,7 @@ public class MekLabTab extends CampaignGuiTab {
             return entity;
         }
 
-        public void reloadTabs() {
+        void reloadTabs() {
             removeAll();
 
             structureTab = new megameklab.com.ui.aerospace.AdvancedAeroStructureTab(this);
@@ -1496,15 +1531,18 @@ public class MekLabTab extends CampaignGuiTab {
             equipmentTab = new megameklab.com.ui.Aero.tabs.EquipmentTab(this);
             buildTab = new megameklab.com.ui.Aero.tabs.BuildTab(this, equipmentTab);
             transportTab = new megameklab.com.ui.tabs.TransportTab(this);
+            FluffTab fluffTab = new FluffTab(this);
             structureTab.addRefreshedListener(this);
             equipmentTab.addRefreshedListener(this);
             buildTab.addRefreshedListener(this);
             transportTab.addRefreshedListener(this);
+            fluffTab.setRefreshedListener(this);
 
             addTab("Structure/Armor", new JScrollPane(structureTab));
             addTab("Equipment", new JScrollPane(equipmentTab));
             addTab("Assign Criticals", new JScrollPane(buildTab));
             addTab("Transport Bays", new JScrollPane(transportTab));
+            addTab("FluffTab", new JScrollPane(fluffTab));
             addTab("Preview", new JScrollPane(previewTab));
             this.repaint();
         }

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -889,7 +889,6 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                     menuItem.setEnabled(unit.isAvailable()
                             && ((unit.getEntity().getEntityType() &
                                     (Entity.ETYPE_JUMPSHIP
-                                            | Entity.ETYPE_PROTOMECH
                                             | Entity.ETYPE_GUN_EMPLACEMENT)) == 0));
                     menu.add(menuItem);
                 }

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -22,17 +22,7 @@ import javax.swing.event.MouseInputAdapter;
 
 import megamek.client.ui.swing.UnitEditorDialog;
 import megamek.client.ui.swing.util.MenuScroller;
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.IBomber;
-import megamek.common.Infantry;
-import megamek.common.Mech;
-import megamek.common.MechSummaryCache;
-import megamek.common.Player;
+import megamek.common.*;
 import megamek.common.loaders.BLKFile;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
@@ -887,9 +877,7 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                     menuItem.setActionCommand("CUSTOMIZE");
                     menuItem.addActionListener(this);
                     menuItem.setEnabled(unit.isAvailable()
-                            && ((unit.getEntity().getEntityType() &
-                                    (Entity.ETYPE_JUMPSHIP
-                                            | Entity.ETYPE_GUN_EMPLACEMENT)) == 0));
+                            && !(unit.getEntity() instanceof GunEmplacement));
                     menu.add(menuItem);
                 }
                 if (unit.isRefitting()) {


### PR DESCRIPTION
When I was adding SV customization support to the MekLab tab I noticed that I had never done it for protomechs or advanced aerospace units. So here it is. I also added the fluff tab, and a preview tab for combat and support vehicles. Protomechs required some adjustments to the armor part to distinguish between standard and EDP.