### PR TITLE
SV part loading fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -39,8 +39,11 @@ public class SVArmor extends Armor {
     private int bar;
     private int techRating;
 
+    /**
+     * Constructor used during campaign deserialization
+     */
     @SuppressWarnings("unused")
-    private SVArmor() {
+    public SVArmor() {
         this(2, RATING_D, 0, Entity.LOC_NONE, null);
     }
 
@@ -162,6 +165,7 @@ public class SVArmor extends Armor {
 
     @Override
     protected void loadFieldsFromXmlNode(Node node) {
+        super.loadFieldsFromXmlNode(node);
         for (int x = 0; x < node.getChildNodes().getLength(); x++) {
             final Node wn = node.getChildNodes().item(x);
             switch (wn.getNodeName()) {

--- a/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
@@ -47,7 +47,7 @@ public class SVEnginePart extends Part {
      * Constructor used during campaign deserialization
      */
     @SuppressWarnings("unused")
-    private SVEnginePart() {
+    public SVEnginePart() {
         this(0, 0.0, Engine.COMBUSTION_ENGINE, RATING_D, FuelType.PETROCHEMICALS, null);
     }
 


### PR DESCRIPTION
1. The default constructor can't be private even though it's invoked through reflection.
2. SVArmor::loadFieldsFromXmlNode doesn't call its super method, so the location (among other fields) doesn't get set and an IndexOutOfBoundsException is thrown when trying to use -1 as an array index.

Partial fix for #1333 