### PR TITLE
fix victory/defeat determination issues

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
@@ -84,10 +84,12 @@ public class CommonObjectiveFactory {
         
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
+        successEffect.howMuch = 1;
         keepFriendliesAlive.addSuccessEffect(successEffect);
         
         ObjectiveEffect friendlyFailureEffect = new ObjectiveEffect();
         friendlyFailureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
+        friendlyFailureEffect.howMuch = 1;
         keepFriendliesAlive.addFailureEffect(friendlyFailureEffect);  
         
         return keepFriendliesAlive;
@@ -115,10 +117,12 @@ public class CommonObjectiveFactory {
 
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
+        successEffect.howMuch = 1;
         keepFriendliesAlive.addSuccessEffect(successEffect);
         
         ObjectiveEffect friendlyFailureEffect = new ObjectiveEffect();
         friendlyFailureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
+        friendlyFailureEffect.howMuch = 1;
         keepFriendliesAlive.addFailureEffect(friendlyFailureEffect);  
         
         return keepFriendliesAlive;
@@ -137,10 +141,12 @@ public class CommonObjectiveFactory {
         
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
+        successEffect.howMuch = 1;
         destroyHostiles.addSuccessEffect(successEffect);
         
         ObjectiveEffect failureEffect = new ObjectiveEffect();
         failureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
+        failureEffect.howMuch = 1;
         destroyHostiles.addFailureEffect(failureEffect);
         
         return destroyHostiles;
@@ -168,7 +174,13 @@ public class CommonObjectiveFactory {
         
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
+        successEffect.howMuch = 1;
         destroyHostiles.addSuccessEffect(successEffect);
+        
+        ObjectiveEffect failureEffect = new ObjectiveEffect();
+        failureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
+        failureEffect.howMuch = 1;
+        destroyHostiles.addFailureEffect(failureEffect);
         
         return destroyHostiles;
     }
@@ -190,10 +202,12 @@ public class CommonObjectiveFactory {
         
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
+        successEffect.howMuch = 1;
         breakthrough.addSuccessEffect(successEffect);
         
         ObjectiveEffect failureEffect = new ObjectiveEffect();
         failureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
+        failureEffect.howMuch = 1;
         breakthrough.addFailureEffect(failureEffect);
         
         return breakthrough;


### PR DESCRIPTION
I changed how the objective scoring worked in a subsequent PR but forgot to update the AtB scenario objectives - need to specify how many points towards scenario victory/defeat an objective gives, as the default is 0.

This would result in scenarios being incorrectly declared draws.