### PR TITLE
Change order of resetting game data.

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3409,12 +3409,12 @@ public class Campaign implements Serializable, ITechManager {
     private void awardTrainingXPByMaximumRole(Lance l) {
         for (UUID trainerId : forceIds.get(l.getForceId()).getAllUnits()) {
             Unit trainerUnit = getUnit(trainerId);
-            
+
             // not sure how this occurs, but it probably shouldn't halt processing of a new day.
             if(trainerUnit == null) {
                 continue;
             }
-            
+
             Person commander = getUnit(trainerId).getCommander();
             // AtB 2.31: Training lance – needs a officer with Veteran skill levels
             //           and adds 1xp point to every Green skilled unit.
@@ -3428,11 +3428,11 @@ public class Campaign implements Serializable, ITechManager {
                     // the personnel under their command...
                     for (UUID traineeId : forceIds.get(l.getForceId()).getAllUnits()) {
                         Unit traineeUnit = getUnit(traineeId);
-                        
+
                         if(traineeUnit == null) {
                             continue;
                         }
-                        
+
                         for (Person p : traineeUnit.getCrew()) {
                             if (p == commander) {
                                 continue;
@@ -6494,12 +6494,12 @@ public class Campaign implements Serializable, ITechManager {
         entity.heat = 0;
         entity.heatBuildup = 0;
         entity.setTransportId(Entity.NONE);
-        entity.setUnloaded(false);
-        entity.setDone(false);
         entity.resetTransporter();
         entity.setDeployRound(0);
         entity.setSwarmAttackerId(Entity.NONE);
         entity.setSwarmTargetId(Entity.NONE);
+        entity.setUnloaded(false);
+        entity.setDone(false);
         entity.setLastTarget(Entity.NONE);
         entity.setNeverDeployed(true);
         entity.setStuck(false);


### PR DESCRIPTION
Calling either Entity.setTransportId(int) or Entity.setSwarmTargetId(int) with an argument of Entity.NONE has the side effect of setting both done and unloadedThisTurn to true. In Campaign::clearGameData, this is done after clearing the transportId but before clearing the swarmTargetId, resulting in all units being sent to MM with both done and unloadedThisTurn set to true. Though it evidently gets cleared later, at the time of PHASE_SET_ARTYAUTOHITHEXES they are still true and cause Entity::isSelectableThisTurn to return false.

Fixes #1337 