### PR TITLE
Fix protomech location replacement

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
@@ -202,13 +202,10 @@ public class MissingProtomekLocation extends MissingPart {
 		 }
         //there must be no usable equipment currently in the location
         //you can only salvage a location that has nothing left on it
-        for (int i = 0; i < unit.getEntity().getNumberOfCriticals(loc); i++) {
-            CriticalSlot slot = unit.getEntity().getCritical(loc, i);
-            // ignore empty & non-hittable slots
-            if ((slot == null) || !slot.isEverHittable()) {
-                continue;
-            }
-            if (slot.isRepairable()) {
+        for (Part part : unit.getParts()) {
+            if ((part.getLocation() == getLocation())
+                    && !(part instanceof MissingPart)
+                    && (!(part instanceof ProtomekArmor) || ((ProtomekArmor) part).getAmount() > 0)) {
                 return "Repairable parts in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first. They can then be re-installed.";
             }
         }
@@ -266,19 +263,19 @@ public class MissingProtomekLocation extends MissingPart {
 
 	@Override
 	public int getLocation() {
-		return Protomech.LOC_TORSO;
+		return loc;
 	}
 
     @Override
     public TechAdvancement getTechAdvancement() {
         return ProtomekLocation.TECH_ADVANCEMENT;
     }
-    
+
     @Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.GENERAL_LOCATION;
     }
-	
+
 	@Override
 	public int getRepairPartType() {
     	return Part.REPAIR_PART_TYPE.MEK_LOCATION;


### PR DESCRIPTION
Unlike other units, Protomech critical slots only point to crits on the location itself, never the equipment installed there (probably because Protomech damage resolution is a bit weird). This results in CriticalSlot#isRepairable returning true, and the part is falsely flagged as still containing equipment. I changed the check to loop through the components and find anything in the same location that is not a MissingPart or armor with any points.

I can't think of a situation that would involve equipment still installed in a missing location, but as MissingMekLocation also performs this check I thought it better to leave it as is since it works. I also tested removing an arm while salvaging, and it correctly switches from impossible to possible when the last component is removed.

Fixes #1349 