### PR TITLE
General support vehicle crew

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -591,10 +591,6 @@ public class Utilities {
         Person consoleCmdr = null;
         int totalGunnery = 0;
         int totalPiloting = 0;
-        drivers.clear();
-        gunners.clear();
-        vesselCrew.clear();
-        navigator = null;
 
         // If the entire crew is dead, we don't want to generate them.
         // Actually, we do because they might not be truly dead - this will be the case for BA for example
@@ -710,7 +706,7 @@ public class Utilities {
 
                 // this will have the side effect of giving every driver on the crew
                 // the SPAs from the entity's crew.
-                // Not really any way around it 
+                // Not really any way around it
                 populateOptionsFromCrew(p, oldCrew);
                 drivers.add(p);
             }
@@ -800,7 +796,8 @@ public class Utilities {
         //Multi-slot crews already have the names set. Single-slot multi-crew units need to assign the commander's name.
         boolean nameset = oldCrew.getSlotCount() > 1;
         while(vesselCrew.size() < u.getTotalCrewNeeds()) {
-            Person p = c.newPerson(Person.T_SPACE_CREW, factionCode);
+            Person p = c.newPerson(u.getEntity().isSupportVehicle() ?
+                    Person.T_VEHICLE_CREW : Person.T_SPACE_CREW, factionCode);
             if (!nameset) {
                 p.setName(commanderName);
                 nameset = true;
@@ -1103,9 +1100,9 @@ public class Utilities {
                 }
             }
         }
-        // For ammo types we want to match the same munition type if possible to avoid 
+        // For ammo types we want to match the same munition type if possible to avoid
         // imposing unnecessary ammo swaps.
-        // However, if we've just done a refit we may very well have changed ammo types, 
+        // However, if we've just done a refit we may very well have changed ammo types,
         // so we need to set the equipment numbers in this case.
         List<Part> notFound = new ArrayList<>();
         for(Part part : remaining) {
@@ -1574,7 +1571,7 @@ public class Utilities {
 
         }
     }
-    
+
     /**
      * Converts a given Image into a BufferedImage
      *

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4637,6 +4637,7 @@ public class Campaign implements Serializable, ITechManager {
                         rskillPrefs.randomizeSkill(), bonus, mod);
                 break;
             case (Person.T_MECHANIC):
+            case Person.T_VEHICLE_CREW:
                 person.addSkill(SkillType.S_TECH_MECHANIC, expLvl,
                         rskillPrefs.randomizeSkill(), bonus, mod);
                 break;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6282,7 +6282,7 @@ public class Campaign implements Serializable, ITechManager {
             unit.addGunner(p);
         }
         while (unit.canTakeMoreVesselCrew()) {
-            Person p = newPerson(Person.T_SPACE_CREW);
+            Person p = newPerson(unit.getEntity().isSupportVehicle() ? Person.T_VEHICLE_CREW : Person.T_SPACE_CREW);
             if (!isGM) {
                 if (!recruitPerson(p)) {
                     return;

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -72,9 +72,9 @@ public class CampaignOptions implements Serializable {
     public final static int REPAIR_SYSTEM_STRATOPS = 0;
     public final static int REPAIR_SYSTEM_WARCHEST_CUSTOM = 1;
     public final static int REPAIR_SYSTEM_GENERIC_PARTS = 2;
-    
+
     public final static int MAXIMUM_D6_VALUE = 6;
-    
+
     //FIXME: This needs to be localized
     public final static String[] REPAIR_SYSTEM_NAMES = {"Strat Ops", "Warchest Custom", "Generic Spare Parts"};
 
@@ -82,13 +82,13 @@ public class CampaignOptions implements Serializable {
     public final static double MAXIMUM_DROPSHIP_EQUIPMENT_PERCENT = 1.0;
     public final static double MAXIMUM_JUMPSHIP_EQUIPMENT_PERCENT = 1.0;
     public final static double MAXIMUM_WARSHIP_EQUIPMENT_PERCENT = 1.0;
-    
+
     public final static int PLANET_ACQUISITION_ALL = 0;
     public final static int PLANET_ACQUISITION_NEUTRAL = 1;
     public final static int PLANET_ACQUISITION_ALLY = 2;
     public final static int PLANET_ACQUISITION_SELF = 3;
 
-    
+
     private boolean useFactionForNames;
     private boolean useUnitRating;
 
@@ -314,7 +314,7 @@ public class CampaignOptions implements Serializable {
     private boolean massRepairUseAssignedTechsFirst;
     private boolean massRepairReplacePod;
     private List<MassRepairOption> massRepairOptions;
-    
+
     //Miscellaneous
     private boolean historicalDailyLog;
 
@@ -501,6 +501,7 @@ public class CampaignOptions implements Serializable {
         salaryTypeBase[Person.T_MEDIC] = Money.of(400);
         salaryTypeBase[Person.T_PROTO_PILOT] = Money.of(960);
         salaryTypeBase[Person.T_LAM_PILOT] = Money.of(1500);
+        salaryTypeBase[Person.T_VEHICLE_CREW] = Money.of(900);
         salaryXpMultiplier = new double[5];
         salaryXpMultiplier[SkillType.EXP_ULTRA_GREEN] = 0.6;
         salaryXpMultiplier[SkillType.EXP_GREEN] = 0.6;
@@ -563,7 +564,7 @@ public class CampaignOptions implements Serializable {
         allowOpforLocalUnits = false;
         opforAeroChance = 5;
         opforLocalUnitChance = 5;
-        
+
         //Mass Repair/Salvage Options
         massRepairUseExtraTime = true;
         massRepairUseRushJob = true;
@@ -573,11 +574,11 @@ public class CampaignOptions implements Serializable {
         massRepairUseAssignedTechsFirst = false;
         massRepairReplacePod = true;
         massRepairOptions = new ArrayList<>();
-        
+
         for (int i = 0; i < MassRepairOption.VALID_REPAIR_TYPES.length; i++) {
         	massRepairOptions.add(new MassRepairOption(MassRepairOption.VALID_REPAIR_TYPES[i]));
         }
-        
+
         historicalDailyLog = false;
    }
 
@@ -609,7 +610,7 @@ public class CampaignOptions implements Serializable {
                 return "Unknown";
         }
     }
-    
+
     public static String getFactionLimitName(int lvl) {
         switch (lvl) {
             case PLANET_ACQUISITION_ALL:
@@ -765,7 +766,7 @@ public class CampaignOptions implements Serializable {
     public void setEdge(boolean b) {
         this.useEdge = b;
     }
-    
+
     public boolean useSupportEdge() {
         return useSupportEdge;
     }
@@ -1111,19 +1112,19 @@ public class CampaignOptions implements Serializable {
     public void setAllowCanonRefitOnly(boolean b) {
         allowCanonRefitOnly = b;
     }
-    
+
     public boolean useVariableTechLevel() {
         return variableTechLevel;
     }
-    
+
     public void setVariableTechLevel(boolean b) {
         variableTechLevel = b;
     }
-    
+
     public void setfactionIntroDate(boolean b) {
         factionIntroDate = b;
     }
-    
+
     public boolean useFactionIntroDate() {
         return factionIntroDate;
     }
@@ -1262,15 +1263,15 @@ public class CampaignOptions implements Serializable {
     public void setAdminXPPeriod(int m) {
         adminXPPeriod = m;
     }
-    
+
     public boolean historicalDailyLog() {
         return historicalDailyLog;
     }
-    
+
     public void setHistoricalDailyLog(boolean b) {
         this.historicalDailyLog = b;
     }
-    
+
     public int getEdgeCost() {
         return edgeCost;
     }
@@ -1358,35 +1359,35 @@ public class CampaignOptions implements Serializable {
     public void setAcquireMinimumTime(int b) {
         acquireMinimumTime = b;
     }
-    
+
     public boolean usesPlanetaryAcquisition() {
     	return usePlanetaryAcquisition;
     }
-    
+
     public void setPlanetaryAcquisition(boolean b) {
     	usePlanetaryAcquisition = b;
     }
-    
+
     public int getPlanetAcquisitionFactionLimit() {
     	return planetAcquisitionFactionLimit;
     }
-    
+
     public void setPlanetAcquisitionFactionLimit(int b) {
     	planetAcquisitionFactionLimit = b;
     }
-    
+
     public boolean disallowPlanetAcquisitionClanCrossover() {
     	return planetAcquisitionNoClanCrossover;
     }
-    
+
     public void setDisallowPlanetAcquisitionClanCrossover(boolean b) {
     	planetAcquisitionNoClanCrossover = b;
     }
-    
+
     public int getMaxJumpsPlanetaryAcquisition() {
     	return maxJumpsPlanetaryAcquisition;
     }
-    
+
     public void setMaxJumpsPlanetaryAcquisition(int m) {
     	maxJumpsPlanetaryAcquisition = m;
     }
@@ -1394,27 +1395,27 @@ public class CampaignOptions implements Serializable {
     public int getPenaltyClanPartsFroIS() {
     	return penaltyClanPartsFromIS;
     }
-    
+
     public void setPenaltyClanPartsFroIS(int i) {
     	penaltyClanPartsFromIS = i ;
     }
-    
+
     public boolean disallowClanPartsFromIS() {
     	return noClanPartsFromIS;
     }
-    
+
     public void setDisallowClanPartsFromIS(boolean b) {
     	noClanPartsFromIS = b;
     }
-    
+
     public boolean usePlanetAcquisitionVerboseReporting() {
     	return planetAcquisitionVerbose;
     }
-    
+
     public void setPlanetAcquisitionVerboseReporting(boolean b) {
     	planetAcquisitionVerbose = b;
     }
-    
+
     public double getEquipmentContractPercent() {
         return equipmentContractPercent;
     }
@@ -1486,7 +1487,7 @@ public class CampaignOptions implements Serializable {
     public void setIsAcquisitionPenalty(int b) {
         isAcquisitionPenalty = b;
     }
-    
+
     public int getPlanetTechAcquisitionBonus(int type) {
         if (type < 0 || type >= planetTechAcquisitionBonus.length) {
             return 0;
@@ -1500,7 +1501,7 @@ public class CampaignOptions implements Serializable {
         }
         this.planetTechAcquisitionBonus[type] = base;
     }
-    
+
     public int getPlanetIndustryAcquisitionBonus(int type) {
         if (type < 0 || type >= planetIndustryAcquisitionBonus.length) {
             return 0;
@@ -1514,7 +1515,7 @@ public class CampaignOptions implements Serializable {
         }
         this.planetIndustryAcquisitionBonus[type] = base;
     }
-    
+
     public int getPlanetOutputAcquisitionBonus(int type) {
         if (type < 0 || type >= planetOutputAcquisitionBonus.length) {
             return 0;
@@ -1616,7 +1617,7 @@ public class CampaignOptions implements Serializable {
     public void setDestroyPartTarget(int d) {
         destroyPartTarget = d;
     }
-    
+
     public boolean useAeroSystemHits() {
         return useAeroSystemHits;
     }
@@ -1968,15 +1969,15 @@ public class CampaignOptions implements Serializable {
 	public boolean useStaticRATs() {
 		return staticRATs;
 	}
-	
+
 	public void setStaticRATs(boolean staticRATs) {
 		this.staticRATs = staticRATs;
 	}
-	
+
 	public boolean canIgnoreRatEra() {
 	    return ignoreRatEra;
 	}
-	
+
 	public void setIgnoreRatEra(boolean ignore) {
 	    ignoreRatEra = ignore;
 	}
@@ -2167,11 +2168,11 @@ public class CampaignOptions implements Serializable {
 	public boolean massRepairScrapImpossible() {
 		return massRepairScrapImpossible;
 	}
-	
+
 	public void setMassRepairScrapImpossible(boolean b) {
 		this.massRepairScrapImpossible = b;
 	}
-	
+
 	public boolean massRepairUseAssignedTechsFirst() {
 		return massRepairUseAssignedTechsFirst;
 	}
@@ -2200,58 +2201,58 @@ public class CampaignOptions implements Serializable {
 		if (mro.getType() == -1) {
 			return;
 		}
-		
+
 		int foundIdx = -1;
-		
+
 		for (int i = 0; i < massRepairOptions.size(); i++) {
 			if (massRepairOptions.get(i).getType() == mro.getType()) {
 				foundIdx = i;
 				break;
 			}
 		}
-		
+
 		if (foundIdx == -1) {
 			massRepairOptions.add(mro);
 		} else {
 			massRepairOptions.add(foundIdx, mro);
 			massRepairOptions.remove(foundIdx + 1);
 		}
-		
+
 		massRepairOptions.sort((o1, o2) -> o1.getType() < o2.getType() ? -1 : 1);
 	}
 
 	public void setAllowOpforAeros(boolean allowOpforAeros) {
 	    this.allowOpforAeros = allowOpforAeros;
 	}
-	
+
 	public boolean getAllowOpforAeros() {
 	    return allowOpforAeros;
 	}
-	
+
 	public void setAllowOpforLocalUnits(boolean allowOpforLocalUnits) {
         this.allowOpforLocalUnits = allowOpforLocalUnits;
     }
-    
+
     public boolean getAllowOpforLocalUnits() {
         return allowOpforLocalUnits;
     }
-    
+
     public void setOpforAeroChance(int chance) {
         this.opforAeroChance = chance;
     }
-    
+
     public int getOpforAeroChance() {
         return opforAeroChance;
     }
-    
+
     public void setOpforLocalUnitChance(int chance) {
         this.opforLocalUnitChance = chance;
     }
-    
+
     public int getOpforLocalUnitChance() {
         return opforLocalUnitChance;
     }
-	
+
 	public void writeToXml(PrintWriter pw1, int indent) {
         pw1.println(MekHqXmlUtil.indentStr(indent) + "<campaignOptions>");
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "clanPriceModifier", clanPriceModifier); //private double
@@ -2451,26 +2452,26 @@ public class CampaignOptions implements Serializable {
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairScrapImpossible", massRepairScrapImpossible);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairUseAssignedTechsFirst", massRepairUseAssignedTechsFirst);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairReplacePod", massRepairReplacePod);
-        
+
         pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<massRepairOptions>");
 
         for (int i = 0; i < massRepairOptions.size(); i++) {
         	MassRepairOption mro = massRepairOptions.get(i);
-        	
+
         	pw1.println(MekHqXmlUtil.indentStr(indent + 2) + "<massRepairOption" + i + ">");
-        	
+
         	MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 3, "type", mro.getType());
         	MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 3, "active", mro.isActive() ? 1 : 0);
         	MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 3, "skillMin", mro.getSkillMin());
         	MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 3, "skillMax", mro.getSkillMax());
         	MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 3, "btnMin", mro.getBthMin());
         	MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 3, "btnMax", mro.getBthMax());
-        	
+
         	pw1.println(MekHqXmlUtil.indentStr(indent + 2) + "</massRepairOption" + i + ">");
         }
-        
+
         pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "</massRepairOptions>");
-        
+
         pw1.println(MekHqXmlUtil.indentStr(indent + 1)
                 + "<planetTechAcquisitionBonus>"
                 + Utilities.printIntegerArray(planetTechAcquisitionBonus)
@@ -2483,7 +2484,7 @@ public class CampaignOptions implements Serializable {
                 + "<planetOutputAcquisitionBonus>"
                 + Utilities.printIntegerArray(planetOutputAcquisitionBonus)
                 + "</planetOutputAcquisitionBonus>");
-        
+
         pw1.println(MekHqXmlUtil.indentStr(indent + 1)
                     + "<salaryTypeBase>"
                     + Utilities.printMoneyArray(salaryTypeBase)
@@ -2954,11 +2955,11 @@ public class CampaignOptions implements Serializable {
             } else if (wn2.getNodeName().equalsIgnoreCase("massRepairOptimizeToCompleteToday")) {
                 retVal.massRepairOptimizeToCompleteToday = Boolean.parseBoolean(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("massRepairScrapImpossible")) {
-                retVal.massRepairScrapImpossible = Boolean.parseBoolean(wn2.getTextContent().trim());        
+                retVal.massRepairScrapImpossible = Boolean.parseBoolean(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("massRepairUseAssignedTechsFirst")) {
-                retVal.massRepairUseAssignedTechsFirst = Boolean.parseBoolean(wn2.getTextContent().trim());                        
+                retVal.massRepairUseAssignedTechsFirst = Boolean.parseBoolean(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("massRepairReplacePod")) {
-                retVal.massRepairReplacePod = Boolean.parseBoolean(wn2.getTextContent().trim());                        
+                retVal.massRepairReplacePod = Boolean.parseBoolean(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("massRepairOptions")) {
                 NodeList mroList = wn2.getChildNodes();
 
@@ -2968,13 +2969,13 @@ public class CampaignOptions implements Serializable {
                     if (mroNode.getNodeType() != Node.ELEMENT_NODE) {
                         continue;
                     }
-                    
+
                     for (int mroTypeIdx = 0; mroTypeIdx < MassRepairOption.VALID_REPAIR_TYPES.length; mroTypeIdx++) {
                     	if (mroNode.getNodeName().equalsIgnoreCase("massRepairOption" + mroTypeIdx)) {
-                    		
+
                     		MassRepairOption mro = new MassRepairOption();
                     		mro.setType(-1);
-                    		
+
                             NodeList mroItemList = mroNode.getChildNodes();
 
                             for (int mroItemIdx = 0; mroItemIdx < mroItemList.getLength(); mroItemIdx++) {
@@ -2983,11 +2984,11 @@ public class CampaignOptions implements Serializable {
                                 if (mroItemNode.getNodeType() != Node.ELEMENT_NODE) {
                                     continue;
                                 }
-                     
+
                                 MekHQ.getLogger().log(CampaignOptions.class, METHOD_NAME, LogLevel.INFO,
                                         String.format("massRepairOption %d.%s\n\t%s", //$NON-NLS-1$
                                                 mroTypeIdx, mroItemNode.getNodeName(), mroItemNode.getTextContent()));
-                                
+
                                 if (mroItemNode.getNodeName().equalsIgnoreCase("type")) {
                                 	mro.setType(Integer.parseInt(mroItemNode.getTextContent().trim()));
                                 } else if (mroItemNode.getNodeName().equalsIgnoreCase("active")) {
@@ -3002,13 +3003,13 @@ public class CampaignOptions implements Serializable {
                                 	mro.setBthMax(Integer.parseInt(mroItemNode.getTextContent().trim()));
                                 }
                             }
-                            
+
                             if (mro.getType() != -1) {
                             	retVal.addMassRepairOption(mro);
                             }
                     	}
-                    }                    
-                }            	
+                    }
+                }
             }
         }
 
@@ -3017,16 +3018,16 @@ public class CampaignOptions implements Serializable {
 
         return retVal;
     }
-    
+
     public static class MassRepairOption {
     	public MassRepairOption() {
-    		
+
     	}
-    	
+
     	public MassRepairOption(int type) {
     		this (type, false, SkillType.EXP_ULTRA_GREEN, SkillType.EXP_ELITE, 4, 4);
     	}
-    	
+
     	public MassRepairOption(int type, boolean active, int skillMin, int skillMax, int bthMin, int bthMax) {
 			this.type = type;
 			this.active = active;
@@ -3036,62 +3037,62 @@ public class CampaignOptions implements Serializable {
 			this.bthMax = bthMax;
 		}
 
-    	public static int[] VALID_REPAIR_TYPES = new int[] { Part.REPAIR_PART_TYPE.ARMOR, Part.REPAIR_PART_TYPE.AMMO, 
-    			Part.REPAIR_PART_TYPE.WEAPON, Part.REPAIR_PART_TYPE.GENERAL_LOCATION, Part.REPAIR_PART_TYPE.ENGINE, 
+    	public static int[] VALID_REPAIR_TYPES = new int[] { Part.REPAIR_PART_TYPE.ARMOR, Part.REPAIR_PART_TYPE.AMMO,
+    			Part.REPAIR_PART_TYPE.WEAPON, Part.REPAIR_PART_TYPE.GENERAL_LOCATION, Part.REPAIR_PART_TYPE.ENGINE,
     			Part.REPAIR_PART_TYPE.GYRO, Part.REPAIR_PART_TYPE.ACTUATOR, Part.REPAIR_PART_TYPE.ELECTRONICS,
     			Part.REPAIR_PART_TYPE.POD_SPACE, Part.REPAIR_PART_TYPE.GENERAL };
-    	
+
 		private int type;
     	private boolean active = true;
     	private int skillMin;
     	private int skillMax;
     	private int bthMin;
     	private int bthMax;
-    	
+
 		public int getType() {
 			return type;
 		}
-		
+
 		public void setType(int type) {
 			this.type = type;
 		}
-		
+
 		public boolean isActive() {
 			return active;
 		}
-		
+
 		public void setActive(boolean active) {
 			this.active = active;
 		}
-		
+
 		public int getSkillMin() {
 			return skillMin;
 		}
-		
+
 		public void setSkillMin(int skillMin) {
 			this.skillMin = skillMin;
 		}
-		
+
 		public int getSkillMax() {
 			return skillMax;
 		}
-		
+
 		public void setSkillMax(int skillMax) {
 			this.skillMax = skillMax;
 		}
-		
+
 		public int getBthMin() {
 			return bthMin;
 		}
-		
+
 		public void setBthMin(int bthMin) {
 			this.bthMin = bthMin;
 		}
-		
+
 		public int getBthMax() {
 			return bthMax;
 		}
-		
+
 		public void setBthMax(int bthMax) {
 			this.bthMax = bthMax;
 		}

--- a/MekHQ/src/mekhq/campaign/MercRosterAccess.java
+++ b/MekHQ/src/mekhq/campaign/MercRosterAccess.java
@@ -23,7 +23,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 
 public class MercRosterAccess extends SwingWorker<Void, Void> {
-   
+
     Campaign campaign;
     String username;
     String hostname;
@@ -43,7 +43,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
     //to track progress
     private String progressNote;
     private int progressTicker;
-    
+
     public MercRosterAccess(String h, int port, String t, String u, String p, Campaign c) {
       username = u;
       hostname = h;
@@ -57,7 +57,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
       progressNote = "";
       progressTicker = 0;
     }
-  
+
     public void connect() throws SQLException {
     	conProperties = new Properties();
     	conProperties.put("user", username);
@@ -73,36 +73,36 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
     }
 
     public void writeCampaignData() {
-        
+
         //TODO throw all SQLExceptions - but then where do they go from doInBackground?
         try {
             statement = connect.createStatement();
         } catch (SQLException e2) {
             e2.printStackTrace();
         };
-        
+
         writeBasicData();
         writeForceData();
         writePersonnelData();
         writeEquipmentData();
         //TODO: writeContractData
         //TODO: write logs?
-        
+
         // Needed because otherwise progress isn't reaching 100 and the progress meter stays open
         setProgress(100);
 
     }
-    
+
     private void writeBasicData() {
-        
+
         try {
             preparedStatement = connect.prepareStatement("UPDATE " + table + ".command SET name=? where id=1");
             preparedStatement.setString(1, truncateString(campaign.getName(), 100));
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             e.printStackTrace();
-        } 
-        
+        }
+
         progressNote = "Uploading dates";
         determineProgress();
         //write dates
@@ -303,6 +303,13 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                     preparedStatement.setInt(2, i);
                     preparedStatement.executeUpdate();
                     break;
+                case Person.T_VEHICLE_CREW:
+                    preparedStatement = connect.prepareStatement("INSERT INTO " + table + ".skillrequirements (skilltype, personneltype) VALUES (?, ?)");
+                    preparedStatement.setInt(1, skillHash.get(SkillType.S_TECH_MECHANIC));
+                    preparedStatement.setInt(2, i);
+                    preparedStatement.executeUpdate();
+                    equipment = 1;
+                    break;
                 }
                 preparedStatement = connect.prepareStatement("INSERT INTO " + table + ".crewtypes (type, squad, vehicletype, prefpos, equipment) VALUES (?, ?, ?, ?, ?)");
                 preparedStatement.setString(1, truncateString(Person.getRoleDesc(i, campaign.getFaction().isClan()), 45));
@@ -317,7 +324,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        
+
         //write equipment types
         progressNote = "Uploading equipment types";
         determineProgress();
@@ -348,12 +355,12 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             e.printStackTrace();
         }
     }
-    
+
     private void writeForceData() {
-        
+
         //clear the table and re-enter a top level command
         try {
-            statement.execute("TRUNCATE TABLE " + table + ".unit");  
+            statement.execute("TRUNCATE TABLE " + table + ".unit");
             preparedStatement = connect.prepareStatement("INSERT INTO " + table + ".unit (type, name, parent, prefpos, text) VALUES (?, ?, ?, ?, ?)");
             preparedStatement.setString(1, "1");
             preparedStatement.setString(2, "Command");
@@ -379,10 +386,10 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             }
         }
     }
-    
+
     private void writeForce(Force force, int parent) {
-        
-        try {           
+
+        try {
             preparedStatement = connect.prepareStatement("INSERT INTO " + table + ".unit (type, name, parent, prefpos, text) VALUES (?, ?, ?, ?, ?)");
             preparedStatement.setString(1, "1");
             preparedStatement.setString(2, force.getName());
@@ -392,7 +399,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             e.printStackTrace();
-        } 
+        }
         //retrieve the mercroster id of this force
         ResultSet rs;
         int id = parent;
@@ -403,7 +410,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        
+
         progressTicker += 2;
         determineProgress();
         //loop through subforces and call again
@@ -422,15 +429,15 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
     }
 
     private void writePersonnelData() {
-       
-        
+
+
         //check for a uuid column
         try {
             //add in a UUID column if not already present
             if(!hasColumn(statement.executeQuery("SELECT * FROM " + table + ".crew"), "uuid")) {
                 statement.execute("TRUNCATE TABLE " + table + ".crew");
                 statement.execute("ALTER TABLE " + table + ".crew ADD uuid VARCHAR(40)");
-            }             
+            }
             statement.execute("TRUNCATE TABLE " + table + ".personnelpositions");
             statement.execute("TRUNCATE TABLE " + table + ".skills");
             statement.execute("TRUNCATE TABLE " + table + ".kills");
@@ -448,7 +455,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 forceId = forceHash.get(p.getId());
             }
             try {
-                preparedStatement = connect.prepareStatement("UPDATE " + table + ".crew SET rank=?, lname=?, fname=?, callsign=?, status=?, parent=?, crewnumber=?, joiningdate=?, notes=?, bday=? WHERE uuid=?"); 
+                preparedStatement = connect.prepareStatement("UPDATE " + table + ".crew SET rank=?, lname=?, fname=?, callsign=?, status=?, parent=?, crewnumber=?, joiningdate=?, notes=?, bday=? WHERE uuid=?");
                 preparedStatement.setInt(1, p.getRankNumeric());
                 preparedStatement.setString(2, truncateString(parseLastName(p.getName()),30));
                 preparedStatement.setString(3, truncateString(parseFirstName(p.getName()), 30));
@@ -517,19 +524,19 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             } catch (SQLException e) {
                 e.printStackTrace();
-            }          
+            }
         }
     }
-    
+
     private void writeEquipmentData() {
         //TODO: we need to clear the equipment table because equipment will come and go
-        
+
         //check for a uuid column
         try {
             //add in a UUID column if not already present
             if(!hasColumn(statement.executeQuery("SELECT * FROM " + table + ".equipment"), "uuid")) {
                 statement.execute("ALTER TABLE " + table + ".equipment ADD uuid VARCHAR(40)");
-            }             
+            }
         } catch (SQLException e1) {
             e1.printStackTrace();
         }
@@ -538,7 +545,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
         determineProgress();
         for(Unit u : campaign.getUnits()) {
             try {
-                preparedStatement = connect.prepareStatement("UPDATE " + table + ".equipment SET type=?, name=?, subtype=?, crew=?, weight=?, regnumber=?, notes=? WHERE uuid=?"); 
+                preparedStatement = connect.prepareStatement("UPDATE " + table + ".equipment SET type=?, name=?, subtype=?, crew=?, weight=?, regnumber=?, notes=? WHERE uuid=?");
                 preparedStatement.setInt(1, u.getEntity().getUnitType() + 1);
                 preparedStatement.setString(2, truncateString(u.getEntity().getChassis(), 45));
                 preparedStatement.setString(3, truncateString(u.getEntity().getModel(), 45));
@@ -573,10 +580,10 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             } catch (SQLException e) {
                 e.printStackTrace();
-            }          
+            }
         }
     }
-    
+
     public void close() {
         try {
             if (preparedStatement != null) {
@@ -587,19 +594,19 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 connect.close();
             }
         } catch (Exception e) {
-            
+
         }
     }
-    
+
     private static String parseFirstName(String name) {
         return name.split(" ")[0];
     }
-    
+
     private static String parseLastName(String name) {
         String[] names = name.split(" ");
         return names[names.length-1];
     }
-    
+
     private static boolean hasColumn(ResultSet rs, String columnName) throws SQLException {
         ResultSetMetaData rsmd = rs.getMetaData();
         int columns = rsmd.getColumnCount();
@@ -610,14 +617,14 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
         }
         return false;
     }
-    
+
     private static String getShortSkillName(String name) {
         name = name.split("/")[0];
         name = name.replaceAll("\\s","");
         name = name.replaceAll("Hyperspace", "");
         return name;
     }
-    
+
     private static String getMercRosterStatusName(int status) {
         switch(status) {
         case Person.S_ACTIVE:
@@ -632,7 +639,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             return "?";
         }
     }
-    
+
     private static String truncateString(String s, int len) {
         if(s.length() < len) {
             return s;
@@ -645,20 +652,20 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
         writeCampaignData();
         return null;
     }
-    
+
     @Override
     public void done() {
         close();
     }
-    
+
     public String getProgressNote() {
         return progressNote;
     }
-    
+
     private int getLengthOfTask() {
         return 2 + campaign.getRanks().getAllRanks().size() + SkillType.skillList.length + Person.T_NUM * 2 + UnitType.SIZE + campaign.getPersonnel().size() * 4 + campaign.getUnits().size() + campaign.getAllForces().size() * 2;
     }
-    
+
     public void determineProgress() {
         double percent = ((double)progressTicker) / getLengthOfTask();
         percent = Math.min(percent, 1.0);

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -895,6 +895,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
             case (T_MECH_TECH):
                 return hasSkill(SkillType.S_TECH_MECH) && getSkill(SkillType.S_TECH_MECH).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN;
             case (T_MECHANIC):
+            case T_VEHICLE_CREW:
                 return hasSkill(SkillType.S_TECH_MECHANIC) && getSkill(SkillType.S_TECH_MECHANIC).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN;
             case (T_AERO_TECH):
                 return hasSkill(SkillType.S_TECH_AERO) && getSkill(SkillType.S_TECH_AERO).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN;
@@ -911,8 +912,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
             case (T_ADMIN_TRA):
             case (T_ADMIN_HR):
                 return hasSkill(SkillType.S_ADMIN);
-            case (T_VEHICLE_CREW):
-                return true;
             default:
                 return false;
         }
@@ -2380,6 +2379,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                     return -1;
                 }
             case T_MECHANIC:
+            case T_VEHICLE_CREW:
                 if (hasSkill(SkillType.S_TECH_MECHANIC)) {
                     return getSkill(SkillType.S_TECH_MECHANIC).getExperienceLevel();
                 } else {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -112,9 +112,10 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public static final int T_ADMIN_HR = 25; // End of support roles
     public static final int T_LAM_PILOT = 26; // Not a separate type, but an alias for MW + Aero pilot
                                               // Does not count as either combat or support role
+    public static final int T_VEHICLE_CREW = 27; // non-gunner/non-driver support vehicle crew
 
     // This value should always be +1 of the last defined role
-    public static final int T_NUM = 27;
+    public static final int T_NUM = 28;
 
     public static final int S_ACTIVE = 0;
     public static final int S_RETIRED = 1;
@@ -157,7 +158,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public static final int DESIG_CHI     = 12;
     public static final int DESIG_GAMMA   = 13;
     public static final int DESIG_NUM     = 14;
-    
+
     private static final Map<Integer, Money> MECHWARRIOR_AERO_RANSOM_VALUES;
     private static final Map<Integer, Money> OTHER_RANSOM_VALUES;
 
@@ -178,12 +179,12 @@ public class Person implements Serializable, MekHqXmlSerializable {
         }
         return Math.min(children, 8); // Limit to octuplets, for the sake of sanity
     };
-    
+
     private static final String[] PREGNANCY_MULTIPLE_NAMES = {null, null,
         "twins", "triplets", "quadruplets", "quintuplets",
         "sextuplets", "septuplets", "octuplets", "nonuplets", "decuplets"
     };
-    
+
     public static final ExtraData.IntKey PREGNANCY_CHILDREN_DATA
         = new ExtraData.IntKey("procreation:children");
     public static final ExtraData.StringKey PREGNANCY_FATHER_DATA
@@ -197,7 +198,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         SkillType.S_TECH_AERO,
         SkillType.S_TECH_VESSEL,
     };
-    
+
     protected UUID id;
     protected int oldId;
 
@@ -316,7 +317,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     private int originalUnitWeight; // uses EntityWeightClass; 0 (Extra-Light) for no original unit
     private int originalUnitTech; // 0 = IS1, 1 = IS2, 2 = Clan
     private UUID originalUnitId;
-    
+
     // Generic extra data, for use with plugins and mods
     private ExtraData extraData = new ExtraData();
 
@@ -343,7 +344,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         MECHWARRIOR_AERO_RANSOM_VALUES.put(SkillType.EXP_REGULAR, Money.of(25000));
         MECHWARRIOR_AERO_RANSOM_VALUES.put(SkillType.EXP_VETERAN, Money.of(75000));
         MECHWARRIOR_AERO_RANSOM_VALUES.put(SkillType.EXP_ELITE, Money.of(150000));
-        
+
         OTHER_RANSOM_VALUES = new HashMap<>();
         OTHER_RANSOM_VALUES.put(SkillType.EXP_ULTRA_GREEN, Money.of(2500));
         OTHER_RANSOM_VALUES.put(SkillType.EXP_GREEN, Money.of(5000));
@@ -351,7 +352,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         OTHER_RANSOM_VALUES.put(SkillType.EXP_VETERAN, Money.of(25000));
         OTHER_RANSOM_VALUES.put(SkillType.EXP_ELITE, Money.of(50000));
     }
-    
+
     //default constructor
     public Person(Campaign c) {
         this("Biff the Understudy", c);
@@ -360,11 +361,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public Person(Campaign c, String factionCode) {
         this("Biff the Understudy", c, factionCode);
     }
-    
+
     public Person(String name, Campaign c) {
         this(name, c, c.getFactionCode());
     }
-    
+
     public Person(String name, Campaign c, String factionCode) {
         this.name = name;
         callsign = "";
@@ -510,11 +511,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public int getPrisonerStatus() {
         return prisonerStatus;
     }
-    
+
     public boolean isWillingToDefect() {
         return willingToDefect;
     }
-    
+
     public void setWillingToDefect(boolean willingToDefect) {
         this.willingToDefect = willingToDefect && (prisonerStatus == PRISONER_YES);
     }
@@ -832,6 +833,8 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 return "Admin/HR";
             case (T_LAM_PILOT):
                 return "LAM Pilot";
+            case (T_VEHICLE_CREW):
+                return "Vehicle Crew";
             default:
                 return "??";
         }
@@ -908,6 +911,8 @@ public class Person implements Serializable, MekHqXmlSerializable {
             case (T_ADMIN_TRA):
             case (T_ADMIN_HR):
                 return hasSkill(SkillType.S_ADMIN);
+            case (T_VEHICLE_CREW):
+                return true;
             default:
                 return false;
         }
@@ -979,7 +984,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
             //use zero if hasn't been recruited yet
             return -1;
         }
-         
+
         int timeinservice = today.get(Calendar.YEAR) - recruitment.get(Calendar.YEAR);
 
         // Add the tentative time in service to the date of recruitment to get this year's service history
@@ -1060,12 +1065,12 @@ public class Person implements Serializable, MekHqXmlSerializable {
         }
         final UUID ancId = anc.getId();
         final String surname = getName().contains(" ") ? getName().split(" ", 2)[1] : "";
-        
+
         // Cleanup
         setDueDate(null);
         extraData.set(PREGNANCY_CHILDREN_DATA, 0);
         extraData.set(PREGNANCY_FATHER_DATA, null);
-        
+
         return IntStream.range(0, size).mapToObj(i -> {
             Person baby = campaign.newPerson(T_NONE);
             baby.setDependent(true);
@@ -1103,7 +1108,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                         concieved = (Compute.randomInt(10000) < 2);
                     }
                 }
-                
+
                 if(concieved) {
                     GregorianCalendar tCal = (GregorianCalendar) campaign.getCalendar().clone();
                     tCal.add(GregorianCalendar.DAY_OF_YEAR, PREGNANCY_DURATION.getAsInt());
@@ -1189,11 +1194,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public void awardXP(int xp) {
         this.xp += xp;
     }
-    
+
     public int getEngineerXp() {
         return engXp;
     }
-    
+
     public void setEngineerXp(int xp) {
         engXp = xp;
     }
@@ -1253,7 +1258,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public boolean isInActive() {
         return getStatus() != S_ACTIVE;
     }
-    
+
     public ExtraData getExtraData() {
         return extraData;
     }
@@ -1552,7 +1557,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
 
     public static Person generateInstanceFromXML(Node wn, Campaign c, Version version) {
         final String METHOD_NAME = "generateInstanceFromXML(Node,Campaign,Version)"; //$NON-NLS-1$
-        
+
         Person retVal = null;
 
         try {
@@ -1969,7 +1974,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                         "ID not pre-defined; generating person's ID."); //$NON-NLS-1$
                 retVal.id = UUID.randomUUID();
             }
-    
+
             // Prisoner and Bondsman updating
             if (retVal.prisonerStatus != PRISONER_NOT && retVal.rank == 0) {
                 if (retVal.prisonerStatus == PRISONER_BONDSMAN) {
@@ -2547,6 +2552,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
             case T_VTOL_PILOT:
             case T_VEE_GUNNER:
             case T_CONV_PILOT:
+            case T_VEHICLE_CREW:
                 sb.append("Lambda");
                 break;
             default: break;
@@ -2641,15 +2647,15 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public Skill getSkill(String skillName) {
         return skills.get(skillName);
     }
-    
+
     public void addSkill(String skillName, int lvl, int bonus) {
         skills.put(skillName, new Skill(skillName, lvl, bonus));
     }
-    
+
     public void addSkill(String skillName, int xpLvl, boolean random, int bonus) {
         skills.put(skillName, new Skill(skillName, xpLvl, random, bonus, 0));
     }
-    
+
     public void addSkill(String skillName, int xpLvl, boolean random, int bonus, int rollMod) {
         skills.put(skillName, new Skill(skillName, xpLvl, random, bonus, rollMod));
     }
@@ -2659,18 +2665,18 @@ public class Person implements Serializable, MekHqXmlSerializable {
             skills.remove(skillName);
         }
     }
-    
+
     public int getSkillNumber() {
         return skills.size();
     }
-    
+
     /**
      * Remove all skills
      */
     public void removeAllSkills() {
         skills.clear();
-    }   
-    
+    }
+
     /**
      * Limit skills to the maximum of the given level
      */
@@ -2723,7 +2729,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         // Check parent locations as well (a hand can be missing if the corresponding arm is)
         return isLocationMissing(loc.parent);
     }
-    
+
     public void heal() {
         hits = Math.max(hits - 1, 0);
         if (!needsFixing()) {
@@ -2739,11 +2745,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
         heal();
         return " <font color='green'><b>Successfully healed one hit.</b></font>";
     }
-    
+
     public PersonnelOptions getOptions() {
         return options;
     }
-    
+
     /**
      * Returns the options of the given category that this pilot has
      */
@@ -2866,15 +2872,15 @@ public class Person implements Serializable, MekHqXmlSerializable {
             }
         }
     }
-    
+
     /**
      * Resets support personnel edge points to the purchased level. Used for weekly refresh.
-     * 
+     *
      */
     public void resetCurrentEdge() {
         setCurrentEdge(getEdge());
     }
-    
+
     /**
      * Sets support personnel edge points to the value 'e'. Used for weekly refresh.
      * @param e - integer used to track this person's edge points available for the current week
@@ -2882,19 +2888,19 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public void setCurrentEdge(int e) {
         currentEdge = e;
     }
-    
+
     /**
      *  Returns this person's currently available edge points. Used for weekly refresh.
-     * 
+     *
      */
     public int getCurrentEdge() {
         return currentEdge;
     }
-    
+
     public void setEdgeUsed(int e) {
         edgeUsedThisRound = e;
     }
-    
+
     public int getEdgeUsed() {
         return edgeUsedThisRound;
     }
@@ -2911,7 +2917,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         }
         MekHQ.triggerEvent(new PersonChangedEvent(this));
     }
-    
+
     /**
      * This will flip the boolean status of the current edge trigger
      *
@@ -2986,7 +2992,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
             }
         }
     }
-    
+
     /**
      * @return true if this person has either a primary or a secondary role that is considered a combat
      *         role
@@ -3002,18 +3008,19 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public boolean isSupport() {
         return isSupportRole(primaryRole) || isSupportRole(secondaryRole);
     }
-    
+
     /**
      * Determines whether a role is considered a combat role. Note that T_LAM_PILOT is a special
      * placeholder which is not used for either primary or secondary role and will return false.
-     * 
+     *
      * @param role A value that can be used for a person's primary or secondary role.
      * @return     Whether the role is considered a combat role
      */
     public static boolean isCombatRole(int role) {
-        return (role > T_NONE) && (role <= T_NAVIGATOR);
+        return ((role > T_NONE) && (role <= T_NAVIGATOR))
+                || (role == T_VEHICLE_CREW);
     }
-    
+
     /**
      * @param role A value that can be used for a person's primary or secondary role.
      * @return     Whether the role is considered a support role
@@ -3363,7 +3370,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         } else {
             toReturn.append(String.format(", %d medics<br />", campaign.getMedicsPerDoctor()));
         }
-        
+
         toReturn.append(String.format("%d patient(s)</font></html>", campaign.getPatientsFor(this)));
 
         return toReturn.toString();
@@ -3415,7 +3422,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
             else if (!first) {
                 toReturn.append("; ");
             }
-            
+
             toReturn.append(SkillType.getExperienceLevelName(skill.getExperienceLevel()));
             toReturn.append(" " + skillName);
             first = false;
@@ -3558,7 +3565,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     private int getHitsInLocation(BodyLocation loc) {
         return ((null != loc) && hitsPerLocation.containsKey(loc)) ? hitsPerLocation.get(loc).intValue() : 0;
     }
-    
+
     public void diagnose(int hits) {
         InjuryUtil.resolveAfterCombat(campaign, this, hits);
         InjuryUtil.resolveCombatDamage(campaign, this, hits);
@@ -3620,7 +3627,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public boolean hasInjury(BodyLocation loc) {
         return (null != getInjuryByLocation(loc));
     }
-    
+
     public boolean hasInjury(BodyLocation loc, InjuryType type) {
         return (null != getInjuryByLocationAndType(loc, type));
     }
@@ -3682,7 +3689,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return injuries.stream().flatMap(i -> i.getModifiers().stream())
             .anyMatch(mod -> mod.tags.contains(InjuryType.MODTAG_INJURY));
     }
-    
+
     public boolean hasInjuries(boolean permCheck) {
         boolean tf = false;
         if (injuries.size() > 0) {
@@ -3758,7 +3765,8 @@ public class Person implements Serializable, MekHqXmlSerializable {
             case T_NVEE_DRIVER:
             case T_VTOL_PILOT:
             case T_VEE_GUNNER:
-            return Ranks.RPROF_VEE;
+            case T_VEHICLE_CREW:
+                return Ranks.RPROF_VEE;
             case T_BA:
             case T_INFANTRY:
                 return Ranks.RPROF_INF;
@@ -3874,7 +3882,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public void setEngineer(boolean b) {
         engineer = b;
     }
-    
+
     public String getChildList() {
         List<UUID> ancestors = new ArrayList<>();
         for (Ancestors a : campaign.getAncestors()) {
@@ -3883,7 +3891,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 ancestors.add(a.getId());
             }
         }
-        
+
         List<String> children = new ArrayList<>();
         for (Person p : campaign.getPersonnel()) {
             if (ancestors.contains(p.getAncestorsID())) {
@@ -3896,7 +3904,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public boolean hasAnyFamily() {
         return hasChildren() || hasSpouse();
     }
-    
+
     public boolean hasChildren() {
         boolean hasKids = false;
         if (getId() != null) {
@@ -3907,10 +3915,10 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 }
             }
         }
-        
+
         return hasKids;
     }
-    
+
     /** Returns the ransom value of this individual
     * Useful for prisoner who you want to ransom or hand off to your employer in an AtB context */
     public Money getRansomValue() {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3572,6 +3572,10 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         return Compute.getTotalDriverNeeds(entity);
     }
 
+    /**
+     * Compute the number of generic space/vehicle crew (e.g. not driver, gunner, or navigator)
+     * @return The number of generic crew required
+     */
     public int getTotalCrewNeeds() {
         int nav = 0;
         if(entity instanceof SmallCraft || entity instanceof Jumpship) {
@@ -3579,6 +3583,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 nav = 1;
             }
             return getAeroCrewNeeds() - getTotalDriverNeeds() - nav;
+        } else if (entity.isSupportVehicle()) {
+            return getFullCrewSize() - getTotalDriverNeeds() - getTotalGunnerNeeds();
         }
         return 0;
     }
@@ -3591,11 +3597,13 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     public boolean canTakeMoreVesselCrew() {
         int nCrew = vesselCrew.size();
         int nav = 0;
-        if(entity instanceof SmallCraft || entity instanceof Jumpship) {
+        if (entity instanceof SmallCraft || entity instanceof Jumpship) {
             if(entity instanceof Jumpship && !(entity instanceof SpaceStation)) {
                 nav = 1;
             }
             return nCrew < (getAeroCrewNeeds() - getTotalDriverNeeds() - nav);
+        } else if (entity.isSupportVehicle()) {
+            return nCrew < (getFullCrewSize() - getTotalDriverNeeds() - getTotalGunnerNeeds());
         }
         return false;
     }

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -137,7 +137,7 @@ public final class PersonnelTab extends CampaignGuiTab {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see mekhq.gui.CampaignGuiTab#initTab()
      */
     @Override
@@ -255,7 +255,7 @@ public final class PersonnelTab extends CampaignGuiTab {
                         splitPersonnel.setDividerLocation(1.0);
                     }
                 }
-            }            
+            }
         });
         TableColumn column = null;
         for (int i = 0; i < PersonnelTableModel.N_COL; i++) {
@@ -314,14 +314,14 @@ public final class PersonnelTab extends CampaignGuiTab {
     public JTable getPersonnelTable() {
         return personnelTable;
     }
-    
+
     public PersonnelTableModel getPersonModel() {
         return personModel;
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see mekhq.gui.CampaignGuiTab#refreshAll()
      */
     @Override
@@ -411,7 +411,7 @@ public final class PersonnelTab extends CampaignGuiTab {
                         || (nGroup == PG_SUPPORT && type > Person.T_SPACE_GUNNER)
                         || (nGroup == PG_MW && type == Person.T_MECHWARRIOR)
                         || (nGroup == PG_CREW && (type == Person.T_GVEE_DRIVER || type == Person.T_NVEE_DRIVER
-                                || type == Person.T_VTOL_PILOT || type == Person.T_VEE_GUNNER))
+                                || type == Person.T_VTOL_PILOT || type == Person.T_VEE_GUNNER || type == Person.T_VEHICLE_CREW))
                         || (nGroup == PG_PILOT && type == Person.T_AERO_PILOT)
                         || (nGroup == PG_CPILOT && type == Person.T_CONV_PILOT)
                         || (nGroup == PG_PROTO && type == Person.T_PROTO_PILOT)
@@ -870,27 +870,27 @@ public final class PersonnelTab extends CampaignGuiTab {
         changePersonnelView();
         personnelListScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(DeploymentChangedEvent ev) {
         filterPersonnelScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(PersonChangedEvent ev) {
         personnelListScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(PersonNewEvent ev) {
         personnelListScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(PersonRemovedEvent ev) {
         personnelListScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(PersonLogEvent ev) {
         refreshPersonnelView();
@@ -910,7 +910,7 @@ public final class PersonnelTab extends CampaignGuiTab {
     public void handle(PartWorkEvent ev) {
         filterPersonnelScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(OvertimeModeEvent ev) {
         filterPersonnelScheduler.schedule();

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1524,7 +1524,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                             gunnerMenu.add(cbMenuItem);
                         }
                         if (unit.canTakeMoreVesselCrew()
-                                && person.hasSkill(SkillType.S_TECH_VESSEL)) {
+                                && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
+                                    || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))){
                             cbMenuItem = new JCheckBoxMenuItem(
                                     unit.getName());
                             // TODO: check the box
@@ -1683,7 +1684,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements
                             continue;
                         }
                         if (unit.canTakeMoreVesselCrew()
-                                && person.hasSkill(SkillType.S_TECH_VESSEL)) {
+                                && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
+                                || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))){
                             cbMenuItem = new JCheckBoxMenuItem(
                                     unit.getName());
                             // TODO: check the box

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -426,7 +426,9 @@ public class PersonnelMarketDialog extends JDialog {
                             (nGroup == PersonnelTab.PG_COMBAT && type <= Person.T_SPACE_GUNNER) ||
                             (nGroup == PersonnelTab.PG_SUPPORT && type > Person.T_SPACE_GUNNER) ||
                             (nGroup == PersonnelTab.PG_MW && type == Person.T_MECHWARRIOR) ||
-                            (nGroup == PersonnelTab.PG_CREW && (type == Person.T_GVEE_DRIVER || type == Person.T_NVEE_DRIVER || type == Person.T_VTOL_PILOT || type == Person.T_VEE_GUNNER)) ||
+                            (nGroup == PersonnelTab.PG_CREW && (type == Person.T_GVEE_DRIVER
+                                    || type == Person.T_NVEE_DRIVER || type == Person.T_VTOL_PILOT
+                                    || type == Person.T_VEE_GUNNER || type == Person.T_VEHICLE_CREW)) ||
                             (nGroup == PersonnelTab.PG_PILOT && type == Person.T_AERO_PILOT) ||
                             (nGroup == PersonnelTab.PG_CPILOT && type == Person.T_CONV_PILOT) ||
                             (nGroup == PersonnelTab.PG_PROTO && type == Person.T_PROTO_PILOT) ||

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -281,7 +281,7 @@ public class RetirementDefectionDialog extends JDialog {
                     }
                 }
             });
- 
+
             JScrollPane scroll = new JScrollPane();
             scroll.setViewportView(personnelTable);
             scroll.setPreferredSize(new Dimension(500, 500));
@@ -656,7 +656,9 @@ public class RetirementDefectionDialog extends JDialog {
                     (nGroup == PersonnelTab.PG_COMBAT && type <= Person.T_SPACE_GUNNER) ||
                     (nGroup == PersonnelTab.PG_SUPPORT && type > Person.T_SPACE_GUNNER) ||
                     (nGroup == PersonnelTab.PG_MW && type == Person.T_MECHWARRIOR) ||
-                    (nGroup == PersonnelTab.PG_CREW && (type == Person.T_GVEE_DRIVER || type == Person.T_NVEE_DRIVER || type == Person.T_VTOL_PILOT || type == Person.T_VEE_GUNNER)) ||
+                    (nGroup == PersonnelTab.PG_CREW && (type == Person.T_GVEE_DRIVER
+                            || type == Person.T_NVEE_DRIVER || type == Person.T_VTOL_PILOT
+                            || type == Person.T_VEE_GUNNER || type == Person.T_VEHICLE_CREW)) ||
                     (nGroup == PersonnelTab.PG_PILOT && type == Person.T_AERO_PILOT) ||
                     (nGroup == PersonnelTab.PG_CPILOT && type == Person.T_CONV_PILOT) ||
                     (nGroup == PersonnelTab.PG_PROTO && type == Person.T_PROTO_PILOT) ||

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -37,7 +37,7 @@ public class StaticChecks {
         }
         return true;
     }
-    
+
     public static boolean areAnyForcesDeployed(Vector<Force> forces) {
         for (Force force : forces) {
             if (force.isDeployed()) {
@@ -55,7 +55,7 @@ public class StaticChecks {
         }
         return true;
     }
-    
+
     public static boolean areAnyUnitsDeployed(Vector<Unit> units) {
         for (Unit unit : units) {
             if (unit.isDeployed()) {
@@ -236,7 +236,8 @@ public class StaticChecks {
 
     public static boolean areAllVesselCrew(Person[] people) {
         for (Person person : people) {
-            if (Person.T_SPACE_CREW != person.getPrimaryRole()) {
+            if (Person.T_SPACE_CREW != person.getPrimaryRole()
+                    && Person.T_VEHICLE_CREW != person.getPrimaryRole()) {
                 return false;
             }
         }
@@ -295,14 +296,14 @@ public class StaticChecks {
         }
         return true;
     }
-    
+
     public static boolean areAllPrisoners(Person[] people) {
         for(Person person : people) {
             if(!person.isPrisoner()) {
                 return false;
             }
         }
-        
+
         return true;
     }
 


### PR DESCRIPTION
Adds a T_VEHICLE_CREW role for support vehicle crew other than the driver/pilot and gunner(s). This allows the unit to be fully crewed so that it can be deployed. To keep things simple there is no distinction made between different vehicle types. In order to have an experience level there needs to be a skill requirement, so I used mechanics as the most reasonable skill.

This does not enforce the officer requirement, but neither do aerospace vessels at this point. A possible future refinement is to allow crewing mobile hospital units with doctors/medics, but I leave that for another time.