### PR TITLE
fix undesirable behavior when setting force techs

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3716,6 +3716,21 @@ public class Campaign implements Serializable, ITechManager {
                 }
             }
         }
+        
+        // clean up non-existent unit references in force unit lists
+        for(Force force : forceIds.values()) {
+            List<UUID> orphanForceUnitIDs = new ArrayList<>();
+            
+            for(UUID unitID : force.getUnits()) {
+                if(getUnit(unitID) == null) {
+                    orphanForceUnitIDs.add(unitID);
+                }
+            }
+            
+            for(UUID unitID : orphanForceUnitIDs) {
+                force.removeUnit(unitID);
+            }
+        }
     }
 
     public boolean isOvertimeAllowed() {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -149,6 +149,8 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                         }
                     }
                 }
+                
+                MekHQ.triggerEvent(new OrganizationChangedEvent(singleForce));
             }
         }
         if (command.contains("ADD_UNIT")) {
@@ -269,6 +271,7 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                     }
                 }
                 singleForce.setTechID(null);
+                MekHQ.triggerEvent(new OrganizationChangedEvent(singleForce));
             }
         } else if (command.contains("REMOVE_UNIT")) {
             for (Unit unit : units) {


### PR DESCRIPTION
Fixes two issues I discovered when setting the force tech.

1. NPE when adding/removing a force tech and the force contains a phantom unit.
2. Adding/removing a force tech doesn't immediately reflect the change in the force display.

The first is addressed by cleaning up unit IDs for non-existent units when loading a campaign. The second is addressed by firing the appropriate event when a force tech is set/removed.