### PR TITLE
Speed up advance day based on profiling data

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3719,17 +3719,17 @@ public class Campaign implements Serializable, ITechManager {
                 }
             }
         }
-        
+
         // clean up non-existent unit references in force unit lists
         for(Force force : forceIds.values()) {
             List<UUID> orphanForceUnitIDs = new ArrayList<>();
-            
+
             for(UUID unitID : force.getUnits()) {
                 if(getUnit(unitID) == null) {
                     orphanForceUnitIDs.add(unitID);
                 }
             }
-            
+
             for(UUID unitID : orphanForceUnitIDs) {
                 force.removeUnit(unitID);
             }
@@ -4229,12 +4229,7 @@ public class Campaign implements Serializable, ITechManager {
             }
         	//now check for planetary events
             for(Planet p : psystem.getPlanets()) {
-                List<Planet.PlanetaryEvent> customEvents = new ArrayList<>();
-	            for(Planet.PlanetaryEvent event : p.getEvents()) {
-	                if(event.custom) {
-	                    customEvents.add(event);
-	                }
-	            }
+                List<Planet.PlanetaryEvent> customEvents = p.getCustomEvents();
 	            if(!customEvents.isEmpty()) {
 	            	if(!startedSystem) {
 	            		//only write this if we haven't already started the system

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -254,30 +254,39 @@ public class Armor extends Part implements IAcquisitionWork {
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<amount>"
-                +amount
-                +"</amount>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<type>"
-                +type
-                +"</type>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<location>"
-                +location
-                +"</location>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<rear>"
-                +rear
-                +"</rear>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<amountNeeded>"
-                +amountNeeded
-                +"</amountNeeded>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<clan>"
-                +clan
-                +"</clan>");
+        String level1 = MekHqXmlUtil.indentStr(indent+1);
+        StringBuilder builder = new StringBuilder(128);
+        builder.append(level1)
+            .append("<amount>")
+                .append(amount)
+                .append("</amount>")
+                .append(NL);
+        builder.append(level1)
+                .append("<type>")
+                .append(type)
+                .append("</type>")
+                .append(NL);
+        builder.append(level1)
+                .append("<location>")
+                .append(location)
+                .append("</location>")
+                .append(NL);
+        builder.append(level1)
+                .append("<rear>")
+                .append(rear)
+                .append("</rear>")
+                .append(NL);
+        builder.append(level1)
+                .append("<amountNeeded>")
+                .append(amountNeeded)
+                .append("</amountNeeded>")
+                .append(NL);
+        builder.append(level1)
+                .append("<clan>")
+                .append(clan)
+                .append("</clan>")
+                .append(NL);
+        pw1.print(builder.toString());
         writeAdditionalFields(pw1, indent + 1);
         writeToXmlEnd(pw1, indent);
     }

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -116,7 +116,9 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         int PHYSICAL_WEAPON = 11;
         int POD_SPACE = 12;
     }
-    
+
+    protected static final String NL = System.lineSeparator();
+
     private static final String[] partTypeLabels = { "Armor", "Weapon", "Ammo",
             "Equipment Part", "Mek Actuator", "Mek Engine", "Mek Gyro",
             "Mek Life Support", "Mek Body Part", "Mek Sensor",
@@ -509,7 +511,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             return getStaticTechLevel();
         }
     }
-    
+
     public SimpleTechLevel getSimpleTechLevel(int year) {
         if (campaign.useVariableTechLevel()) {
             return getSimpleLevel(year);
@@ -517,7 +519,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             return getStaticTechLevel();
         }
     }
-    
+
     public SimpleTechLevel getSimpleTechLevel(int year, boolean clan, int faction) {
         if (campaign.useVariableTechLevel()) {
             return getSimpleLevel(year, clan, faction);
@@ -564,102 +566,133 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     public abstract void writeToXml(PrintWriter pw1, int indent);
 
     protected void writeToXmlBegin(PrintWriter pw1, int indent) {
-        pw1.println(MekHqXmlUtil.indentStr(indent) + "<part id=\""
-                +id
-                +"\" type=\""
-                +this.getClass().getName()
-                +"\">");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<id>"
-                +this.id
-                +"</id>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<name>"
-                +MekHqXmlUtil.escape(name)
-                +"</name>");
+        String level = MekHqXmlUtil.indentStr(indent),
+            level1 = MekHqXmlUtil.indentStr(indent + 1);
+
+        StringBuilder builder = new StringBuilder(256);
+        builder.append(level)
+            .append("<part id=\"")
+            .append(id)
+            .append("\" type=\"")
+            .append(this.getClass().getName())
+            .append("\">")
+            .append(NL)
+            .append(level1)
+            .append("<id>")
+            .append(id)
+            .append("</id>")
+            .append(NL)
+            .append(level1)
+            .append("<name>")
+            .append(MekHqXmlUtil.escape(name))
+            .append("</name>");
         if (omniPodded) {
-            pw1.println(MekHqXmlUtil.indentStr(indent+1) + "<omniPodded/>");
+            builder.append(level1)
+                .append("<omniPodded/>")
+                .append(NL);
         }
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<unitTonnage>"
-                +unitTonnage
-                +"</unitTonnage>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<hits>"
-                +hits
-                +"</hits>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<timeSpent>"
-                +timeSpent
-                +"</timeSpent>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<mode>"
-                +mode
-                +"</mode>");
+        builder.append(level1)
+            .append("<unitTonnage>")
+            .append(unitTonnage)
+            .append("</unitTonnage>")
+            .append(NL);
+        builder.append(level1)
+            .append("<hits>")
+            .append(hits)
+            .append("</hits>")
+            .append(NL);
+        builder.append(level1)
+            .append("<timeSpent>")
+            .append(timeSpent)
+            .append("</timeSpent>")
+            .append(NL);
+        builder.append(level1)
+            .append("<mode>")
+            .append(mode)
+            .append("</mode>")
+            .append(NL);
         if(null != teamId) {
-            pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                    +"<teamId>"
-                    +teamId.toString()
-                    +"</teamId>");
+            builder.append(level1)
+                .append("<teamId>")
+                .append(teamId)
+                .append("</teamId>")
+                .append(NL);
         }
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<skillMin>"
-                +skillMin
-                +"</skillMin>");
+        builder.append(level1)
+            .append("<skillMin>")
+            .append(skillMin)
+            .append("</skillMin>")
+            .append(NL);
         if(null != unitId) {
-            pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                    +"<unitId>"
-                    +unitId.toString()
-                    +"</unitId>");
+            builder.append(level1)
+                .append("<unitId>")
+                .append(unitId)
+                .append("</unitId>")
+                .append(NL);
         }
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<workingOvertime>"
-                +workingOvertime
-                +"</workingOvertime>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<shorthandedMod>"
-                +shorthandedMod
-                +"</shorthandedMod>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<refitId>"
-                +refitId
-                +"</refitId>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<daysToArrival>"
-                +daysToArrival
-                +"</daysToArrival>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<brandNew>"
-                +brandNew
-                +"</brandNew>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<quantity>"
-                +quantity
-                +"</quantity>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<daysToWait>"
-                +daysToWait
-                +"</daysToWait>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<replacementId>"
-                +replacementId
-                +"</replacementId>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<quality>"
-                +quality
-                +"</quality>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<isTeamSalvaging>"
-                +isTeamSalvaging
-                +"</isTeamSalvaging>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<parentPartId>"
-                +parentPartId
-                +"</parentPartId>");
+        builder.append(level1)
+            .append("<workingOvertime>")
+            .append(workingOvertime)
+            .append("</workingOvertime>")
+            .append(NL);
+        builder.append(level1)
+            .append("<shorthandedMod>")
+            .append(shorthandedMod)
+            .append("</shorthandedMod>")
+            .append(NL);
+        builder.append(level1)
+            .append("<refitId>")
+            .append(refitId)
+            .append("</refitId>")
+            .append(NL);
+        builder.append(level1)
+            .append("<daysToArrival>")
+            .append(daysToArrival)
+            .append("</daysToArrival>")
+            .append(NL);
+        builder.append(level1)
+            .append("<brandNew>")
+            .append(brandNew)
+            .append("</brandNew>")
+            .append(NL);
+        builder.append(level1)
+            .append("<quantity>")
+            .append(quantity)
+            .append("</quantity>")
+            .append(NL);
+        builder.append(level1)
+            .append("<daysToWait>")
+            .append(daysToWait)
+            .append("</daysToWait>")
+            .append(NL);
+        builder.append(level1)
+            .append("<replacementId>")
+            .append(replacementId)
+            .append("</replacementId>")
+            .append(NL);
+        builder.append(level1)
+            .append("<quality>")
+            .append(quality)
+            .append("</quality>")
+            .append(NL);
+        builder.append(level1)
+            .append("<isTeamSalvaging>")
+            .append(isTeamSalvaging)
+            .append("</isTeamSalvaging>")
+            .append(NL);
+        builder.append(level1)
+            .append("<parentPartId>")
+            .append(parentPartId)
+            .append("</parentPartId>")
+            .append(NL);
         for(int childId : childPartIds) {
-            pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<childPartId>"
-                    + childId + "</childPartId>");
+            builder.append(level1)
+                .append("<childPartId>")
+                .append(childId)
+                .append("</childPartId>")
+                .append(NL);
         }
+        pw1.print(builder.toString());
     }
 
     protected void writeToXmlEnd(PrintWriter pw1, int indent) {
@@ -847,7 +880,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 	        this.mode = WorkTime.NORMAL;
 	    }
 	}
-	
+
 	/*
 	 * Reset our WorkTime back to normal so that we can adjust as
 	 * necessary
@@ -855,7 +888,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 	public void resetModeToNormal() {
 		setMode(WorkTime.NORMAL);
 	}
-	
+
 	@Override
 	public boolean canChangeWorkMode() {
 	    return !(isOmniPodded() && isSalvaging());
@@ -864,16 +897,16 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 	@Override
 	public TargetRoll getAllMods(Person tech) {
 	    int difficulty = getDifficulty();
-	    
+
 	    if (isOmniPodded() && (isSalvaging() || this instanceof MissingPart)
 	            && (null != unit) && !(unit.getEntity() instanceof Tank)) {
 	        difficulty -= 2;
 	    }
-	    
+
 	    if (null == mode) {
 	    	mode = WorkTime.NORMAL;
 	    }
-	    
+
 		TargetRoll mods = new TargetRoll(difficulty, "difficulty");
 		int modeMod = mode.getMod(campaign.getCampaignOptions().isDestroyByMargin());
 		if (modeMod != 0) {
@@ -894,18 +927,18 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 				mods.addModifier(2, "Clan tech");
 			}
 		}
-		if(null != tech 
+		if(null != tech
 				&& tech.getOptions().booleanOption(PersonnelOptions.TECH_WEAPON_SPECIALIST)
-				&& (IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.WEAPON 
+				&& (IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.WEAPON
 				|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.PHYSICAL_WEAPON)) {
 			mods.addModifier(-1, "Weapon specialist");
 		}
-		if(null != tech 
+		if(null != tech
 				&& tech.getOptions().booleanOption(PersonnelOptions.TECH_ARMOR_SPECIALIST)
 						&& IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.ARMOR) {
 			mods.addModifier(-1, "Armor specialist");
 		}
-		if(null != tech 
+		if(null != tech
 				&& tech.getOptions().booleanOption(PersonnelOptions.TECH_INTERNAL_SPECIALIST)
 				&& (IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.ACTUATOR
 			 	|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.ELECTRONICS
@@ -1250,7 +1283,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             campaign.removePart(this);
         }
     }
-    
+
     /**
      * A method to set the number of parts en masse
      * @param number The new number of spares in the pile
@@ -1356,19 +1389,19 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     public void setParentPartId(int id) {
         parentPartId = id;
     }
-    
+
     public int getParentPartId() {
         return parentPartId;
     }
-    
+
     public boolean hasParentPart() {
         return parentPartId != -1;
     }
-    
+
     public ArrayList<Integer> getChildPartIds() {
         return childPartIds;
     }
-    
+
     public void addChildPart(Part child) {
         childPartIds.add(child.getId());
         child.setParentPartId(id);
@@ -1388,7 +1421,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
         childPartIds = tempArray;
     }
-     
+
     public void removeAllChildParts() {
         for(int childId : childPartIds) {
             Part part = campaign.getPart(childId);
@@ -1398,7 +1431,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
         childPartIds = new ArrayList<>();
     }
-    
+
     /**
      * Reserve a part for overnight work
      */
@@ -1406,26 +1439,26 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     public void reservePart() {
         //nothing goes here for real parts. Only missing parts need to reserve a replacement
     }
-    
+
     @Override
     public void cancelReservation() {
         //nothing goes here for real parts. Only missing parts need to reserve a replacement
     }
-    
+
     /**
      * Make any changes to the part needed for adding to the campaign
      */
     public void postProcessCampaignAddition() {
         //do nothing
     }
-    
+
     public boolean isInLocation(String loc) {
         if (null == unit || null == unit.getEntity()) {
             return false;
         }
         return getLocation() == getUnit().getEntity().getLocationFromAbbr(loc);
     }
-    
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(getName());
@@ -1474,7 +1507,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     public static String[] findPartImage(IPartWork part) {
         String imgBase = null;
         int repairType = IPartWork.findCorrectRepairType(part);
-        
+
         switch (repairType) {
             case Part.REPAIR_PART_TYPE.ARMOR:
                 imgBase = "armor";
@@ -1553,12 +1586,12 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     public int getTechBase() {
         return getTechAdvancement().getTechBase();
     }
-    
+
     @Override
     public int getTechRating() {
         return getTechAdvancement().getTechRating();
     }
-    
+
     @Override
     public int getIntroductionDate() {
         if (omniPodded) {
@@ -1566,7 +1599,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
         return getTechAdvancement().getIntroductionDate();
     }
-    
+
     @Override
     public int getIntroductionDate(boolean clan) {
         if (omniPodded) {
@@ -1574,7 +1607,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
         return getTechAdvancement().getIntroductionDate(clan);
     }
-    
+
     @Override
     public int getPrototypeDate() {
         if (omniPodded) {
@@ -1614,7 +1647,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
         return getTechAdvancement().getCommonDate();
     }
-    
+
     @Override
     public int getCommonDate(boolean clan) {
         if (omniPodded) {
@@ -1622,7 +1655,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
         return getTechAdvancement().getCommonDate(clan);
     }
-    
+
     @Override
     public int getExtinctionDate() {
         return getTechAdvancement().getExtinctionDate();
@@ -1650,13 +1683,13 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
         return getTechAdvancement().getBaseAvailability(era);
     }
-    
+
     public int getAvailability() {
         return calcYearAvailability(campaign.getGameYear(),
                 campaign.useClanTechBase(),
                 campaign.getTechFaction());
     }
-    
+
     @Override
     public int calcYearAvailability(int year, boolean clan) {
         int av = getTechAdvancement().calcYearAvailability(campaign.getCalendar().get(Calendar.YEAR),

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -503,6 +503,18 @@ public class Planet implements Serializable {
         return new ArrayList<PlanetaryEvent>(events.values());
     }
 
+    public List<PlanetaryEvent> getCustomEvents() {
+        List<PlanetaryEvent> customEvents = new ArrayList<>();
+        if (events != null) {
+            for (PlanetaryEvent event : events.values()) {
+                if (event.custom) {
+                    customEvents.add(event);
+                }
+            }
+        }
+        return Collections.unmodifiableList(customEvents);
+    }
+
     protected <T> T getEventData(DateTime when, T defaultValue, EventGetter<T> getter) {
         if( null == when || null == events || null == getter ) {
             return defaultValue;
@@ -879,7 +891,7 @@ public class Planet implements Serializable {
      * @param dryRun Whether to actually perform the updates.
      * @return Human readable form of what was/would have been updated.
      */
-    public String updateFromTSVPlanet(Planet tsvPlanet, boolean dryRun) {
+    public String updateFromTSVPlanet(final Planet tsvPlanet, boolean dryRun) {
         StringBuilder sb = new StringBuilder();
 
         if(!tsvPlanet.x.equals(this.x) || !tsvPlanet.y.equals(this.y)) {
@@ -894,8 +906,9 @@ public class Planet implements Serializable {
         // loop using index
         // look ahead by one event (if possible) and check that getFaction(next event year) isn't already
         // the same as the faction from the current event : sometimes, our data is more exact than the incoming data
-        for(int eventIndex = 0; eventIndex < tsvPlanet.getEvents().size(); eventIndex++) {
-            PlanetaryEvent event = tsvPlanet.getEvents().get(eventIndex);
+        List<PlanetaryEvent> tsvEvents = tsvPlanet.getEvents();
+        for(int eventIndex = 0; eventIndex < tsvEvents.size(); eventIndex++) {
+            PlanetaryEvent event = tsvEvents.get(eventIndex);
             // check other planet events (currently only updating faction change events)
             // if the other planet has an 'ownership change' event with a non-"U" faction
             // check that this planet does not have an existing non-"U" faction already owning it at the event date
@@ -920,7 +933,7 @@ public class Planet implements Serializable {
                         // now we travel into the future, to the next "other" event, and if this planet has acquired a faction
                         // before the next "other" event, then we
                         int nextEventIndex = eventIndex + 1;
-                        PlanetaryEvent nextEvent = nextEventIndex < tsvPlanet.getEvents().size() ? tsvPlanet.getEvents().get(nextEventIndex) : null;
+                        PlanetaryEvent nextEvent = nextEventIndex < tsvEvents.size() ? tsvEvents.get(nextEventIndex) : null;
                         DateTime nextEventDate;
 
                         // if we're at the last event, then just check that the planet doesn't have a faction in the year 3600

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -172,6 +173,15 @@ public class Planet implements Serializable {
      */
     @XmlTransient
     TreeMap<DateTime, PlanetaryEvent> events;
+
+    /**
+     * This is a cache of the current event data based
+     * on the latest date given. {@link Planet#refreshEvents()}
+     * should be called if event data has been modified
+     * or the current date moved backwards.
+     */
+    @XmlTransient
+    CurrentEvents currentEvents;
 
     //a hash to keep track of dynamic garrison changes
     //TreeMap<DateTime, List<String>> garrisonHistory;
@@ -473,7 +483,7 @@ public class Planet implements Serializable {
 
     // Date-dependant data
 
-    public PlanetaryEvent getOrCreateEvent(DateTime when) {
+    public synchronized PlanetaryEvent getOrCreateEvent(DateTime when) {
         if(null == when) {
             return null;
         }
@@ -486,6 +496,7 @@ public class Planet implements Serializable {
             event.date = when;
             events.put(when, event);
         }
+        currentEvents = null;
         return event;
     }
 
@@ -520,19 +531,82 @@ public class Planet implements Serializable {
             return defaultValue;
         }
 
-        T result = null;
+        PlanetaryEvent event = getCurrentEvent(when);
 
-        // Walk backwards starting from the defined date...
-        Map<DateTime, PlanetaryEvent> map = events.headMap(when, /*inclusive:*/true).descendingMap();
-        for (Map.Entry<DateTime, PlanetaryEvent> event : map.entrySet()) {
-            result = getter.get(event.getValue());
-            if (result != null) {
-                // ...taking the first non-null value.
-                break;
+        T result = getter.get(event);
+
+        return Utilities.nonNull(result, defaultValue);
+    }
+
+    private synchronized PlanetaryEvent getCurrentEvent(DateTime now) {
+        if (currentEvents == null) {
+            currentEvents = new CurrentEvents();
+        }
+
+        return currentEvents.getCurrentEvent(now);
+    }
+
+    /**
+     * This methed signals that the internal cache of event data
+     * should be refreshed. This should be called when any
+     * field on a planetary event is updated, or if any events
+     * are added and/or removed.
+     */
+    public synchronized void refreshEvents() {
+        currentEvents = null;
+    }
+
+    /**
+     * This class tracks the current {@link PlanetaryEvent}.
+     */
+    class CurrentEvents {
+        private DateTime lastUpdated;
+        private PlanetaryEvent planetaryEvent = new PlanetaryEvent();
+        private Map.Entry<DateTime, PlanetaryEvent> nextEvent;
+        private Iterator<Map.Entry<DateTime, PlanetaryEvent>> eventStream;
+
+        private void initialize(DateTime now) {
+            lastUpdated = now;
+            if (events != null) {
+                eventStream = events.entrySet().iterator();
+                if (eventStream.hasNext()) {
+                    nextEvent = eventStream.next();
+                }
             }
         }
 
-        return Utilities.nonNull(result, defaultValue);
+        /**
+         * Gets the current {@link PlanetaryEvent} for the time.
+         * @param now The current time.
+         * @return The up-to-date {@link PlanetaryEvent} as of {@code now}.
+         */
+        public PlanetaryEvent getCurrentEvent(DateTime now) {
+            if (lastUpdated == null || lastUpdated.isAfter(now)) {
+                // initialize ourselves if we're fresh or if we
+                // went back in time (which breaks how the event stream works)
+                initialize(now);
+            }
+
+            // if we have no more events for this planet,
+            // or if our current date is before the next date
+            // return our cached event
+            if (nextEvent == null || now.isBefore(nextEvent.getKey())) {
+                return planetaryEvent;
+            }
+
+            // fast-forward to the next event
+            do {
+                planetaryEvent.copyDataFrom(nextEvent.getValue());
+                if (eventStream.hasNext()) {
+                    nextEvent = eventStream.next();
+                } else {
+                    nextEvent = null;
+                }
+
+            } while(nextEvent != null && !now.isBefore(nextEvent.getKey()));
+
+            return planetaryEvent;
+        }
     }
 
     /** @return events for this year. Never returns <i>null</i>. */
@@ -1062,6 +1136,8 @@ public class Planet implements Serializable {
         public String shortName;
         @XmlJavaTypeAdapter(StringListAdapter.class)
         public List<String> faction;
+        @XmlTransient
+        public Set<Faction> factions;
         @XmlJavaTypeAdapter(LifeFormAdapter.class)
         public LifeForm lifeForm;
         @XmlJavaTypeAdapter(ClimateAdapter.class)
@@ -1086,6 +1162,7 @@ public class Planet implements Serializable {
         public void copyDataFrom(PlanetaryEvent other) {
             climate = Utilities.nonNull(other.climate, climate);
             faction = Utilities.nonNull(other.faction, faction);
+            factions = updateFactions(factions, faction, other.faction);
             hpg = Utilities.nonNull(other.hpg, hpg);
             lifeForm = Utilities.nonNull(other.lifeForm, lifeForm);
             message = Utilities.nonNull(other.message, message);
@@ -1100,6 +1177,17 @@ public class Planet implements Serializable {
             population = Utilities.nonNull(other.population, population);
             dayLength = Utilities.nonNull(other.dayLength, dayLength);
             custom = (other.custom || custom);
+        }
+
+        private Set<Faction> updateFactions(Set<Faction> current, List<String> codes, List<String> otherCodes) {
+            // CAW: reference equality intended
+            if (codes != otherCodes) {
+                current = new HashSet<>(codes.size());
+                for (String code : codes) {
+                    current.add(Faction.getFaction(code));
+                }
+            }
+            return current;
         }
 
         public void replaceDataFrom(PlanetaryEvent other) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -28,6 +28,7 @@ import java.awt.GridBagLayout;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.*;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -1639,12 +1640,12 @@ public class CampaignGUI extends JPanel {
             if (path.endsWith(".gz")) {
                 os = new GZIPOutputStream(fos);
             }
-
+            os = new BufferedOutputStream(os);
             pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
             campaign.writeToXml(pw);
             pw.flush();
             pw.close();
-            fos.close();
+            os.close();
             // delete the backup file because we didn't need it
             if (backupFile.exists()) {
                 backupFile.delete();
@@ -1652,6 +1653,9 @@ public class CampaignGUI extends JPanel {
             MekHQ.getLogger().log(CampaignGUI.class, METHOD_NAME, LogLevel.INFO, //$NON-NLS-1$
                     "Campaign saved to " + file); //$NON-NLS-1$
         } catch (Exception ex) {
+            if (os != null) {
+                try { os.close(); } catch (Exception ignored) { }
+            }
             MekHQ.getLogger().error(CampaignGUI.class, METHOD_NAME, ex); //$NON-NLS-1$
             JOptionPane
                     .showMessageDialog(

--- a/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
@@ -13,7 +13,6 @@ import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -29,30 +28,25 @@ import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
-import javax.swing.SpinnerNumberModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import mekhq.MekHQ;
-import mekhq.gui.preferences.JWindowPreference;
-import mekhq.preferences.PreferencesNode;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import megamek.common.EquipmentType;
-import megamek.common.PlanetaryConditions;
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.adapter.SocioIndustrialDataAdapter;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.universe.Climate;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Planet;
-import mekhq.campaign.universe.Planet.PlanetaryEvent;
+import mekhq.gui.preferences.JWindowPreference;
+import mekhq.preferences.PreferencesNode;
 
 public class NewPlanetaryEventDialog extends JDialog {
     private static final long serialVersionUID = 6025304629282204159L;
@@ -389,6 +383,7 @@ public class NewPlanetaryEventDialog extends JDialog {
                 if(chooser.isChanged()) {
                     event.faction = chooser.getResult();
                     event.custom = true;
+                    planet.refreshEvents();
                     updateDate();
                 }
             }
@@ -534,6 +529,7 @@ public class NewPlanetaryEventDialog extends JDialog {
             default: break;
         }
         event.custom = true;
+        planet.refreshEvents();
     }
 
     private String nullEmptyText(JTextField field) {
@@ -561,6 +557,7 @@ public class NewPlanetaryEventDialog extends JDialog {
             default: return;
         }
         event.custom = true;
+        planet.refreshEvents();
     }
 
     private static class HPGChoice {

--- a/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
@@ -56,7 +56,7 @@ import mekhq.campaign.universe.Planet.PlanetaryEvent;
 
 public class NewPlanetaryEventDialog extends JDialog {
     private static final long serialVersionUID = 6025304629282204159L;
-    
+
     private static final String FIELD_MESSAGE = "message"; //$NON-NLS-1$
     private static final String FIELD_NAME = "name"; //$NON-NLS-1$
     private static final String FIELD_SHORTNAME = "shortName"; //$NON-NLS-1$
@@ -73,16 +73,16 @@ public class NewPlanetaryEventDialog extends JDialog {
     private static final String FIELD_ATMOSPHERE = "atmosphere"; //$NON-NLS-1$
     private static final String FIELD_POPULATION = "population"; //$NON-NLS-1$
     private static final String FIELD_GOVERNMENT = "government"; //$NON-NLS-1$
-    
+
     private final static DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd"); //$NON-NLS-1$
     private final static SocioIndustrialDataAdapter SOCIO_INDUSTRIAL_ADAPTER = new SocioIndustrialDataAdapter();
-    
+
     ResourceBundle resourceMap;
 
     private final Planet planet;
-    
+
     private DateTime date;
-    
+
     private List<Planet.PlanetaryEvent> changedEvents = null;
 
     private JButton dateButton;
@@ -98,7 +98,7 @@ public class NewPlanetaryEventDialog extends JDialog {
     private JCheckBox factionKeep;
     private JCheckBox socioindustrialKeep;
     private JCheckBox hpgKeep;
-    
+
     private JLabel nameCombined;
     private JLabel shortNameCombined;
     private JLabel factionCombined;
@@ -108,7 +108,7 @@ public class NewPlanetaryEventDialog extends JDialog {
     public NewPlanetaryEventDialog(Frame parent, Campaign campaign, Planet planet) {
         this(parent, campaign, planet, true);
     }
-    
+
     public NewPlanetaryEventDialog(Frame parent, Campaign campaign, Planet planet, boolean modal) {
         super(parent, modal);
         this.planet = new Planet(Objects.requireNonNull(planet).getId());
@@ -118,33 +118,33 @@ public class NewPlanetaryEventDialog extends JDialog {
         setLocationRelativeTo(parent);
         setUserPreferences();
     }
-    
+
     public List<Planet.PlanetaryEvent> getChangedEvents() {
         return changedEvents;
     }
-    
+
     protected void initComponents() {
         resourceMap = ResourceBundle.getBundle("mekhq.resources.NewPlanetaryEventDialog", new EncodeControl()); //$NON-NLS-1$
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName("form"); //$NON-NLS-1$
         setTitle(resourceMap.getString("Form.title")); //$NON-NLS-1$
         setPreferredSize(new Dimension(600, 600));
-        
+
         final Container content = getContentPane();
         content.setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
-        
+
         gbc.gridx = 0;
         gbc.gridy = 0;
         gbc.gridwidth = 3;
         content.add(new JLabel(String.format(resourceMap.getString("planetId.format"), planet.getId())), gbc); //$NON-NLS-1$
-        
+
         gbc.gridy = 1;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.EAST;
         content.add(new JButton(new AbstractAction(resourceMap.getString("previousDay.label")){ //$NON-NLS-1$
             private static final long serialVersionUID = -4901868873472027052L;
-            
+
             {
                 putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, ActionEvent.CTRL_MASK));
                 putValue(SHORT_DESCRIPTION, resourceMap.getString("previousDay.tooltip")); //$NON-NLS-1$
@@ -162,7 +162,7 @@ public class NewPlanetaryEventDialog extends JDialog {
                 updateDate();
             }
         }), gbc);
-        
+
         gbc.gridx = 1;
         gbc.anchor = GridBagConstraints.CENTER;
         dateButton = new JButton(new AbstractAction() {
@@ -181,12 +181,12 @@ public class NewPlanetaryEventDialog extends JDialog {
             }
         });
         content.add(dateButton, gbc);
-        
+
         gbc.gridx = 2;
         gbc.anchor = GridBagConstraints.WEST;
         content.add(new JButton(new AbstractAction(resourceMap.getString("nextDay.label")){ //$NON-NLS-1$
             private static final long serialVersionUID = -4901868873472027053L;
-            
+
             {
                 putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, ActionEvent.CTRL_MASK));
                 putValue(ACTION_COMMAND_KEY, "nextDay"); //$NON-NLS-1$
@@ -219,9 +219,9 @@ public class NewPlanetaryEventDialog extends JDialog {
             BorderFactory.createTitledBorder(resourceMap.getString("eventData.text")), //$NON-NLS-1$
             BorderFactory.createEmptyBorder(1, 5, 1, 5)));
         content.add(data, gbc);
-        
+
         preparaDataPane(data);
-        
+
         gbc.gridy = 3;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
@@ -232,12 +232,7 @@ public class NewPlanetaryEventDialog extends JDialog {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                changedEvents = new ArrayList<>();
-                for(PlanetaryEvent event : planet.getEvents()) {
-                    if(event.custom) {
-                        changedEvents.add(event);
-                    }
-                }
+                changedEvents = new ArrayList<>(planet.getCustomEvents());
                 setVisible(false);
             }
         }), gbc);
@@ -256,10 +251,10 @@ public class NewPlanetaryEventDialog extends JDialog {
         updateDate();
         pack();
     }
-    
+
     private void preparaDataPane(JPanel pane) {
         GridBagConstraints gbc = new GridBagConstraints();
-        
+
         Action changeValueAction = new AbstractAction() {
             private static final long serialVersionUID = 7405843636038153841L;
 
@@ -269,7 +264,7 @@ public class NewPlanetaryEventDialog extends JDialog {
                 updateDate();
             }
         };
-        
+
         ChangeListener changeListener = new ChangeListener() {
             @Override
             public void stateChanged(ChangeEvent e) {
@@ -291,7 +286,7 @@ public class NewPlanetaryEventDialog extends JDialog {
                 }
             }
         };
-        
+
         FocusAdapter textFocusAdapter = new FocusAdapter() {
             @Override
             public void focusGained(FocusEvent e) {
@@ -306,11 +301,11 @@ public class NewPlanetaryEventDialog extends JDialog {
                 {
                     final JTextField source = (JTextField) e.getSource();
                     source.dispatchEvent(new KeyEvent(source, KeyEvent.KEY_PRESSED,
-                            System.currentTimeMillis(), 0, KeyEvent.VK_ENTER, '\n'));  
+                            System.currentTimeMillis(), 0, KeyEvent.VK_ENTER, '\n'));
                 }
             }
         };
-        
+
         gbc.gridx = 0;
         gbc.gridy = 0;
         pane.add(new JLabel(resourceMap.getString("changeOf.text")), gbc); //$NON-NLS-1$
@@ -320,12 +315,12 @@ public class NewPlanetaryEventDialog extends JDialog {
         gbc.gridx = 3;
         gbc.weightx = 0.0;
         pane.add(new JLabel(resourceMap.getString("combinedValue.text")), gbc); //$NON-NLS-1$
-        
+
         gbc.gridx = 0;
         gbc.gridy = 1;
         gbc.anchor = GridBagConstraints.WEST;
         pane.add(new JLabel(resourceMap.getString("message.text")), gbc); //$NON-NLS-1$
-        
+
         gbc.gridx = 1;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         messageField = new JTextField();
@@ -337,7 +332,7 @@ public class NewPlanetaryEventDialog extends JDialog {
         gbc.gridx = 0;
         gbc.gridy = 2;
         pane.add(new JLabel(resourceMap.getString("name.text")), gbc); //$NON-NLS-1$
-        
+
         gbc.gridx = 1;
         nameField = new JTextField();
         nameField.addActionListener(changeValueAction);
@@ -352,15 +347,15 @@ public class NewPlanetaryEventDialog extends JDialog {
         nameKeep.setName(FIELD_NAME);
         pane.add(nameKeep, gbc);
         gbc.ipadx = 0;
-        
+
         gbc.gridx = 3;
         nameCombined = new JLabel();
         pane.add(nameCombined, gbc);
-        
+
         gbc.gridx = 0;
         gbc.gridy = 3;
         pane.add(new JLabel(resourceMap.getString("shortName.text")), gbc); //$NON-NLS-1$
-        
+
         gbc.gridx = 1;
         shortNameField = new JTextField();
         shortNameField.addActionListener(changeValueAction);
@@ -373,15 +368,15 @@ public class NewPlanetaryEventDialog extends JDialog {
         shortNameKeep.setText(resourceMap.getString("noChange.text")); //$NON-NLS-1$
         shortNameKeep.setName(FIELD_SHORTNAME);
         pane.add(shortNameKeep, gbc);
-        
+
         gbc.gridx = 3;
         shortNameCombined = new JLabel();
         pane.add(shortNameCombined, gbc);
-        
+
         gbc.gridx = 0;
         gbc.gridy = 4;
         pane.add(new JLabel(resourceMap.getString("factionList.text")), gbc); //$NON-NLS-1$
-        
+
         gbc.gridx = 1;
         factionsButton = new JButton(new AbstractAction("") { //$NON-NLS-1$
             private static final long serialVersionUID = -168994356642401048L;
@@ -405,13 +400,13 @@ public class NewPlanetaryEventDialog extends JDialog {
         factionKeep.setText(resourceMap.getString("noChange.text")); //$NON-NLS-1$
         factionKeep.setName(FIELD_FACTION);
         pane.add(factionKeep, gbc);
-        
+
         gbc.gridx = 3;
         factionCombined = new JLabel();
         pane.add(factionCombined, gbc);
 
         gbc.gridx = 1;
-        
+
         gbc.gridx = 0;
         gbc.gridy = 9;
         pane.add(new JLabel(resourceMap.getString("socioindustrial.text")), gbc); //$NON-NLS-1$
@@ -440,7 +435,7 @@ public class NewPlanetaryEventDialog extends JDialog {
         socioindustrialKeep.setText(resourceMap.getString("noChange.text")); //$NON-NLS-1$
         socioindustrialKeep.setName(FIELD_SOCIO_INDUSTRIAL);
         pane.add(socioindustrialKeep, gbc);
-        
+
         gbc.gridx = 3;
         socioindustrialCombined = new JLabel();
         pane.add(socioindustrialCombined, gbc);
@@ -465,7 +460,7 @@ public class NewPlanetaryEventDialog extends JDialog {
         hpgKeep.setText(resourceMap.getString("noChange.text")); //$NON-NLS-1$
         hpgKeep.setName(FIELD_HPG);
         pane.add(hpgKeep, gbc);
-        
+
         gbc.gridx = 3;
         hpgCombined = new JLabel();
         pane.add(hpgCombined, gbc);
@@ -483,7 +478,7 @@ public class NewPlanetaryEventDialog extends JDialog {
     private Planet.PlanetaryEvent getCurrentEvent() {
         return planet.getEvent(date);
     }
-    
+
     private void updateDate() {
         dateButton.setText(date.toString(DATE_FORMATTER));
         Planet.PlanetaryEvent event = getCurrentEvent();
@@ -512,7 +507,7 @@ public class NewPlanetaryEventDialog extends JDialog {
         factionKeep.setSelected((null == event) || (null == event.faction));
         socioindustrialKeep.setSelected((null == event) || (null == event.socioIndustrial));
         hpgKeep.setSelected((null == event) || (null == event.hpg));
-        
+
         nameCombined.setText(Utilities.nonNull(planet.getName(date), resourceMap.getString("undefined.text"))); //$NON-NLS-1$
         shortNameCombined.setText(Utilities.nonNull(planet.getShortName(date), resourceMap.getString("undefined.text"))); //$NON-NLS-1$
         factionCombined.setText(planet.getFactionDesc(date));
@@ -525,7 +520,7 @@ public class NewPlanetaryEventDialog extends JDialog {
         socioindustrialCombined.setText(socioIndustrialText);
         hpgCombined.setText(planet.getHPGClass(date));
     }
-    
+
     private void cleanEventField(Planet.PlanetaryEvent event, String field) {
         if((null == event) || (null == field)) {
             return;
@@ -540,12 +535,12 @@ public class NewPlanetaryEventDialog extends JDialog {
         }
         event.custom = true;
     }
-    
+
     private String nullEmptyText(JTextField field) {
         final String text = field.getText();
         return ((null == text) || text.isEmpty()) ? null : text;
     }
-    
+
     private void updateEvent(Component source, Planet.PlanetaryEvent event) {
         switch(source.getName()) {
             case FIELD_MESSAGE: event.message = nullEmptyText(messageField); break;
@@ -567,21 +562,21 @@ public class NewPlanetaryEventDialog extends JDialog {
         }
         event.custom = true;
     }
-    
+
     private static class HPGChoice {
         public Integer hpg;
         public String text;
-        
+
         public HPGChoice(Integer hpg, String text) {
             this.hpg = hpg;
             this.text = text;
         }
-        
+
         @Override
         public String toString() {
             return text;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hashCode(hpg);


### PR DESCRIPTION
*[This is best viewed with whitespace ignored.](https://github.com/MegaMek/mekhq/pull/1382/files?w=1)*

This speeds up Advance Day through the following profiling driven enhancements:
1. `Part::writeToXmlBegin` was a huge time sink and was sped up using a `StringBuilder` and memoizing indentation for XML. (15% -> 9%)
2. `Armor::writeToXml` was the second largest time sink and was sped up in a similar fashion. (3% -> 0.7%)
3. `Planet::getEventData` was the third largest time sink and was sped up with a cache based on the last event date requested. (7% -> too few samples to profile)
4. `PlanetarySystem::getFactionSet` was the fourth largest time sink and was sped up with a new cached entry on `PlanetaryEvent`. (1.9% -> 0.1%)

Other classes' `writeToXml` are likely ripe for performance improvements, but they did not show up unless you had silly things (e.g. `ExtraData` and 4000+ personnel).

Tested with this campaign [10.zip](https://github.com/MegaMek/mekhq/files/4021507/10.zip) loaded and hitting ENTER on Advance Day as fast as humanly possible, ignoring all pop-ups.