### PR TITLE
Bug: fix XML parsing failure when putting customs in CPNX #1390

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4366,9 +4366,9 @@ public class Campaign implements Serializable, ITechManager {
             pw1.println("\t<custom>");
             pw1.println("\t\t<name>" + name + "</name>");
             if (en instanceof Mech) {
-                pw1.print("\t\t<mtf>");
+                pw1.print("\t\t<mtf><![CDATA[");
                 pw1.print(((Mech) en).getMtf());
-                pw1.print("\t\t</mtf>\n");
+                pw1.println("]]></mtf>");
             } else {
                 pw1.print("\t\t<blk><![CDATA[");
 
@@ -4377,9 +4377,9 @@ public class Campaign implements Serializable, ITechManager {
                     if (s.isEmpty()) {
                         continue;
                     }
-                    pw1.print(s + "\n");
+                    pw1.println(s);
                 }
-                pw1.print("]]>\n\t\t</blk>\n");
+                pw1.println("]]></blk>");
             }
             pw1.println("\t</custom>");
         }

--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -160,12 +160,12 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
     public void setColorIndex(int index) {
         colorIndex = index;
     }
-    
+
     public int getTotalBV() {
         final String METHOD_NAME = "getTotalBV";
 
         int bv = 0;
-        
+
         for(Entity entity : getEntityList()) {
             if (entity == null) {
                 MekHQ.getLogger().error(BotForce.class, METHOD_NAME, "Null entity when calculating the BV a bot force, we should never find a null here. Please investigate");
@@ -173,7 +173,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
                 bv += entity.calculateBattleValue(true, false);
             }
         }
-        
+
         return bv;
     }
 
@@ -188,18 +188,18 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
     public void setDestinationEdge(int i) {
         behaviorSettings.setDestinationEdge(findCardinalEdge(i));
     }
-    
+
     public void setRetreatEdge(int i) {
         behaviorSettings.setRetreatEdge(findCardinalEdge(i));
     }
 
     public void writeToXml(PrintWriter pw1, int indent) {
         final String METHOD_NAME = "writeToXml";
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "name", MekHqXmlUtil.escape(name));
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "name", name);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "team", team);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "start", start);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "camoCategory", MekHqXmlUtil.escape(camoCategory));
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "camoFileName", MekHqXmlUtil.escape(camoFileName));
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "camoCategory", camoCategory);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "camoFileName", camoFileName);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent+1, "colorIndex", colorIndex);
 
         pw1.println(MekHqXmlUtil.indentStr(indent+1) + "<entities>");
@@ -228,7 +228,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
 
     public void setFieldsFromXmlNode(Node wn) {
         final String METHOD_NAME = "setFieldsFromXmlNode(Node)"; //$NON-NLS-1$
-        
+
         NodeList nl = wn.getChildNodes();
         for (int x = 0; x < nl.getLength(); x++) {
             Node wn2 = nl.item(x);


### PR DESCRIPTION
When we write customs in the MTF format we were not wrapping them in CDATA blocks. This caused certain issues with units, see #1390. This makes MTF formats written to the CPNX file XML safe, mirroring the code used for BLK files.

This also resolves a double encoding problem in BotForce, found during code review, as `MekHqXmlUtil.writeSimpleXmlTag` already XML escapes string arguments.

Test campaigns (broken and fixed):
[campaigns.zip](https://github.com/MegaMek/mekhq/files/4054958/campaigns.zip)
