### PR TITLE
Pirate rebel contracts

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2018 - The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,35 +44,35 @@ import mekhq.campaign.event.NewDayEvent;
  * planets in the region, which planets they control, and which foreign-controlled planets are within a
  * certain distance of a friendly planet. For improved performance the region is defined as a hexagon
  * rather than a circle, with the radius being the distance from the center to each vertex.
- * 
+ *
  * Recalculates in the background whenever the date or the bound of the region to examine change. By
  * default queries made while the background thread is working will block until it finishes, but thresholds
  * can be set for a number of days or a distance, any query made while a change falls under that threshold
  * will use the partially updated data.
- * 
+ *
  * Changes in campaign date or location will update automatically on each new campaign day if the instance
  * is registered with the event bus.
- * 
+ *
  * @author Neoancient
  *
  */
 public class FactionBorderTracker {
-    
+
     private final RegionHex regionHex;
     private DateTime lastUpdate;
     private DateTime now;
-    
+
     private Map<Faction, FactionBorders> borders;
     private Map<Faction, Map<Faction, List<PlanetarySystem>>> borderSystems;
-    
+
     private double isBorderSize = 60;
     private double peripheryBorderSize = 90;
     private double clanBorderSize = 90;
-    private Map<Faction, Double> factionBorderSize = new HashMap<>();;
-    
+    private Map<Faction, Double> factionBorderSize = new HashMap<>();
+
     private int dayThreshold = 0;
     private double distanceThreshold = 0;
-    
+
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private volatile boolean invalid = true;
     private volatile boolean cancelTask = false;
@@ -83,24 +83,24 @@ public class FactionBorderTracker {
     public FactionBorderTracker() {
         this(0, 0, 1000);
     }
-    
+
     /**
      * Constructs a FactionBorderTracker with the supplied region limits.
-     * 
-     * @param x
-     * @param y
-     * @param radius
+     *
+     * @param x       The x coordinate of the center of the region
+     * @param y       The y coordinate of the center of the region
+     * @param radius  The radius of the region
      */
     public FactionBorderTracker(double x, double y, double radius) {
         regionHex = new RegionHex(x, y, radius);
         now = new DateTime();
         lastUpdate = now;
-        
+
         borders = new ConcurrentHashMap<>();
         borderSystems = new ConcurrentHashMap<>();
         recalculate();
     }
-    
+
     /**
      * @return The X coordinate of the bounding hex
      */
@@ -114,7 +114,7 @@ public class FactionBorderTracker {
     public double getCenterY() {
         return regionHex.center[1];
     }
-    
+
     /**
      * @return The radius coordinate of the bounding hex (distance from the center to each vertex)
      */
@@ -125,9 +125,9 @@ public class FactionBorderTracker {
     /**
      * Sets the center of the region's bounding hex and recalculates the faction borders
      * if it has moved.
-     * 
-     * @param x
-     * @param y
+     *
+     * @param x The x coordinate of the center of the region
+     * @param y The y coordinate of the center of the region
      */
     public void setRegionCenter(double x, double y) {
         double distance = regionHex.distanceTo(x, y);
@@ -139,11 +139,11 @@ public class FactionBorderTracker {
             }
         }
     }
-    
+
     /**
      * Sets the size of the region's bounding hex and recalculates the faction borders if it has changed.
      * Any value less than zero will include the entire map.
-     * 
+     *
      * @param radius The distance from the center of the hex to each vertex.
      */
     public void setRegionRadius(double radius) {
@@ -156,10 +156,10 @@ public class FactionBorderTracker {
             }
         }
     }
-    
+
     /**
      * Sets the current date and recalculates the faction borders if it has changed.
-     * 
+     *
      * @param when The campaign date
      */
     public synchronized void setDate(DateTime when) {
@@ -168,28 +168,28 @@ public class FactionBorderTracker {
         now = when;
         recalculate();
     }
-    
+
     /**
      * @return The campaign date of the last completed border calculation
      */
     public synchronized DateTime getLastUpdated() {
         return lastUpdate;
     }
-    
+
     /**
      * Retrieves a {@code Set} of all factions that control at least one planet in the region.
-     * 
+     *
      * If the borders are being recalculated, this method may block until the calculation is complete.
      * If the change that caused the borders to be recalculated are under the time or distance thresholds,
      * the return value will be current if it has already been calculated, otherwise it will be the value
      * determined by the last completed recalculation.
-     * 
+     *
      * @return  A {@code Set} of the factions present in the region
-     *                              
+     *
      * @see #setDayThreshold(int)
      * @see #setDistanceThreshold(double)
      */
-            
+
     public synchronized Set<Faction> getFactionsInRegion() {
         while (invalid) {
             try {
@@ -203,21 +203,21 @@ public class FactionBorderTracker {
 
     /**
      * Retrieves a FactionBorders object for the given faction.
-     * 
+     *
      * If the borders are being recalculated, this method may block until the calculation is complete.
      * If the change that caused the borders to be recalculated are under the time or distance thresholds,
      * the return value will be current if it has already been calculated, otherwise it will be the value
      * determined by the last completed recalculation.
      * recalculation.
-     * 
+     *
      * @param f A faction
      * @return  A {@link FactionBorders} instance for the faction, or null if the faction does not control
      *          any systems in the region's bounding hex
-     *                              
+     *
      * @see #setDayThreshold(int)
      * @see #setDistanceThreshold(double)
      */
-            
+
     @Nullable public synchronized FactionBorders getBorders(Faction f) {
         while (invalid) {
             try {
@@ -228,25 +228,24 @@ public class FactionBorderTracker {
         }
         return borders.get(f);
     }
-    
+
     /**
      * Retrieves a FactionBorders object for the given faction.
-     * 
+     *
      * If the borders are being recalculated, this method may block until the calculation is complete.
      * If the change that caused the borders to be recalculated are under the time or distance thresholds,
      * the return value will be current if it has already been calculated, otherwise it will be the value
      * determined by the last completed recalculation.
      * recalculation.
-     * 
-     * @param f A faction key
+     *
+     * @param fKey A faction key
      * @return  A {@link FactionBorders} instance for the faction, or null if the faction does not control
      *          any systems in the region's bounding hex or the key is invalid
-     *                              
+     *
      * @see #setDayThreshold(int)
      * @see #setDistanceThreshold(double)
      */
-    @Nullable public synchronized FactionBorders getBorders(String fKey)
-            throws InterruptedException {
+    @Nullable public synchronized FactionBorders getBorders(String fKey) {
         while (invalid) {
             try {
                 wait();
@@ -260,23 +259,23 @@ public class FactionBorderTracker {
         }
         return null;
     }
-    
+
     /**
      * Retrieves list of all planets controlled by one faction that are within a set distance of planets
      * controlled by another faction, all within the defined region. The distance used to determine the
      * border size is the larger of {@link #getBorderSize(Faction)} for the two factions.
-     * 
+     *
      * If the borders are being recalculated, this method may block until the calculation is complete.
      * If the change that caused the borders to be recalculated are under the time or distance thresholds,
      * the return value will be current if it has already been calculated, otherwise it will be the value
      * determined by the last completed recalculation.
-     * 
+     *
      * @param self  The faction whose planets are used to test proximity
      * @param other The faction whose planets are added to the returned {@code List} if they are within a certain
-     *              distance. 
+     *              distance.
      * @return  A List of all planets in the region that are controlled by {@code other} that are considered
      *          to be within the border region.
-     *                              
+     *
      * @see #setDayThreshold(int)
      * @see #setDistanceThreshold(double)
      */
@@ -294,74 +293,72 @@ public class FactionBorderTracker {
         }
         return Collections.emptyList();
     }
-    
+
     /**
      * Sets the distance threshold for blocking recalculations. If the size or position of the
      * bounding hex is changed by more than this distance, methods that access calculated border
      * data will block until the calculation is complete. Any distance less than this is considered
      * close enough that the previous data is accurate enough.
-     * 
+     *
      * @param distance A distance in light years
      */
     public void setDistanceThreshold(double distance) {
         this.distanceThreshold = distance;
     }
-    
+
     /**
      * Retrieves the distance threshold for blocking recalculations. If the size or position of the
      * bounding hex is changed by more than this distance, methods that access calculated border
      * data will block until the calculation is complete. Any distance less than this is considered
      * close enough that the previous data is accurate enough.
-     * 
+     *
      * @return The distance in light years
      */
     public double getDistanceThreshold() {
         return distanceThreshold;
     }
-    
+
     /**
      * Sets the time threshold for blocking recalculations. If the campaign date changes by more than
      * this in either direction, methods that access calculated border data will block until the
      * calculation is complete. Any distance less than this is considered close enough that the
      * previous data is accurate enough.
-     * 
-     * @param distance A number of days
+     *
+     * @param days A number of days
      */
     public void setDayThreshold(int days) {
         this.dayThreshold = days;
     }
-    
+
     /**
      * Retrieves the time threshold for blocking recalculations. If the campaign date changes by more than
      * this in either direction, methods that access calculated border data will block until the
      * calculation is complete. Any distance less than this is considered close enough that the
      * previous data is accurate enough.
-     * 
-     * @param distance A number of days
      */
     public int getDayThreshold() {
         return dayThreshold;
     }
-    
+
     /**
      * The distance from a faction's borders to check for neighboring foreign planets. This defaults
      * to a set value depending on whether the faction is IS, Clan, or Periphery, but can be set
      * for factions individually.
-     *  
+     *
      * @param f  A faction
      * @return   The distance in light years to look for neighboring foreign planets.
-     * 
+     *
      * @see #getDefaultBorderSize(Faction)
      */
     public double getBorderSize(Faction f) {
         return factionBorderSize.getOrDefault(f, getDefaultBorderSize(f));
     }
-    
+
     /**
      * The default distance from a faction's borders to check for neighboring foreign planets. This
      * is the value that is used if a specific value has not be set, and is based on whether the
      * faction is IS, Clan, or Periphery.
-     * 
+     *
      * @param f A faction
      * @return  The distance in light years to look for neighboring foreign planets.
      */
@@ -374,30 +371,30 @@ public class FactionBorderTracker {
             return isBorderSize;
         }
     }
-    
+
     /**
      * Sets the distance from a faction's borders to check for neighboring foreign planets. This
      * overrides the default distance for this faction.
-     *  
+     *
      * @param faction    A faction
      * @param borderSize The distance in light years to look for neighboring foreign planets.
-     * 
+     *
      * @see #setDefaultBorderSize(double, double, double)
      */
-    public void setBorderSize(Faction f, double borderSize) {
+    public void setBorderSize(Faction faction, double borderSize) {
         if (borderSize >= 0) {
-            factionBorderSize.put(f, borderSize);
+            factionBorderSize.put(faction, borderSize);
         } else {
-            factionBorderSize.remove(f);
+            factionBorderSize.remove(faction);
         }
     }
-    
+
     /**
      * Sets the default border size for IS, Periphery, and Clan factions. This value will be used
      * as the distance from a faction's borders to check for neighboring foreign planets unless a
      * specific value is provided for this faction.
-     * 
-     * @param is          Default border size for Inner Sphere factions 
+     *
+     * @param is          Default border size for Inner Sphere factions
      * @param periphery   Default border size for Periphery factions
      * @param clan        Default border size for Clan factions
      */
@@ -406,25 +403,25 @@ public class FactionBorderTracker {
         peripheryBorderSize = periphery;
         clanBorderSize = clan;
     }
-    
+
     /**
      * Recalculates planetary borders as a background task, after first canceling any that are currently
      * running.
      */
     private void recalculate() {
         cancelTask = true;
-        executor.execute(() -> rebuildBorderData());
+        executor.execute(this::rebuildBorderData);
     }
-    
+
     /**
      * Allows a child class to provide a custom list of planets.
-     * 
+     *
      * @return A collection of all available planets.
      */
     protected Collection<PlanetarySystem> getSystemList() {
         return Systems.getInstance().getSystems().values();
     }
-    
+
     /**
      * The task that checks all planets within the region and notes which are controlled by which factions
      * and which are within a certain distance of another faction's systems.
@@ -481,12 +478,12 @@ public class FactionBorderTracker {
             notify();
         }
     }
-    
+
     /**
      * If this instance has been registered with the event bus, listens for new day events and
      * starts the recalculation process.
-     *  
-     * @param event
+     *
+     * @param event The event
      */
     @Subscribe
     public synchronized void handleNewDayEvent(NewDayEvent event) {
@@ -502,17 +499,17 @@ public class FactionBorderTracker {
         }
         recalculate();
     }
-    
+
     /**
      * If this instance has been registered with the event bus, listens for location change events
      * and starts the recalculation thread.
-     *  
-     * @param event
+     *
+     * @param event The event
      */
     @Subscribe
-    public synchronized void handleLocationChangedEvent(LocationChangedEvent ev) {
-        if (!ev.isKFJump()) {
-            PlanetarySystem loc = ev.getLocation().getCurrentSystem();
+    public synchronized void handleLocationChangedEvent(LocationChangedEvent event) {
+        if (!event.isKFJump()) {
+            PlanetarySystem loc = event.getLocation().getCurrentSystem();
             if (!regionHex.isCenter(loc.getX(), loc.getY())) {
                 invalid |= (distanceThreshold > 0)
                         && (regionHex.distanceTo(loc.getX(), loc.getY()) > distanceThreshold);
@@ -521,7 +518,7 @@ public class FactionBorderTracker {
             recalculate();
         }
     }
-    
+
     /**
      * Class for the region bounding hex.
      *
@@ -534,40 +531,40 @@ public class FactionBorderTracker {
         private static final int RIGHT_TOP = 4;
         private static final int LEFT_TOP = 5;
         private static final double HEIGHT_FACTOR = Math.sqrt(3.0) / 2;
-        
+
         double[] center;
         double radius;
         double[][] vertices;
-        
+
         RegionHex(double x, double y, double radius) {
             vertices = new double[6][];
             center = new double[] { x, y };
             this.radius = radius;
             calcVertices();
         }
-        
+
         void calcVertices() {
             final double halfRadius = radius * 0.5;
             final double dy = radius * HEIGHT_FACTOR;
-            vertices[LEFT_TOP] = new double[] { center[0] - halfRadius, center[1] + dy }; 
-            vertices[RIGHT_TOP] = new double[] { center[0] + halfRadius, center[1] + dy }; 
+            vertices[LEFT_TOP] = new double[] { center[0] - halfRadius, center[1] + dy };
+            vertices[RIGHT_TOP] = new double[] { center[0] + halfRadius, center[1] + dy };
             vertices[LEFT_MID] = new double[] { center[0] - radius, center[1] };
             vertices[RIGHT_MID] = new double[] { center[0] + radius, center[1] };
-            vertices[LEFT_BOTTOM] = new double[] { center[0] - halfRadius, center[1] - dy }; 
-            vertices[RIGHT_BOTTOM] = new double[] { center[0] + halfRadius, center[1] - dy }; 
+            vertices[LEFT_BOTTOM] = new double[] { center[0] - halfRadius, center[1] - dy };
+            vertices[RIGHT_BOTTOM] = new double[] { center[0] + halfRadius, center[1] - dy };
         }
-        
+
         void setCenter(double x, double y) {
             center[0] = x;
             center[1] = y;
             calcVertices();
         }
-        
+
         void setRadius(double radius) {
             this.radius = radius;
             calcVertices();
         }
-        
+
         boolean contains(double x, double y) {
             if ((x < vertices[LEFT_MID][0]) || (x > vertices[RIGHT_MID][0])
                     || (y > vertices[LEFT_TOP][1]) || (y < vertices[LEFT_BOTTOM][1])) {
@@ -590,16 +587,16 @@ public class FactionBorderTracker {
                 }
             }
         }
-        
+
         private boolean isInside(double x, double y, double[] p1, double[] p2) {
             return (p2[0] - p1[0]) * (y - p1[1])
                     > (p2[1] - p1[1]) * (x - p1[0]);
         }
-        
+
         double distanceTo(double x, double y) {
             return Math.sqrt(Math.pow(center[0] - x, 2) + Math.pow(center[1] - y, 2));
         }
-        
+
         boolean isCenter(double x, double y) {
             return (Math.abs(vertices[LEFT_MID][1]) - y < 0.001)
                     && (Math.abs((vertices[LEFT_MID][0] + vertices[RIGHT_MID][0]) / 2.0 - x) < 0.001);

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -21,15 +21,7 @@
 
 package mekhq.campaign.universe;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.joda.time.DateTime;
@@ -65,7 +57,8 @@ public class RandomFactionGenerator {
     private static final int BORDER_RANGE_NEAR_PERIPHERY = 90;
     private static final int BORDER_RANGE_DEEP_PERIPHERY = 210; //a bit more than this distance between HL and NC
 
-    private static final Date FORTRESS_REPUBLIC = new Date (new GregorianCalendar(3135,10,1).getTimeInMillis());
+    private static final Date FORTRESS_REPUBLIC = new Date (new GregorianCalendar(3135,
+            Calendar.NOVEMBER,1).getTimeInMillis());
 
     private static RandomFactionGenerator rfg = null;
 
@@ -288,8 +281,8 @@ public class RandomFactionGenerator {
     /**
      * Builds a map of potential enemies keyed to cumulative weight
      *
-     * @param employer
-     * @return
+     * @param employer The employer faction
+     * @return         The weight map of potential enemies
      */
     protected WeightedMap<Faction> buildEnemyMap(Faction employer) {
         WeightedMap<Faction> enemyMap = new WeightedMap<>();
@@ -364,7 +357,7 @@ public class RandomFactionGenerator {
 
     /**
      * Constructs a list of a faction's potential enemies based on common borders.
-     * @param employerName The employer faction
+     * @param employer     The employer faction
      * @return             A list of faction that share a border
      */
     public List<String> getEnemyList(Faction employer) {
@@ -419,7 +412,7 @@ public class RandomFactionGenerator {
      */
     protected double adjustBorderWeight(double count, Faction f,
             Faction enemy, Date date) {
-        final Date TUKKAYID = new Date (new GregorianCalendar(3052,5,20).getTimeInMillis());
+        final Date TUKKAYID = new Date(new GregorianCalendar(3052, Calendar.JUNE,20).getTimeInMillis());
 
         if (factionHints.isNeutral(f, enemy, currentDate())
                 || factionHints.isNeutral(enemy, f, currentDate())) {
@@ -453,8 +446,8 @@ public class RandomFactionGenerator {
     /**
      * Selects a random planet from a list of potential targets based on the attacking and defending factions.
      *
-     * @param attacker
-     * @param defender
+     * @param attacker  The faction key of the attacker
+     * @param defender  The faction key of the defender
      * @return          The planetId of the chosen planet, or null if there are no target candidates
      */
     @Nullable public String getMissionTarget(String attacker, String defender) {
@@ -509,8 +502,8 @@ public class RandomFactionGenerator {
      * Builds a list of planets controlled by the defender that are near one or more of the attacker's
      * planets.
      *
-     * @param attackerKey   The attacking faction
-     * @param defenderKey   The defending faction
+     * @param attacker   The attacking faction
+     * @param defender   The defending faction
      * @return              A list of potential mission targets
      */
     public List<PlanetarySystem> getMissionTargetList(Faction attacker, Faction defender) {

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -507,23 +507,31 @@ public class RandomFactionGenerator {
      * @return              A list of potential mission targets
      */
     public List<PlanetarySystem> getMissionTargetList(Faction attacker, Faction defender) {
-        if (!borderTracker.getFactionsInRegion().contains(attacker)) {
+        // If the attacker or defender are not in the set of factions that control planets,
+        // and they are not rebels or pirates, they will be a faction contained within another
+        // (e.g. Nova Cat in the Draconis Combine, or Wolf-in-Exile in Lyran space
+        if (!borderTracker.getFactionsInRegion().contains(attacker)
+                && !attacker.is(Faction.Tag.PIRATE)) {
             attacker = factionHints.getContainedFactionHost(attacker, currentDate());
         }
-        if (!borderTracker.getFactionsInRegion().contains(defender)) {
+        if (!borderTracker.getFactionsInRegion().contains(defender)
+                && !defender.is(Faction.Tag.PIRATE)
+                && !defender.is(Faction.Tag.REBEL)) {
             defender = factionHints.getContainedFactionHost(defender, currentDate());
         }
         if ((null == attacker) || (null == defender)) {
             return Collections.emptyList();
         }
         // Locate rebels on any of the attacker's planet
-        if (defender.getShortName().equals("REB")) {
+        if (defender.is(Faction.Tag.REBEL)) {
             return new ArrayList<>(borderTracker.getBorders(attacker).getSystems());
         }
 
         Set<PlanetarySystem> planetSet = new HashSet<>(borderTracker.getBorderSystems(attacker, defender));
-        // Locate missions by or against pirates on border worlds
-        if (attacker.getShortName().equals("PIR") || defender.getShortName().equals("PIR")) {
+        // If mission is against generic pirates (those that don't control any systems),
+        // add all border systems as possible locations
+        if ((attacker.is(Faction.Tag.PIRATE) && !borderTracker.getFactionsInRegion().contains(attacker))
+                || (defender.is(Faction.Tag.PIRATE) && !borderTracker.getFactionsInRegion().contains(defender))) {
             for (Faction f : borderTracker.getFactionsInRegion()) {
                 planetSet.addAll(borderTracker.getBorderSystems(f, attacker));
                 planetSet.addAll(borderTracker.getBorderSystems(attacker, f));


### PR DESCRIPTION
When selecting a location for a generated contract, if the attacker or defender does not control any systems in the region under examination, the only possibility that is considered is that it is contained within another faction, such as Clan Nova Cat inside the Draconis Combine, and if not found as an internal faction, an empty list is returned as possible locations. The other possibility that is not considered is that the faction is a rebel or generic pirate faction, which has special handling to place it anywhere within the attacking faction (rebels) or on a border world (pirates) but this special handling is never reached.

Also did a little whitespace cleanup and javadoc fixes.

Fixes #1384
Fixes #1284