### PR TITLE
Bug: Use current shopping list in ProcurementTableModel and restrict acquisitions #1366 #1345

### DIFF
--- a/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
@@ -1,8 +1,6 @@
 package mekhq.gui.model;
 
 import java.awt.Component;
-import java.util.ArrayList;
-
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -12,14 +10,14 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.work.IAcquisitionWork;
 
 /**
- * A table model for displaying acquisitions. Unlike the other table models here, this one 
+ * A table model for displaying acquisitions. Unlike the other table models here, this one
  * can apply to multiple tables and so we have to be more careful in its design
  */
 public class ProcurementTableModel extends DataTableModel {
     private static final long serialVersionUID = 534443424190075264L;
 
     Campaign campaign;
-    
+
     public final static int COL_NAME    =    0;
     public final static int COL_COST     =   1;
     public final static int COL_TOTAL_COST = 2;
@@ -29,7 +27,7 @@ public class ProcurementTableModel extends DataTableModel {
     public final static int N_COL          = 6;
 
     public ProcurementTableModel(Campaign c) {
-        data = new ArrayList<IAcquisitionWork>();
+        data = c.getShoppingList().getPartList();
         campaign = c;
     }
 
@@ -176,18 +174,18 @@ public class ProcurementTableModel extends DataTableModel {
             return null;
         }
         switch(col) {
-        case COL_TARGET:                    
+        case COL_TARGET:
             TargetRoll target = getCampaign().getTargetForAcquisition(shoppingItem, getCampaign().getLogisticsPerson(), false);
             return target.getDesc();
-        default:                    
-            return "<html>You can increase or decrease the quantity with the left/right arrows keys or the plus/minus keys.<br>Quantities reduced to zero will remain on the list until the next procurement cycle.</html>"; 
+        default:
+            return "<html>You can increase or decrease the quantity with the left/right arrows keys or the plus/minus keys.<br>Quantities reduced to zero will remain on the list until the next procurement cycle.</html>";
         }
     }
-    
+
     private Campaign getCampaign() {
         return campaign;
     }
-    
+
     public ProcurementTableModel.Renderer getRenderer() {
         return new ProcurementTableModel.Renderer();
     }


### PR DESCRIPTION
The ProcurementTableModel defaulted to loading without the campaign's current parts list, causing CPNX reloads to display an empty procurement table in the warehouse tab #1366.