### PR TITLE
Add the unit ID to the log when unable to parse a unit

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1944,7 +1944,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             }
         } catch (Exception ex) {
             // Doh!
-            MekHQ.getLogger().error(Unit.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(Unit.class, METHOD_NAME, "Could not parse unit " + idNode.getTextContent().trim(), ex);
+            return null;
         }
 
         if (retVal.id == null) {


### PR DESCRIPTION
While trying to debug an issue in a user's campaign file, it was difficult to pin down exactly which unit caused the exception. This adds the unit's ID (from the CPNX) to the message.