### PR TITLE
Improve performance of purchasing parts and fix refit bug

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -247,6 +247,7 @@ public class Campaign implements Serializable, ITechManager {
 
     // calendar stuff
     private GregorianCalendar calendar;
+    private DateTime currentDateTime;
     private String dateFormat;
     private String shortDateFormat;
 
@@ -309,6 +310,7 @@ public class Campaign implements Serializable, ITechManager {
         player = new Player(0, "self");
         game.addPlayer(0, player);
         calendar = new GregorianCalendar(3067, Calendar.JANUARY, 1);
+        currentDateTime = new DateTime(calendar);
         CurrencyManager.getInstance().setCampaign(this);
         location = new CurrentLocation(Systems.getInstance().getSystems()
                 .get("Outreach"), 0);
@@ -442,6 +444,7 @@ public class Campaign implements Serializable, ITechManager {
 
     public void setCalendar(GregorianCalendar c) {
         calendar = c;
+        currentDateTime = new DateTime(c);
     }
 
     public GregorianCalendar getCalendar() {
@@ -465,7 +468,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public String getCurrentSystemName() {
-        return location.getCurrentSystem().getPrintableName(Utilities.getDateTimeDay(calendar));
+        return location.getCurrentSystem().getPrintableName(getDateTime());
     }
 
     public PlanetarySystem getCurrentSystem() {
@@ -1367,8 +1370,13 @@ public class Campaign implements Serializable, ITechManager {
         ServiceLogger.joined(p, getDate(), getName(), rankEntry);
     }
 
+    @Deprecated
     public Date getDate() {
         return calendar.getTime();
+    }
+
+    public DateTime getDateTime() {
+        return currentDateTime;
     }
 
     public Collection<Person> getPersonnel() {
@@ -2825,7 +2833,7 @@ public class Campaign implements Serializable, ITechManager {
      */
     public void readNews() {
         //read the news
-        DateTime now = Utilities.getDateTimeDay(calendar);
+        DateTime now = getDateTime();
         for(NewsItem article : news.fetchNewsFor(now)) {
             addReport(article.getHeadlineForReport());
         }
@@ -3249,6 +3257,8 @@ public class Campaign implements Serializable, ITechManager {
         this.autosaveService.requestDayAdvanceAutosave(this, this.calendar.get(Calendar.DAY_OF_WEEK));
 
         calendar.add(Calendar.DAY_OF_MONTH, 1);
+        currentDateTime = new DateTime(calendar);
+
         currentReport.clear();
         currentReportHTML = "";
         newReports.clear();
@@ -4454,13 +4464,13 @@ public class Campaign implements Serializable, ITechManager {
     public Vector<String> getSystemNames() {
         Vector<String> systemNames = new Vector<String>();
         for (PlanetarySystem key : Systems.getInstance().getSystems().values()) {
-            systemNames.add(key.getPrintableName(Utilities.getDateTimeDay(calendar)));
+            systemNames.add(key.getPrintableName(getDateTime()));
         }
         return systemNames;
     }
 
     public PlanetarySystem getSystemByName(String name) {
-        return Systems.getInstance().getSystemByName(name, Utilities.getDateTimeDay(calendar));
+        return Systems.getInstance().getSystemByName(name, getDateTime());
     }
 
     /**
@@ -4861,7 +4871,7 @@ public class Campaign implements Serializable, ITechManager {
         String startKey = start.getId();
         String endKey = end.getId();
 
-        final DateTime now = Utilities.getDateTimeDay(calendar);
+        final DateTime now = getDateTime();
         String current = startKey;
         Set<String> closed = new HashSet<>();
         Set<String> open = new HashSet<>();
@@ -8333,7 +8343,7 @@ public class Campaign implements Serializable, ITechManager {
 
     @Override
     public int getGameYear() {
-        return calendar.get(Calendar.YEAR);
+        return currentDateTime.getYear();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -28,6 +28,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -3933,6 +3934,28 @@ public class Campaign implements Serializable, ITechManager {
         return spares;
     }
 
+    /**
+     * Finds the first spare part matching a predicate.
+     *
+     * @param predicate The predicate to use when searching
+     *                  for a suitable spare part.
+     * @return A matching spare {@link Part} or {@code null}
+     *         if no suitable match was found.
+     */
+    @Nullable
+    public Part findSparePart(Predicate<Part> predicate) {
+        for (Part part : parts.values()) {
+            if (part.isSpare() && predicate.test(part)) {
+                return part;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Streams the spare parts in the campaign.
+     * @return A stream of spare parts in the campaign.
+     */
     public Stream<Part> streamSpareParts() {
         return parts.values().stream().filter(Part::isSpare);
     }

--- a/MekHQ/src/mekhq/campaign/finances/CurrencyDataLookupWriter.java
+++ b/MekHQ/src/mekhq/campaign/finances/CurrencyDataLookupWriter.java
@@ -22,7 +22,7 @@
 package mekhq.campaign.finances;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.joda.money.BigMoney;
 import org.joda.money.format.MoneyPrintContext;
@@ -35,9 +35,9 @@ import org.joda.money.format.MoneyPrinter;
  * @author Vicente Cartas Espinel <vicente.cartas at outlook.com>
  */
 class CurrencyDataLookupWriter implements MoneyPrinter {
-    private HashMap<String, String> currencyExtraData;
+    private Map<String, String> currencyExtraData;
 
-    CurrencyDataLookupWriter(HashMap<String, String> currencyExtraData) {
+    CurrencyDataLookupWriter(Map<String, String> currencyExtraData) {
         this.currencyExtraData = currencyExtraData;
     }
 

--- a/MekHQ/src/mekhq/campaign/finances/FinancialReport.java
+++ b/MekHQ/src/mekhq/campaign/finances/FinancialReport.java
@@ -174,8 +174,8 @@ public class FinancialReport {
         }
 
         r.spareParts = r.spareParts.plus(
-            campaign.getSpareParts()
-                .stream().map(x -> x.getActualValue().multipliedBy(x.getQuantity()))
+            campaign.streamSpareParts()
+                .map(x -> x.getActualValue().multipliedBy(x.getQuantity()))
                 .collect(Collectors.toList()));
 
         CampaignOptions campaignOptions = campaign.getCampaignOptions();

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -282,29 +282,26 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         resetDaysToWait();
         return "<font color='red'><b> part not found</b>.</font>";
     }
-    
-    public void changeAmountAvailable(int amount, AmmoType curType) {
-        AmmoStorage a = null;
-        long curMunition = curType.getMunitionType();
-        for(Part part : campaign.getSpareParts()) {
-            if(!part.isPresent()) {
-                continue;
+
+    public void changeAmountAvailable(int amount, final AmmoType curType) {
+        final long curMunition = curType.getMunitionType();
+        AmmoStorage a = (AmmoStorage)campaign.findSparePart(part -> {
+            return part instanceof AmmoStorage
+                && part.isPresent()
+                && ((AmmoType)((AmmoStorage)part).getType()).equals(curType)
+                && curMunition == ((AmmoType)((AmmoStorage)part).getType()).getMunitionType();
+        });
+
+        if (null != a) {
+            a.changeShots(amount);
+            if (a.getShots() <= 0) {
+                campaign.removePart(a);
             }
-            if(part instanceof AmmoStorage 
-                    && ((AmmoType)((AmmoStorage)part).getType()).equals((Object)curType)
-                    && curMunition == ((AmmoType)((AmmoStorage)part).getType()).getMunitionType()) {
-                a = (AmmoStorage)part;
-                a.changeShots(amount);
-                break;
-            }
-        }
-        if(null != a && a.getShots() <= 0) {
-            campaign.removePart(a);
-        } else if(null == a && amount > 0) {
-            campaign.addPart(new AmmoStorage(1,curType,amount,campaign), 0);
+        } else if(amount > 0) {
+            campaign.addPart(new AmmoStorage(1, curType, amount, campaign), 0);
         }
     }
-    
+
     @Override
     public String getAcquisitionDesc() {
         String toReturn = "<html><font size='2'";

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -222,8 +222,8 @@ public class Armor extends Part implements IAcquisitionWork {
     @Override
     public boolean isSamePartType(Part part) {
         return part instanceof Armor
-                && isSameType((Armor)part)
-                && getRefitId() == part.getRefitId();
+                && Objects.equals(getRefitId(), part.getRefitId())
+                && isSameType((Armor)part);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -130,8 +130,8 @@ public class BaArmor extends Armor implements IAcquisitionWork {
     public boolean isSamePartType(Part part) {
         return part instanceof BaArmor
                 && isClanTechBase() == part.isClanTechBase()
-                && ((BaArmor)part).getType() == this.getType()
-                && getRefitId() == part.getRefitId();
+                && Objects.equals(getRefitId(), part.getRefitId())
+                && ((BaArmor)part).getType() == getType();
     }
     
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -21,6 +21,8 @@
 
 package mekhq.campaign.parts;
 
+import java.util.Objects;
+
 import megamek.common.EquipmentType;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -149,38 +151,32 @@ public class BaArmor extends Armor implements IAcquisitionWork {
     public Part getNewPart() {
         return new BaArmor(0, (int)Math.round(5 * getPointsPerTon()), type, -1, clan, campaign);
     }
-    
+
     public int getAmountAvailable() {
-        for(Part part : campaign.getSpareParts()) {
-            if(part instanceof BaArmor) {
-                BaArmor a = (BaArmor)part;
-                if(a.isClanTechBase() == clan 
-                        && a.getType() == type
-                        && !a.isReservedForRefit() && a.isPresent()) {
-                    return a.getAmount();
-                }
-            }
-        }
-        return 0;
+        BaArmor a = (BaArmor)campaign.findSparePart(part -> {
+            return part instanceof BaArmor
+                && part.isPresent()
+                && !part.isReservedForRefit()
+                && isClanTechBase() == part.isClanTechBase()
+                && ((BaArmor)part).getType() == getType();
+        });
+
+        return a != null ? a.getAmount() : 0;
     }
-    
+
     @Override
     public void changeAmountAvailable(int amount) {
-        BaArmor a = null;
-        for(Part part : campaign.getSpareParts()) {
-            if(part instanceof BaArmor 
-                    && ((BaArmor)part).isClanTechBase() == clan 
-                    && ((BaArmor)part).getType() == type
-                    && getRefitId() == part.getRefitId()
-                    && part.isPresent()) {
-                a = (BaArmor)part;                
-                a.setAmount(a.getAmount() + amount);
-                break;
+        BaArmor a = (BaArmor)campaign.findSparePart(part -> {
+            return isSamePartType(part)
+                && part.isPresent();
+        });
+
+        if(null != a) {
+            a.setAmount(a.getAmount() + amount);
+            if (a.getAmount() <= 0) {
+                campaign.removePart(a);
             }
-        }
-        if(null != a && a.getAmount() <= 0) {
-            campaign.removePart(a);
-        } else if(null == a && amount > 0) {            
+        } else if(amount > 0) {
             campaign.addPart(new BaArmor(getUnitTonnage(), amount, type, -1, isClanTechBase(), campaign), 0);
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1101,8 +1101,29 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
     }
 
+    /**
+     * Gets a string containing details regarding the part,
+     * e.g. OmniPod or how many hits it has taken and its
+     * repair cost.
+     * @return A string containing details regarding the part.
+     */
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    /**
+     * Gets a string containing details regarding the part,
+     * and optionally include information on its repair
+     * status.
+     * @param includeRepairDetails {@code true} if the details
+     *        should include information such as the number of
+     *        hits or how much it would cost to repair the
+     *        part.
+     * @return A string containing details regarding the part.
+     */
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         StringJoiner sj = new StringJoiner(", ");
         if (getLocationName() != null) {
             sj.add(getLocationName());
@@ -1110,10 +1131,12 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         if (isOmniPodded()) {
             sj.add("OmniPod");
         }
-        sj.add(hits + " hit(s)");
-        if (campaign.getCampaignOptions().payForRepairs() && (hits > 0)) {
-            Money repairCost = getStickerPrice().multipliedBy(0.2);
-            sj.add(repairCost.toAmountAndSymbolString() + " to repair");
+        if (includeRepairDetails) {
+            sj.add(hits + " hit(s)");
+            if (campaign.getCampaignOptions().payForRepairs() && (hits > 0)) {
+                Money repairCost = getStickerPrice().multipliedBy(0.2);
+                sj.add(repairCost.toAmountAndSymbolString() + " to repair");
+            }
         }
         return sj.toString();
     }

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -18,7 +18,7 @@ public class PartInUse {
     private Money cost = Money.zero();
 
     private void appendDetails(StringBuilder sb, Part part) {
-        String details = part.getDetails();
+        String details = part.getDetails(/*includeRepairDetails:*/false);
         if(!details.isEmpty()) {
             sb.append(" (").append(details).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
         }

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -1,7 +1,6 @@
 package mekhq.campaign.parts;
 
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import megamek.common.AmmoType;
 import mekhq.campaign.finances.Money;
@@ -9,9 +8,6 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
 
 public class PartInUse {
-    private static final Pattern cleanUp1 = Pattern.compile("\\d+\\shit\\(s\\),\\s"); //$NON-NLS-1$
-    private static final Pattern cleanUp2 = Pattern.compile("\\d+\\shit\\(s\\)"); //$NON-NLS-1$
-
     private String description;
     private IAcquisitionWork partToBuy;
     private int useCount;
@@ -20,16 +16,14 @@ public class PartInUse {
     private int transferCount;
     private int plannedCount;
     private Money cost = Money.zero();
-    
+
     private void appendDetails(StringBuilder sb, Part part) {
         String details = part.getDetails();
-        details = cleanUp1.matcher(details).replaceFirst(""); //$NON-NLS-1$
-        details = cleanUp2.matcher(details).replaceFirst(""); //$NON-NLS-1$
-        if(details.length() > 0) {
+        if(!details.isEmpty()) {
             sb.append(" (").append(details).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
         }
     }
-    
+
     public PartInUse(Part part) {
         StringBuilder sb = new StringBuilder(part.getName());
         Unit u = part.getUnit();
@@ -65,81 +59,81 @@ public class PartInUse {
             this.cost = partToBuy.getBuyCost();
         }
     }
-    
+
     public PartInUse(String description, IAcquisitionWork partToBuy, Money cost) {
         this.description = Objects.requireNonNull(description);
         this.partToBuy = Objects.requireNonNull(partToBuy);
         this.cost = cost;
     }
-    
+
     public PartInUse(String description, IAcquisitionWork partToBuy) {
         this(description, partToBuy, partToBuy.getBuyCost());
     }
-    
+
     public String getDescription() {
         return description;
     }
-    
+
     public IAcquisitionWork getPartToBuy() {
         return partToBuy;
     }
-    
+
     public int getUseCount() {
         return useCount;
     }
-    
+
     public void setUseCount(int useCount) {
         this.useCount = useCount;
     }
-    
+
     public void incUseCount() {
         ++ useCount;
     }
-    
+
     public int getStoreCount() {
         return storeCount;
     }
-    
+
     public double getStoreTonnage() {
         return storeCount * tonnagePerItem;
     }
-    
+
     public void setStoreCount(int storeCount) {
         this.storeCount = storeCount;
     }
-    
+
     public void incStoreCount() {
         ++ storeCount;
     }
-    
+
     public int getTransferCount() {
         return transferCount;
     }
-    
+
     public void incTransferCount() {
         ++ transferCount;
     }
-    
+
     public void setTransferCount(int transferCount) {
         this.transferCount = transferCount;
     }
-    
+
     public int getPlannedCount() {
         return plannedCount;
     }
-    
+
     public void setPlannedCount(int plannedCount) {
         this.plannedCount = plannedCount;
     }
-    
+
     public void incPlannedCount() {
         ++ plannedCount;
     }
-    
+
     public Money getCost() {
         return cost;
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hashCode(description);

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -404,6 +404,11 @@ public class PodSpace implements Serializable, IPartWork {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         int allParts = 0;
         int replacements = 0;
         int inTransit = 0;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
@@ -88,9 +88,9 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
     @Override
     public boolean isSamePartType(Part part) {
         return part instanceof ProtomekArmor
-                && type == ((ProtomekArmor) part).type
+                && getType() == ((ProtomekArmor) part).getType()
                 && isClanTechBase() == part.isClanTechBase()
-                && getRefitId() == part.getRefitId();
+                && Objects.equals(getRefitId(), part.getRefitId());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -33,6 +33,7 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -1283,7 +1284,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         List<IAcquisitionWork> toRemove = new ArrayList<>();
         toRemove.add(this);
         for (IAcquisitionWork part : campaign.getShoppingList().getPartList()) {
-            if ((part instanceof Part) && ((Part) part).getRefitId() == this.getRefitId()) {
+            if ((part instanceof Part) && Objects.equals(((Part) part).getRefitId(), this.getRefitId())) {
                 toRemove.add(part);
             }
         }

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -29,6 +29,7 @@ import mekhq.campaign.work.IAcquisitionWork;
 import org.w3c.dom.Node;
 
 import java.io.PrintWriter;
+import java.util.Objects;
 
 /**
  * Standard support vehicle armor, which can differ by BAR and tech rating.
@@ -142,7 +143,8 @@ public class SVArmor extends Armor {
     public void changeAmountAvailable(int amount) {
         SVArmor a = (SVArmor)campaign.findSparePart(part -> {
             return isSamePartType(part)
-                && part.isPresent();
+                && part.isPresent()
+                && Objects.equals(getRefitId(), part.getRefitId());
         });
 
         if (null != a) {

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -130,26 +130,27 @@ public class SVArmor extends Armor {
     }
 
     public int getAmountAvailable() {
-        for(Part part : campaign.getSpareParts()) {
-            if (isSamePartType(part) && !part.isReservedForRefit() && part.isPresent()) {
-                return ((SVArmor) part).getAmount();
-            }
-        }
-        return 0;
+        SVArmor a = (SVArmor)campaign.findSparePart(part -> {
+            return isSamePartType(part)
+                && part.isPresent()
+                && !part.isReservedForRefit();
+        });
+
+        return a != null ? a.getAmount() : 0;
     }
 
     public void changeAmountAvailable(int amount) {
-        SVArmor a = null;
-        for(Part part : campaign.getSpareParts()) {
-            if (isSamePartType(part) && getRefitId() == part.getRefitId() && part.isPresent()) {
-                a = (SVArmor) part;
-                a.setAmount(a.getAmount() + amount);
-                break;
+        SVArmor a = (SVArmor)campaign.findSparePart(part -> {
+            return isSamePartType(part)
+                && part.isPresent();
+        });
+
+        if (null != a) {
+            a.setAmount(a.getAmount() + amount);
+            if (a.getAmount() <= 0) {
+                campaign.removePart(a);
             }
-        }
-        if(null != a && a.getAmount() <= 0) {
-            campaign.removePart(a);
-        } else if(null == a && amount > 0) {
+        } else if(amount > 0) {
             campaign.addPart(new SVArmor(bar, techRating, amount, -1, campaign), 0);
         }
     }

--- a/MekHQ/src/mekhq/campaign/work/IPartWork.java
+++ b/MekHQ/src/mekhq/campaign/work/IPartWork.java
@@ -65,7 +65,26 @@ public interface IPartWork extends IWork {
     MissingPart getMissingPart();
     
     String getDesc();
+
+    /**
+     * Gets a string containing details regarding the part,
+     * e.g. OmniPod or how many hits it has taken and its
+     * repair cost.
+     * @return A string containing details regarding the part.
+     */
     String getDetails();
+    
+    /**
+     * Gets a string containing details regarding the part,
+     * and optionally include information on its repair
+     * status.
+     * @param includeRepairDetails {@code true} if the details
+     *        should include information such as the number of
+     *        hits or how much it would cost to repair the
+     *        part.
+     * @return A string containing details regarding the part.
+     */
+    String getDetails(boolean includeRepairDetails);
     int getLocation();
     
     Unit getUnit();


### PR DESCRIPTION
While investigating an issue where ammo could not be bought, I noticed a number of huge performance slowdowns in the Purchase Parts screen. I also found a bug w.r.t. refit ID's.

1. Cache CurrencyManager::getDefaultCurrency. This was extremely expensive and called constantly 25bed25.
2. Remove text "sanitizing" from PartsInUse 21d2f0f.
3. Add Campaign::streamSpareParts and use it where allocating a huge ArrayList is unnecessary 51ffcd3.
4. Add Campaign::findSparePart to take a predicate to quickly find a matching part e8b0652.
5. Speed up AmmoStorage 43da701, Armor 72ce2f3, BaArmor b1c5751, ProtomekArmor c9fc5c5, and SVArmor a0ab221 bc100ad with findSparePart.
6. Speed up AmmoBin with findSparePart and streamSpareParts 18a608a. **This one could use some eyes**
7. Fix incorrect usage of reference equality of Refit ID's when value equality was intended a90d59b.

The time it takes to purchase 1000 units of AC/20 ammo by clicking 'Buy' is cut by ~70% on my desktop.

These commits are best viewed one by one with whitespace ignored (although I tried to minimize whitespace changes).