### PR TITLE
Contract market performance improvement

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -390,10 +390,11 @@ public class ContractMarket implements Serializable {
 		}
 		JumpPath jp = null;
 		try {
-			jp = campaign.calculateJumpPath(campaign.getCurrentSystem(), contract.getSystem());
+			jp = contract.getJumpPath(campaign);
 		} catch (NullPointerException ex) {
 			// could not calculate jump path; leave jp null
 		}
+		
 		if (jp == null) {
 			if (retries > 0) {
 				return generateAtBContract(campaign, employer, unitRatingMod, retries - 1);

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -392,11 +392,16 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
         signingAmount = amount;
     }
 
+    @Override
     public void setSystemId(String n) {
         super.setSystemId(n);
         cachedJumpPath = null;
     }
     
+    /**
+     * Gets the currently calculated jump path for this contract,
+     * only recalculating if it's not valid any longer or hasn't been calculated yet.
+     */
     public JumpPath getJumpPath(Campaign c) {
         // if we don't have a cached jump path, or if the jump path's starting/ending point 
         // no longer match the campaign's current location or contract's destination

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -401,6 +401,7 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
         // if we don't have a cached jump path, or if the jump path's starting/ending point 
         // no longer match the campaign's current location or contract's destination
         if((cachedJumpPath == null) ||
+                (cachedJumpPath.size() == 0) ||
                 !cachedJumpPath.getFirstSystem().getId().equals(c.getCurrentSystem().getId()) ||
                 !cachedJumpPath.getLastSystem().getId().equals(getSystem().getId())) {
             cachedJumpPath = c.calculateJumpPath(c.getCurrentSystem(), getSystem());


### PR DESCRIPTION
While working on a contract generation feature, I noticed that the jump path was getting recalculated many times for the same contract. Introduced a caching mechanism to greatly reduce the number of jump path calculations for each individual contract.