### PR TITLE
Fix bug introduced in getDetails via #1419

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
@@ -1,20 +1,20 @@
 /*
  * AeroSensor.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -59,19 +59,19 @@ public class AeroSensor extends Part {
     public AeroSensor() {
         this(0, false, null);
     }
-    
+
     public AeroSensor(int tonnage, boolean lc, Campaign c) {
         super(tonnage, c);
         this.name = "Aerospace Sensors";
         this.largeCraft = lc;
     }
-    
+
     public AeroSensor clone() {
         AeroSensor clone = new AeroSensor(getUnitTonnage(), largeCraft, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-        
+
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         int priorHits = hits;
@@ -100,7 +100,7 @@ public class AeroSensor extends Part {
             }
             if (hits == 1) {
                 time *= 1;
-            } 
+            }
             if (hits == 2) {
                 time *= 2;
             }
@@ -134,7 +134,7 @@ public class AeroSensor extends Part {
             }
             if (hits == 1) {
                 return -1;
-            } 
+            }
             if (hits == 2) {
                 return 0;
             }
@@ -244,11 +244,24 @@ public class AeroSensor extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         String dropper = "";
         if(largeCraft) {
             dropper = " (spacecraft)";
         }
-        return super.getDetails() + ", " + getUnitTonnage() + " tons" + dropper;
+
+        String details = super.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
+            details += ", ";
+        }
+
+        details += getUnitTonnage() + " tons" + dropper;
+
+        return details;
     }
 
     @Override
@@ -271,7 +284,7 @@ public class AeroSensor extends Part {
         }
         return Entity.LOC_NONE;
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return TECH_ADVANCEMENT;

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -1,20 +1,20 @@
 /*
  * AmmoStorage.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,7 +45,7 @@ import mekhq.campaign.work.IAcquisitionWork;
 
 /**
  * This will be a special type of part that will only exist as spares
- * It will determine the amount of ammo of a particular type that 
+ * It will determine the amount of ammo of a particular type that
  * is available
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
@@ -54,11 +54,11 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 
 	protected long munition;
 	protected int shots;
-	
+
     public AmmoStorage() {
     	this(0, null, 0, null);
     }
-    
+
     public AmmoStorage(int tonnage, EquipmentType et, int shots, Campaign c) {
         super(tonnage, et, -1, c);
         this.shots = shots;
@@ -67,14 +67,14 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         }
 
     }
-    
+
     public AmmoStorage clone() {
     	AmmoStorage storage = new AmmoStorage(0, getType(), shots, campaign);
         storage.copyBaseData(this);
     	storage.munition = this.munition;
     	return storage;
     }
-    
+
     @Override
     public double getTonnage() {
     	if(((AmmoType)type).getKgPerShot() > 0) {
@@ -82,7 +82,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     	}
      	return ((double)shots / ((AmmoType)type).getShots());
     }
-    
+
     @Override
     public Money getStickerPrice() {
     	//costs are a total nightmare
@@ -109,12 +109,12 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         }
     	return itemCost;
     }
-    
+
     @Override
     public Money getBuyCost() {
         return getStickerPrice();
     }
-    
+
     @Override
     public Money getCurrentValue() {
         if (((AmmoType)type).getShots() <= 0) {
@@ -129,7 +129,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     public int getShots() {
     	return shots;
     }
-    
+
     @Override
     public boolean isSamePartType(Part part) {
         if (part instanceof AmmoStorage) {
@@ -140,22 +140,22 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
                 return ((AmmoType)getType()).getMunitionType() == ((AmmoType)((AmmoStorage)part).getType()).getMunitionType()
                         && ((AmmoType)getType()).equals( (Object)((EquipmentPart)part).getType());
             }
-            
+
         }
         return false;
     }
-    
+
     public void changeShots(int s) {
     	shots = Math.max(0, shots + s);
     }
-    
+
     public void setShots(int s) {
         shots = Math.max(0, s);
     }
-    
+
 	@Override
 	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);		
+		writeToXmlBegin(pw1, indent);
 		pw1.println(MekHqXmlUtil.indentStr(indent+1)
 				+"<equipmentNum>"
 				+equipmentNum
@@ -178,7 +178,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 	@Override
 	protected void loadFieldsFromXmlNode(Node wn) {
 		NodeList nl = wn.getChildNodes();
-		
+
 		for (int x=0; x<nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
 			if (wn2.getNodeName().equalsIgnoreCase("equipmentNum")) {
@@ -193,12 +193,12 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 		}
 		restore();
 	}
-	
+
 	@Override
 	public TechAdvancement getTechAdvancement() {
 	    return type.getTechAdvancement();
 	}
-	
+
 	@Override
 	public void fix() {
 		//nothing to fix
@@ -209,12 +209,12 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 		//nothing to do here
 		return null;
 	}
-	
+
 	@Override
     public IAcquisitionWork getAcquisitionWork() {
         return new AmmoStorage(1,type,((AmmoType)type).getShots(),campaign);
     }
-	
+
 	@Override
 	public TargetRoll getAllMods(Person tech) {
 		//nothing to do here
@@ -225,7 +225,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		//nothing to do here
 	}
-	
+
 	@Override
 	public void updateConditionFromPart() {
 		//nothing to do here
@@ -235,14 +235,14 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 	public boolean needsFixing() {
 		return false;
 	}
-	
+
 	public String getDesc() {
 		String toReturn = "<html><font size='2'";
 		String scheduled = "";
 		if (getTeamId() != null) {
 			scheduled = " (scheduled) ";
 		}
-	
+
 		toReturn += ">";
 		toReturn += "<b>Reload " + getName() + "</b><br/>";
 		toReturn += getDetails() + "<br/>";
@@ -250,17 +250,22 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 		toReturn += "</font></html>";
 		return toReturn;
 	}
-	
+
     @Override
     public String getDetails() {
-    	return shots + " shots";
+    	return getDetails(true);
     }
-	
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        return shots + " shots";
+    }
+
 	@Override
     public String checkFixable() {
         return null;
     }
-	
+
 	@Override
     public String find(int transitDays) {
 	    Part newPart = getNewPart();
@@ -271,12 +276,12 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
             return "<font color='red'><b> You cannot afford this part. Transaction cancelled</b>.</font>";
         }
     }
-    
+
 	@Override
     public Object getNewEquipment() {
         return getNewPart();
     }
-	
+
     @Override
     public String failToFind() {
         resetDaysToWait();
@@ -305,21 +310,21 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     @Override
     public String getAcquisitionDesc() {
         String toReturn = "<html><font size='2'";
-        
+
         toReturn += ">";
         toReturn += "<b>" + getAcquisitionDisplayName() + "</b> " + getAcquisitionBonus() + "<br/>";
         toReturn += getAcquisitionExtraDesc() + "<br/>";
         PartInventory inventories = campaign.getPartInventory(getAcquisitionPart());
-        toReturn += inventories.getTransitOrderedDetails() + "<br/>"; 
+        toReturn += inventories.getTransitOrderedDetails() + "<br/>";
         toReturn += getStickerPrice().toAmountAndSymbolString() + "<br/>";
         toReturn += "</font></html>";
         return toReturn;
     }
-	
+
     @Override
     public String getAcquisitionDisplayName() {
     	return type.getDesc();
-    }    
+    }
 
 	@Override
 	public String getAcquisitionExtraDesc() {
@@ -355,7 +360,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         }
         else if(campaign.getCampaignOptions().getIsAcquisitionPenalty() > 0) {
             target.addModifier(campaign.getCampaignOptions().getIsAcquisitionPenalty(), "Inner Sphere tech");
-        }   
+        }
         //availability mod
         int avail = getAvailability();
         int availabilityMod = Availability.getAvailabilityModifier(avail);
@@ -366,7 +371,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     public Part getNewPart() {
         return new AmmoStorage(1,type,shots,campaign);
     }
-    
+
     @Override
     public String getQuantityName(int quan) {
         int totalShots = quan * getShots();
@@ -376,7 +381,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         }
         return report;
     }
-    
+
     @Override
     public String getArrivalReport() {
         double totalShots = quantity * getShots();
@@ -388,12 +393,12 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         }
         return report;
     }
-    
+
     @Override
     public boolean needsMaintenance() {
         return true;
     }
-    
+
     @Override
     public boolean isPriceAdjustedForAmount() {
         return true;

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -147,6 +147,11 @@ public class Armor extends Part implements IAcquisitionWork {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             String rearMount = "";
             if(rear) {
@@ -190,12 +195,14 @@ public class Armor extends Part implements IAcquisitionWork {
         return amount + amountNeeded;
     }
 
+    @Override
     public int getLocation() {
         return location;
     }
 
+    @Override
     public String getLocationName() {
-        return unit.getEntity().getLocationName(location);
+        return unit != null ? unit.getEntity().getLocationName(location) : null;
     }
 
     public boolean isRearMounted() {

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -409,7 +409,7 @@ public class BattleArmorSuit extends Part {
             }
         }
     }
-    
+
     @Override
     public void fix() {
         super.fix();
@@ -504,8 +504,8 @@ public class BattleArmorSuit extends Part {
             }
         }
     }
-    
-    @Override 
+
+    @Override
     public int getBaseTime() {
         return 0;
     }
@@ -517,6 +517,11 @@ public class BattleArmorSuit extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             return "Trooper " + trooper;
         } else {
@@ -536,7 +541,7 @@ public class BattleArmorSuit extends Part {
                 return nEquip + " pieces of equipment; " + armor + " armor points";
             }
         }
-        return super.getDetails();
+        return super.getDetails(includeRepairDetails);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -408,14 +408,25 @@ public class EnginePart extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        String details = super.getDetails(includeRepairDetails);
         if (null != unit) {
-            return super.getDetails();
+            return details;
         }
+
+        if (!details.isEmpty()) {
+            details += ", ";
+        }
+
         String hvrString = "";
         if (forHover) {
             hvrString = " (hover)";
         }
-        return super.getDetails() + ", " + getUnitTonnage() + " tons" + hvrString;
+        return details + getUnitTonnage() + " tons" + hvrString;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/InfantryArmorPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryArmorPart.java
@@ -1,20 +1,20 @@
 /*
  * InfantryMotiveType.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -57,7 +57,7 @@ public class InfantryArmorPart extends Part {
     public InfantryArmorPart() {
         this(0, null, 1.0, false, false, false, false, false, false);
     }
-    
+
     public InfantryArmorPart(int tonnage, Campaign c, double divisor, boolean enc, boolean dest, boolean camo, boolean ir, boolean ecm, boolean space) {
         super(tonnage, c);
         this.damageDivisor = divisor;
@@ -69,7 +69,7 @@ public class InfantryArmorPart extends Part {
         this.spaceSuit = space;
         assignName();
     }
-    
+
     private void assignName() {
         String heavyString = "";
         if(damageDivisor > 1) {
@@ -86,9 +86,14 @@ public class InfantryArmorPart extends Part {
 
         this.name = heavyString + baseName;
     }
-    
+
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         String details = "";
         if(isEncumbering()) {
             details += "encumbering";
@@ -113,7 +118,7 @@ public class InfantryArmorPart extends Part {
         }
         return details;
     }
-    
+
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         //do nothing

--- a/MekHQ/src/mekhq/campaign/parts/KFChargingSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFChargingSystem.java
@@ -1,20 +1,20 @@
 /*
  * KFChargingSystem.java
- * 
+ *
  * Copyright (c) 2019, The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -42,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class KFChargingSystem extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -3393108641476578377L;
 
@@ -94,15 +95,15 @@ public class KFChargingSystem extends Part {
                     hits = 0;
                 }
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time;
         if(isSalvaging()) {
@@ -211,7 +212,7 @@ public class KFChargingSystem extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof KFChargingSystem 
+        return part instanceof KFChargingSystem
                 && coreType == ((KFChargingSystem)part).getCoreType()
                 && docks == ((KFChargingSystem)part).getDocks();
     }
@@ -235,7 +236,7 @@ public class KFChargingSystem extends Part {
         NodeList nl = wn.getChildNodes();
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            
+
             if (wn2.getNodeName().equalsIgnoreCase("coreType")) {
                 coreType = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("docks")) {
@@ -246,9 +247,19 @@ public class KFChargingSystem extends Part {
 
     @Override
     public String getDetails() {
-        return super.getDetails() 
-                + ", " + getUnitTonnage() + " tons" 
-                + ", " + getDocks() + " collars";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringJoiner joiner = new StringJoiner(", ");
+        String details = super.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
+            joiner.add(details);
+        }
+        joiner.add(getUnitTonnage() + " tons")
+              .add(getDocks() + " collars");
+        return joiner.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/KFDriveCoil.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFDriveCoil.java
@@ -1,20 +1,20 @@
 /*
  * KFDriveCoil.java
- * 
+ *
  * Copyright (c) 2019, The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -42,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class KFDriveCoil extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 4515211961051281110L;
 
@@ -61,7 +62,7 @@ public class KFDriveCoil extends Part {
 
     //How many docking collars does this drive support?
     private int docks;
-    
+
     public int getDocks() {
         return docks;
     }
@@ -94,15 +95,15 @@ public class KFDriveCoil extends Part {
                     hits = 0;
                 }
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time;
         if(isSalvaging()) {
@@ -210,7 +211,7 @@ public class KFDriveCoil extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof KFDriveCoil 
+        return part instanceof KFDriveCoil
                 && coreType == ((KFDriveCoil)part).getCoreType()
                 && docks == ((KFDriveCoil)part).getDocks();
     }
@@ -234,7 +235,7 @@ public class KFDriveCoil extends Part {
         NodeList nl = wn.getChildNodes();
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            
+
             if (wn2.getNodeName().equalsIgnoreCase("coreType")) {
                 coreType = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("docks")) {
@@ -245,9 +246,19 @@ public class KFDriveCoil extends Part {
 
     @Override
     public String getDetails() {
-        return super.getDetails() 
-                + ", " + getUnitTonnage() + " tons" 
-                + ", " + getDocks() + " collars";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringJoiner joiner = new StringJoiner(", ");
+        String details = super.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
+            joiner.add(details);
+        }
+        joiner.add(getUnitTonnage() + " tons")
+              .add(getDocks() + " collars");
+        return joiner.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/KFDriveController.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFDriveController.java
@@ -1,20 +1,20 @@
 /*
  * KFDriveController.java
- * 
+ *
  * Copyright (c) 2019, The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -42,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class KFDriveController extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 9055868918414331808L;
 
@@ -94,15 +95,15 @@ public class KFDriveController extends Part {
                     hits = 0;
                 }
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time;
         if(isSalvaging()) {
@@ -213,7 +214,7 @@ public class KFDriveController extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof KFDriveController 
+        return part instanceof KFDriveController
                 && coreType == ((KFDriveController)part).getCoreType()
                 && docks == ((KFDriveController)part).getDocks();
     }
@@ -237,7 +238,7 @@ public class KFDriveController extends Part {
         NodeList nl = wn.getChildNodes();
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            
+
             if (wn2.getNodeName().equalsIgnoreCase("coreType")) {
                 coreType = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("docks")) {
@@ -248,9 +249,19 @@ public class KFDriveController extends Part {
 
     @Override
     public String getDetails() {
-        return super.getDetails() 
-                + ", " + getUnitTonnage() + " tons" 
-                + ", " + getDocks() + " collars";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringJoiner joiner = new StringJoiner(", ");
+        String details = super.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
+            joiner.add(details);
+        }
+        joiner.add(getUnitTonnage() + " tons")
+              .add(getDocks() + " collars");
+        return joiner.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/KFFieldInitiator.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFFieldInitiator.java
@@ -1,20 +1,20 @@
 /*
  * KFFieldInitiator.java
- * 
+ *
  * Copyright (c) 2019, The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -42,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class KFFieldInitiator extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 855888549623558483L;
 
@@ -94,15 +95,15 @@ public class KFFieldInitiator extends Part {
                     hits = 0;
                 }
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time;
         if(isSalvaging()) {
@@ -215,7 +216,7 @@ public class KFFieldInitiator extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof KFFieldInitiator 
+        return part instanceof KFFieldInitiator
                 && coreType == ((KFFieldInitiator)part).getCoreType()
                 && docks == ((KFFieldInitiator)part).getDocks();
     }
@@ -239,7 +240,7 @@ public class KFFieldInitiator extends Part {
         NodeList nl = wn.getChildNodes();
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            
+
             if (wn2.getNodeName().equalsIgnoreCase("coreType")) {
                 coreType = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("docks")) {
@@ -250,9 +251,19 @@ public class KFFieldInitiator extends Part {
 
     @Override
     public String getDetails() {
-        return super.getDetails() 
-                + ", " + getUnitTonnage() + " tons" 
-                + ", " + getDocks() + " collars";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringJoiner joiner = new StringJoiner(", ");
+        String details = super.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
+            joiner.add(details);
+        }
+        joiner.add(getUnitTonnage() + " tons")
+              .add(getDocks() + " collars");
+        return joiner.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/KFHeliumTank.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFHeliumTank.java
@@ -1,20 +1,20 @@
 /*
  * KFHeliumTank.java
- * 
+ *
  * Copyright (c) 2019, The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -42,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class KFHeliumTank extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 5737177123881418170L;
 
@@ -94,15 +95,15 @@ public class KFHeliumTank extends Part {
                     hits = 0;
                 }
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time;
         if(isSalvaging()) {
@@ -216,7 +217,7 @@ public class KFHeliumTank extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof KFHeliumTank 
+        return part instanceof KFHeliumTank
                 && coreType == ((KFHeliumTank)part).getCoreType()
                 && docks == ((KFHeliumTank)part).getDocks();
     }
@@ -240,7 +241,7 @@ public class KFHeliumTank extends Part {
         NodeList nl = wn.getChildNodes();
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            
+
             if (wn2.getNodeName().equalsIgnoreCase("coreType")) {
                 coreType = Integer.parseInt(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("docks")) {
@@ -251,9 +252,19 @@ public class KFHeliumTank extends Part {
 
     @Override
     public String getDetails() {
-        return super.getDetails() 
-                + ", " + getUnitTonnage() + " tons" 
-                + ", " + getDocks() + " collars";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringJoiner joiner = new StringJoiner(", ");
+        String details = super.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
+            joiner.add(details);
+        }
+        joiner.add(getUnitTonnage() + " tons")
+              .add(getDocks() + " collars");
+        return joiner.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/LFBattery.java
+++ b/MekHQ/src/mekhq/campaign/parts/LFBattery.java
@@ -1,20 +1,20 @@
 /*
  * LFBattery.java
- * 
+ *
  * Copyright (c) 2019, The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -42,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class LFBattery extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 6590685996383689912L;
 
@@ -95,15 +96,15 @@ public class LFBattery extends Part {
                     hits = 0;
                 }
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time;
         if(isSalvaging()) {
@@ -200,7 +201,7 @@ public class LFBattery extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof LFBattery 
+        return part instanceof LFBattery
                 && coreType == ((LFBattery)part).getCoreType()
                 && docks == ((LFBattery)part).getDocks();
     }
@@ -235,9 +236,19 @@ public class LFBattery extends Part {
 
     @Override
     public String getDetails() {
-        return super.getDetails() 
-                + ", " + getUnitTonnage() + " tons" 
-                + ", " + getDocks() + " collars";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringJoiner joiner = new StringJoiner(", ");
+        String details = super.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
+            joiner.add(details);
+        }
+        joiner.add(getUnitTonnage() + " tons")
+              .add(getDocks() + " collars");
+        return joiner.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekActuator.java
@@ -1,20 +1,20 @@
 /*
  * MekActuator.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,6 +25,8 @@ import java.io.PrintWriter;
 import java.util.StringJoiner;
 
 import mekhq.campaign.finances.Money;
+
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -247,12 +249,17 @@ public class MekActuator extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if (null != unit) {
             StringJoiner sj = new StringJoiner(", ");
-            if (getLocationName() != null) {
+            if (!StringUtils.isEmpty(getLocationName())) {
                 sj.add(getLocationName());
             }
-            if (campaign.getCampaignOptions().payForRepairs()) {
+            if (includeRepairDetails && campaign.getCampaignOptions().payForRepairs()) {
                 Money repairCost = getStickerPrice().multipliedBy(0.2);
                 sj.add(repairCost.toAmountAndSymbolString() + " to repair");
             }
@@ -321,7 +328,7 @@ public class MekActuator extends Part {
 
     @Override
     public String getLocationName() {
-        return unit.getEntity().getLocationName(location);
+        return unit != null ? unit.getEntity().getLocationName(location) : null;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -22,6 +22,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -494,34 +495,40 @@ public class MekLocation extends Part {
 
 	@Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
 	    String toReturn = "";
 		if(null != unit) {
-			toReturn = unit.getEntity().getLocationName(loc);
-			if(isBlownOff()) {
-				toReturn += " (Blown Off)";
-			} else if(isBreached()) {
-				toReturn += " (Breached)";
-			} else {
-				toReturn += " (" + Math.round(100*percent) + "%)";
-			}
+            toReturn = unit.getEntity().getLocationName(loc);
+            if (includeRepairDetails) {
+                if(isBlownOff()) {
+                    toReturn += " (Blown Off)";
+                } else if(isBreached()) {
+                    toReturn += " (Breached)";
+                } else {
+                    toReturn += " (" + Math.round(100*percent) + "%)";
+                }
+            }
 			return toReturn;
 		}
-		toReturn += getUnitTonnage() + " tons" + " (" + Math.round(100*percent) + "%)";
+        toReturn += getUnitTonnage() + " tons";
+        if (includeRepairDetails) {
+            toReturn += " (" + Math.round(100*percent) + "%)";
+        }
 		if(loc == Mech.LOC_HEAD) {
-		    String components = "";
+		    StringJoiner components = new StringJoiner(", ");
     		if(hasSensors()) {
-                components += "Sensors";
+                components.add("Sensors");
             }
             if(hasLifeSupport()) {
-                if(components.length() > 0) {
-                    components += ", ";
-                }
-                components += "Life Support";
+                components.add("Life Support");
             }
             if(components.length() > 0) {
-                components = " [" + components + "]";
+                toReturn += " [" + components.toString() + "]";
             }
-            toReturn += components;
 		}
 		return toReturn;
     }

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -224,7 +224,16 @@ public class MekSensor extends Part {
 
     @Override
     public String getDetails() {
-        return super.getDetails() + ", " + getUnitTonnage() + " tons";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        String details = super.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
+            details += ", ";
+        }
+        return  details + getUnitTonnage() + " tons";
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -294,12 +294,17 @@ public class MissingBattleArmorSuit extends MissingPart {
 
 	@Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
     	if(null == unit) {
-    		return super.getDetails();
+    		return super.getDetails(includeRepairDetails);
 
         }
     	String toReturn = unit.getEntity().getLocationName(trooper) + "<br>";
-		return toReturn + super.getDetails();
+		return toReturn + super.getDetails(includeRepairDetails);
     }
 
 	@Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
@@ -1,20 +1,20 @@
 /*
  * MissingMekActuator.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,15 +45,15 @@ public class MissingMekActuator extends MissingPart {
 	public MissingMekActuator() {
 		this(0, 0, null);
 	}
-	
+
     public int getType() {
         return type;
     }
-    
+
     public MissingMekActuator(int tonnage, int type, Campaign c) {
         this(tonnage, type, -1, c);
     }
-    
+
     public MissingMekActuator(int tonnage, int type, int loc, Campaign c) {
     	super(tonnage, c);
         this.type = type;
@@ -61,12 +61,12 @@ public class MissingMekActuator extends MissingPart {
         this.name = m.getSystemName(type) + " Actuator" ;
         this.location = loc;
     }
-    
-    @Override 
+
+    @Override
 	public int getBaseTime() {
 		return isOmniPodded()? 30 : 90;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return -3;
@@ -78,11 +78,11 @@ public class MissingMekActuator extends MissingPart {
     	//apparently nothing
     	return 0;
     }
-    
+
     public int getLocation() {
     	return location;
     }
-    
+
 	@Override
 	public void writeToXml(PrintWriter pw1, int indent) {
 		writeToXmlBegin(pw1, indent);
@@ -100,19 +100,19 @@ public class MissingMekActuator extends MissingPart {
 	@Override
 	protected void loadFieldsFromXmlNode(Node wn) {
 		NodeList nl = wn.getChildNodes();
-		
+
 		for (int x=0; x<nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
-			
+
 			if (wn2.getNodeName().equalsIgnoreCase("type")) {
 				type = Integer.parseInt(wn2.getTextContent());
 			} else if (wn2.getNodeName().equalsIgnoreCase("location")) {
 				location = Integer.parseInt(wn2.getTextContent());
-			} 
+			}
 		}
 	}
 
-	@Override 
+	@Override
 	public void fix() {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
@@ -122,11 +122,11 @@ public class MissingMekActuator extends MissingPart {
 			replacement.decrementQuantity();
 			((MekActuator)actualReplacement).setLocation(location);
 			remove(false);
-			//assign the replacement part to the unit			
+			//assign the replacement part to the unit
 			actualReplacement.updateConditionFromPart();
 		}
 	}
-	
+
 	@Override
 	public boolean isAcceptableReplacement(Part part, boolean refit) {
 		if(part instanceof MekActuator) {
@@ -135,7 +135,7 @@ public class MissingMekActuator extends MissingPart {
 		}
 		return false;
 	}
-	
+
 	@Override
 	public String checkFixable() {
 		if(null == unit) {
@@ -149,7 +149,7 @@ public class MissingMekActuator extends MissingPart {
 		}
 		return null;
 	}
-	
+
 	@Override
 	public boolean onBadHipOrShoulder() {
 		return null != unit && unit.hasBadHipOrShoulder(location);
@@ -166,12 +166,12 @@ public class MissingMekActuator extends MissingPart {
 			unit.destroySystem(CriticalSlot.TYPE_SYSTEM, type, location);
 		}
 	}
-	
+
 	@Override
 	public boolean isOmniPoddable() {
 		return type == Mech.ACTUATOR_LOWER_ARM || type == Mech.ACTUATOR_HAND;
 	}
-	
+
 	@Override
 	public boolean isOmniPodded() {
 	    return isOmniPoddable() && getUnit() != null && getUnit().getEntity().isOmni();
@@ -179,14 +179,14 @@ public class MissingMekActuator extends MissingPart {
 
 	@Override
 	public String getLocationName() {
-		return unit.getEntity().getLocationName(location);
+		return unit != null ? unit.getEntity().getLocationName(location) : null;
 	}
-	
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return (getUnitTonnage() <= 100)? MekActuator.TA_STANDARD : MekActuator.TA_SUPERHEAVY;
     }
-    	
+
 	@Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ACTUATOR;

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -349,7 +349,7 @@ public class MissingMekLocation extends MissingPart {
 
 	@Override
 	public String getLocationName() {
-		return unit.getEntity().getLocationName(loc);
+		return unit != null ? unit.getEntity().getLocationName(loc) : null;
 	}
 
 	@Override
@@ -361,13 +361,13 @@ public class MissingMekLocation extends MissingPart {
     public TechAdvancement getTechAdvancement() {
         return EquipmentType.getStructureTechAdvancement(structureType, clan);
     }
-    
-	
+
+
 	@Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.GENERAL_LOCATION;
     }
-	
+
 	@Override
 	public int getRepairPartType() {
     	return Part.REPAIR_PART_TYPE.MEK_LOCATION;

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -1,20 +1,20 @@
 /*
  * MissingPart.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,50 +44,50 @@ import mekhq.campaign.work.WorkTime;
 public abstract class MissingPart extends Part implements Serializable, MekHqXmlSerializable, IPartWork, IAcquisitionWork {
 
 	/**
-	 * 
+	 *
 	 */
-	private static final long serialVersionUID = 300672661487966982L;	
-	
+	private static final long serialVersionUID = 300672661487966982L;
+
 	public MissingPart(int tonnage, Campaign c) {
 	    super(tonnage, false, c);
 	}
-	
+
 	public MissingPart(int tonnage, boolean isOmniPodded, Campaign c) {
 		super(tonnage, isOmniPodded, c);
 	}
-	
+
 	public MissingPart clone() {
 		//should never be called
 		return null;
 	}
-	
+
 	@Override
 	public Money getStickerPrice() {
 		//missing parts aren't worth a thing
 		return Money.zero();
 	}
-	
+
 	@Override
 	public Money getBuyCost() {
 	    return getNewPart().getStickerPrice();
 	}
-	
+
 	@Override
 	public boolean isSalvaging() {
 		return false;
 	}
-	
+
 	@Override
 	public String getStatus() {
 		return "Destroyed";
 	}
-	
-	@Override 
+
+	@Override
 	public boolean isSamePartType(Part part) {
 		//missing parts should always return false
 		return false;
 	}
-	
+
 	public String getDesc() {
 		String bonus = getAllMods(null).getValueAsString();
 		if (getAllMods(null).getValue() > -1) {
@@ -99,7 +99,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		if (getTeamId() != null) {
 			scheduled = " (scheduled) ";
 		}
-	
+
 		//if (this instanceof ReplacementItem
 		//		&& !((ReplacementItem) this).hasPart()) {
 		//	toReturn += " color='white'";
@@ -122,14 +122,14 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		toReturn += "</font></html>";
 		return toReturn;
 	}
-	
+
 	@Override
-	public String succeed() {	
+	public String succeed() {
 		fix();
 		return " <font color='green'><b> replaced.</b></font>";
 	}
-	
-	@Override 
+
+	@Override
 	public void fix() {
 		Part replacement = findReplacement(false);
 		if(null != replacement) {
@@ -138,11 +138,11 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 			campaign.addPart(actualReplacement, 0);
 			replacement.decrementQuantity();
 			remove(false);
-			//assign the replacement part to the unit			
+			//assign the replacement part to the unit
 			actualReplacement.updateConditionFromPart();
 		}
 	}
-	
+
 	@Override
 	public void remove(boolean salvage) {
 		campaign.removePart(this);
@@ -155,11 +155,11 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		    parentPart.removeChildPart(this.getId());
 		}
 	}
-	
+
 	public abstract boolean isAcceptableReplacement(Part part, boolean refit);
-	
+
 	public Part findReplacement(boolean refit) {
-		Part bestPart = null;	
+		Part bestPart = null;
 
 		//check to see if we already have a replacement assigned
 		if(replacementId > -1) {
@@ -173,7 +173,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 			if(part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart()) {
 				continue;
 			}
-			
+
 			if(isAcceptableReplacement(part, refit)) {
 				if(null == bestPart) {
 					bestPart = part;
@@ -184,13 +184,18 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		}
 		return bestPart;
 	}
-	
+
 	public boolean isReplacementAvailable() {
 		return null != findReplacement(false);
 	}
 
 	@Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
 		if(isReplacementAvailable()) {
 			return "Replacement part available";
 		} else {
@@ -198,7 +203,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 			return "<font color='red'>No replacement (" + inventories.getTransitOrderedDetails() + ")</font>";
 		}
     }
-	
+
 	@Override
 	public boolean needsFixing() {
 		//missing parts always need fixing
@@ -207,18 +212,18 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		}
 		return false;
 	}
-	
+
 	@Override
 	public MissingPart getMissingPart() {
 		//do nothing - this should never be accessed
 		return null;
 	}
-	
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		//do nothing
 	}
-	
+
 	@Override
 	public String fail(int rating) {
 		skillMin = ++rating;
@@ -235,15 +240,15 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 			return " <font color='red'><b> failed.</b></font>";
 		}
 	}
-	
+
 	@Override
 	public boolean canChangeWorkMode() {
 	    return !isOmniPodded();
 	}
-	
+
 	@Override
 	public TargetRoll getAllAcquisitionMods() {
-        TargetRoll target = new TargetRoll();   
+        TargetRoll target = new TargetRoll();
         if(getTechBase() == T_CLAN && campaign.getCampaignOptions().getClanAcquisitionPenalty() > 0) {
             target.addModifier(campaign.getCampaignOptions().getClanAcquisitionPenalty(), "clan-tech");
         }
@@ -260,14 +265,14 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
         int avail = getAvailability();
         int availabilityMod = Availability.getAvailabilityModifier(avail);
         target.addModifier(availabilityMod, "availability (" + ITechnology.getRatingName(avail) + ")");
-        
+
         return target;
     }
-	
+
 	@Override
 	public String getAcquisitionDesc() {
 		String toReturn = "<html><font size='2'";
-		
+
 		toReturn += ">";
 		toReturn += "<b>" + getAcquisitionDisplayName() + "</b> " + getAcquisitionBonus() + "<br/>";
 		PartInventory inventories = campaign.getPartInventory(getNewPart());
@@ -276,7 +281,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		    Part newPart = getAcquisitionPart();
 		    newPart.setOmniPodded(true);
 		    inventories = campaign.getPartInventory(newPart);
-		    if (inventories.getSupply() > 0) { 
+		    if (inventories.getSupply() > 0) {
 		        toReturn += ", " + inventories.supplyAsString() + " OmniPod";
 		    }
 		}
@@ -285,11 +290,11 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		toReturn += "</font></html>";
 		return toReturn;
 	}
-	
+
     @Override
     public String getAcquisitionDisplayName() {
     	return getAcquisitionName();
-    }    
+    }
 
 	@Override
 	public String getAcquisitionExtraDesc() {
@@ -322,19 +327,19 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		    return "<font color='red'><b> You cannot afford this part. Transaction cancelled</b>.</font>";
 		}
 	}
-	
+
 	@Override
 	public Object getNewEquipment() {
 	    return getNewPart();
 	}
-	
+
 	public abstract Part getNewPart();
-	
+
 	@Override
 	public String failToFind() {
 		return "<font color='red'><b> part not found</b>.</font>";
 	}
-	
+
 	@Override
 	public void writeToXmlBegin(PrintWriter pw1, int indent) {
 		super.writeToXmlBegin(pw1, indent);
@@ -347,13 +352,13 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 				+replacementId
 				+"</replacementId>");
 	}
-	
+
 	@Override
 	public void writeToXml(PrintWriter pw1, int indent) {
 		writeToXmlBegin(pw1, indent);
 		writeToXmlEnd(pw1, indent);
 	}
-	
+
 	@Override
 	public String checkScrappable() {
 		if(!isReplacementAvailable()) {
@@ -361,7 +366,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		}
 		return null;
 	}
-	
+
 	@Override
 	public String scrap() {
 		Part replace = findReplacement(false);
@@ -371,24 +376,24 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		skillMin = SkillType.EXP_GREEN;
 		return replace.getName() + " scrapped.";
 	}
-	
+
 	@Override
 	public String getAcquisitionName() {
 	    String details = getNewPart().getDetails();
 	    details = details.replaceFirst("\\d+\\shit\\(s\\)", "");
 		return getPartName() + " " + details;
 	}
-	
+
 	@Override
 	public int getTechLevel() {
 		return getNewPart().getTechLevel();
 	}
-	
+
 	@Override
 	public void reservePart() {
 		//this is being set as an overnight repair, so
-		//we also need to reserve the replacement. If the 
-		//quantity of the replacement is more than one, we will 
+		//we also need to reserve the replacement. If the
+		//quantity of the replacement is more than one, we will
 		//also need to split off a separate one
 		//shouldn't be null, but it never hurts to check
 		Part replacement = findReplacement(false);
@@ -406,7 +411,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 			}
 		}
 	}
-	
+
 	@Override
 	public void cancelReservation() {
 		Part replacement = findReplacement(false);
@@ -422,7 +427,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 			}
 		}
 	}
-	
+
 	@Override
 	public boolean needsMaintenance() {
         return false;

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
@@ -1,20 +1,20 @@
 /*
  * MissingProtomekActuator.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -43,43 +43,43 @@ public class MissingProtomekArmActuator extends MissingPart {
     public MissingProtomekArmActuator() {
         this(0, 0, null);
     }
-    
+
     public MissingProtomekArmActuator(int tonnage, Campaign c) {
         this(tonnage, -1, c);
     }
-    
+
     public MissingProtomekArmActuator(int tonnage, int loc, Campaign c) {
         super(tonnage, c);
         this.name = "Protomech Arm Actuator";
         this.location = loc;
     }
-    
-    @Override 
+
+    @Override
 	public int getBaseTime() {
 		return 120;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return 0;
 	}
-    
+
     public void setLocation(int loc) {
         this.location = loc;
     }
-    
-   
+
+
     @Override
     public double getTonnage() {
         //TODO: how much do actuators weight?
         //apparently nothing
         return 0;
     }
-    
+
     public int getLocation() {
         return location;
     }
-    
+
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
@@ -93,13 +93,13 @@ public class MissingProtomekArmActuator extends MissingPart {
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
         NodeList nl = wn.getChildNodes();
-        
+
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            
+
             if (wn2.getNodeName().equalsIgnoreCase("location")) {
                 location = Integer.parseInt(wn2.getTextContent());
-            } 
+            }
         }
     }
 
@@ -124,7 +124,7 @@ public class MissingProtomekArmActuator extends MissingPart {
         return null;
     }
 
-    @Override 
+    @Override
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
@@ -134,11 +134,11 @@ public class MissingProtomekArmActuator extends MissingPart {
             replacement.decrementQuantity();
             ((ProtomekArmActuator)actualReplacement).setLocation(location);
             remove(false);
-            //assign the replacement part to the unit           
+            //assign the replacement part to the unit
             actualReplacement.updateConditionFromPart();
         }
     }
-    
+
     @Override
     public boolean isAcceptableReplacement(Part part, boolean refit) {
         return part instanceof ProtomekArmActuator
@@ -152,14 +152,14 @@ public class MissingProtomekArmActuator extends MissingPart {
 
 	@Override
 	public String getLocationName() {
-		return unit.getEntity().getLocationName(location);
+		return unit != null ? unit.getEntity().getLocationName(location) : null;
 	}
-	
+
 	@Override
 	public TechAdvancement getTechAdvancement() {
 	    return ProtomekLocation.TECH_ADVANCEMENT;
 	}
-	
+
 	@Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ACTUATOR;

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLegActuator.java
@@ -122,7 +122,7 @@ public class MissingProtomekLegActuator extends MissingPart {
 
     @Override
    	public String getLocationName() {
-   		return unit.getEntity().getLocationName(getLocation());
+   		return unit != null ? unit.getEntity().getLocationName(getLocation()) : null;
    	}
 
 	@Override
@@ -134,7 +134,7 @@ public class MissingProtomekLegActuator extends MissingPart {
     public TechAdvancement getTechAdvancement() {
         return ProtomekLocation.TECH_ADVANCEMENT;
     }
-	
+
 	@Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ACTUATOR;

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekLocation.java
@@ -259,7 +259,7 @@ public class MissingProtomekLocation extends MissingPart {
 
     @Override
    	public String getLocationName() {
-   		return unit.getEntity().getLocationName(getLocation());
+   		return unit != null ? unit.getEntity().getLocationName(getLocation()) : null;
    	}
 
 	@Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekSensor.java
@@ -122,7 +122,7 @@ public class MissingProtomekSensor extends MissingPart {
 
     @Override
    	public String getLocationName() {
-   		return unit.getEntity().getLocationName(getLocation());
+   		return unit != null ? unit.getEntity().getLocationName(getLocation()) : null;
    	}
 
 	@Override
@@ -134,7 +134,7 @@ public class MissingProtomekSensor extends MissingPart {
     public TechAdvancement getTechAdvancement() {
         return ProtomekLocation.TECH_ADVANCEMENT;
     }
-    
+
     @Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ELECTRONICS;

--- a/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
@@ -1,20 +1,20 @@
 /*
  * MissingVeeStabiliser.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -38,31 +38,31 @@ import mekhq.campaign.Campaign;
 public class MissingVeeStabiliser extends MissingPart {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 2806921577150714477L;
 	private int loc;
-	
+
 	public MissingVeeStabiliser() {
     	this(0, 0, null);
     }
-    
+
     public MissingVeeStabiliser(int tonnage, int loc, Campaign c) {
     	super(0, c);
     	this.name = "Vehicle Stabiliser";
     	this.loc = loc;
     }
-    
-    @Override 
+
+    @Override
 	public int getBaseTime() {
 		return 60;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return 0;
 	}
-    
+
 	@Override
 	public String checkFixable() {
 		return null;
@@ -96,17 +96,17 @@ public class MissingVeeStabiliser extends MissingPart {
 	@Override
 	protected void loadFieldsFromXmlNode(Node wn) {
 		NodeList nl = wn.getChildNodes();
-		
+
 		for (int x=0; x<nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
-			
+
 			if (wn2.getNodeName().equalsIgnoreCase("loc")) {
 				loc = Integer.parseInt(wn2.getTextContent());
 			}
 		}
 	}
-	
-	@Override 
+
+	@Override
 	public void fix() {
 		VeeStabiliser replacement = (VeeStabiliser)findReplacement(false);
 		if(null != replacement) {
@@ -116,11 +116,11 @@ public class MissingVeeStabiliser extends MissingPart {
 			replacement.decrementQuantity();
 			actualReplacement.setLocation(loc);
 			remove(false);
-			//assign the replacement part to the unit			
+			//assign the replacement part to the unit
 			actualReplacement.updateConditionFromPart();
 		}
 	}
-	
+
 	public int getLocation() {
 		return loc;
 	}
@@ -134,13 +134,13 @@ public class MissingVeeStabiliser extends MissingPart {
 
 	@Override
 	public String getLocationName() {
-		return unit.getEntity().getLocationName(loc);
+		return unit != null ? unit.getEntity().getLocationName(loc) : null;
 	}
-	
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return TankLocation.TECH_ADVANCEMENT;
     }
-	
-	
+
+
 }

--- a/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
@@ -1,20 +1,20 @@
 /*
  * MotiveSystem.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -40,40 +40,40 @@ import mekhq.campaign.Campaign;
 public class MotiveSystem extends Part {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -5637743997294510810L;
 
 	int damage;
 	int penalty;
-	
+
 	public MotiveSystem() {
 		this(0, null);
 	}
-	
+
 	public MotiveSystem(int ton, Campaign c) {
 		super(ton, c);
 		this.name = "Motive System";
 		this.damage = 0;
 		this.penalty = 0;
 	}
-	
-	@Override 
+
+	@Override
 	public int getBaseTime() {
 		return 60;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return -1;
 	}
-	
+
 	public MotiveSystem clone() {
 		MotiveSystem clone = new MotiveSystem(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
         return clone;
 	}
-	
+
 	@Override
 	public int getBaseAvailability(int era) {
 		return RATING_B;
@@ -84,7 +84,7 @@ public class MotiveSystem extends Part {
 		// TODO Auto-generated method stub
 		return Money.zero();
 	}
-	
+
 	@Override
 	public double getTonnage() {
 		// TODO Auto-generated method stub
@@ -99,17 +99,17 @@ public class MotiveSystem extends Part {
 	@Override
 	protected void loadFieldsFromXmlNode(Node wn) {
 		NodeList nl = wn.getChildNodes();
-		
+
 		for (int x=0; x<nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
-			
+
 			if (wn2.getNodeName().equalsIgnoreCase("damage")) {
 				damage = Integer.parseInt(wn2.getTextContent());
 			} else if (wn2.getNodeName().equalsIgnoreCase("penalty")) {
 				penalty = Integer.parseInt(wn2.getTextContent());
-			} 
+			}
 		}
-		
+
 	}
 
 	@Override
@@ -124,7 +124,7 @@ public class MotiveSystem extends Part {
 				+penalty
 				+"</penalty>");
 		writeToXmlEnd(pw1, indent);
-		
+
 	}
 
 	@Override
@@ -152,12 +152,12 @@ public class MotiveSystem extends Part {
 	@Override
 	public void remove(boolean salvage) {
 		// you can't do this so nothing here
-		
+
 	}
 
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
-		//motive systems don't have to check for destruction since they 
+		//motive systems don't have to check for destruction since they
 		//cannot be removed
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			Tank t = (Tank)unit.getEntity();
@@ -176,17 +176,26 @@ public class MotiveSystem extends Part {
 	public boolean needsFixing() {
 		return damage > 0 || penalty > 0;
 	}
-	
+
 	@Override
     public String getDetails() {
-        return "-" + damage + " MP/-" + penalty + " Piloting";
+        return getDetails(true);
     }
-	
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        if (includeRepairDetails) {
+            return "-" + damage + " MP/-" + penalty + " Piloting";
+        } else {
+            return super.getDetails(includeRepairDetails);
+        }
+    }
+
 	@Override
 	public String checkScrappable() {
 		return "Motive type cannot be scrapped";
 	}
-	
+
 	@Override
 	public boolean canNeverScrap() {
 		return true;
@@ -207,7 +216,7 @@ public class MotiveSystem extends Part {
 	public int getLocation() {
 		return Entity.LOC_NONE;
 	}
-	
+
 	@Override
 	public TechAdvancement getTechAdvancement() {
 	    return TankLocation.TECH_ADVANCEMENT;

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (C) 2017 MegaMek team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,17 +44,17 @@ import mekhq.campaign.personnel.SkillType;
 /**
  * An empty omnipod, which can be purchased or created when equipment is removed from a pod.
  * When fixed, the omnipod is removed from the warehouse and one replacement part is podded.
- * 
+ *
  * @author Neoancient
  *
  */
 public class OmniPod extends Part {
 
     private static final long serialVersionUID = -8236359530423260992L;
-    
+
     // Pods are specific to the type of equipment they contain.
     private Part partType;
-    
+
     public OmniPod() {
         this(new EquipmentPart(), null);
     }
@@ -67,7 +67,7 @@ public class OmniPod extends Part {
         }
         name = "OmniPod";
     }
-    
+
     @Override
     public void setCampaign(Campaign c) {
         super.setCampaign(c);
@@ -76,14 +76,19 @@ public class OmniPod extends Part {
 
     @Override
     public String getDetails() {
-        String details = partType.getDetails().replaceAll("\\d+ hit\\(s\\)(,\\s)?", "");
-        if (details.length() > 0) {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        String details = partType.getDetails(includeRepairDetails);
+        if (!details.isEmpty()) {
             return partType.getName() + " (" + details + ")";
         } else {
             return partType.getName();
         }
     }
-    
+
     @Override
     public int getBaseTime() {
         return partType.getMissingPart().getBaseTime();
@@ -122,7 +127,7 @@ public class OmniPod extends Part {
             return "Part not available";
         }
     }
-    
+
     //Weight is negligible
     @Override
     public double getTonnage() {
@@ -134,7 +139,7 @@ public class OmniPod extends Part {
     public int getTechRating() {
         return EquipmentType.RATING_E;
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return Entity.getOmniAdvancement();
@@ -229,7 +234,7 @@ public class OmniPod extends Part {
     public boolean needsFixing() {
         return true;
     }
-    
+
     @Override
     public void fix() {
         Part newPart = partType.clone();
@@ -240,8 +245,8 @@ public class OmniPod extends Part {
             oldPart.decrementQuantity();
         }
     }
-    
-    
+
+
     @Override
     public String fail(int rating) {
         skillMin = ++rating;
@@ -250,12 +255,12 @@ public class OmniPod extends Part {
         if(skillMin > SkillType.EXP_ELITE) {
             return " <font color='red'><b> failed and part destroyed.</b></font>";
         } else {
-            //OmniPod is only added back to warehouse if repair fails without destroying part. 
+            //OmniPod is only added back to warehouse if repair fails without destroying part.
             campaign.addPart(this, 0);
             return " <font color='red'><b> failed.</b></font>";
         }
     }
-    
+
     @Override
     public String getStatus() {
         String toReturn = "Empty";
@@ -301,7 +306,7 @@ public class OmniPod extends Part {
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         final String METHOD_NAME = "writeToXml(PrintWriter,int)"; //$NON-NLS-1$
-        
+
         writeToXmlBegin(pw1, indent);
         pw1.print(MekHqXmlUtil.indentStr(indent + 1) + "<partType tonnage='" + partType.getUnitTonnage()
             + "' type='");

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -30,6 +30,8 @@ import java.util.StringJoiner;
 import java.util.UUID;
 
 import mekhq.campaign.finances.Money;
+
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -1125,7 +1127,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     @Override
     public String getDetails(boolean includeRepairDetails) {
         StringJoiner sj = new StringJoiner(", ");
-        if (getLocationName() != null) {
+        if (!StringUtils.isEmpty(getLocationName())) {
             sj.add(getLocationName());
         }
         if (isOmniPodded()) {

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
@@ -1,20 +1,20 @@
 /*
  * ProtomekActuator.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -42,41 +42,41 @@ import mekhq.campaign.personnel.SkillType;
  */
 public class ProtomekArmActuator extends Part {
     private static final long serialVersionUID = 719878556021696393L;
-    
+
     protected int location;
-    
+
     public ProtomekArmActuator() {
         this(0, 0, null);
     }
-    
+
     public ProtomekArmActuator clone() {
         ProtomekArmActuator clone = new ProtomekArmActuator(getUnitTonnage(), location, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     public ProtomekArmActuator(int tonnage, Campaign c) {
         this(tonnage, -1, c);
     }
-    
+
     public ProtomekArmActuator(int tonnage, int loc, Campaign c) {
         super(tonnage, c);
         this.name = "Protomech Arm Actuator";
         this.location = loc;
     }
-    
+
     public void setLocation(int loc) {
         this.location = loc;
     }
-    
-   
+
+
     @Override
     public double getTonnage() {
         //TODO: how much do actuators weight?
         //apparently nothing
         return 0;
     }
-    
+
     @Override
     public Money getStickerPrice() {
         return Money.of(getUnitTonnage() * 180);
@@ -87,11 +87,11 @@ public class ProtomekArmActuator extends Part {
         return part instanceof ProtomekArmActuator
                 && getUnitTonnage() == ((ProtomekArmActuator)part).getUnitTonnage();
     }
-    
+
     public int getLocation() {
         return location;
     }
-    
+
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
@@ -105,13 +105,13 @@ public class ProtomekArmActuator extends Part {
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
         NodeList nl = wn.getChildNodes();
-        
+
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            
+
             if (wn2.getNodeName().equalsIgnoreCase("location")) {
                 location = Integer.parseInt(wn2.getTextContent());
-            } 
+            }
         }
     }
 
@@ -122,12 +122,12 @@ public class ProtomekArmActuator extends Part {
             unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_ARMCRIT, location);
         }
     }
-    
+
     @Override
     public int getTechBase() {
         return T_CLAN;
     }
-    
+
     @Override
     public int getTechLevel() {
         return TechConstants.T_CLAN_TW;
@@ -154,7 +154,7 @@ public class ProtomekArmActuator extends Part {
             Part missing = getMissingPart();
             unit.addPart(missing);
             campaign.addPart(missing, 0);
-        }   
+        }
         setUnit(null);
         updateConditionFromEntity(false);
         location = -1;
@@ -162,25 +162,25 @@ public class ProtomekArmActuator extends Part {
 
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
-        if(null != unit) {      
+        if(null != unit) {
         	int priorHits = hits;
             hits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_ARMCRIT, location);
-            if(checkForDestruction 
-					&& hits > priorHits 
+            if(checkForDestruction
+					&& hits > priorHits
 					&& Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
 				remove(false);
 			}
         }
     }
-    
-    @Override 
+
+    @Override
 	public int getBaseTime() {
 		if(isSalvaging()) {
 			return 120;
 		}
         if(hits <= 1) {
             return 100;
-        } 
+        }
         else if(hits == 2) {
             return 150;
         }
@@ -188,7 +188,7 @@ public class ProtomekArmActuator extends Part {
         	return 200;
         }
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		if(isSalvaging()) {
@@ -196,7 +196,7 @@ public class ProtomekArmActuator extends Part {
 		}
 		if(hits <= 1) {
             return 0;
-        } 
+        }
         else if(hits == 2) {
             return 1;
         }
@@ -209,9 +209,14 @@ public class ProtomekArmActuator extends Part {
     public boolean needsFixing() {
         return hits > 0;
     }
-    
+
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             return unit.getEntity().getLocationName(location);
         }
@@ -226,9 +231,9 @@ public class ProtomekArmActuator extends Part {
             } else {
                 unit.repairSystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_ARMCRIT, location);
             }
-        }   
+        }
     }
-    
+
     @Override
     public String checkFixable() {
     	if(null == unit) {
@@ -245,27 +250,27 @@ public class ProtomekArmActuator extends Part {
         }
         return null;
     }
-    
+
     @Override
     public boolean isMountedOnDestroyedLocation() {
         return null != unit && unit.isLocationDestroyed(location);
     }
-    
+
     @Override
     public boolean onBadHipOrShoulder() {
         return false;
     }
-    
+
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
         return false;//index == type && loc == location;
     }
-    
+
     @Override
     public boolean isRightTechType(String skillType) {
         return skillType.equals(SkillType.S_TECH_MECH);
     }
-    
+
     @Override
     public boolean isOmniPoddable() {
         return false;
@@ -273,14 +278,14 @@ public class ProtomekArmActuator extends Part {
 
 	@Override
 	public String getLocationName() {
-		return unit.getEntity().getLocationName(location);
+		return unit != null ? unit.getEntity().getLocationName(location) : null;
 	}
-	
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return ProtomekLocation.TECH_ADVANCEMENT;
     }
-    
+
     @Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ACTUATOR;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
@@ -41,7 +41,7 @@ import mekhq.campaign.personnel.SkillType;
  */
 public class ProtomekJumpJet extends Part {
     private static final long serialVersionUID = 719878556021696393L;
-    
+
     static final TechAdvancement TECH_ADVANCEMENT = new TechAdvancement(TECH_BASE_CLAN)
             .setClanAdvancement(3055,3060,3060).setClanApproximate(true, false, false)
             .setPrototypeFactions(F_CSJ).setProductionFactions(F_CSJ)
@@ -196,6 +196,11 @@ public class ProtomekJumpJet extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             return unit.getEntity().getLocationName(Protomech.LOC_TORSO);
         }
@@ -285,14 +290,14 @@ public class ProtomekJumpJet extends Part {
 
     @Override
    	public String getLocationName() {
-   		return unit.getEntity().getLocationName(getLocation());
+   		return unit != null ? unit.getEntity().getLocationName(getLocation()) : null;
    	}
 
 	@Override
 	public int getLocation() {
 		return Protomech.LOC_TORSO;
 	}
-	
+
 	@Override
 	public TechAdvancement getTechAdvancement() {
 	    return TECH_ADVANCEMENT;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
@@ -177,6 +177,11 @@ public class ProtomekLegActuator extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             return unit.getEntity().getLocationName(Protomech.LOC_LEG);
         }
@@ -244,7 +249,7 @@ public class ProtomekLegActuator extends Part {
 
     @Override
    	public String getLocationName() {
-   		return unit.getEntity().getLocationName(getLocation());
+   		return unit != null ? unit.getEntity().getLocationName(getLocation()) : null;
    	}
 
 	@Override
@@ -256,7 +261,7 @@ public class ProtomekLegActuator extends Part {
     public TechAdvancement getTechAdvancement() {
         return ProtomekLocation.TECH_ADVANCEMENT;
     }
-    
+
     @Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ACTUATOR;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
@@ -53,7 +53,7 @@ public class ProtomekLocation extends Part {
             .setPrototypeFactions(F_CSJ).setProductionFactions(F_CSJ)
             .setTechRating(RATING_D).setAvailability(RATING_X, RATING_X, RATING_D, RATING_D)
             .setStaticTechLevel(SimpleTechLevel.STANDARD);
-    
+
     //some of these aren't used but may be later for advanced designs (i.e. WoR)
     protected int loc;
     protected int structureType;
@@ -405,19 +405,29 @@ public class ProtomekLocation extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         String toReturn = "";
         if(null != unit) {
             toReturn = unit.getEntity().getLocationName(loc);
-            if(isBlownOff()) {
-                toReturn += " (Blown Off)";
-            } else if(isBreached()) {
-                toReturn += " (Breached)";
-            } else {
-                toReturn += " (" + Math.round(100*percent) + "%)";
+            if (includeRepairDetails) {
+                if(isBlownOff()) {
+                    toReturn += " (Blown Off)";
+                } else if(isBreached()) {
+                    toReturn += " (Breached)";
+                } else {
+                    toReturn += " (" + Math.round(100*percent) + "%)";
+                }
             }
             return toReturn;
         }
-        toReturn += getUnitTonnage() + " tons" + " (" + Math.round(100*percent) + "%)";
+        toReturn += getUnitTonnage() + " tons";
+        if (includeRepairDetails) {
+            toReturn += " (" + Math.round(100*percent) + "%)";
+        }
         return toReturn;
     }
 
@@ -629,7 +639,7 @@ public class ProtomekLocation extends Part {
 
 	@Override
 	public String getLocationName() {
-		return unit.getEntity().getLocationName(loc);
+		return unit != null ? unit.getEntity().getLocationName(loc) : null;
 	}
 
 	@Override
@@ -641,12 +651,12 @@ public class ProtomekLocation extends Part {
 	public TechAdvancement getTechAdvancement() {
 	    return TECH_ADVANCEMENT;
 	}
-    
+
     @Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.GENERAL_LOCATION;
     }
-	
+
 	@Override
 	public int getRepairPartType() {
     	return Part.REPAIR_PART_TYPE.MEK_LOCATION;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
@@ -177,6 +177,11 @@ public class ProtomekSensor extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             return unit.getEntity().getLocationName(Protomech.LOC_HEAD);
         }
@@ -257,7 +262,7 @@ public class ProtomekSensor extends Part {
         // No separate listing for the sensors; using same TA as structural components
         return ProtomekLocation.TECH_ADVANCEMENT;
     }
-    
+
     @Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ELECTRONICS;

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1778,6 +1778,11 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         return "(" + getRefitClassName() + "/" + getTimeLeft() + " minutes/" + getCost().toAmountAndSymbolString() + ")";
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
+++ b/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
@@ -1,20 +1,20 @@
 /*
  * StructuralIntegrity.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -141,6 +141,11 @@ public class StructuralIntegrity extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             return pointsNeeded + " points destroyed";
         }
@@ -233,7 +238,7 @@ public class StructuralIntegrity extends Part {
         }
         return Entity.LOC_NONE;
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         if (null == getUnit()) {

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -1,20 +1,20 @@
 /*
  * TankLocation.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -60,7 +60,7 @@ public class TankLocation extends Part {
     public TankLocation() {
         this(0, 0, null);
     }
-    
+
     public TankLocation clone() {
         TankLocation clone = new TankLocation(loc, getUnitTonnage(), campaign);
         clone.copyBaseData(this);
@@ -69,11 +69,11 @@ public class TankLocation extends Part {
         clone.breached = this.breached;
         return clone;
     }
-    
+
     public int getLoc() {
         return loc;
     }
-    
+
     public TankLocation(int loc, int tonnage, Campaign c) {
         super(tonnage, c);
         this.loc = loc;
@@ -96,18 +96,18 @@ public class TankLocation extends Part {
         }
         computeCost();
     }
-    
+
     protected void computeCost () {
         //TODO: implement
     }
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof TankLocation 
+        return part instanceof TankLocation
                 && getLoc() == ((TankLocation)part).getLoc()
                 && getUnitTonnage() == ((TankLocation)part).getUnitTonnage();
-    }	
-    
+    }
+
     @Override
     public boolean isSameStatus(Part part) {
         return super.isSameStatus(part) && this.getDamage() == ((TankLocation)part).getDamage();
@@ -116,7 +116,7 @@ public class TankLocation extends Part {
     public int getDamage() {
         return damage;
     }
-    
+
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
@@ -238,10 +238,19 @@ public class TankLocation extends Part {
 
     @Override
     public String getDetails() {
-        if(isBreached()) {
-            return "Breached";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        if (includeRepairDetails) {
+            if(isBreached()) {
+                return "Breached";
+            } else {
+                return  damage + " point(s) of damage";
+            }
         } else {
-            return  damage + " point(s) of damage";
+            return super.getDetails(includeRepairDetails);
         }
     }
 
@@ -323,7 +332,7 @@ public class TankLocation extends Part {
 
     @Override
     public String getLocationName() {
-        return unit.getEntity().getLocationName(loc);
+        return unit != null ? unit.getEntity().getLocationName(loc) : null;
     }
 
     @Override
@@ -335,7 +344,7 @@ public class TankLocation extends Part {
     public TechAdvancement getTechAdvancement() {
         return TECH_ADVANCEMENT;
     }
-    
+
     @Override
     public int getMassRepairOptionType() {
         return Part.REPAIR_PART_TYPE.GENERAL_LOCATION;

--- a/MekHQ/src/mekhq/campaign/parts/Turret.java
+++ b/MekHQ/src/mekhq/campaign/parts/Turret.java
@@ -1,20 +1,20 @@
 /*
  * Turret.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -47,13 +47,13 @@ public class Turret extends TankLocation {
     public Turret() {
         this(0, 0, null);
     }
-    
+
     public Turret(int loc, int tonnage, Campaign c) {
         super(loc, tonnage, c);
         weight = 0;
         this.name = "Turret";
     }
-    
+
     public Turret clone() {
         Turret clone = new Turret(0, getUnitTonnage(), weight, campaign);
         clone.copyBaseData(this);
@@ -62,13 +62,13 @@ public class Turret extends TankLocation {
         clone.breached = this.breached;
         return clone;
     }
-    
+
     public Turret(int loc, int tonnage, double weight, Campaign c) {
         super(loc, tonnage, c);
         this.weight = weight;
         this.name = "Turret";
     }
-    
+
     @Override
     public void setUnit(Unit u) {
         super.setUnit(u);
@@ -86,7 +86,7 @@ public class Turret extends TankLocation {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof Turret 
+        return part instanceof Turret
                 && getLoc() == ((Turret)part).getLoc()
                 && getTonnage() == ((Turret)part).getTonnage();
     }
@@ -214,7 +214,7 @@ public class Turret extends TankLocation {
             }
             if (slot.isRepairable()) {
                 return "You must scrap all equipment in the turret first";
-            } 
+            }
         }
         return null;
     }
@@ -226,7 +226,16 @@ public class Turret extends TankLocation {
 
     @Override
     public String getDetails() {
-        return weight + " tons, " + damage + " point(s) of damage";
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        String details = weight + " tons";
+        if (includeRepairDetails) {
+            details += ", " + damage + " point(s) of damage";
+        }
+        return details;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
@@ -1,20 +1,20 @@
 /*
  * VeeStabiliser.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -195,6 +195,11 @@ public class VeeStabiliser extends Part {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             return unit.getEntity().getLocationName(loc);
         }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
@@ -165,15 +165,15 @@ public class BattleArmorEquipmentPart extends EquipmentPart {
 			}
 		}
     }
-    
-    @Override 
+
+    @Override
 	public int getBaseTime() {
 		if(isSalvaging()) {
 			return 30;
 		}
 		return super.getBaseTime();
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		if(isSalvaging()) {
@@ -209,10 +209,15 @@ public class BattleArmorEquipmentPart extends EquipmentPart {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if(null != unit) {
             return unit.getEntity().getLocationName(trooper);
         }
-        return super.getDetails();
+        return super.getDetails(includeRepairDetails);
     }
 
     public int getTrooper() {
@@ -272,7 +277,7 @@ public class BattleArmorEquipmentPart extends EquipmentPart {
     public boolean needsMaintenance() {
         return false;
     }
-    
+
     public boolean canNeverScrap() {
     	return isModular();
 	}

--- a/MekHQ/src/mekhq/campaign/parts/equipment/JumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/JumpJet.java
@@ -1,20 +1,20 @@
 /*
  * JumpJet.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -40,7 +40,7 @@ public class JumpJet extends EquipmentPart {
 	public JumpJet() {
     	this(0, null, -1, false, null);
     }
-    
+
     public JumpJet(int tonnage, EquipmentType et, int equipNum, boolean omniPodded, Campaign c) {
         // TODO Memorize all entity attributes needed to calculate cost
         // As it is a part bought with one entity can be used on another entity
@@ -48,13 +48,13 @@ public class JumpJet extends EquipmentPart {
         // account for compatibility)
         super(tonnage, et, equipNum, omniPodded, c);
     }
-    
+
     public JumpJet clone() {
     	JumpJet clone = new JumpJet(getUnitTonnage(), getType(), getEquipmentNum(), omniPodded, campaign);
         clone.copyBaseData(this);
     	return clone;
     }
-	
+
     @Override
     public double getTonnage() {
         double ton;
@@ -80,7 +80,7 @@ public class JumpJet extends EquipmentPart {
     	}
     	return ton;
     }
-    
+
     /**
      * Copied from megamek.common.Entity.getWeaponsAndEquipmentCost(StringBuffer detail, boolean ignoreAmmo)
      *
@@ -93,11 +93,16 @@ public class JumpJet extends EquipmentPart {
             return Money.of(200 * getUnitTonnage());
         }
     }
-    
+
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
     	if(null != unit) {
-			return super.getDetails();
+			return super.getDetails(includeRepairDetails);
     	}
     	return getUnitTonnage() + " ton unit";
     }
@@ -116,25 +121,25 @@ public class JumpJet extends EquipmentPart {
 				if(mounted.isMissing()) {
 					remove(false);
 					return;
-				} 
+				}
 				hits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT, equipmentNum, mounted.getLocation());
 			}
-			if(checkForDestruction 
-					&& hits > priorHits 
+			if(checkForDestruction
+					&& hits > priorHits
 					&& Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
 				remove(false);
 			}
 		}
 	}
-	
-	@Override 
+
+	@Override
 	public int getBaseTime() {
 		if(isSalvaging()) {
 			return isOmniPodded()? 30 : 60;
 		}
 		return 100;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		if(isSalvaging()) {
@@ -142,12 +147,12 @@ public class JumpJet extends EquipmentPart {
 		}
 		return -3;
 	}
-	
+
 	@Override
 	public boolean needsFixing() {
 		return hits > 0;
 	}
-	
+
 	@Override
 	public boolean isOmniPoddable() {
 	    return true;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2017 - The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -43,29 +43,29 @@ import mekhq.campaign.work.IAcquisitionWork;
  * Ammo bin for a weapon bay that combines multiple tons of ammo into a single bin. Reload times
  * are calculated per ton, and a  reload tech action handles a single ton of ammo (or whatever the
  * smallest amount is for capital weapon ammo).
- * 
+ *
  * When the munition type is changed, fix actions diminish the capacity of this bay and add to
  * the capacity of the appropriate bin in the same bay.
- * 
+ *
  * @author Neoancient
  *
  */
 public class LargeCraftAmmoBin extends AmmoBin {
-    
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -7931419849350769887L;
-    
+
     private double capacity;
     private int bayEqNum;
-    
+
     transient private Mounted bay;
-    
+
     public LargeCraftAmmoBin() {
         this(0, null, -1, 0, 0, null);
     }
-    
+
     public LargeCraftAmmoBin(int tonnage, EquipmentType et, int equipNum, int shotsNeeded, double capacity,
             Campaign c) {
         super(tonnage, et, equipNum, shotsNeeded, false, false, c);
@@ -79,7 +79,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     /**
      * @return The <code>Mounted</code> of the unit's <code>Entity</code> that contains this ammo bin,
      *         or null if there is no unit or the ammo bin is not in any bay.
@@ -105,8 +105,8 @@ public class LargeCraftAmmoBin extends AmmoBin {
                 "Could not find weapon bay for " + typeName + " for " + unit.getName());
         return null;
     }
-    
-    
+
+
     public int getBayEqNum() {
         return bayEqNum;
     }
@@ -121,7 +121,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
             this.bay = bay;
         }
     }
-    
+
     /**
      * Sets the bay for this ammo bin. Does not check whether the ammo bin is actually in the bay.
      * @param bayEqNum the number of the bay that will contain this ammo bin
@@ -132,29 +132,29 @@ public class LargeCraftAmmoBin extends AmmoBin {
             bay = unit.getEntity().getEquipment(bayEqNum);
         }
     }
-    
+
     @Override
     public double getTonnage() {
         return getCurrentShots() * type.getTonnage(null) / ((AmmoType) type).getShots();
     }
-    
+
     public double getCapacity() {
         return capacity;
     }
-    
+
     public void setCapacity(double capacity) {
         this.capacity = capacity;
     }
-    
+
     public double getUnusedCapacity() {
         return capacity - Math.ceil(getCurrentShots() * type.getTonnage(null) / ((AmmoType) type).getShots());
     }
-    
+
     @Override
     public int getFullShots() {
         return (int) Math.floor(capacity * ((AmmoType) type).getShots() / type.getTonnage(null));
     }
-    
+
     @Override
     public Money getValueNeeded() {
         if (getShotsPerTon() <= 0) {
@@ -173,7 +173,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
         // of the bay and the unit should be the same.
         return Money.of(getType().getRawCost());
     }
-    
+
     @Override
     public Money getStickerPrice() {
         if (getShotsPerTon() <= 0) {
@@ -221,7 +221,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
             loadBinSingle();
         }
     }
-    
+
     public void loadBinSingle() {
         int shots = Math.min(getAmountAvailable(), Math.min(shotsNeeded, ((AmmoType) type).getShots()));
         if(null != unit) {
@@ -250,12 +250,12 @@ public class LargeCraftAmmoBin extends AmmoBin {
             changeAmountAvailable(shots, curType);
         }
     }
-    
+
     @Override
     public boolean isSalvaging() {
         return super.isSalvaging() && (getCurrentShots() > 0);
     }
-    
+
     @Override
     public void remove(boolean salvage) {
         // The bin represents capacity rather than an actual part, and cannot be
@@ -325,7 +325,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
     @Override
     public boolean needsFixing() {
         return (shotsNeeded < 0)
-                || ((shotsNeeded > 0) && (type.getTonnage(null) <= Math.ceil(bayAvailableCapacity()))); 
+                || ((shotsNeeded > 0) && (type.getTonnage(null) <= Math.ceil(bayAvailableCapacity())));
     }
 
     /**
@@ -374,8 +374,13 @@ public class LargeCraftAmmoBin extends AmmoBin {
 
     @Override
     public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
         if (isSalvaging()) {
-            return super.getDetails();
+            return super.getDetails(includeRepairDetails);
         }
         if (shotsNeeded < 0) {
             return ((AmmoType) type).getDesc() + ", " + (-shotsNeeded) + " shots to remove";
@@ -408,5 +413,5 @@ public class LargeCraftAmmoBin extends AmmoBin {
     public boolean isOmniPoddable() {
         return false;
     }
-    
+
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
@@ -1,20 +1,20 @@
 /*
  * MASC.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,30 +45,30 @@ public class MASC extends EquipmentPart {
 	private static final long serialVersionUID = 2892728320891712304L;
 
 	protected int engineRating;
-	
+
 	public MASC() {
     	this(0, null, -1, null, 0, false);
     }
-    
+
     public MASC(int tonnage, EquipmentType et, int equipNum, Campaign c, int rating, boolean omniPodded) {
         super(tonnage, et, equipNum, omniPodded, c);
         this.engineRating = rating;
         equipTonnage = calculateTonnage();
     }
-    
+
     public MASC clone() {
     	MASC clone = new MASC(getUnitTonnage(), getType(), getEquipmentNum(), campaign, engineRating, omniPodded);
         clone.copyBaseData(this);
     	return clone;
     }
- 
+
     public void setUnit(Unit u) {
     	super.setUnit(u);
     	if(null != unit && null != unit.getEntity().getEngine()) {
     		engineRating = unit.getEntity().getEngine().getRating();
     	}
     }
-    
+
     private double calculateTonnage() {
     	if(null == type) {
     		return 0;
@@ -79,25 +79,25 @@ public class MASC extends EquipmentPart {
         }
         return Math.round(getUnitTonnage() / 20.0f);
     }
-    
+
     @Override
     public Money getStickerPrice() {
     	if (isSupercharger()) {
     		return Money.of(engineRating * (isOmniPodded()? 1250 : 10000));
-    	} else {           
+    	} else {
             return Money.of(engineRating * getTonnage() * 1000);
         }
     }
-    
+
     public int getEngineRating() {
     	return engineRating;
     }
-    
+
     private boolean isSupercharger() {
     	return type.hasSubType(MiscType.S_SUPERCHARGER);
     }
-    
-    
+
+
     @Override
     public boolean isSamePartTypeAndStatus (Part part) {
     	if(needsFixing() || part.needsFixing()) {
@@ -109,10 +109,10 @@ public class MASC extends EquipmentPart {
         		&& getEngineRating() == ((MASC)part).getEngineRating();
     }
 
-    
+
     @Override
 	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);		
+		writeToXmlBegin(pw1, indent);
 		pw1.println(MekHqXmlUtil.indentStr(indent+1)
 				+"<equipmentNum>"
 				+equipmentNum
@@ -135,7 +135,7 @@ public class MASC extends EquipmentPart {
 	@Override
 	protected void loadFieldsFromXmlNode(Node wn) {
 		NodeList nl = wn.getChildNodes();
-		
+
 		for (int x=0; x<nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
 			if (wn2.getNodeName().equalsIgnoreCase("equipmentNum")) {
@@ -153,24 +153,33 @@ public class MASC extends EquipmentPart {
 		}
 		restore();
 	}
-	
+
 	@Override
 	public MissingPart getMissingPart() {
 		return new MissingMASC(getUnitTonnage(), type, equipmentNum, campaign, equipTonnage, engineRating,
 		        omniPodded);
 	}
-	
+
 	@Override
 	public String getDetails() {
+        return getDetails(true);
+    }
+
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        String details = super.getDetails(includeRepairDetails);
 		if(null != unit) {
-			return super.getDetails();
-		}
+			return details;
+        }
+        if (!details.isEmpty()) {
+            details += ", ";
+        }
 		if(isSupercharger()) {
-			return super.getDetails() + ", " + getEngineRating() + " rating";
+			return details + ", " + getEngineRating() + " rating";
 		}
-		return super.getDetails() + ", " + getUnitTonnage() + " tons, " + getEngineRating() + " rating";
+		return details + ", " + getUnitTonnage() + " tons, " + getEngineRating() + " rating";
 	 }
-	
+
 	@Override
     public boolean isOmniPoddable() {
     	return isSupercharger();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
@@ -54,12 +54,12 @@ public class MissingBattleArmorEquipmentPart extends MissingEquipmentPart {
         super(tonnage, et, equipNum, c, etonnage);
         this.trooper = trooper;
     }
-    
-    @Override 
+
+    @Override
 	public int getBaseTime() {
 		return 30;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return -2;
@@ -203,12 +203,16 @@ public class MissingBattleArmorEquipmentPart extends MissingEquipmentPart {
 
     @Override
     public String getDetails() {
-    	if(null == unit) {
-    		return super.getDetails();
+        return getDetails(true);
+    }
 
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+    	if(null == unit) {
+    		return super.getDetails(includeRepairDetails);
         }
     	String toReturn = unit.getEntity().getLocationName(trooper) + "<br>";
-		return toReturn + super.getDetails();
+		return toReturn + super.getDetails(includeRepairDetails);
     }
 
 


### PR DESCRIPTION
This is a nasty bug I introduced in #1419 which blocks the PartsInUse tab from working. Ensure all overrides of getDetails include an override of getDetails(boolean).

[Best viewed with whitespace ignored](https://github.com/MegaMek/mekhq/pull/1426/files?w=1).