### PR TITLE
Fix bug where GM Add'ing ammo with 0 shots did not add new ammo #1427

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -22,7 +22,6 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
-import java.math.RoundingMode;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -212,7 +211,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 	
 	@Override
     public IAcquisitionWork getAcquisitionWork() {
-        return new AmmoStorage(1,type,((AmmoType)type).getShots(),campaign);
+        return (IAcquisitionWork)getNewPart();
     }
 	
 	@Override
@@ -364,7 +363,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
     public Part getNewPart() {
-        return new AmmoStorage(1,type,shots,campaign);
+        return new AmmoStorage(1,type,((AmmoType)type).getShots(),campaign);
     }
     
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -98,9 +98,9 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         clone.munition = this.munition;
         return clone;
     }
-    
+
     /* Per TM, ammo for fighters is stored in the fuselage. This makes a difference for omnifighter
-     * pod space, so we're going to stick them in LOC_NONE where the heat sinks are */ 
+     * pod space, so we're going to stick them in LOC_NONE where the heat sinks are */
     @Override
     public String getLocationName() {
         if (unit.getEntity() instanceof Aero
@@ -109,7 +109,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         }
         return super.getLocationName();
     }
-    
+
     @Override
     public int getLocation() {
         if (unit.getEntity() instanceof Aero
@@ -118,12 +118,12 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         }
         return super.getLocation();
     }
-    
+
     @Override
     public double getTonnage() {
         return (1.0 * getFullShots())/((AmmoType)type).getShots();
     }
-    
+
     public int getFullShots() {
         int fullShots = ((AmmoType)type).getShots();
         if(unit != null) {
@@ -143,7 +143,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         }
         return fullShots;
     }
-    
+
     protected int getCurrentShots() {
         return getFullShots() - shotsNeeded;
     }
@@ -159,7 +159,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     protected Money getPricePerTon() {
-        //if on a unit, then use the ammo type on the existing entity, to avoid getting it wrong due to 
+        //if on a unit, then use the ammo type on the existing entity, to avoid getting it wrong due to
         //ammo swaps
         EquipmentType curType = type;
         if(null != unit && null != unit.getEntity()) {
@@ -170,7 +170,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         }
         return Money.of(curType.getRawCost());
     }
-    
+
     protected int getShotsPerTon() {
         AmmoType atype = (AmmoType)type;
         if(atype.getKgPerShot() > 0) {
@@ -179,7 +179,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         //if not listed by kg per shot, we assume this is a single ton increment
         return ((AmmoType)type).getShots();
     }
-    
+
     @Override
     public Money getStickerPrice() {
         if (getShotsPerTon() <= 0) {
@@ -210,7 +210,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         }
         updateConditionFromEntity(false);
     }
-    
+
     public void changeMunition(EquipmentType type) {
         if (type instanceof AmmoType) {
             munition = ((AmmoType) type).getMunitionType();
@@ -220,7 +220,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             updateConditionFromEntity(false);
         }
     }
-    
+
     private boolean ammoTypeChanged() {
         if (null != unit) {
             Mounted m = unit.getEntity().getEquipment(equipmentNum);
@@ -259,7 +259,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 +"</oneShot>");
         writeToXmlEnd(pw1, indent);
     }
-    
+
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
         super.loadFieldsFromXmlNode(wn);
@@ -512,9 +512,9 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             String availability;
             int shotsAvailable = getAmountAvailable();
             PartInventory inventories = campaign.getPartInventory(getNewPart());
-            
+
             String orderTransitString = getOrderTransitStringForDetails(inventories);
-            
+
             if(shotsAvailable == 0) {
                 availability = "<br><font color='red'>No ammo " + orderTransitString + "</font>";
             } else if(shotsAvailable < getShotsNeeded()) {
@@ -522,7 +522,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             } else {
                 availability = "<br><font color='green'>" + shotsAvailable + " available " + orderTransitString + "</font>";
             }
-            
+
             return type.getDesc() + ", " + getShotsNeeded() + " shots needed" + availability;
         } else {
             return "";
@@ -719,11 +719,11 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         toReturn += "</font></html>";
         return toReturn;
     }
-    
+
     @Override
     public String getAcquisitionDisplayName() {
         return type.getDesc();
-    }    
+    }
 
     @Override
     public String getAcquisitionExtraDesc() {
@@ -773,7 +773,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     public Part getNewPart() {
-        return new AmmoStorage(1,type,shotsNeeded,campaign);
+        return new AmmoStorage(1,type,((AmmoType)type).getShots(),campaign);
     }
 
     @Override
@@ -795,12 +795,12 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     public int getMassRepairOptionType() {
         return Part.REPAIR_PART_TYPE.AMMO;
     }
-    
+
     @Override
     public boolean isOmniPoddable() {
         return true;
     }
-    
+
     /**
      * Since ammo bins aren't real parts they can't be podded in the warehouse, and
      * whether they're podded on the unit depends entirely on the unit they're installed on.
@@ -813,7 +813,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         Mounted m = getUnit().getEntity().getEquipment(equipmentNum);
         return m != null && m.isOmniPodMounted();
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return type.getTechAdvancement();


### PR DESCRIPTION
When we call PartInUse::getNewPart it would call AmmoStorage::getNewPart that simply returned a clone of this part, rather than returning an actual new part #1427. If the ammo in question had 0 shots remaining, when you GM added it from the Parts in Use tab, you just added a bunch of 0 shot ammo parts.

This should land after #1426.