### PR TITLE
Adds dark themes to MekHQ #1385

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'org.apache.commons:commons-text:1.4'
     implementation 'org.apache.commons:commons-csv:1.4'
     implementation 'javax.vecmath:vecmath:1.5.2'
+    implementation 'com.formdev:flatlaf:0.26'
 
     implementation 'com.atlassian.commonmark:commonmark:0.13.0'
 

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -236,7 +236,7 @@ public class MekHQ implements GameListener {
 	 * Default to log level 3.
 	 *
 	 * @param msg The message you want to log.
-	 * @deprecated Use {@link #getLogger()} instead.              
+	 * @deprecated Use {@link #getLogger()} instead.
 	 */
 	@Deprecated
 	public static void logMessage(String msg) {
@@ -248,7 +248,7 @@ public class MekHQ implements GameListener {
 	 *
 	 * @param msg The message you want to log.
 	 * @param logLevel The log level of the message.
-	 * @deprecated Use {@link #getLogger()} instead.              
+	 * @deprecated Use {@link #getLogger()} instead.
 	 */
 	@Deprecated
 	public static void logMessage(String msg, int logLevel) {
@@ -289,6 +289,11 @@ public class MekHQ implements GameListener {
      * At startup create and show the main frame of the application.
      */
     protected void startup() {
+        UIManager.installLookAndFeel("Flat Light", "com.formdev.flatlaf.FlatLightLaf");
+        UIManager.installLookAndFeel("Flat IntelliJ", "com.formdev.flatlaf.FlatIntelliJLaf");
+        UIManager.installLookAndFeel("Flat Dark", "com.formdev.flatlaf.FlatDarkLaf");
+        UIManager.installLookAndFeel("Flat Darcula", "com.formdev.flatlaf.FlatDarculaLaf");
+
         showInfo();
 
         //Setup user preferences
@@ -362,9 +367,12 @@ public class MekHQ implements GameListener {
     public static void main(String[] args) {
     	System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name","MekHQ");
-        //redirect output to log file
-        redirectOutput();
-        MekHQ.getInstance().startup();
+
+        SwingUtilities.invokeLater(() -> {
+            //redirect output to log file
+            redirectOutput();
+            MekHQ.getInstance().startup();
+        });
     }
 
     private void showInfo() {
@@ -454,7 +462,7 @@ public class MekHQ implements GameListener {
     public void joinGame(Scenario scenario, ArrayList<Unit> meks) {
 		LaunchGameDialog lgd = new LaunchGameDialog(campaigngui.getFrame(), false, campaign);
 		lgd.setVisible(true);
-		
+
 		if(lgd.cancelled) {
 		    return;
 		}
@@ -490,7 +498,7 @@ public class MekHQ implements GameListener {
                 port = lgd.port;
                 playerName = lgd.playerName;
             }
-            lgd.dispose(); // Force cleanup of the current modal, since we are 
+            lgd.dispose(); // Force cleanup of the current modal, since we are
                            // (possibly) about to display a new one and MacOS
                            // seems to struggle with that.
                            // (see https://github.com/MegaMek/mekhq/issues/953)
@@ -695,7 +703,7 @@ public class MekHQ implements GameListener {
 	public IconPackage getIconPackage() {
 	    return iconPackage;
 	}
-	
+
     /**
      * Helper function that calculates the maximum screen width available locally.
      * @return Maximum screen width.
@@ -710,21 +718,21 @@ public class MekHQ implements GameListener {
                 maxWidth = b.getWidth();
             }
         }
-        
+
         return maxWidth;
     }
-	
+
 	/*
 	 * Access methods for event bus.
 	 */
 	static public void registerHandler(Object handler) {
 	    EVENT_BUS.register(handler);
 	}
-	
+
 	static public boolean triggerEvent(MMEvent event) {
 	    return EVENT_BUS.trigger(event);
 	}
-	
+
 	static public void unregisterHandler(Object handler) {
 	    EVENT_BUS.unregister(handler);
 	}
@@ -770,7 +778,7 @@ public class MekHQ implements GameListener {
             }
         }
     }
-    
+
     private static void addOSXKeyStrokes(InputMap inputMap) {
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_C, KeyEvent.META_DOWN_MASK), DefaultEditorKit.copyAction);
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_X, KeyEvent.META_DOWN_MASK), DefaultEditorKit.cutAction);

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -742,7 +742,7 @@ public class MekHQ implements GameListener {
 	    EVENT_BUS.register(new XPHandler());
 	}
 
-    private static void setLookAndFeel(String themeName, Frame window) {
+    private static void setLookAndFeel(String themeName) {
 	    final String METHOD_NAME = "setLookAndFeel";
         Runnable runnable = () -> {
             try {
@@ -755,7 +755,10 @@ public class MekHQ implements GameListener {
                     addOSXKeyStrokes((InputMap) UIManager.get("TextPane.focusInputMap"));
                     addOSXKeyStrokes((InputMap) UIManager.get("TextArea.focusInputMap"));
                   }
-                if (window != null) {
+                for (Frame frame : Frame.getFrames()) {
+                    SwingUtilities.updateComponentTreeUI(frame);
+                }
+                for (Window window : Window.getWindows()) {
                     SwingUtilities.updateComponentTreeUI(window);
                 }
             } catch (ClassNotFoundException |
@@ -774,7 +777,7 @@ public class MekHQ implements GameListener {
     private class MekHqPropertyChangedListener implements PropertyChangeListener {
         public void propertyChange(PropertyChangeEvent evt) {
             if (evt.getSource() == selectedTheme) {
-                setLookAndFeel((String)evt.getNewValue(), window);
+                setLookAndFeel((String)evt.getNewValue());
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/BasicInfo.java
+++ b/MekHQ/src/mekhq/gui/BasicInfo.java
@@ -1,6 +1,5 @@
 package mekhq.gui;
 
-import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Image;
@@ -12,6 +11,8 @@ import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.border.LineBorder;
 
 import megamek.client.ui.swing.util.PlayerColors;
 import megamek.common.Crew;
@@ -23,190 +24,192 @@ import mekhq.campaign.unit.Unit;
 /**
  * An extension of JPanel that is intended to be used for visual table renderers
  * allowing for a visual image and html coded text
+ * 
  * @author Jay Lawson
  *
  */
 public class BasicInfo extends JPanel {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = -7337823041775639463L;
+    /**
+     *
+     */
+    private static final long serialVersionUID = -7337823041775639463L;
 
-        private JLabel lblImage;
-        private JLabel lblLoad;
-        IconPackage icons;
-        
+    private JLabel lblImage;
+    private JLabel lblLoad;
+    IconPackage icons;
 
-        public BasicInfo(IconPackage i) {
-            this.icons = i;
-            lblImage = new JLabel();
-            lblLoad = new JLabel();
+    public BasicInfo(IconPackage i) {
+        this.icons = i;
+        lblImage = new JLabel();
+        lblLoad = new JLabel();
 
-            GridBagLayout gridbag = new GridBagLayout();
-            GridBagConstraints c = new GridBagConstraints();
-            setLayout(gridbag);
+        GridBagLayout gridbag = new GridBagLayout();
+        GridBagConstraints c = new GridBagConstraints();
+        setLayout(gridbag);
 
-            c.fill = GridBagConstraints.NONE;
-            c.insets = new Insets(1, 1, 1, 1);
-            c.gridx = 0;
-            c.gridy = 0;
-            c.weightx = 0.0;
-            c.weighty = 0.0;
-            c.gridwidth = 1;
-            c.gridheight = 1;
-            c.anchor = GridBagConstraints.CENTER;
-            gridbag.setConstraints(lblLoad, c);
-            add(lblLoad);
+        c.fill = GridBagConstraints.NONE;
+        c.insets = new Insets(1, 1, 1, 1);
+        c.gridx = 0;
+        c.gridy = 0;
+        c.weightx = 0.0;
+        c.weighty = 0.0;
+        c.gridwidth = 1;
+        c.gridheight = 1;
+        c.anchor = GridBagConstraints.CENTER;
+        gridbag.setConstraints(lblLoad, c);
+        add(lblLoad);
 
-            c.fill = GridBagConstraints.BOTH;
-            c.insets = new Insets(1, 1, 1, 1);
-            c.gridx = 1;
-            c.gridy = 0;
-            c.weightx = 1.0;
-            c.weighty = 1.0;
-            c.gridwidth = 1;
-            c.gridheight = 1;
-            c.anchor = GridBagConstraints.NORTHWEST;
-            gridbag.setConstraints(lblImage, c);
-            add(lblImage);
+        c.fill = GridBagConstraints.BOTH;
+        c.insets = new Insets(1, 1, 1, 1);
+        c.gridx = 1;
+        c.gridy = 0;
+        c.weightx = 1.0;
+        c.weighty = 1.0;
+        c.gridwidth = 1;
+        c.gridheight = 1;
+        c.anchor = GridBagConstraints.NORTHWEST;
+        gridbag.setConstraints(lblImage, c);
+        add(lblImage);
 
-            lblImage.setBorder(BorderFactory.createEmptyBorder());
+        lblImage.setBorder(BorderFactory.createEmptyBorder());
+    }
+
+    public void setText(String s, String color) {
+        lblImage.setText("<html><font size='2' color='" + color + "'>" + s + "</font></html>");
+    }
+
+    public void setText(String s) {
+        lblImage.setText("<html><font size='2'>" + s + "</font></html>");
+    }
+
+    public void highlightBorder() {
+        lblImage.setBorder(new LineBorder(UIManager.getColor("Tree.selectionBorderColor"), 4, true));
+    }
+
+    public void unhighlightBorder() {
+        lblImage.setBorder(javax.swing.BorderFactory.createEtchedBorder());
+    }
+
+    public void clearImage() {
+        lblImage.setIcon(null);
+    }
+
+    public void setImage(Image img) {
+        lblImage.setIcon(new ImageIcon(img));
+    }
+
+    public JLabel getLabel() {
+        return lblImage;
+    }
+
+    public void setLoad(boolean load) {
+        // if this is a loaded unit then do something with lblLoad to make
+        // it show up
+        // otherwise clear lblLoad
+        if (load) {
+            lblLoad.setText(" +");
+        } else {
+            lblLoad.setText("");
+        }
+    }
+
+    protected Image getImageFor(Unit u) {
+
+        if (null == icons.getMechTiles()) {
+            return null;
+        }
+        Image base = icons.getMechTiles().imageFor(u.getEntity(), this, -1);
+        if (null == base) {
+            return null;
+        }
+        int tint = PlayerColors.getColorRGB(u.getCampaign().getColorIndex());
+        EntityImage entityImage = new EntityImage(base, tint, getCamo(u), this);
+        return entityImage.loadPreviewImage();
+    }
+
+    protected Image getCamo(Unit unit) {
+        // Try to get the player's camo file.
+        Image camo = null;
+        try {
+            camo = (Image) icons.getCamos().getItem(unit.getCamoCategory(), unit.getCamoFileName());
+        } catch (Exception err) {
+            err.printStackTrace();
+        }
+        return camo;
+    }
+
+    protected void setPortrait(Person p) {
+
+        String category = p.getPortraitCategory();
+        String filename = p.getPortraitFileName();
+
+        // Return a null if the player has selected no portrait file.
+        if ((null == category) || (null == filename)) {
+            return;
         }
 
-        public void setText(String s, String color) {
-            lblImage.setText("<html><font size='2' color='" + color + "'>" + s
-                    + "</font></html>");
-        }
-        
-
-        public void highlightBorder() {
-            lblImage.setBorder(new javax.swing.border.LineBorder(Color.BLACK, 5, true));
+        if (Crew.ROOT_PORTRAIT.equals(category)) {
+            category = "";
         }
 
-        public void unhighlightBorder() {
-            lblImage.setBorder(javax.swing.BorderFactory.createEtchedBorder());
+        if (Crew.PORTRAIT_NONE.equals(filename)) {
+            filename = "default.gif";
         }
 
-        public void clearImage() {
-            lblImage.setIcon(null);
-        }
-
-        public void setImage(Image img) {
-            lblImage.setIcon(new ImageIcon(img));
-        }
-
-        public JLabel getLabel() {
-            return lblImage;
-        }
-
-        public void setLoad(boolean load) {
-            // if this is a loaded unit then do something with lblLoad to make
-            // it show up
-            // otherwise clear lblLoad
-            if (load) {
-                lblLoad.setText(" +");
-            } else {
-                lblLoad.setText("");
-            }
-        }
-        
-        protected Image getImageFor(Unit u) {
-            
-            if(null == icons.getMechTiles()) { 
-                return null;
-            }
-            Image base = icons.getMechTiles().imageFor(u.getEntity(), this, -1);
-            if (null == base) {
-                return null;
-            }
-            int tint = PlayerColors.getColorRGB(u.getCampaign().getColorIndex());
-            EntityImage entityImage = new EntityImage(base, tint, getCamo(u), this);
-            return entityImage.loadPreviewImage();
-        }
-        
-        protected Image getCamo(Unit unit) {
-            // Try to get the player's camo file.
-            Image camo = null;
-            try {
-                camo = (Image) icons.getCamos().getItem(unit.getCamoCategory(), unit.getCamoFileName());
-            } catch (Exception err) {
-                err.printStackTrace();
-            }
-            return camo;
-        }
-        
-        protected void setPortrait(Person p) {
-
-            String category = p.getPortraitCategory();
-            String filename = p.getPortraitFileName();
-
-            // Return a null if the player has selected no portrait file.
-            if ((null == category) || (null == filename)) {
-                return;
-            }
-
-            if (Crew.ROOT_PORTRAIT.equals(category)) {
+        // Try to get the player's portrait file.
+        Image portrait = null;
+        try {
+            portrait = (Image) icons.getPortraits().getItem(category, filename);
+            if (null == portrait) {
+                // the image could not be found so switch to default one
+                p.setPortraitCategoryOverride(Crew.ROOT_PORTRAIT);
                 category = "";
-            }
-
-            if (Crew.PORTRAIT_NONE.equals(filename)) {
+                p.setPortraitFileNameOverride(Crew.PORTRAIT_NONE);
                 filename = "default.gif";
-            }
-
-            // Try to get the player's portrait file.
-            Image portrait = null;
-            try {
                 portrait = (Image) icons.getPortraits().getItem(category, filename);
-                if (null == portrait) {
-                    // the image could not be found so switch to default one
-                    p.setPortraitCategoryOverride(Crew.ROOT_PORTRAIT);
-                    category = "";
-                    p.setPortraitFileNameOverride(Crew.PORTRAIT_NONE);
-                    filename = "default.gif";
-                    portrait = (Image) icons.getPortraits().getItem(category, filename);
-                }
-                // make sure no images are longer than 72 pixels
-                if (null != portrait) {
-                    portrait = portrait.getScaledInstance(-1, 58,
-                            Image.SCALE_SMOOTH);
-                    setImage(portrait);
-                }
-            } catch (Exception err) {
-                err.printStackTrace();
             }
+            // make sure no images are longer than 72 pixels
+            if (null != portrait) {
+                portrait = portrait.getScaledInstance(-1, 58, Image.SCALE_SMOOTH);
+                setImage(portrait);
+            }
+        } catch (Exception err) {
+            err.printStackTrace();
         }
-        
-        protected Image getImageFor(Force force) {
-            String category = force.getIconCategory();
-            String filename = force.getIconFileName();
-            LinkedHashMap<String, Vector<String>> iconMap = force.getIconMap();
+    }
 
-            if(Crew.ROOT_PORTRAIT.equals(category)) {
-             category = "";
-            }
+    protected Image getImageFor(Force force) {
+        String category = force.getIconCategory();
+        String filename = force.getIconFileName();
+        LinkedHashMap<String, Vector<String>> iconMap = force.getIconMap();
 
-            // Return a null if the player has selected no portrait file.
-            if ((null == category) || (null == filename) || (Crew.PORTRAIT_NONE.equals(filename) && !Force.ROOT_LAYERED.equals(category))) {
-             filename = "empty.png";
-            }
+        if (Crew.ROOT_PORTRAIT.equals(category)) {
+            category = "";
+        }
 
-            // Try to get the player's portrait file.
-            Image portrait = null;
-            try {
-             portrait = IconPackage.buildForceIcon(category, filename, icons.getForceIcons(), iconMap);
-            if(null != portrait) {
+        // Return a null if the player has selected no portrait file.
+        if ((null == category) || (null == filename)
+                || (Crew.PORTRAIT_NONE.equals(filename) && !Force.ROOT_LAYERED.equals(category))) {
+            filename = "empty.png";
+        }
+
+        // Try to get the player's portrait file.
+        Image portrait = null;
+        try {
+            portrait = IconPackage.buildForceIcon(category, filename, icons.getForceIcons(), iconMap);
+            if (null != portrait) {
                 portrait = portrait.getScaledInstance(58, -1, Image.SCALE_SMOOTH);
             } else {
                 portrait = (Image) icons.getForceIcons().getItem("", "empty.png");
-                if(null != portrait) {
+                if (null != portrait) {
                     portrait = portrait.getScaledInstance(58, -1, Image.SCALE_SMOOTH);
                 }
             }
             return portrait;
-            } catch (Exception err) {
-                err.printStackTrace();
-                return null;
-            }
-       }
+        } catch (Exception err) {
+            err.printStackTrace();
+            return null;
+        }
     }
+}

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -223,7 +223,6 @@ public final class BriefingTab extends CampaignGuiTab {
 
         scrollMissionView = new JScrollPane();
         scrollMissionView.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollMissionView.getViewport().setBackground(Color.WHITE);
         scrollMissionView.setViewportView(null);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -245,7 +244,6 @@ public final class BriefingTab extends CampaignGuiTab {
         JScrollPane scrollScenarioTable = new JScrollPane(scenarioTable);
         scrollScenarioTable.setMinimumSize(new java.awt.Dimension(200, 200));
         scrollScenarioTable.setPreferredSize(new java.awt.Dimension(200, 200));
-        scrollScenarioTable.getViewport().setBackground(Color.WHITE);
 
         splitMission = new JSplitPane(JSplitPane.VERTICAL_SPLIT, panBriefing, scrollScenarioTable);
         splitMission.setOneTouchExpandable(true);
@@ -307,7 +305,6 @@ public final class BriefingTab extends CampaignGuiTab {
         panScenarioButtons.add(btnClearAssignedUnits);
 
         scrollScenarioView = new JScrollPane();
-        scrollScenarioView.getViewport().setBackground(Color.WHITE);
         scrollScenarioView.setViewportView(null);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -324,7 +321,6 @@ public final class BriefingTab extends CampaignGuiTab {
         paneLanceDeployment.setMinimumSize(new java.awt.Dimension(200, 300));
         paneLanceDeployment.setPreferredSize(new java.awt.Dimension(200, 300));
         paneLanceDeployment.setVisible(getCampaign().getCampaignOptions().getUseAtB());
-        paneLanceDeployment.getViewport().setBackground(Color.WHITE);
         splitScenario = new javax.swing.JSplitPane(javax.swing.JSplitPane.VERTICAL_SPLIT, panScenario,
                 paneLanceDeployment);
         splitScenario.setOneTouchExpandable(true);

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JTree;
+import javax.swing.UIManager;
 import javax.swing.tree.DefaultTreeCellRenderer;
 
 import megamek.client.ui.Messages;
@@ -42,12 +43,11 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
                 tree, value, sel,
                 expanded, leaf, row,
                 hasFocus);
-        setOpaque(true);
-        setBackground(Color.WHITE);
-        setForeground(Color.BLACK);
+        setBackground(UIManager.getColor("Tree.background"));
+        setForeground(UIManager.getColor("Tree.textForeground"));
         if(sel) {
-            setBackground(Color.DARK_GRAY);
-            setForeground(Color.WHITE);
+            setBackground(UIManager.getColor("Tree.selectionBackground"));
+            setForeground(UIManager.getColor("Tree.selectionForeground"));
         }
 
         if(value instanceof Unit) {

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -295,7 +295,6 @@ public final class HangarTab extends CampaignGuiTab {
         });
 
         JScrollPane scrollAcquireUnitTable = new JScrollPane(acquireUnitsTable);
-        scrollAcquireUnitTable.getViewport().setBackground(Color.WHITE);
         JPanel panAcquireUnit = new JPanel(new GridLayout(0, 1));
         panAcquireUnit.setBorder(BorderFactory.createTitledBorder("Procurement List"));
         panAcquireUnit.add(scrollAcquireUnitTable);
@@ -303,7 +302,6 @@ public final class HangarTab extends CampaignGuiTab {
         panAcquireUnit.setPreferredSize(new Dimension(200, 200));
 
         JScrollPane scrollUnitTable = new JScrollPane(unitTable);
-        scrollUnitTable.getViewport().setBackground(Color.WHITE);
         JSplitPane splitLeftUnit = new JSplitPane(JSplitPane.VERTICAL_SPLIT, scrollUnitTable,
                 panAcquireUnit);
         splitLeftUnit.setOneTouchExpandable(true);
@@ -313,7 +311,6 @@ public final class HangarTab extends CampaignGuiTab {
         scrollUnitView.setMinimumSize(new java.awt.Dimension(UNIT_VIEW_WIDTH, 600));
         scrollUnitView.setPreferredSize(new java.awt.Dimension(UNIT_VIEW_WIDTH, 600));
         scrollUnitView.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollUnitView.getViewport().setBackground(Color.WHITE);
         scrollUnitView.setViewportView(null);
 
         splitUnit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, splitLeftUnit, scrollUnitView);

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -151,7 +151,6 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         scrollPlanetView.setMinimumSize(new java.awt.Dimension(400, 600));
         scrollPlanetView.setPreferredSize(new java.awt.Dimension(400, 600));
         scrollPlanetView.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollPlanetView.getViewport().setBackground(Color.WHITE);
         scrollPlanetView.setViewportView(null);
         splitMap = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapView, scrollPlanetView);
         splitMap.setOneTouchExpandable(true);

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -267,11 +267,9 @@ public final class PersonnelTab extends CampaignGuiTab {
         scrollPersonnelView.setMinimumSize(new java.awt.Dimension(PERSONNEL_VIEW_WIDTH, 600));
         scrollPersonnelView.setPreferredSize(new java.awt.Dimension(PERSONNEL_VIEW_WIDTH, 600));
         scrollPersonnelView.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollPersonnelView.getViewport().setBackground(Color.WHITE);
         scrollPersonnelView.setViewportView(null);
 
         JScrollPane scrollPersonnelTable = new JScrollPane(personnelTable);
-        scrollPersonnelTable.getViewport().setBackground(Color.WHITE);
         splitPersonnel = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scrollPersonnelTable,
                 scrollPersonnelView);
         splitPersonnel.setOneTouchExpandable(true);

--- a/MekHQ/src/mekhq/gui/RepairTaskInfo.java
+++ b/MekHQ/src/mekhq/gui/RepairTaskInfo.java
@@ -1,6 +1,5 @@
 package mekhq.gui;
 
-import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Image;
@@ -10,6 +9,8 @@ import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.border.LineBorder;
 
 import mekhq.IconPackage;
 
@@ -64,14 +65,13 @@ public class RepairTaskInfo extends JPanel {
         this.setBorder(BorderFactory.createEmptyBorder());
     }
 
-    public void setText(String s, String color) {
-        lblImage.setText("<html><font size='2' color='" + color + "'>" + s
-                + "</font></html>");
+    public void setText(String s) {
+        lblImage.setText("<html><font size='2'>" + s + "</font></html>");
     }
-    
 
     public void highlightBorder() {
-    	this.setBorder(new javax.swing.border.LineBorder(Color.BLACK, 5, true));
+    	this.setBorder(new LineBorder(
+            UIManager.getColor("Tree.selectionBorderColor"), 4, true));
     }
 
     public void unhighlightBorder() {

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -102,7 +102,6 @@ public final class TOETab extends CampaignGuiTab {
         panForceView.setLayout(new BorderLayout());
 
         JScrollPane scrollOrg = new JScrollPane(orgTree);
-        scrollOrg.getViewport().setBackground(Color.WHITE);
         splitOrg = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scrollOrg, panForceView);
         splitOrg.setOneTouchExpandable(true);
         splitOrg.setResizeWeight(1.0);
@@ -143,7 +142,6 @@ public final class TOETab extends CampaignGuiTab {
             if (crewSize > 0) {
                 JPanel crewPanel = new JPanel(new BorderLayout());
                 final JScrollPane scrollPerson = new JScrollPane();
-                scrollPerson.getViewport().setBackground(Color.WHITE);
                 crewPanel.add(scrollPerson, BorderLayout.CENTER);
                 CrewListModel model = new CrewListModel();
                 model.setData(u);
@@ -185,7 +183,6 @@ public final class TOETab extends CampaignGuiTab {
                 });
             }
             final JScrollPane scrollUnit = new JScrollPane(new UnitViewPanel(u, getCampaign(), getIconPackage().getCamos(), getIconPackage().getMechTiles()));
-            scrollUnit.getViewport().setBackground(Color.WHITE);
             tabUnit.add("Unit", scrollUnit);
             panForceView.add(tabUnit, BorderLayout.CENTER);
             javax.swing.SwingUtilities.invokeLater(() -> {
@@ -193,7 +190,6 @@ public final class TOETab extends CampaignGuiTab {
             });
         } else if (node instanceof Force) {
             final JScrollPane scrollForce = new JScrollPane(new ForceViewPanel((Force) node, getCampaign(), getIconPackage()));
-            scrollForce.getViewport().setBackground(Color.WHITE);
             panForceView.add(scrollForce, BorderLayout.CENTER);
             javax.swing.SwingUtilities.invokeLater(() -> {
                 scrollForce.getVerticalScrollBar().setValue(0);

--- a/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
@@ -189,7 +189,7 @@ public class AcquisitionsDialog extends JDialog {
 
     private String generateSummaryText() {
         StringBuilder sbText = new StringBuilder();
-        sbText.append("<html><font size='3' color='black'>");
+        sbText.append("<html><font size='3'>");
 
         sbText.append("Required: ");
         sbText.append(PartsAcquisitionService.getRequiredCount());
@@ -376,7 +376,7 @@ public class AcquisitionsDialog extends JDialog {
 
         private String generateText() {
             StringBuilder sbText = new StringBuilder();
-            sbText.append("<html><font size='3' color='black'>");
+            sbText.append("<html><font size='3'>");
 
             sbText.append("<b>");
             sbText.append(targetWork.getAcquisitionDisplayName());

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -52,6 +52,7 @@ import mekhq.gui.preferences.JToggleButtonPreference;
 import mekhq.gui.preferences.JWindowPreference;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.RankSorter;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 import mekhq.preferences.PreferencesNode;
 
 public final class BatchXPDialog extends JDialog {
@@ -150,7 +151,7 @@ public final class BatchXPDialog extends JDialog {
             TableColumn column = personnelTable.getColumnModel().getColumn(i);
             if(personnelColumns.contains(Integer.valueOf(i))) {
                 column.setPreferredWidth(personnelModel.getColumnWidth(i));
-                column.setCellRenderer(new CellRenderer());
+                column.setCellRenderer(new MekHqTableCellRenderer());
             } else {
                 personnelTable.removeColumn(column);
             }
@@ -347,28 +348,6 @@ public final class BatchXPDialog extends JDialog {
 
     public boolean hasDataChanged() {
         return dataChanged;
-    }
-
-    public static class CellRenderer extends DefaultTableCellRenderer {
-        private static final long serialVersionUID = 8387527228725524653L;
-
-        @Override
-        public Component getTableCellRendererComponent(JTable table,
-                Object value, boolean isSelected, boolean hasFocus,
-                int row, int column) {
-            super.getTableCellRendererComponent(table, value, isSelected,
-                    hasFocus, row, column);
-            setOpaque(true);
-
-            setForeground(Color.BLACK);
-            if((row % 2) == 0) {
-                setBackground(new Color(220, 220, 220));
-            } else {
-                setBackground(Color.WHITE);
-            }
-
-            return this;
-        }
     }
 
     public static class PersonnelFilter extends RowFilter<PersonnelTableModel, Integer> {

--- a/MekHQ/src/mekhq/gui/dialog/CamoChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CamoChoiceDialog.java
@@ -6,7 +6,6 @@
 
 package mekhq.gui.dialog;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics2D;
 import java.awt.Image;
@@ -30,6 +29,7 @@ import megamek.common.util.DirectoryItems;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.gui.preferences.JWindowPreference;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 import mekhq.preferences.PreferencesNode;
 
 /**
@@ -321,7 +321,6 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
             return new CamoTableModel.Renderer(camos);
         }
 
-
         public class Renderer extends CamoPanel implements TableCellRenderer {
 			
         	public Renderer(DirectoryItems camos) {
@@ -331,18 +330,12 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
 			private static final long serialVersionUID = -7106605749246434963L;
 
 			public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
-                Component c = this;
-                setOpaque(true);
                 String name = getValueAt(row, column).toString();
                 setText(getValueAt(row, column).toString());
                 setImage(category, name, row);
-                if(isSelected) {
-                    setBackground(new Color(220,220,220));
-                } else {
-                    setBackground(Color.WHITE);
-                }
-
-                return c;
+                
+                MekHqTableCellRenderer.setupTableColors(this, table, isSelected, hasFocus, row);
+                return this;
             }
        }
     }

--- a/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
@@ -35,6 +35,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
+import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -49,6 +50,7 @@ import mekhq.IconPackage;
 import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
 import mekhq.gui.preferences.JWindowPreference;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 import mekhq.preferences.PreferencesNode;
 
 /**
@@ -737,18 +739,12 @@ public class ImageChoiceDialog extends JDialog {
 
             @Override
             public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
-                Component c = this;
-                setOpaque(true);
                 String name = getValueAt(row, column).toString();
                 setText(getValueAt(row, column).toString());
                 setImage(category, name);
-                if(isSelected) {
-                    setBackground(new Color(220,220,220));
-                } else {
-                    setBackground(Color.WHITE);
-                }
-
-                return c;
+                
+                MekHqTableCellRenderer.setupTableColors(this, table, isSelected, hasFocus, row);
+                return this;
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -203,7 +203,6 @@ public class MedicalViewDialog extends JDialog {
 
         };
         
-        setBackground(Color.WHITE);
         getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
         Container scrollPanel = new JPanel();
         getContentPane().add(new JScrollPane(scrollPanel, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER));
@@ -223,7 +222,6 @@ public class MedicalViewDialog extends JDialog {
     }
     
     private void initComponents(Container cont) {
-        cont.setBackground(Color.WHITE);
         cont.setLayout(new GridBagLayout());
         
         GridBagConstraints gbc;

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -556,7 +556,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
             gridBagConstraints.weightx = 1.0;
             pnlSalvageValue.add(lblSalvageValueEmployer2, gridBagConstraints);
             i++;
-            String lead = "<html><font color='black'>";
+            String lead = "<html><font>";
             if(currentSalvagePct > maxSalvagePct) {
                 lead = "<html><font color='red'>";
             }
@@ -569,7 +569,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
             gridBagConstraints.insets = new Insets(5, 5, 0, 0);
             gridBagConstraints.weightx = 0.0;
             pnlSalvageValue.add(lblSalvagePct1, gridBagConstraints);
-            lblSalvagePct2 = new JLabel(lead + currentSalvagePct + "%</font> <font color='black'>(max " + maxSalvagePct + "%)</font></html>");
+            lblSalvagePct2 = new JLabel(lead + currentSalvagePct + "%</font> <span>(max " + maxSalvagePct + "%)</span></html>");
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 1;
             gridBagConstraints.gridy = 2;
@@ -1487,11 +1487,11 @@ public class ResolveScenarioWizardDialog extends JDialog {
         }
         lblSalvageValueUnit2.setText(salvageUnit.toAmountAndSymbolString());
         lblSalvageValueEmployer2.setText(salvageEmployer.toAmountAndSymbolString());
-        String lead = "<html><font color='black'>";
+        String lead = "<html><font>";
         if(currentSalvagePct > maxSalvagePct) {
             lead = "<html><font color='red'>";
         }
-        lblSalvagePct2.setText(lead + currentSalvagePct + "%</font> <font color='black'>(max " + maxSalvagePct + "%)</font></html>");
+        lblSalvagePct2.setText(lead + currentSalvagePct + "%</font> <span>(max " + maxSalvagePct + "%)</span></html>");
 
     }
 

--- a/MekHQ/src/mekhq/gui/model/CrewListModel.java
+++ b/MekHQ/src/mekhq/gui/model/CrewListModel.java
@@ -150,7 +150,7 @@ public class CrewListModel extends AbstractListModel<Person> {
                 sb.append("-");
             }
             sb.append(")</font></html>");
-            setText(sb.toString(), "black");
+            setText(sb.toString());
             if (isSelected) {
                 highlightBorder();
             } else {

--- a/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
@@ -8,9 +8,11 @@ import java.util.ArrayList;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
 
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.Transaction;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 /**
  * A table model for displaying financial transactions (i.e. a ledger)
@@ -18,13 +20,13 @@ import mekhq.campaign.finances.Transaction;
 public class FinanceTableModel extends DataTableModel {
     private static final long serialVersionUID = 534443424190075264L;
 
-    public final static int COL_DATE    =    0;
-    public final static int COL_CATEGORY =   1;
-    public final static int COL_DESC       = 2;
-    public final static int COL_DEBIT     =  3;
-    public final static int COL_CREDIT   =   4;
-    public final static int COL_BALANCE  =   5;
-    public final static int N_COL          = 6;
+    public final static int COL_DATE = 0;
+    public final static int COL_CATEGORY = 1;
+    public final static int COL_DESC = 2;
+    public final static int COL_DEBIT = 3;
+    public final static int COL_CREDIT = 4;
+    public final static int COL_BALANCE = 5;
+    public final static int N_COL = 6;
 
     public FinanceTableModel() {
         data = new ArrayList<Transaction>();
@@ -41,7 +43,7 @@ public class FinanceTableModel extends DataTableModel {
 
     @Override
     public String getColumnName(int column) {
-        switch(column) {
+        switch (column) {
         case COL_DATE:
             return "Date";
         case COL_CATEGORY:
@@ -63,33 +65,33 @@ public class FinanceTableModel extends DataTableModel {
         Transaction transaction = getTransaction(row);
         Money amount = transaction.getAmount();
         Money balance = Money.zero();
-        for(int i = 0; i <= row; i++) {
+        for (int i = 0; i <= row; i++) {
             balance = balance.plus(getTransaction(i).getAmount());
         }
-        if(col == COL_CATEGORY) {
+        if (col == COL_CATEGORY) {
             return transaction.getCategoryName();
         }
-        if(col == COL_DESC) {
+        if (col == COL_DESC) {
             return transaction.getDescription();
         }
-        if(col == COL_DEBIT) {
-            if(amount.isNegative()) {
+        if (col == COL_DEBIT) {
+            if (amount.isNegative()) {
                 return amount.absolute().toAmountAndSymbolString();
             } else {
                 return "";
             }
         }
-        if(col == COL_CREDIT) {
-            if(amount.isPositive()) {
+        if (col == COL_CREDIT) {
+            if (amount.isPositive()) {
                 return amount.toAmountAndSymbolString();
             } else {
                 return "";
             }
         }
-        if(col == COL_BALANCE) {
+        if (col == COL_BALANCE) {
             return balance.toAmountAndSymbolString();
         }
-        if(col == COL_DATE) {
+        if (col == COL_DATE) {
             SimpleDateFormat shortDateFormat = new SimpleDateFormat("MM/dd/yyyy");
             return shortDateFormat.format(transaction.getDate());
         }
@@ -97,7 +99,7 @@ public class FinanceTableModel extends DataTableModel {
     }
 
     public int getColumnWidth(int c) {
-        switch(c) {
+        switch (c) {
         case COL_DESC:
             return 150;
         case COL_CATEGORY:
@@ -108,7 +110,7 @@ public class FinanceTableModel extends DataTableModel {
     }
 
     public int getAlignment(int col) {
-        switch(col) {
+        switch (col) {
         case COL_DEBIT:
         case COL_CREDIT:
         case COL_BALANCE:
@@ -129,12 +131,12 @@ public class FinanceTableModel extends DataTableModel {
     }
 
     public Transaction getTransaction(int row) {
-        return (Transaction)data.get(row);
+        return (Transaction) data.get(row);
     }
 
     public void setTransaction(int row, Transaction transaction) {
-        //FIXME
-        //data.set(row, transaction);
+        // FIXME
+        // data.set(row, transaction);
     }
 
     public void deleteTransaction(int row) {
@@ -145,7 +147,7 @@ public class FinanceTableModel extends DataTableModel {
         return new FinanceTableModel.Renderer();
     }
 
-    public class Renderer extends DefaultTableCellRenderer {
+    public class Renderer extends MekHqTableCellRenderer {
 
         private static final long serialVersionUID = 9054581142945717303L;
 
@@ -154,23 +156,9 @@ public class FinanceTableModel extends DataTableModel {
                 int row, int column) {
             super.getTableCellRendererComponent(table, value, isSelected,
                     hasFocus, row, column);
-            setOpaque(true);
             setHorizontalAlignment(getAlignment(column));
 
-            setForeground(Color.BLACK);
-            if (isSelected) {
-                setBackground(Color.DARK_GRAY);
-                setForeground(Color.WHITE);
-            } else {
-                // tiger stripes
-                if (row % 2 == 1) {
-                    setBackground(new Color(230,230,230));
-                } else {
-                    setBackground(Color.WHITE);
-                }
-            }
             return this;
         }
-
     }
 }

--- a/MekHQ/src/mekhq/gui/model/LoanTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/LoanTableModel.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 import javax.swing.table.DefaultTableCellRenderer;
 
 import mekhq.campaign.finances.Finances;
@@ -155,15 +156,15 @@ public class LoanTableModel extends DataTableModel {
             setHorizontalAlignment(getAlignment(column));
             Loan loan = getLoan(table.convertRowIndexToModel(row));
 
-            setForeground(Color.BLACK);
+            setForeground(UIManager.getColor("Table.foreground"));
             if (isSelected) {
-                setBackground(Color.DARK_GRAY);
-                setForeground(Color.WHITE);
+                setBackground(UIManager.getColor("Table.selectionBackground"));
+                setForeground(UIManager.getColor("Table.selectionForeground"));
             } else {
                 if(loan.isOverdue()) {
                     setBackground(Color.RED);
                 } else {
-                    setBackground(Color.WHITE);
+                    setBackground(UIManager.getColor("Table.background"));
                 }
             }
 

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -26,6 +26,7 @@ import javax.swing.table.TableColumnModel;
 
 import megamek.common.util.EncodeControl;
 import mekhq.campaign.parts.PartInUse;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 public class PartsInUseTableModel extends DataTableModel {
     private static final long serialVersionUID = -7166100476703184175L;
@@ -226,7 +227,7 @@ public class PartsInUseTableModel extends DataTableModel {
         return new PartsInUseTableModel.Renderer();
     }
 
-    public static class Renderer extends DefaultTableCellRenderer {
+    public static class Renderer extends MekHqTableCellRenderer {
         private static final long serialVersionUID = 1403740113670268591L;
 
         @Override
@@ -235,19 +236,6 @@ public class PartsInUseTableModel extends DataTableModel {
             super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             setOpaque(true);
             setHorizontalAlignment(((PartsInUseTableModel)table.getModel()).getAlignment(column));
-
-            setForeground(Color.BLACK);
-            if (isSelected) {
-                setBackground(Color.DARK_GRAY);
-                setForeground(Color.WHITE);
-            } else {
-                // tiger stripes
-                if (row % 2 == 1) {
-                    setBackground(new Color(230,230,230));
-                } else {
-                    setBackground(Color.WHITE);
-                }
-            }
             return this;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/PatientTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PatientTableModel.java
@@ -1,5 +1,6 @@
 package mekhq.gui.model;
 
+import java.awt.Color;
 import java.awt.Component;
 import java.util.ArrayList;
 
@@ -81,6 +82,7 @@ public class PatientTableModel extends AbstractListModel<Person> {
                 unhighlightBorder();
             }
             setPortrait(p);
+            c.setBackground(new Color(220, 220, 220));
             return c;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -18,6 +18,7 @@ import javax.swing.text.StyleConstants;
 
 import megamek.common.util.EncodeControl;
 import mekhq.campaign.log.LogEntry;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 public class PersonnelEventLogModel extends DataTableModel {
     private static final long serialVersionUID = 2930826794853379580L;
@@ -161,13 +162,7 @@ public class PersonnelEventLogModel extends DataTableModel {
                 table.setRowHeight(row, height);
             }
 
-            setForeground(Color.BLACK);
-            // tiger stripes
-            if (row % 2 == 0) {
-                setBackground(new Color(230,230,230));
-            } else {
-                setBackground(Color.WHITE);
-            }
+            MekHqTableCellRenderer.setupTableColors(this, table, isSelected, hasFocus, row);
             return this;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -18,6 +18,7 @@ import javax.swing.text.StyleConstants;
 
 import megamek.common.util.EncodeControl;
 import mekhq.campaign.Kill;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 public class PersonnelKillLogModel extends DataTableModel {
     private static final long serialVersionUID = 2930826794853379579L;
@@ -159,13 +160,7 @@ public class PersonnelKillLogModel extends DataTableModel {
                 table.setRowHeight(row, height);
             }
 
-            setForeground(Color.BLACK);
-            // tiger stripes
-            if (row % 2 == 0) {
-                setBackground(new Color(230,230,230));
-            } else {
-                setBackground(Color.WHITE);
-            }
+            MekHqTableCellRenderer.setupTableColors(this, table, isSelected, hasFocus, row);
             return this;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -688,7 +688,6 @@ public class PersonnelTableModel extends DataTableModel {
                 setBackground(UIManager.getColor("Table.selectionBackground"));
                 setForeground(UIManager.getColor("Table.selectionForeground"));
             } else {
-                // tiger stripes
                 if (isDeployed(actualRow)) {
                     setBackground(Color.LIGHT_GRAY);
                 } else if ((Integer.parseInt((String) getValueAt(actualRow,COL_HITS)) > 0) || getPerson(actualRow).hasInjuries(true)) {
@@ -720,21 +719,18 @@ public class PersonnelTableModel extends DataTableModel {
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
             Person p = getPerson(actualRow);
-            String color = "black";
-            if (isSelected) {
-                color = "white";
-            }
-            setText(getValueAt(actualRow, actualCol).toString(), color);
+
+            setText(getValueAt(actualRow, actualCol).toString());
 
             switch(actualCol) {
                 case COL_RANK:
                     setPortrait(p);
-                    setText(p.getFullDesc(false), color);
+                    setText(p.getFullDesc(false));
                     break;
                 case COL_ASSIGN:
                     if (loadAssignmentFromMarket) {
                         Entity en = personnelMarket.getAttachedEntity(p);
-                        setText(en != null ? en.getDisplayName() : "-", color);
+                        setText(en != null ? en.getDisplayName() : "-");
                     } else {
                         Unit u = getCampaign().getUnit(p.getUnitId());
                         if (!p.getTechUnitIDs().isEmpty()) {
@@ -747,7 +743,7 @@ public class PersonnelTableModel extends DataTableModel {
                                 desc += " " + UnitType.getTypeDisplayableName(u.getEntity().getUnitType());
                             }
                             desc += "<br>" + u.getStatus() + "";
-                            setText(desc, color);
+                            setText(desc);
                             Image mekImage = getImageFor(u);
                             if (null != mekImage) {
                                 setImage(mekImage);
@@ -772,7 +768,7 @@ public class PersonnelTableModel extends DataTableModel {
                             parent = parent.getParentForce();
                         }
                         desc += "</html>";
-                        setText(desc, color);
+                        setText(desc);
                         Image forceImage = getImageFor(force);
                         if (null != forceImage) {
                             setImage(forceImage);
@@ -790,7 +786,7 @@ public class PersonnelTableModel extends DataTableModel {
                     } else {
                         clearImage();
                     }
-                    setText("", color);
+                    setText("");
                     break;
             }
 

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
@@ -681,10 +682,10 @@ public class PersonnelTableModel extends DataTableModel {
             setHorizontalAlignment(getAlignment(actualCol));
             setToolTipText(getTooltip(actualRow, actualCol));
 
-            setForeground(Color.BLACK);
+            setForeground(UIManager.getColor("Table.foreground"));
             if (isSelected) {
-                setBackground(Color.DARK_GRAY);
-                setForeground(Color.WHITE);
+                setBackground(UIManager.getColor("Table.selectionBackground"));
+                setForeground(UIManager.getColor("Table.selectionForeground"));
             } else {
                 // tiger stripes
                 if (isDeployed(actualRow)) {
@@ -694,7 +695,7 @@ public class PersonnelTableModel extends DataTableModel {
                 } else if (getPerson(actualRow).hasOnlyHealedPermanentInjuries()) {
                     setBackground(new Color(0xee9a00));
                 } else {
-                    setBackground(Color.WHITE);
+                    setBackground(UIManager.getColor("Table.background"));
                 }
             }
             return this;

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -46,6 +46,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
 import mekhq.gui.BasicInfo;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 /**
  * A table Model for displaying information about personnel
@@ -793,16 +794,7 @@ public class PersonnelTableModel extends DataTableModel {
                     break;
             }
 
-            if (isSelected) {
-                c.setBackground(Color.DARK_GRAY);
-            } else {
-                // tiger stripes
-                if ((row % 2) == 0) {
-                    c.setBackground(new Color(220, 220, 220));
-                } else {
-                    c.setBackground(Color.WHITE);
-                }
-            }
+            MekHqTableCellRenderer.setupTableColors(c, table, isSelected, hasFocus, row);
             return c;
         }
 

--- a/MekHQ/src/mekhq/gui/model/RankTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RankTableModel.java
@@ -9,6 +9,8 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 
+import mekhq.gui.utilities.MekHqTableCellRenderer;
+
 public class RankTableModel extends DefaultTableModel {
     private static final long serialVersionUID = 534443424190075264L;
 
@@ -111,7 +113,7 @@ public class RankTableModel extends DefaultTableModel {
         return new RankTableModel.Renderer();
     }
 
-    public class Renderer extends DefaultTableCellRenderer {
+    public class Renderer extends MekHqTableCellRenderer {
 
         private static final long serialVersionUID = 9054581142945717303L;
 
@@ -125,18 +127,6 @@ public class RankTableModel extends DefaultTableModel {
             int actualRow = table.convertRowIndexToModel(row);
             setHorizontalAlignment(getAlignment(actualCol));
             setToolTipText(getTooltip(actualRow, actualCol));
-            setForeground(Color.BLACK);
-            if (isSelected) {
-                setBackground(Color.DARK_GRAY);
-                setForeground(Color.WHITE);
-            } else {
-            	// tiger stripes
-                if ((row % 2) == 0) {
-                    setBackground(new Color(220, 220, 220));
-                } else {
-                    setBackground(Color.WHITE);
-                }
-            }
             return this;
         }
 

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -29,6 +29,7 @@ import mekhq.campaign.personnel.RetirementDefectionTracker;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
 import mekhq.gui.dialog.RetirementDefectionDialog;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 public class RetirementTableModel extends AbstractTableModel {
     /**
@@ -383,7 +384,7 @@ public class RetirementTableModel extends AbstractTableModel {
         } else return new TextRenderer();
     }
 
-    public class TextRenderer extends DefaultTableCellRenderer {
+    public class TextRenderer extends MekHqTableCellRenderer {
         /**
          *
          */
@@ -398,18 +399,10 @@ public class RetirementTableModel extends AbstractTableModel {
             int actualCol = table.convertColumnIndexToModel(column);
             Person p = getPerson(actualRow);
             setHorizontalAlignment(getAlignment(actualCol));
-            setForeground(isSelected?Color.WHITE:Color.BLACK);
-            if (isSelected) {
-                setBackground(Color.DARK_GRAY);
-            } else if (null != campaign.getRetirementDefectionTracker().getPayout(p.getId()) &&
+            if (!isSelected) {
+                if (null != campaign.getRetirementDefectionTracker().getPayout(p.getId()) &&
                     campaign.getRetirementDefectionTracker().getPayout(p.getId()).getWeightClass() > 0) {
-                setBackground(Color.LIGHT_GRAY);
-            } else {
-                // tiger stripes
-                if ((row % 2) == 0) {
-                    setBackground(new Color(220, 220, 220));
-                } else {
-                    setBackground(Color.WHITE);
+                    setBackground(Color.LIGHT_GRAY);
                 }
             }
             return this;

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -484,19 +484,14 @@ public class RetirementTableModel extends AbstractTableModel {
                 }
             }
 
-            if (isSelected) {
-                c.setBackground(Color.DARK_GRAY);
-            } else if (null != campaign.getRetirementDefectionTracker().getPayout(p.getId()) &&
+            MekHqTableCellRenderer.setupTableColors(c, table, isSelected, hasFocus, row);
+            if (!isSelected) {
+                if (null != campaign.getRetirementDefectionTracker().getPayout(p.getId()) &&
                         campaign.getRetirementDefectionTracker().getPayout(p.getId()).getWeightClass() > 0) {
-                c.setBackground(Color.LIGHT_GRAY);
-            } else {
-                // tiger stripes
-                if ((row % 2) == 0) {
-                    c.setBackground(new Color(220, 220, 220));
-                } else {
-                    c.setBackground(Color.WHITE);
+                    c.setBackground(Color.LIGHT_GRAY);
                 }
             }
+            
             return c;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
-import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
 import megamek.common.EntityWeightClass;
@@ -427,14 +426,10 @@ public class RetirementTableModel extends AbstractTableModel {
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
             Person p = getPerson(actualRow);
-            String color = "black";
-            if(isSelected) {
-                color = "white";
-            }
-            setText(getValueAt(actualRow, actualCol).toString(), color);
+            setText(getValueAt(actualRow, actualCol).toString());
             if (actualCol == COL_PERSON) {
                 setPortrait(p);
-                setText(p.getFullDesc(false), color);
+                setText(p.getFullDesc(false));
             }
             if(actualCol == COL_ASSIGN) {
                 Unit u = campaign.getUnit(p.getUnitId());
@@ -448,7 +443,7 @@ public class RetirementTableModel extends AbstractTableModel {
                         desc += " " + UnitType.getTypeDisplayableName(u.getEntity().getUnitType());
                     }
                     desc += "<br>" + u.getStatus() + "";
-                    setText(desc, color);
+                    setText(desc);
                     Image mekImage = getImageFor(u);
                     if(null != mekImage) {
                         setImage(mekImage);
@@ -472,7 +467,7 @@ public class RetirementTableModel extends AbstractTableModel {
                         parent = parent.getParentForce();
                     }
                     desc += "</html>";
-                    setText(desc, color);
+                    setText(desc);
                     Image forceImage = getImageFor(force);
                     if(null != forceImage) {
                         setImage(forceImage);

--- a/MekHQ/src/mekhq/gui/model/TaskTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TaskTableModel.java
@@ -23,6 +23,7 @@ import mekhq.campaign.work.IPartWork;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.ITechWorkPanel;
 import mekhq.gui.RepairTaskInfo;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 /**
  * A table model for displaying work items
@@ -85,13 +86,15 @@ public class TaskTableModel extends DataTableModel {
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
             
-            setOpaque(true);
-            setText("<html>" + getValueAt(actualRow, actualCol).toString() + "</html>", "black");
+            setText("<html>" + getValueAt(actualRow, actualCol).toString() + "</html>");
             if (isSelected) {
                 highlightBorder();
             } else {
                 unhighlightBorder();
-            }
+			}
+			
+            c.setBackground(table.getBackground());
+            c.setForeground(table.getForeground());
             
             IPartWork part = getTaskAt(actualRow);
             
@@ -208,7 +211,7 @@ public class TaskTableModel extends DataTableModel {
             } else {
             	this.setSecondaryImage(null);
             }
-            
+			
             return c;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/TechTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TechTableModel.java
@@ -61,16 +61,15 @@ public class TechTableModel extends DataTableModel {
             int actualRow = table.convertRowIndexToModel(row);
             setOpaque(true);
             setPortrait(getTechAt(actualRow));
-            setText(getTechAt(actualRow).getTechDesc(getCampaign().isOvertimeAllowed(), panel.getSelectedTask()),
-                    "black");
+            setText(getTechAt(actualRow).getTechDesc(getCampaign().isOvertimeAllowed(), panel.getSelectedTask()));
             if (isSelected) {
                 highlightBorder();
             } else {
                 unhighlightBorder();
             }
-            c.setBackground(new Color(220, 220, 220));
+            c.setBackground(table.getBackground());
+            c.setForeground(table.getForeground());
             return c;
         }
-
     }
 }

--- a/MekHQ/src/mekhq/gui/model/UnitAssignmentTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitAssignmentTableModel.java
@@ -20,6 +20,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
 import mekhq.gui.dialog.RetirementDefectionDialog;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 public class UnitAssignmentTableModel extends AbstractTableModel {
 
@@ -132,7 +133,7 @@ public class UnitAssignmentTableModel extends AbstractTableModel {
         } else return new TextRenderer();
     }
 
-    public class TextRenderer extends DefaultTableCellRenderer {
+    public class TextRenderer extends MekHqTableCellRenderer {
 
         /**
          *
@@ -146,17 +147,6 @@ public class UnitAssignmentTableModel extends AbstractTableModel {
                     hasFocus, row, column);
             int actualCol = table.convertColumnIndexToModel(column);
             setHorizontalAlignment(getAlignment(actualCol));
-            setForeground(isSelected?Color.WHITE:Color.BLACK);
-            if (isSelected) {
-                setBackground(Color.DARK_GRAY);
-            } else {
-                // tiger stripes
-                if ((row % 2) == 0) {
-                    setBackground(new Color(220, 220, 220));
-                } else {
-                    setBackground(Color.WHITE);
-                }
-            }
             return this;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/UnitAssignmentTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitAssignmentTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
 import java.util.ArrayList;
@@ -9,7 +8,6 @@ import java.util.UUID;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
-import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
 import megamek.common.Jumpship;
@@ -169,11 +167,7 @@ public class UnitAssignmentTableModel extends AbstractTableModel {
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
             Unit u = getUnit(actualRow);
-            String color = "black";
-            if(isSelected) {
-                color = "white";
-            }
-            setText(getValueAt(actualRow, actualCol).toString(), color);
+            setText(getValueAt(actualRow, actualCol).toString());
             if (actualCol == COL_UNIT) {
                 if(null != u) {
                     String desc = "<b>" + u.getName() + "</b><br>";
@@ -182,7 +176,7 @@ public class UnitAssignmentTableModel extends AbstractTableModel {
                         desc += " " + UnitType.getTypeDisplayableName(u.getEntity().getUnitType());
                     }
                     desc += "<br>" + u.getStatus() + "";
-                    setText(desc, color);
+                    setText(desc);
                     Image mekImage = getImageFor(u);
                     if(null != mekImage) {
                         setImage(mekImage);

--- a/MekHQ/src/mekhq/gui/model/UnitAssignmentTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitAssignmentTableModel.java
@@ -194,16 +194,7 @@ public class UnitAssignmentTableModel extends AbstractTableModel {
                 }
             }
 
-            if (isSelected) {
-                c.setBackground(Color.DARK_GRAY);
-            } else {
-                // tiger stripes
-                if ((row % 2) == 0) {
-                    c.setBackground(new Color(220, 220, 220));
-                } else {
-                    c.setBackground(Color.WHITE);
-                }
-            }
+            MekHqTableCellRenderer.setupTableColors(c, table, isSelected, hasFocus, row);
             return c;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -364,17 +364,15 @@ public class UnitTableModel extends DataTableModel {
             Component c = this;
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
-            String color = "black";
-            if(isSelected) {
-                color = "white";
-            }
-            setText(getValueAt(actualRow, actualCol).toString(), color);
+
+            setText(getValueAt(actualRow, actualCol).toString());
+
             Unit u = getUnit(actualRow);
             if (actualCol == COL_PILOT) {
                 Person p = u.getCommander();
                 if(null != p) {
                     setPortrait(p);
-                    setText(p.getFullDesc(false), color);
+                    setText(p.getFullDesc(false));
                 } else {
                     clearImage();
                 }
@@ -383,7 +381,7 @@ public class UnitTableModel extends DataTableModel {
                 Person p = u.getTech();
                 if(null != p) {
                     setPortrait(p);
-                    setText(p.getFullDesc(false), color);
+                    setText(p.getFullDesc(false));
                 } else {
                     clearImage();
                 }
@@ -396,7 +394,7 @@ public class UnitTableModel extends DataTableModel {
                         desc += " " + UnitType.getTypeDisplayableName(u.getEntity().getUnitType());
                     }
                     desc += "<br>" + u.getStatus() + "</html>";
-                    setText(desc, color);
+                    setText(desc);
                     Image mekImage = getImageFor(u);
                     if(null != mekImage) {
                         setImage(mekImage);

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -22,6 +22,7 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 /**
  * A table Model for displaying information about units
@@ -407,19 +408,8 @@ public class UnitTableModel extends DataTableModel {
                 }
             }
 
-            if (isSelected) {
-                c.setBackground(Color.DARK_GRAY);
-            } else {
-                // tiger stripes
-                if ((row % 2) == 0) {
-                    c.setBackground(new Color(220, 220, 220));
-                } else {
-                    c.setBackground(Color.WHITE);
-
-                }
-            }
+            MekHqTableCellRenderer.setupTableColors(c, table, isSelected, hasFocus, row);
             return c;
         }
     }
-
 }

--- a/MekHQ/src/mekhq/gui/utilities/MarkdownEditorPanel.java
+++ b/MekHQ/src/mekhq/gui/utilities/MarkdownEditorPanel.java
@@ -176,7 +176,6 @@ public class MarkdownEditorPanel extends JPanel {
         tabPane.add("Write", editorPanel);
 
         viewer = new JTextPane();
-        viewer.setBackground(Color.WHITE);
         viewer.setEditable(false);
         viewer.setContentType("text/html");
         scrollViewer = new JScrollPane(viewer);

--- a/MekHQ/src/mekhq/gui/utilities/MekHqTableCellRenderer.java
+++ b/MekHQ/src/mekhq/gui/utilities/MekHqTableCellRenderer.java
@@ -17,7 +17,7 @@
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- package mekhq.gui.utilities;
+package mekhq.gui.utilities;
 
 import java.awt.Color;
 import java.awt.Component;
@@ -25,6 +25,7 @@ import java.awt.Component;
 import javax.swing.JTable;
 import javax.swing.UIManager;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
 
 public class MekHqTableCellRenderer extends DefaultTableCellRenderer {
     private static final long serialVersionUID = -1L;
@@ -36,39 +37,48 @@ public class MekHqTableCellRenderer extends DefaultTableCellRenderer {
         super.getTableCellRendererComponent(table, value, isSelected,
                 hasFocus, row, column);
 
+        setupTableColors(this, table, isSelected, hasFocus, row);
+
+        return this;
+    }
+
+    public static void setupTableColors(Component c, JTable table, boolean isSelected, 
+            boolean hasFocus, int row) {
         if (isSelected) {
-            setForeground(table.getSelectionForeground());
-            setBackground(table.getSelectionBackground());
+            c.setForeground(table.getSelectionForeground());
+            c.setBackground(table.getSelectionBackground());
         } else {
-            Color background = table.getBackground();
-            if (row % 2 != 0) {
-                Color alternateColor = UIManager.getColor("Table.alternateRowColor");
-                if (alternateColor == null) {
-                    // If we don't have an alternate row color, use 'controlHighlight'
-                    // as it is pretty reasonable across the various themes.
-                    alternateColor = UIManager.getColor("controlHighlight");
-                }
-                if (alternateColor != null) {
-                    background = alternateColor;
-                }
-            }
-            setForeground(table.getForeground());
-            setBackground(background);
+            setupTigerStripes(c, table, row);
         }
 
         if (hasFocus) {
             if (!isSelected ) {
-                Color col = UIManager.getColor("Table.focusCellForeground");
-                if (col != null) {
-                    setForeground(col);
+                Color color = UIManager.getColor("Table.focusCellForeground");
+                if (color != null) {
+                    c.setForeground(color);
                 }
-                col = UIManager.getColor("Table.focusCellBackground");
-                if (col != null) {
-                    setBackground(col);
+                color = UIManager.getColor("Table.focusCellBackground");
+                if (color != null) {
+                    c.setBackground(color);
                 }
             }
         }
+    }
 
-        return this;
+    public static void setupTigerStripes(Component c, JTable table, int row) {
+        Color background = table.getBackground();
+        if (row % 2 != 0) {
+            Color alternateColor = UIManager.getColor("Table.alternateRowColor");
+            if (alternateColor == null) {
+                // If we don't have an alternate row color, use 'controlHighlight'
+                // as it is pretty reasonable across the various themes.
+                alternateColor = UIManager.getColor("controlHighlight");
+            }
+            if (alternateColor != null) {
+                background = alternateColor;
+            }
+        }
+        c.setForeground(table.getForeground());
+        c.setBackground(background);
     }
 }

--- a/MekHQ/src/mekhq/gui/utilities/MekHqTableCellRenderer.java
+++ b/MekHQ/src/mekhq/gui/utilities/MekHqTableCellRenderer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020 The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ package mekhq.gui.utilities;
+
+import java.awt.Color;
+import java.awt.Component;
+
+import javax.swing.JTable;
+import javax.swing.UIManager;
+import javax.swing.table.DefaultTableCellRenderer;
+
+public class MekHqTableCellRenderer extends DefaultTableCellRenderer {
+    private static final long serialVersionUID = -1L;
+
+    @Override
+    public Component getTableCellRendererComponent(JTable table,
+            Object value, boolean isSelected, boolean hasFocus,
+            int row, int column) {
+        super.getTableCellRendererComponent(table, value, isSelected,
+                hasFocus, row, column);
+
+        if (isSelected) {
+            setForeground(table.getSelectionForeground());
+            setBackground(table.getSelectionBackground());
+        } else {
+            Color background = table.getBackground();
+            if (row % 2 != 0) {
+                Color alternateColor = UIManager.getColor("Table.alternateRowColor");
+                if (alternateColor == null) {
+                    // If we don't have an alternate row color, use 'controlHighlight'
+                    // as it is pretty reasonable across the various themes.
+                    alternateColor = UIManager.getColor("controlHighlight");
+                }
+                if (alternateColor != null) {
+                    background = alternateColor;
+                }
+            }
+            setForeground(table.getForeground());
+            setBackground(background);
+        }
+
+        if (hasFocus) {
+            if (!isSelected ) {
+                Color col = UIManager.getColor("Table.focusCellForeground");
+                if (col != null) {
+                    setForeground(col);
+                }
+                col = UIManager.getColor("Table.focusCellBackground");
+                if (col != null) {
+                    setBackground(col);
+                }
+            }
+        }
+
+        return this;
+    }
+}

--- a/MekHQ/src/mekhq/gui/view/AtBContractViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBContractViewPanel.java
@@ -108,11 +108,8 @@ public class AtBContractViewPanel extends ScrollablePanel {
 
         setLayout(new GridBagLayout());
 
-        setBackground(Color.WHITE);
-
         pnlStats.setName("pnlStats");
         pnlStats.setBorder(BorderFactory.createTitledBorder(contract.getName()));
-        pnlStats.setBackground(Color.WHITE);
         fillStats();
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -171,14 +171,12 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
 
         setLayout(new GridBagLayout());
 
-        setBackground(Color.WHITE);
         setScrollableTracksViewportWidth(false);
 
         int y = 0;
 
         panStats.setName("pnlStats");
         panStats.setBorder(BorderFactory.createTitledBorder(scenario.getName()));
-        panStats.setBackground(Color.WHITE);
         fillStats();
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -131,11 +131,8 @@ public class ContractSummaryPanel extends JPanel {
 
 		setLayout(new java.awt.GridBagLayout());
 
-		setBackground(Color.WHITE);
-
 		mainPanel.setName("pnlStats");
 		mainPanel.setBorder(BorderFactory.createTitledBorder(contract.getName()));
-		mainPanel.setBackground(Color.WHITE);
         contractPaymentBreakdown = new ContractPaymentBreakdown(mainPanel, contract, campaign);
 
 		fillStats();

--- a/MekHQ/src/mekhq/gui/view/ContractViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractViewPanel.java
@@ -374,11 +374,11 @@ public class ContractViewPanel extends ScrollablePanel {
                         .intValue();
             }
 
-            String lead = "<html><font color='black'>";
+            String lead = "<html><font>";
             if(currentSalvagePct > maxSalvagePct) {
                 lead = "<html><font color='red'>";
             }
-            lblSalvagePct2.setText(lead + currentSalvagePct + "%</font> <font color='black'>(max " + maxSalvagePct + "%)</font></html>");
+            lblSalvagePct2.setText(lead + currentSalvagePct + "%</font> <span>(max " + maxSalvagePct + "%)</span></html>");
         }
 
         gridBagConstraints = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/ContractViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractViewPanel.java
@@ -86,11 +86,8 @@ public class ContractViewPanel extends ScrollablePanel {
 
         setLayout(new GridBagLayout());
 
-        setBackground(Color.WHITE);
-
         pnlStats.setName("pnlStats");
         pnlStats.setBorder(BorderFactory.createTitledBorder(contract.getName()));
-        pnlStats.setBackground(Color.WHITE);
         fillStats();
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -89,10 +89,8 @@ public class ForceViewPanel extends ScrollablePanel {
 
 		setLayout(new java.awt.GridBagLayout());
 
-		setBackground(Color.WHITE);
 
 		lblIcon.setName("lblPortrait"); // NOI18N
-		lblIcon.setBackground(Color.WHITE);
 		setIcon(force, lblIcon, 150);
 		gridBagConstraints = new java.awt.GridBagConstraints();
 		gridBagConstraints.gridx = 0;
@@ -104,7 +102,6 @@ public class ForceViewPanel extends ScrollablePanel {
 
 		pnlStats.setName("pnlStats");
 		pnlStats.setBorder(BorderFactory.createTitledBorder(force.getName()));
-		pnlStats.setBackground(Color.WHITE);
 		fillStats();
 		gridBagConstraints = new java.awt.GridBagConstraints();
 		gridBagConstraints.gridx = 1;
@@ -117,7 +114,6 @@ public class ForceViewPanel extends ScrollablePanel {
 		add(pnlStats, gridBagConstraints);
 
 		pnlSubUnits.setName("pnlSubUnits");
-		pnlSubUnits.setBackground(Color.WHITE);
 		fillSubUnits();
 		gridBagConstraints = new java.awt.GridBagConstraints();
 		gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -59,11 +59,9 @@ public class JumpPathViewPanel extends ScrollablePanel {
                
         setLayout(new java.awt.GridBagLayout());
 
-        setBackground(Color.WHITE);
 
         pnlStats.setName("pnlStats");
         pnlStats.setBorder(BorderFactory.createTitledBorder("Summary"));
-        pnlStats.setBackground(Color.WHITE);
         fillStats();
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -77,7 +75,6 @@ public class JumpPathViewPanel extends ScrollablePanel {
         
         pnlPath.setName("pnlPath");
         pnlPath.setBorder(BorderFactory.createTitledBorder("Full Path"));
-        pnlPath.setBackground(Color.WHITE);
         getPath();
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -59,11 +59,8 @@ public class MissionViewPanel extends ScrollablePanel {
 
 		setLayout(new GridBagLayout());
 
-		setBackground(Color.WHITE);
-
 		pnlStats.setName("pnlStats");
 		pnlStats.setBorder(BorderFactory.createTitledBorder(mission.getName()));
-		pnlStats.setBackground(Color.WHITE);
 		fillStats();
 		gridBagConstraints = new GridBagConstraints();
 		gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -90,7 +90,6 @@ public class PersonViewPanel extends ScrollablePanel {
         GridBagConstraints gridBagConstraints;
 
         setLayout(new GridBagLayout());
-        setBackground(Color.WHITE);
 
         JPanel pnlPortrait = setPortrait();
         GridBagConstraints gbc_pnlPortrait = new GridBagConstraints();
@@ -168,12 +167,10 @@ public class PersonViewPanel extends ScrollablePanel {
             JPanel pnlAllAwards = new JPanel();
             pnlAllAwards.setLayout(new BoxLayout(pnlAllAwards, BoxLayout.PAGE_AXIS));
             pnlAllAwards.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("pnlAwards.title")));
-            pnlAllAwards.setBackground(Color.WHITE);
 
             if (person.awardController.hasAwardsWithMedals()) {
                 JPanel pnlMedals = drawMedals();
                 pnlMedals.setName("pnlMedals");
-                pnlMedals.setBackground(Color.WHITE);
                 pnlMedals.setLayout(new WrapLayout(FlowLayout.LEFT));
                 pnlAllAwards.add(pnlMedals);
             }
@@ -181,7 +178,6 @@ public class PersonViewPanel extends ScrollablePanel {
             if (person.awardController.hasAwardsWithMiscs()) {
                 JPanel pnlMiscAwards = drawMiscAwards();
                 pnlMiscAwards.setName("pnlMiscAwards");
-                pnlMiscAwards.setBackground(Color.WHITE);
                 pnlMiscAwards.setLayout(new WrapLayout(FlowLayout.LEFT));
                 pnlAllAwards.add(pnlMiscAwards);
             }
@@ -202,7 +198,6 @@ public class PersonViewPanel extends ScrollablePanel {
         if (person.getBiography().length() > 0) {
             JTextPane txtDesc = new JTextPane();
             txtDesc.setName("txtDesc"); //$NON-NLS-1$
-            txtDesc.setBackground(Color.WHITE);
             txtDesc.setEditable(false);
             txtDesc.setContentType("text/html");
             txtDesc.setText(MarkdownRenderer.getRenderedHtml(person.getBiography()));
@@ -224,7 +219,6 @@ public class PersonViewPanel extends ScrollablePanel {
             JPanel pnlLog = fillLog();
             pnlLog.setName("pnlLog"); //$NON-NLS-1$
             pnlLog.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("pnlLog.title"))); //$NON-NLS-1$
-            pnlLog.setBackground(Color.WHITE);
 
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 0;
@@ -244,7 +238,6 @@ public class PersonViewPanel extends ScrollablePanel {
             pnlMissionsLog.setBorder(BorderFactory.createCompoundBorder(
                     BorderFactory.createTitledBorder(resourceMap.getString("missionLog.title")), //$NON-NLS-1$
                     BorderFactory.createEmptyBorder(5, 5, 5, 5)));
-            pnlMissionsLog.setBackground(Color.WHITE);
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = gridy;
@@ -264,7 +257,6 @@ public class PersonViewPanel extends ScrollablePanel {
                     BorderFactory.createTitledBorder(resourceMap.getString("pnlKills.title")), //$NON-NLS-1$
                     BorderFactory.createEmptyBorder(5, 5, 5, 5)));
             gridBagConstraints = new GridBagConstraints();
-            pnlKills.setBackground(Color.WHITE);
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = gridy;
             gridBagConstraints.gridwidth = 2;
@@ -414,12 +406,10 @@ public class PersonViewPanel extends ScrollablePanel {
 
         // Panel portrait will include the person picture and the ribbons
         pnlPortrait.setName("pnlPortrait");
-        pnlPortrait.setBackground(Color.WHITE);
         pnlPortrait.setLayout(new GridBagLayout());
 
         JLabel lblPortrait = new JLabel();
         lblPortrait.setName("lblPortrait"); // NOI18N
-        lblPortrait.setBackground(Color.WHITE);
 
         String category = person.getPortraitCategory();
         String filename = person.getPortraitFileName();
@@ -464,7 +454,6 @@ public class PersonViewPanel extends ScrollablePanel {
     private JPanel fillInfo() {
         JPanel pnlInfo = new JPanel(new GridBagLayout());
         pnlInfo.setBorder(BorderFactory.createTitledBorder(person.getFullTitle()));
-        pnlInfo.setBackground(Color.WHITE);
         JLabel lblType = new JLabel();
         JLabel lblStatus1 = new JLabel();
         JLabel lblStatus2 = new JLabel();
@@ -720,7 +709,6 @@ public class PersonViewPanel extends ScrollablePanel {
     private JPanel fillFamily() {
         JPanel pnlFamily = new JPanel(new GridBagLayout());
         pnlFamily.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("pnlFamily.title")));
-        pnlFamily.setBackground(Color.WHITE);
 
         //family panel
         JLabel lblSpouse1 = new JLabel();
@@ -869,7 +857,6 @@ public class PersonViewPanel extends ScrollablePanel {
         //skill panel
         JPanel pnlSkills = new JPanel(new GridBagLayout());
         pnlSkills.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("pnlSkills.title")));
-        pnlSkills.setBackground(Color.WHITE);
 
         //abilities and implants
         JLabel lblAbility1 = new JLabel();
@@ -1135,7 +1122,6 @@ public class PersonViewPanel extends ScrollablePanel {
 
         JPanel pnlInjuries = new JPanel(new BorderLayout());
         pnlInjuries.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("pnlInjuries.title"))); //$NON-NLS-1$
-        pnlInjuries.setBackground(Color.WHITE);
 
         JButton medicalButton = new JButton(new ImageIcon("data/images/misc/medical.png")); //$NON-NLS-1$
         medicalButton.addActionListener(event -> {
@@ -1151,14 +1137,12 @@ public class PersonViewPanel extends ScrollablePanel {
             MekHQ.triggerEvent(new PersonChangedEvent(person));
         });
         medicalButton.setMaximumSize(new Dimension(32, 32));
-        medicalButton.setBackground(Color.WHITE);
         medicalButton.setMargin(new Insets(0, 0, 0, 0));
         medicalButton.setToolTipText(resourceMap.getString("btnMedical.tooltip")); //$NON-NLS-1$
         medicalButton.setAlignmentY(Component.TOP_ALIGNMENT);
         pnlInjuries.add(medicalButton, BorderLayout.LINE_START);
 
         JPanel pnlInjuryDetails = new JPanel(new GridBagLayout());
-        pnlInjuryDetails.setBackground(Color.WHITE);
         pnlInjuryDetails.setAlignmentY(Component.TOP_ALIGNMENT);
 
 

--- a/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
@@ -67,11 +67,9 @@ public class PlanetViewPanel extends ScrollablePanel {
 
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PlanetViewPanel", new EncodeControl()); //$NON-NLS-1
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-        setBackground(Color.WHITE);
 
         pnlSystem = getSystemPanel();
         pnlSystem.setBorder(BorderFactory.createTitledBorder(system.getPrintableName(Utilities.getDateTimeDay(campaign.getCalendar())) + " " + resourceMap.getString("system.text")));
-        pnlSystem.setBackground(Color.WHITE);
         add(pnlSystem);
 
         Planet planet = system.getPlanet(planetPos);
@@ -82,7 +80,6 @@ public class PlanetViewPanel extends ScrollablePanel {
         if(null != planet) {
             pnlPlanet = getPlanetPanel(planet);
             pnlPlanet.setBorder(BorderFactory.createTitledBorder(planet.getPrintableName(Utilities.getDateTimeDay(campaign.getCalendar()))));
-            pnlPlanet.setBackground(Color.WHITE);
             add(pnlPlanet);
         };
     }

--- a/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
@@ -89,11 +89,8 @@ public class ScenarioViewPanel extends ScrollablePanel {
                
         setLayout(new java.awt.GridBagLayout());
 
-        setBackground(Color.WHITE);
-
         pnlStats.setName("pnlStats");
         pnlStats.setBorder(BorderFactory.createTitledBorder(scenario.getName()));
-        pnlStats.setBackground(Color.WHITE);
         fillStats();
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -90,8 +90,6 @@ public class UnitViewPanel extends ScrollablePanel {
 
 		setLayout(new java.awt.GridBagLayout());
 
-		setBackground(Color.WHITE);
-
         int compWidth = 1;
         Image image = FluffImageHelper.getFluffImage(entity);
         if(null != image) {
@@ -110,7 +108,6 @@ public class UnitViewPanel extends ScrollablePanel {
             //no fluff image, so just use image icon from top-down view
             compWidth=2;
             lblImage = new JLabel();
-            lblImage.setBackground(Color.WHITE);
             image = getImageFor(unit, lblImage);
             if(null != image) {
                 ImageIcon icon = new ImageIcon(image);
@@ -128,7 +125,6 @@ public class UnitViewPanel extends ScrollablePanel {
         
 		pnlStats.setName("pnlBasic");
 		pnlStats.setBorder(BorderFactory.createTitledBorder(unit.getName()));
-		pnlStats.setBackground(Color.WHITE);
 		fillStats(resourceMap);
 		gridBagConstraints = new java.awt.GridBagConstraints();
 		gridBagConstraints.gridx = 0;


### PR DESCRIPTION
This starts the ball rolling with dark themes in MekHQ, mostly implementing #1385. This is good enough for a development release, but a few panels need attention, notably the Unit Table which needs to have its colors customizable.

![Screen Shot 2020-02-14 at 2 55 52 AM](https://user-images.githubusercontent.com/8238690/74512032-5dfbb900-4ed5-11ea-8f17-e77fe28d5416.png)

![Screen Shot 2020-02-14 at 3 20 21 AM](https://user-images.githubusercontent.com/8238690/74513526-c5ffce80-4ed8-11ea-8766-42319d206e0b.png)

![Screen Shot 2020-02-14 at 3 20 53 AM](https://user-images.githubusercontent.com/8238690/74513552-d3b55400-4ed8-11ea-8d51-2338db45bd0f.png)

![Screen Shot 2020-02-14 at 3 26 01 AM](https://user-images.githubusercontent.com/8238690/74513878-8be2fc80-4ed9-11ea-84bf-5bb8fb9fe156.png)

![Screen Shot 2020-02-14 at 3 26 29 AM](https://user-images.githubusercontent.com/8238690/74513910-9c937280-4ed9-11ea-9c2e-9c036c2256a2.png)
