### PR TITLE
Fix and log invalid lc ammo bin

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -270,9 +270,14 @@ public class LargeCraftAmmoBin extends AmmoBin {
 
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
+        final String METHOD_NAME = "updateConditionFromEntity()"; //$NON-NLS-1$
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
+            if (!(mounted.getType() instanceof AmmoType)) {
+                MekHQ.getLogger().log(LargeCraftAmmoBin.class, METHOD_NAME, LogLevel.WARNING,
+                        unit.getName() + " has invalid ammo bin at equipment number " + equipmentNum);
+            }
+            if(null != mounted && mounted.getType() instanceof AmmoType) {
                 capacity = mounted.getAmmoCapacity();
                 type = mounted.getType();
                 if(mounted.isMissing() || mounted.isDestroyed()) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -273,11 +273,15 @@ public class LargeCraftAmmoBin extends AmmoBin {
         final String METHOD_NAME = "updateConditionFromEntity()"; //$NON-NLS-1$
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
+            if (mounted == null) {
+                MekHQ.getLogger().log(LargeCraftAmmoBin.class, METHOD_NAME, LogLevel.WARNING,
+                        unit.getName() + " has a null Mounted at equipment number " + equipmentNum);
+                return;
+            }
             if (!(mounted.getType() instanceof AmmoType)) {
                 MekHQ.getLogger().log(LargeCraftAmmoBin.class, METHOD_NAME, LogLevel.WARNING,
-                        unit.getName() + " has invalid ammo bin at equipment number " + equipmentNum);
-            }
-            if(null != mounted && mounted.getType() instanceof AmmoType) {
+                        unit.getName() + " has an " + mounted.getName() + " that thinks it's an ammo bin at equipment number " + equipmentNum);
+            } else {
                 capacity = mounted.getAmmoCapacity();
                 type = mounted.getType();
                 if(mounted.isMissing() || mounted.isDestroyed()) {


### PR DESCRIPTION
Corrects an issue where campaigns fail to load due to an invalid class cast to largecraftammobin

This happens infrequently with dropship refits.  Fix allows the campaign to load anyway and logs which ship and equipment number are bugged so the unit can be repaired.