### PR TITLE
Add missing import for OptionsConstants

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -83,6 +83,7 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.IBasicOption;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
+import megamek.common.options.OptionsConstants;
 import megamek.common.util.BuildingBlock;
 import megamek.common.util.DirectoryItems;
 import mekhq.campaign.event.AcquisitionEvent;


### PR DESCRIPTION
Fixes PR #1440 which died during CI due to release day Maven issues, but once those cleared it actually dies due to the unresolved `OptionsConstants` symbol.
```
PS E:\Source\megamek\mekhq> .\gradlew jar

> Task :MekHQ:compileJava
E:\Source\megamek\mekhq\MekHQ\src\mekhq\campaign\Campaign.java:7890: error: cannot find symbol
        if(u.getEntity().hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_1)) {
                                  ^
  symbol:   variable OptionsConstants
  location: class Campaign
E:\Source\megamek\mekhq\MekHQ\src\mekhq\campaign\Campaign.java:7894: error: cannot find symbol
        if(u.getEntity().hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_2)) {
                                  ^
  symbol:   variable OptionsConstants
  location: class Campaign
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.      
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors

> Task :MekHQ:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':MekHQ:compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 4s
3 actionable tasks: 1 executed, 2 up-to-date
```