### PR TITLE
Dropship Unit Assignment fixes

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -325,7 +325,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     // A set of methods for working with transport ship assignment for this unit
 
     public boolean hasTransportShipId() {
-        return transportShipId != null;
+        return !transportShipId.isEmpty();
     }
 
     public Map<UUID,Integer> getTransportShipId() {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1825,26 +1825,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         }
         
         //Temp storage for used bay capacities
-        double asfCap = 0.0;
-        boolean asfSet = false;
-        double baCap = 0.0;
-        boolean baSet = false;
-        int dockCap = 0;
-        boolean dockSet = false;
-        double hVeeCap = 0.0;
-        boolean hVeeSet = false;
-        double infCap = 0.0;
-        boolean infSet = false;
-        double lVeeCap = 0.0;
-        boolean lVeeSet = false;
-        double mechCap = 0.0;
-        boolean mechSet = false;
-        double protoCap = 0.0;
-        boolean protoSet = false;
-        double shVeeCap = 0.0;
-        boolean shVeeSet = false;
-        double scCap = 0.0;
-        boolean scSet = false;
+        boolean needsBayInitialization = true;
 
         // Okay, now load Part-specific fields!
         NodeList nl = wn.getChildNodes();
@@ -1913,44 +1894,44 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     retVal.addTransportedUnit(UUID.fromString(wn2.getTextContent()));
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("asfCapacity")) {
-                    asfCap = Double.parseDouble(wn2.getTextContent());
-                    asfSet = true;
+                    retVal.setASFCapacity(Double.parseDouble(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("baCapacity")) {
-                    baCap = Double.parseDouble(wn2.getTextContent());
-                    baSet = true;
+                    retVal.setBattleArmorCapacity(Double.parseDouble(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("dockCapacity")) {
-                    dockCap = Integer.parseInt(wn2.getTextContent());
-                    dockSet = true;
+                    retVal.setDocks(Integer.parseInt(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("hVeeCapacity")) {
-                   hVeeCap = Double.parseDouble(wn2.getTextContent());
-                   hVeeSet = true;
+                    retVal.setHeavyVehicleCapacity(Double.parseDouble(wn2.getTextContent()));
+                   needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("infCapacity")) {
-                    infCap = Double.parseDouble(wn2.getTextContent());
-                    infSet = true;
+                    retVal.setInfantryCapacity(Double.parseDouble(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("lVeeCapacity")) {
-                    lVeeCap = Double.parseDouble(wn2.getTextContent());
-                    lVeeSet = true;
+                    retVal.setLightVehicleCapacity(Double.parseDouble(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("mechCapacity")) {
-                    mechCap = Double.parseDouble(wn2.getTextContent());
-                    mechSet = true;
+                    retVal.setMechCapacity(Double.parseDouble(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("protoCapacity")) {
-                    protoCap = Double.parseDouble(wn2.getTextContent());
-                    protoSet = true;
+                    retVal.setProtoCapacity(Double.parseDouble(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("scCapacity")) {
-                    scCap = Double.parseDouble(wn2.getTextContent());
-                    scSet = true;
+                    retVal.setSmallCraftCapacity(Double.parseDouble(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("shVeeCapacity")) {
-                    shVeeCap = Double.parseDouble(wn2.getTextContent());
-                    shVeeSet = true;
+                    retVal.setSuperHeavyVehicleCapacity(Double.parseDouble(wn2.getTextContent()));
+                    needsBayInitialization = false;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("forceId")) {
                     retVal.forceId = Integer.parseInt(wn2.getTextContent());
@@ -1974,39 +1955,9 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     retVal.mothballInfo = MothballInfo.generateInstanceFromXML(wn2, version);
                 }
                 // Set up bay space values after we've loaded everything from the unit record
-                // Otherwise you can get some initialized values where they shouldn't be
-                if (retVal.entity != null && retVal.getEntity().isLargeCraft()) {
+                // Used for older campaign 
+                if (retVal.entity != null && retVal.getEntity().isLargeCraft() && needsBayInitialization) {
                     retVal.initializeBaySpace();
-                    if (asfSet) {
-                        retVal.setASFCapacity(asfCap);
-                    }
-                    if (baSet) {
-                        retVal.setBattleArmorCapacity(baCap);
-                    }
-                    if (dockSet) {
-                        retVal.setDocks(dockCap);
-                    }
-                    if (hVeeSet) {
-                        retVal.setHeavyVehicleCapacity(hVeeCap);
-                    }
-                    if (infSet) {
-                        retVal.setInfantryCapacity(infCap);
-                    }
-                    if (lVeeSet) {
-                        retVal.setLightVehicleCapacity(lVeeCap);
-                    }
-                    if (mechSet) {
-                        retVal.setMechCapacity(mechCap);
-                    }
-                    if (protoSet) {
-                        retVal.setProtoCapacity(protoCap);
-                    }
-                    if (scSet) {
-                        retVal.setSmallCraftCapacity(scCap);
-                    }
-                    if (shVeeSet) {
-                        retVal.setSuperHeavyVehicleCapacity(shVeeCap);
-                    }
                 }
             }
         } catch (Exception ex) {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1826,15 +1826,25 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         
         //Temp storage for used bay capacities
         double asfCap = 0.0;
+        boolean asfSet = false;
         double baCap = 0.0;
+        boolean baSet = false;
         int dockCap = 0;
+        boolean dockSet = false;
         double hVeeCap = 0.0;
+        boolean hVeeSet = false;
         double infCap = 0.0;
+        boolean infSet = false;
         double lVeeCap = 0.0;
+        boolean lVeeSet = false;
         double mechCap = 0.0;
+        boolean mechSet = false;
         double protoCap = 0.0;
+        boolean protoSet = false;
         double shVeeCap = 0.0;
+        boolean shVeeSet = false;
         double scCap = 0.0;
+        boolean scSet = false;
 
         // Okay, now load Part-specific fields!
         NodeList nl = wn.getChildNodes();
@@ -1904,33 +1914,43 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("asfCapacity")) {
                     asfCap = Double.parseDouble(wn2.getTextContent());
+                    asfSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("baCapacity")) {
                     baCap = Double.parseDouble(wn2.getTextContent());
+                    baSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("dockCapacity")) {
                     dockCap = Integer.parseInt(wn2.getTextContent());
+                    dockSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("hVeeCapacity")) {
                    hVeeCap = Double.parseDouble(wn2.getTextContent());
+                   hVeeSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("infCapacity")) {
                     infCap = Double.parseDouble(wn2.getTextContent());
+                    infSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("lVeeCapacity")) {
                     lVeeCap = Double.parseDouble(wn2.getTextContent());
+                    lVeeSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("mechCapacity")) {
                     mechCap = Double.parseDouble(wn2.getTextContent());
+                    mechSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("protoCapacity")) {
                     protoCap = Double.parseDouble(wn2.getTextContent());
+                    protoSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("scCapacity")) {
                     scCap = Double.parseDouble(wn2.getTextContent());
+                    scSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("shVeeCapacity")) {
                     shVeeCap = Double.parseDouble(wn2.getTextContent());
+                    shVeeSet = true;
                 }
                 else if (wn2.getNodeName().equalsIgnoreCase("forceId")) {
                     retVal.forceId = Integer.parseInt(wn2.getTextContent());
@@ -1955,18 +1975,38 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 }
                 // Set up bay space values after we've loaded everything from the unit record
                 // Otherwise you can get some initialized values where they shouldn't be
-                if (retVal.entity != null && !retVal.getEntity().getTransportBays().isEmpty()) {
+                if (retVal.entity != null && retVal.getEntity().isLargeCraft()) {
                     retVal.initializeBaySpace();
-                    retVal.setASFCapacity(asfCap);
-                    retVal.setBattleArmorCapacity(baCap);
-                    retVal.setDocks(dockCap);
-                    retVal.setHeavyVehicleCapacity(hVeeCap);
-                    retVal.setInfantryCapacity(infCap);
-                    retVal.setLightVehicleCapacity(lVeeCap);
-                    retVal.setMechCapacity(mechCap);
-                    retVal.setProtoCapacity(protoCap);
-                    retVal.setSmallCraftCapacity(scCap);
-                    retVal.setSuperHeavyVehicleCapacity(shVeeCap);
+                    if (asfSet) {
+                        retVal.setASFCapacity(asfCap);
+                    }
+                    if (baSet) {
+                        retVal.setBattleArmorCapacity(baCap);
+                    }
+                    if (dockSet) {
+                        retVal.setDocks(dockCap);
+                    }
+                    if (hVeeSet) {
+                        retVal.setHeavyVehicleCapacity(hVeeCap);
+                    }
+                    if (infSet) {
+                        retVal.setInfantryCapacity(infCap);
+                    }
+                    if (lVeeSet) {
+                        retVal.setLightVehicleCapacity(lVeeCap);
+                    }
+                    if (mechSet) {
+                        retVal.setMechCapacity(mechCap);
+                    }
+                    if (protoSet) {
+                        retVal.setProtoCapacity(protoCap);
+                    }
+                    if (scSet) {
+                        retVal.setSmallCraftCapacity(scCap);
+                    }
+                    if (shVeeSet) {
+                        retVal.setSuperHeavyVehicleCapacity(shVeeCap);
+                    }
                 }
             }
         } catch (Exception ex) {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1149,20 +1149,28 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                 if (unitsInForces.size() > 0) {
                     Unit unit = unitsInForces.get(0);
                     String unitIds = "" + unit.getId().toString();
+                    boolean shipInSelection = false;
                     for (int i = 1; i < unitsInForces.size(); i++) {
                         unitIds += "|" + unitsInForces.get(i).getId().toString();
-                    }
-
-                    for (UUID id : gui.getCampaign().getTransportShips()) {
-                        Unit ship = gui.getCampaign().getUnit(id);
-                        if (ship == null || ship.isSalvage() || ship.getCommander() == null) {
-                            continue;
+                        unit = unitsInForces.get(i);
+                        if (unit != null && (unit.getEntity() != null && unit.getEntity().isLargeCraft())) {
+                            shipInSelection = true;
                         }
-                        menuItem = new JMenuItem(ship.getName());
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(true);
-                        menu.add(menuItem);
+                    }
+                    //Only display the Assign to Ship command if your command has at least 1 valid transport
+                    //and if your selection does not include a transport
+                    if (!shipInSelection && !gui.getCampaign().getTransportShips().isEmpty()) {
+                        for (UUID id : gui.getCampaign().getTransportShips()) {
+                            Unit ship = gui.getCampaign().getUnit(id);
+                            if (ship == null || ship.isSalvage() || ship.getCommander() == null) {
+                                continue;
+                            }
+                            menuItem = new JMenuItem(ship.getName());
+                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(true);
+                            menu.add(menuItem);
+                        }
                     }
                     if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
                         popup.add(menu);
@@ -1389,21 +1397,33 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                         popup.add(menu);
                     }
 
-                    //Attempt to Assign unit to a transport ship. This checks to see if the ship
-                    //is in a basic state that can accept units. Capacity gets checked once the action
-                    //is submitted.
-                    menu = new JMenu("Assign Unit to Transport Ship");
-                    for (UUID id : gui.getCampaign().getTransportShips()) {
-                        Unit ship = gui.getCampaign().getUnit(id);
-                        if (ship == null || ship.isSalvage() || ship.getCommander() == null) {
-                            continue;
+                    
+                    //First, only display the Assign to Ship command if your command has at least 1 valid transport
+                    //and if your selection does not include a transport
+                    boolean shipInSelection = false;
+                    for (Unit u : units) {
+                        if (u.getEntity() != null && u.getEntity().isLargeCraft()) {
+                            shipInSelection = true;
+                            break;
                         }
-                        menuItem = new JMenuItem(ship.getName());
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP
-                                + id + "|" + unitIds);
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(true);
-                        menu.add(menuItem);
+                    }
+                    if (!shipInSelection && !gui.getCampaign().getTransportShips().isEmpty()) {
+                        //Attempt to Assign unit to a transport ship. This checks to see if the ship
+                        //is in a basic state that can accept units. Capacity gets checked once the action
+                        //is submitted.
+                        menu = new JMenu("Assign Unit to Transport Ship");
+                        for (UUID id : gui.getCampaign().getTransportShips()) {
+                            Unit ship = gui.getCampaign().getUnit(id);
+                            if (ship == null || ship.isSalvage() || ship.getCommander() == null) {
+                                continue;
+                            }
+                            menuItem = new JMenuItem(ship.getName());
+                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP
+                                    + id + "|" + unitIds);
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(true);
+                            menu.add(menuItem);
+                        }
                     }
                     if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
                         popup.add(menu);

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -252,11 +252,13 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                             Unit oldShip = gui.getCampaign().getUnit(oldShipId);
                             if (oldShip != null) {
                                 oldShip.unloadFromTransportShip(u);
+                                MekHQ.triggerEvent(new UnitChangedEvent(oldShip));
                             }
                         }
                     }
                     //now load the units
                     ship.loadTransportShip(units);
+                    MekHQ.triggerEvent(new UnitChangedEvent(ship));
                 }
             }
         }
@@ -267,6 +269,7 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                         Unit oldShip = gui.getCampaign().getUnit(oldShipId);
                         if (oldShip != null) {
                             oldShip.unloadFromTransportShip(u);
+                            MekHQ.triggerEvent(new UnitChangedEvent(oldShip));
                         }
                     }
                 }


### PR DESCRIPTION
Fixes a handful of reported bugs with unit to dropship assignment:

-Refreshes TOE tab on load/unload to fix some graphical errors
-Corrects issue where ships have no available space when loaded from legacy campaigns
-Removes menu option to assign large craft to a transport
-Properly checks that all selected units are assigned to a transport before displaying 'unassign from transport' menu option.