### PR TITLE
Infantry autoload tonnage fix

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -1675,7 +1675,7 @@ public class Utilities {
             for (Bay b: transport.getTransportBays()) {
                 if (b instanceof InfantryBay && b.canLoad(cargo)) {
                     //Update bay tonnage based on platoon/squad weight
-                    b.setCurrentSpace(cargo.getWeight());
+                    b.setCurrentSpace(b.spaceForUnit(cargo));
                     return b.getBayNumber();
                 }
             }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1453,7 +1453,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         double bays = 0;
         for (Bay b : getEntity().getTransportBays()) {
             if (b instanceof InfantryBay) {
-                bays += b.getCapacity() / ((InfantryBay) b).getPlatoonType().getWeight();
+                bays += b.getCapacity();
             }
         }
         return bays;

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import megamek.common.*;
+import megamek.common.InfantryBay.PlatoonType;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.parts.*;
@@ -1559,11 +1560,30 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     public void loadTransportShip(Vector<Unit> units) {
         for (Unit u : units) {
             int unitType = u.getEntity().getUnitType();
-            double unitWeight = u.getEntity().getWeight();
+            double unitWeight;
+            if (u.getEntity().getUnitType() == UnitType.INFANTRY) {
+                unitWeight = calcInfantryBayWeight(u.getEntity());
+            } else {
+                unitWeight = u.getEntity().getWeight();
+            }
             int bayNumber = Utilities.selectBestBayFor(u.getEntity(), getEntity());
             u.setTransportShipId(getId(),bayNumber);
             addTransportedUnit(u.getId());
             updateBayCapacity(unitType, unitWeight, false, bayNumber);
+        }
+    }
+    
+    /**
+     * Calculates transport bay space required by an infantry platoon,
+     * which is not the same as the flat weight of that platoon
+     * @param unit The Entity that we need the weight for
+     */
+    public double calcInfantryBayWeight(Entity unit) {
+        PlatoonType type = PlatoonType.getPlatoonType(unit);
+        if ((unit instanceof Infantry) && (type == PlatoonType.MECHANIZED)) {
+            return type.getWeight() * ((Infantry)unit).getSquadN();
+        } else {
+            return type.getWeight();
         }
     }
 
@@ -1574,7 +1594,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
      */
     public void unloadFromTransportShip(Unit u) {
         int unitType = u.getEntity().getUnitType();
-        double unitWeight = u.getEntity().getWeight();
+        double unitWeight;
+        if (u.getEntity().getUnitType() == UnitType.INFANTRY) {
+            unitWeight = calcInfantryBayWeight(u.getEntity());
+        } else {
+            unitWeight = u.getEntity().getWeight();
+        }
         for (UUID id : u.getTransportShipId().keySet()) {
             int bayNumber = u.getTransportShipId().get(id);
             updateBayCapacity(unitType, unitWeight, true, bayNumber);

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -131,6 +131,15 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
 
     private static final String ASSIGN_FORCE_TRN_TITLE = "Assign Force to Transport Ship";
     private static final String UNASSIGN_FORCE_TRN_TITLE = "Unassign Force from Transport Ship";
+    private static final String MECH_CARRIERS = "Mech Transports";
+    private static final String PROTOMECH_CARRIERS = "ProtoMech Transports";
+    private static final String LVEE_CARRIERS = "Light Vehicle Transports";
+    private static final String HVEE_CARRIERS = "Heavy Vehicle Transports";
+    private static final String SHVEE_CARRIERS = "SuperHeavy Vehicle Transports";
+    private static final String BA_CARRIERS = "Battle Armor Transports";
+    private static final String INFANTRY_CARRIERS = "Infantry Transports";
+    private static final String ASF_CARRIERS = "Aerospace Fighter Transports";
+    private static final String SC_CARRIERS = "Small Craft Transports";
 
     @Override
     public void actionPerformed(ActionEvent action) {
@@ -1149,6 +1158,16 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                 //This checks to see if the ship is in a basic state that can accept units.
                 //Capacity gets checked once the action is submitted.
                 menu = new JMenu(TOEMouseAdapter.ASSIGN_FORCE_TRN_TITLE);
+                // Add submenus for different types of transports
+                JMenu m_trn = new JMenu(TOEMouseAdapter.MECH_CARRIERS);
+                JMenu pm_trn = new JMenu(TOEMouseAdapter.PROTOMECH_CARRIERS);
+                JMenu lv_trn = new JMenu(TOEMouseAdapter.LVEE_CARRIERS);
+                JMenu hv_trn = new JMenu(TOEMouseAdapter.HVEE_CARRIERS);
+                JMenu shv_trn = new JMenu(TOEMouseAdapter.SHVEE_CARRIERS);
+                JMenu ba_trn = new JMenu(TOEMouseAdapter.BA_CARRIERS);
+                JMenu i_trn = new JMenu(TOEMouseAdapter.INFANTRY_CARRIERS);
+                JMenu a_trn = new JMenu(TOEMouseAdapter.ASF_CARRIERS);
+                JMenu sc_trn = new JMenu(TOEMouseAdapter.SC_CARRIERS);
                 if (unitsInForces.size() > 0) {
                     Unit unit = unitsInForces.get(0);
                     String unitIds = "" + unit.getId().toString();
@@ -1168,12 +1187,72 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                             if (ship == null || ship.isSalvage() || ship.getCommander() == null) {
                                 continue;
                             }
-                            menuItem = new JMenuItem(ship.getName());
-                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(true);
-                            menu.add(menuItem);
+                            //Now, add this ship to the appropriate submenu(s). Most transports will fit into multiple
+                            //categories
+                            if (ship.getASFCapacity() > 0) {
+                                a_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                a_trn.setEnabled(true);
+                            }
+                            if (ship.getBattleArmorCapacity() > 0) {
+                                ba_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                ba_trn.setEnabled(true);
+                            }
+                            if (ship.getInfantryCapacity() > 0) {
+                                i_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                i_trn.setEnabled(true);
+                            }
+                            if (ship.getMechCapacity() > 0) {
+                                m_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                m_trn.setEnabled(true);
+                            }
+                            if (ship.getProtomechCapacity() > 0) {
+                                pm_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                pm_trn.setEnabled(true);
+                            }
+                            if (ship.getSmallCraftCapacity() > 0) {
+                                sc_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                sc_trn.setEnabled(true);
+                            }
+                            if (ship.getLightVehicleCapacity() > 0) {
+                                lv_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                lv_trn.setEnabled(true);
+                            }
+                            if (ship.getHeavyVehicleCapacity() > 0) {
+                                hv_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                hv_trn.setEnabled(true);
+                            }
+                            if (ship.getSuperHeavyVehicleCapacity() > 0) {
+                                shv_trn.add(transportMenuItem(ship.getName(),id,unitIds));
+                                shv_trn.setEnabled(true);
+                            }
                         }
+                    }
+                    if (a_trn.getMenuComponentCount() > 0 || a_trn.getItemCount() > 0) {
+                        menu.add(a_trn);
+                    }
+                    if (ba_trn.getMenuComponentCount() > 0 || ba_trn.getItemCount() > 0) {
+                        menu.add(ba_trn);
+                    }
+                    if (i_trn.getMenuComponentCount() > 0 || i_trn.getItemCount() > 0) {
+                        menu.add(i_trn);
+                    }
+                    if (m_trn.getMenuComponentCount() > 0 || m_trn.getItemCount() > 0) {
+                        menu.add(m_trn);
+                    }
+                    if (pm_trn.getMenuComponentCount() > 0 || pm_trn.getItemCount() > 0) {
+                        menu.add(pm_trn);
+                    }
+                    if (sc_trn.getMenuComponentCount() > 0 || sc_trn.getItemCount() > 0) {
+                        menu.add(sc_trn);
+                    }
+                    if (lv_trn.getMenuComponentCount() > 0 || lv_trn.getItemCount() > 0) {
+                        menu.add(lv_trn);
+                    }
+                    if (hv_trn.getMenuComponentCount() > 0 || hv_trn.getItemCount() > 0) {
+                        menu.add(hv_trn);
+                    }
+                    if (shv_trn.getMenuComponentCount() > 0 || shv_trn.getItemCount() > 0) {
+                        menu.add(shv_trn);
                     }
                     if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
                         popup.add(menu);
@@ -1539,5 +1618,23 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                 currentUnit.unloadTransportShip();
             }
         }
+    }
+    
+    /**
+     * Worker function that creates a new instance of a JMenuItem for a set of transport ship characteristics
+     * Used to have a single ship appear on multiple menu entries defined by type of unit transported
+     * 
+     * @param shipName String name of this ship. 
+     * @param shipId 
+     * @param unitIds  String of units delimited by | used to fill out actionPerformed(ActionEvent)
+     */
+    
+    private JMenuItem transportMenuItem(String shipName, UUID shipId, String unitIds) {
+        JMenuItem menuItem = new JMenuItem(shipName);
+        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + shipId + "|" + unitIds);
+        menuItem.addActionListener(this);
+        menuItem.setEnabled(true);
+        
+        return menuItem;
     }
 }


### PR DESCRIPTION
Another fix for Unit > Ship assignment

- Properly calculates the Infantry Bay space available on a ship and that consumed by platoons of various types

- Adds UI tweak, separating available transport ships by type of unit transported.