### PR TITLE
Add -Dfile.encoding=utf-8 to Gradle JVM arguments.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmArgs=-Dfile.encoding=utf-8


### PR DESCRIPTION
This should fix problems with encoding non-ascii characters in file names when packaging on Windows.

See #1459 