### PR TITLE
Add bounds check when initializing parts

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1572,7 +1572,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             updateBayCapacity(unitType, unitWeight, false, bayNumber);
         }
     }
-    
+
     /**
      * Calculates transport bay space required by an infantry platoon,
      * which is not the same as the flat weight of that platoon
@@ -1848,7 +1848,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         } else {
             retVal.id = UUID.fromString(idNode.getTextContent());
         }
-        
+
         //Temp storage for used bay capacities
         boolean needsBayInitialization = true;
 
@@ -1980,7 +1980,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     retVal.mothballInfo = MothballInfo.generateInstanceFromXML(wn2, version);
                 }
                 // Set up bay space values after we've loaded everything from the unit record
-                // Used for older campaign 
+                // Used for older campaign
                 if (retVal.entity != null && retVal.getEntity().isLargeCraft() && needsBayInitialization) {
                     retVal.initializeBaySpace();
                 }
@@ -2260,33 +2260,34 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 }
             }  else if(part instanceof StructuralIntegrity) {
                 structuralIntegrity = part;
-            } else if(part instanceof MekLocation) {
+            } else if (part instanceof MekLocation && ((MekLocation) part).getLoc() < locations.length) {
                 locations[((MekLocation)part).getLoc()] = part;
-            } else if(part instanceof MissingMekLocation) {
+            } else if (part instanceof MissingMekLocation && part.getLocation() < locations.length) {
                 locations[part.getLocation()] = part;
-            } else if(part instanceof TankLocation) {
+            } else if (part instanceof TankLocation && ((TankLocation) part).getLoc() < locations.length) {
                 locations[((TankLocation)part).getLoc()] = part;
-            } else if(part instanceof MissingRotor) {
+            } else if (part instanceof MissingRotor) {
                 locations[VTOL.LOC_ROTOR] = part;
-            } else if(part instanceof MissingTurret) {
+            } else if (part instanceof MissingTurret && Tank.LOC_TURRET < locations.length) {
                 locations[Tank.LOC_TURRET] = part;
-            } else if(part instanceof ProtomekLocation) {
+            } else if (part instanceof ProtomekLocation && ((ProtomekLocation) part).getLoc() < locations.length) {
                 locations[((ProtomekLocation)part).getLoc()] = part;
-            } else if(part instanceof MissingProtomekLocation) {
+            } else if (part instanceof MissingProtomekLocation
+                    && ((MissingProtomekLocation) part).getLoc() < locations.length) {
                 locations[((MissingProtomekLocation)part).getLoc()] = part;
-            } else if(part instanceof BattleArmorSuit) {
+            } else if (part instanceof BattleArmorSuit && ((BattleArmorSuit) part).getTrooper() < locations.length) {
                 locations[((BattleArmorSuit)part).getTrooper()] = part;
-            } else if(part instanceof MissingBattleArmorSuit) {
+            } else if (part instanceof MissingBattleArmorSuit
+                    && ((MissingBattleArmorSuit) part).getTrooper() < locations.length) {
                 locations[((MissingBattleArmorSuit)part).getTrooper()] = part;
-            } else if(part instanceof Armor) {
+            } else if (part instanceof Armor && part.getLocation() < armor.length) {
                 if(((Armor)part).isRearMounted()) {
                     armorRear[part.getLocation()] = part;
                 } else {
                     armor[part.getLocation()] = part;
                 }
-            } else if(part instanceof VeeStabiliser) {
-                stabilisers[part.getLocation()] = part;
-            } else if(part instanceof MissingVeeStabiliser) {
+            } else if ((part instanceof VeeStabiliser || part instanceof MissingVeeStabiliser)
+                    && part.getLocation() < stabilisers.length) {
                 stabilisers[part.getLocation()] = part;
             } else if(part instanceof AmmoBin) {
                 ammoParts.put(((AmmoBin)part).getEquipmentNum(), part);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2260,35 +2260,63 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 }
             }  else if(part instanceof StructuralIntegrity) {
                 structuralIntegrity = part;
-            } else if (part instanceof MekLocation && ((MekLocation) part).getLoc() < locations.length) {
-                locations[((MekLocation)part).getLoc()] = part;
-            } else if (part instanceof MissingMekLocation && part.getLocation() < locations.length) {
-                locations[part.getLocation()] = part;
-            } else if (part instanceof TankLocation && ((TankLocation) part).getLoc() < locations.length) {
-                locations[((TankLocation)part).getLoc()] = part;
+            } else if (part instanceof MekLocation) {
+                if (((MekLocation) part).getLoc() < locations.length) {
+                    locations[((MekLocation) part).getLoc()] = part;
+                } else {
+                    partsToRemove.add(part);
+                }
+            } else if (part instanceof TankLocation) {
+                if (((TankLocation) part).getLoc() < locations.length) {
+                    locations[((TankLocation) part).getLoc()] = part;
+                } else {
+                    partsToRemove.add(part);
+                }
             } else if (part instanceof MissingRotor) {
                 locations[VTOL.LOC_ROTOR] = part;
             } else if (part instanceof MissingTurret && Tank.LOC_TURRET < locations.length) {
                 locations[Tank.LOC_TURRET] = part;
-            } else if (part instanceof ProtomekLocation && ((ProtomekLocation) part).getLoc() < locations.length) {
-                locations[((ProtomekLocation)part).getLoc()] = part;
-            } else if (part instanceof MissingProtomekLocation
-                    && ((MissingProtomekLocation) part).getLoc() < locations.length) {
-                locations[((MissingProtomekLocation)part).getLoc()] = part;
-            } else if (part instanceof BattleArmorSuit && ((BattleArmorSuit) part).getTrooper() < locations.length) {
-                locations[((BattleArmorSuit)part).getTrooper()] = part;
-            } else if (part instanceof MissingBattleArmorSuit
-                    && ((MissingBattleArmorSuit) part).getTrooper() < locations.length) {
-                locations[((MissingBattleArmorSuit)part).getTrooper()] = part;
-            } else if (part instanceof Armor && part.getLocation() < armor.length) {
-                if(((Armor)part).isRearMounted()) {
-                    armorRear[part.getLocation()] = part;
+            } else if (part instanceof ProtomekLocation) {
+                if (((ProtomekLocation) part).getLoc() < locations.length) {
+                    locations[((ProtomekLocation) part).getLoc()] = part;
                 } else {
-                    armor[part.getLocation()] = part;
+                    partsToRemove.add(part);
                 }
-            } else if ((part instanceof VeeStabiliser || part instanceof MissingVeeStabiliser)
-                    && part.getLocation() < stabilisers.length) {
-                stabilisers[part.getLocation()] = part;
+            } else if (part instanceof MissingMekLocation
+                    || part instanceof MissingProtomekLocation) {
+                if (part.getLocation() < locations.length) {
+                    locations[part.getLocation()] = part;
+                } else {
+                    partsToRemove.add(part);
+                }
+            } else if (part instanceof BattleArmorSuit) {
+                if (((BattleArmorSuit) part).getTrooper() < locations.length) {
+                    locations[((BattleArmorSuit) part).getTrooper()] = part;
+                } else {
+                    partsToRemove.add(part);
+                }
+            } else if (part instanceof MissingBattleArmorSuit) {
+                if (((MissingBattleArmorSuit) part).getTrooper() < locations.length) {
+                    locations[((MissingBattleArmorSuit) part).getTrooper()] = part;
+                } else {
+                    partsToRemove.add(part);
+                }
+            } else if (part instanceof Armor) {
+                if (part.getLocation() < armor.length) {
+                    if (((Armor) part).isRearMounted()) {
+                        armorRear[part.getLocation()] = part;
+                    } else {
+                        armor[part.getLocation()] = part;
+                    }
+                } else {
+                    partsToRemove.add(part);
+                }
+            } else if ((part instanceof VeeStabiliser || part instanceof MissingVeeStabiliser)) {
+                if (part.getLocation() < stabilisers.length) {
+                    stabilisers[part.getLocation()] = part;
+                } else {
+                    partsToRemove.add(part);
+                }
             } else if(part instanceof AmmoBin) {
                 ammoParts.put(((AmmoBin)part).getEquipmentNum(), part);
             } else if(part instanceof MissingAmmoBin) {


### PR DESCRIPTION
Fixing the Thumper Artillery Vehicle by removing the turret that wasn't supposed to be there is causing MekHQ campaigns that contain one to fail to load because the turret location, armor, and stabilizer parts are still there but the arrays are sized by number of current locations. I added range checks where appropriate. I believe that it is safe just to remove the part, since this is not likely to happen except when the part shouldn't be there due to a change in the unit file.

Fixes #1470