### PR TITLE
Add customization for colors used throughout MekHQ #1480

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -20,7 +20,6 @@
 package mekhq.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -1,6 +1,5 @@
 package mekhq.gui;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
 import java.util.UUID;
@@ -24,7 +23,8 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
 
     private static final long serialVersionUID = -553191867660269247L;
 
-    private IconPackage icons;
+    private final IconPackage icons;
+    private final MekHqColors colors = new MekHqColors();
 
     public ForceRenderer(IconPackage i) {
         icons = i;
@@ -133,12 +133,14 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
             }
             setText("<html>" + name + ", " + uname + c3network + transport + "</html>");
             if(u.isDeployed() && !sel) {
-                setBackground(Color.LIGHT_GRAY);
+                colors.getDeployed().getColor().ifPresent(c -> setBackground(c));
+                colors.getDeployed().getAlternateColor().ifPresent(c -> setForeground(c));
             }
         }
         if(value instanceof Force) {
             if(!hasFocus && ((Force)value).isDeployed()) {
-                setBackground(Color.LIGHT_GRAY);
+                colors.getDeployed().getColor().ifPresent(c -> setBackground(c));
+                colors.getDeployed().getAlternateColor().ifPresent(c -> setForeground(c));
             }
         }
         setIcon(getIcon(value));

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -76,7 +75,6 @@ import mekhq.gui.model.UnitTableModel;
 import mekhq.gui.model.XTableColumnModel;
 import mekhq.gui.preferences.JComboBoxPreference;
 import mekhq.gui.preferences.JTablePreference;
-import mekhq.gui.preferences.JToggleButtonPreference;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.TargetSorter;
 import mekhq.gui.sorter.UnitStatusSorter;
@@ -126,7 +124,7 @@ public final class HangarTab extends CampaignGuiTab {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see mekhq.gui.CampaignGuiTab#initTab()
      */
     @Override
@@ -217,7 +215,7 @@ public final class HangarTab extends CampaignGuiTab {
                         splitUnit.setDividerLocation(1.0);
                     }
                 }
-            }            
+            }
         });
         unitTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         TableColumn column = null;
@@ -346,7 +344,7 @@ public final class HangarTab extends CampaignGuiTab {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see mekhq.gui.CampaignGuiTab#refreshAll()
      */
     @Override
@@ -558,7 +556,7 @@ public final class HangarTab extends CampaignGuiTab {
         }
         getCampaignGui().refreshLab();
     }
-    
+
     private void refreshAcquisitionList() {
         acquireUnitsModel.setData(getCampaign().getShoppingList().getUnitList());
     }
@@ -571,12 +569,12 @@ public final class HangarTab extends CampaignGuiTab {
     public void handle(DeploymentChangedEvent ev) {
         filterUnitScheduler.schedule();;
     }
-    
+
     @Subscribe
     public void handle(PersonChangedEvent ev) {
         filterUnitScheduler.schedule();;
     }
-    
+
     @Subscribe
     public void handle(ScenarioResolvedEvent ev) {
         unitListScheduler.schedule();
@@ -586,17 +584,17 @@ public final class HangarTab extends CampaignGuiTab {
     public void handle(UnitChangedEvent ev) {
         filterUnitScheduler.schedule();;
     }
-    
+
     @Subscribe
     public void handle(UnitNewEvent ev) {
         unitListScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(UnitRemovedEvent ev) {
         unitListScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(RepairStatusChangedEvent ev) {
         filterUnitScheduler.schedule();
@@ -609,28 +607,28 @@ public final class HangarTab extends CampaignGuiTab {
             acquisitionListScheduler.schedule();
         }
     }
-    
+
     @Subscribe
     public void handle(ProcurementEvent ev) {
         if (ev.getAcquisition() instanceof UnitOrder) {
             acquisitionListScheduler.schedule();
         }
     }
-    
+
     @Subscribe
     public void handle(PartEvent ev) {
         if (ev.getPart().getUnit() != null) {
             filterUnitScheduler.schedule();
         }
     }
-    
+
     @Subscribe
     public void handle(PartWorkEvent ev) {
         if (ev.getPartWork().getUnit() != null) {
             filterUnitScheduler.schedule();
         }
     }
-    
+
     @Subscribe
     public void handle(OvertimeModeEvent ev) {
         filterUnitScheduler.schedule();

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -19,7 +19,6 @@
 package mekhq.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;

--- a/MekHQ/src/mekhq/gui/MekHqColors.java
+++ b/MekHQ/src/mekhq/gui/MekHqColors.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2020 The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui;
+
+import java.awt.Color;
+
+import javax.swing.UIManager;
+
+import mekhq.MekHQ;
+import mekhq.gui.preferences.ColorPreference;
+import mekhq.preferences.PreferencesNode;
+
+public class MekHqColors {
+
+    //
+    // General Colors
+    //
+
+    private static ColorPreference iconButtonColors;
+
+    //
+    // Force Colors
+    //
+
+    private static ColorPreference deployedColors;
+    private static ColorPreference belowContractMinimumColors;
+
+    //
+    // Unit Colors
+    //
+
+    private static ColorPreference inTransitColors;
+    private static ColorPreference refittingColors;
+    private static ColorPreference mothballingColors;
+    private static ColorPreference mothballedColors;
+    private static ColorPreference notRepairableColors;
+    private static ColorPreference nonfunctionalColors;
+    private static ColorPreference needsPartsFixedColors;
+    private static ColorPreference uncrewedColors;
+
+    //
+    // Financial Colors
+    //
+
+    private static ColorPreference loanOverdueColors;
+
+    //
+    // Personnel Colors
+    //
+
+    private static ColorPreference injuredColors;
+    private static ColorPreference healedInjuriesColors;
+    private static ColorPreference paidRetirementColors;
+
+    static {
+        final PreferencesNode preferences = MekHQ.getPreferences().forClass(MekHqColors.class);
+
+        iconButtonColors = new ColorPreference("iconButton", Color.LIGHT_GRAY, Color.BLACK);
+
+        deployedColors = new ColorPreference("deployed", Color.LIGHT_GRAY, Color.BLACK);
+        belowContractMinimumColors = new ColorPreference("belowContractMinimum", UIManager.getColor("Table.background"), Color.RED);
+
+        inTransitColors = new ColorPreference("inTransit", Color.ORANGE, Color.BLACK);
+        refittingColors = new ColorPreference("refitting", Color.CYAN, Color.BLACK);
+        mothballingColors = new ColorPreference("mothballing", new Color(153,153,255), Color.BLACK);
+        mothballedColors = new ColorPreference("mothballed", new Color(204, 204, 255), Color.BLACK);
+        notRepairableColors = new ColorPreference("notRepairable", new Color(190, 150, 55), Color.BLACK);
+        nonfunctionalColors = new ColorPreference("nonfunctional", new Color(205, 92, 92), Color.BLACK);
+        needsPartsFixedColors = new ColorPreference("needsPartsFixed", new Color(238, 238, 0), Color.BLACK);
+        uncrewedColors = new ColorPreference("uncrewed", Color.RED, Color.BLACK);
+
+        loanOverdueColors = new ColorPreference("loanOverdue", Color.RED, Color.BLACK);
+
+        injuredColors = new ColorPreference("injured", Color.RED, Color.BLACK);
+        healedInjuriesColors = new ColorPreference("healed", new Color(0xee9a00), Color.BLACK);
+        paidRetirementColors = new ColorPreference("paidRetirement", Color.LIGHT_GRAY, Color.BLACK);
+
+        preferences.manage(iconButtonColors, deployedColors, belowContractMinimumColors, inTransitColors, refittingColors,
+            mothballingColors, mothballedColors, notRepairableColors, nonfunctionalColors, needsPartsFixedColors,
+            uncrewedColors, loanOverdueColors, injuredColors, healedInjuriesColors, paidRetirementColors);
+    }
+
+    public ColorPreference getIconButton() {
+        return iconButtonColors;
+    }
+
+    public ColorPreference getDeployed() {
+        return deployedColors;
+    }
+
+    public ColorPreference getBelowContractMinimum() {
+        return belowContractMinimumColors;
+    }
+
+    public ColorPreference getInTransit() {
+        return inTransitColors;
+    }
+
+    public ColorPreference getRefitting() {
+        return refittingColors;
+    }
+
+    public ColorPreference getMothballing() {
+        return mothballingColors;
+    }
+
+    public ColorPreference getMothballed() {
+        return mothballedColors;
+    }
+
+    public ColorPreference getNotRepairable() {
+        return notRepairableColors;
+    }
+
+    public ColorPreference getNonFunctional() {
+        return nonfunctionalColors;
+    }
+
+    public ColorPreference getNeedsPartsFixed() {
+        return needsPartsFixedColors;
+    }
+
+    public ColorPreference getUncrewed() {
+        return uncrewedColors;
+    }
+
+    public ColorPreference getLoanOverdue() {
+        return loanOverdueColors;
+    }
+
+    public ColorPreference getInjured() {
+        return injuredColors;
+    }
+
+    public ColorPreference getHealedInjuries() {
+        return healedInjuriesColors;
+    }
+
+    public ColorPreference getPaidRetirement() {
+        return paidRetirementColors;
+    }
+}

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -80,7 +80,6 @@ import mekhq.gui.model.TechTableModel;
 import mekhq.gui.model.UnitTableModel;
 import mekhq.gui.model.XTableColumnModel;
 import mekhq.gui.preferences.JTablePreference;
-import mekhq.gui.preferences.JWindowPreference;
 import mekhq.gui.sorter.TaskSorter;
 import mekhq.gui.sorter.TechSorter;
 import mekhq.gui.sorter.UnitStatusSorter;
@@ -113,7 +112,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     private JComboBox<String> choiceLocation;
     private JButton btnAcquisitions;
     private JScrollPane scrollServicedUnitView;
-    
+
     private UnitTableModel servicedUnitModel;
     private TaskTableModel taskModel;
     private TechTableModel techsModel;
@@ -121,7 +120,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     private TableRowSorter<UnitTableModel> servicedUnitSorter;
     private TableRowSorter<TaskTableModel> taskSorter;
     private TableRowSorter<TechTableModel> techSorter;
-    
+
     //Maintain selections after refresh
     private int selectedRow = -1;
     private int selectedLocation = -1;
@@ -184,7 +183,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
 			@Override
 			public void propertyChange(PropertyChangeEvent evt) {
 				String txt = "Parts Acquisition";
-				
+
 				if (PartsAcquisitionService.getMissingCount() > 0) {
 					if (PartsAcquisitionService.getUnavailableCount() > 0) {
 						txt += String.format(" (%s missing, %s unavailable)", PartsAcquisitionService.getMissingCount(), PartsAcquisitionService.getUnavailableCount());
@@ -192,13 +191,13 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
 						txt += String.format(" (%s missing)", PartsAcquisitionService.getMissingCount());
 					}
 				}
-				
+
 				btnAcquisitions.setText(txt);
-				
+
 				btnAcquisitions.repaint();
 			}
 		});
-        
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
@@ -212,7 +211,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         gridBagConstraints.weightx = 0.5;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         actionButtons.add(btnMRMSInstantAll, gridBagConstraints);
-        
+
 		gridBagConstraints = new java.awt.GridBagConstraints();
 		gridBagConstraints.gridx = 0;
 		gridBagConstraints.gridy = 1;
@@ -805,7 +804,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
 
     public void refreshTaskList() {
         selectedRow = taskTable.getSelectedRow();
-        
+
         UUID uuid = null;
         if (null != getSelectedServicedUnit()) {
             uuid = getSelectedServicedUnit().getId();
@@ -837,7 +836,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
             choiceLocation.setEnabled(false);
         }
         filterTasks();
-        
+
         if (selectedRow != -1 && taskTable.getRowCount() > 0) {
             if (taskTable.getRowCount() <= selectedRow) {
                 selectedRow = taskTable.getRowCount() - 1;
@@ -888,7 +887,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     public void refreshPartsAcquisition() {
         refreshPartsAcquisitionService(true);
     }
-    
+
 	public void refreshPartsAcquisitionService(boolean rebuildPartsList) {
 		if (rebuildPartsList) {
 			PartsAcquisitionService.buildPartsList(getCampaign());
@@ -906,7 +905,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     public void handle(DeploymentChangedEvent ev) {
         servicedUnitListScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(ScenarioResolvedEvent ev) {
         servicedUnitListScheduler.schedule();
@@ -936,19 +935,19 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
             servicedUnitListScheduler.schedule();
         }
     }
-    
+
     @Subscribe
     public void handle(AcquisitionEvent ev) {
         acquireScheduler.schedule();
         taskScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(ProcurementEvent ev) {
         filterTasks();
         acquireScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(PartWorkEvent ev) {
         if (ev.getPartWork().getUnit() == null) {
@@ -959,12 +958,12 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         }
         techsScheduler.schedule();
     }
-    
+
     @Subscribe
     public void handle(OvertimeModeEvent ev) {
         filterTechs();
     }
-    
+
     @Subscribe
     public void handle(AstechPoolChangedEvent ev) {
         filterTechs();

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -20,7 +20,6 @@
 package mekhq.gui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -1,8 +1,6 @@
 package mekhq.gui.dialog;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
@@ -31,7 +29,6 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.SortOrder;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
-import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 

--- a/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
@@ -6,7 +6,6 @@
 
 package mekhq.gui.dialog;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
@@ -35,7 +34,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
-import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -61,7 +59,7 @@ public class ImageChoiceDialog extends JDialog {
 
     private static final String PANEL_IMAGES = "panel_images";
     private static final String PANEL_LAYERED = "panel_layered";
-    
+
     /**
      *
      */
@@ -73,7 +71,7 @@ public class ImageChoiceDialog extends JDialog {
     private ImageTableModel imageTableModel = new ImageTableModel();
     private String category;
     private String filename;
-    private LinkedHashMap<String, Vector<String>> iconMap; // Key = Image Category, Value = Vector of Image Filenames 
+    private LinkedHashMap<String, Vector<String>> iconMap; // Key = Image Category, Value = Vector of Image Filenames
     private ImageTableMouseAdapter imagesMouseAdapter;
     private boolean force = false;
     private JButton btnCancel;
@@ -82,7 +80,7 @@ public class ImageChoiceDialog extends JDialog {
     private JScrollPane scrImages;
     private JTable tableImages;
     private boolean changed = false;
-    
+
     // BEGIN: Layered Images Support
     private ImageIcon imageIcon = null;
     private JLabel preview = new JLabel();
@@ -414,7 +412,7 @@ public class ImageChoiceDialog extends JDialog {
                 logosModel.addImage(imageNamesLogos.next());
             }
             layerTabs.addTab(resourceMap.getString("Force.logos"), panelLogos);
-            
+
             // Put it all together nice and pretty on the layerPanel
             layerPanel.setLayout(new GridBagLayout());
             layerPanel.add(layerTabs, gbc);
@@ -545,7 +543,7 @@ public class ImageChoiceDialog extends JDialog {
     public void setIconMap(LinkedHashMap<String, Vector<String>> iconMap) {
         this.iconMap = iconMap;
     }
-    
+
     private void refreshLayeredPreview() {
         // Add the image frame
         iconMap.clear();
@@ -742,7 +740,7 @@ public class ImageChoiceDialog extends JDialog {
                 String name = getValueAt(row, column).toString();
                 setText(getValueAt(row, column).toString());
                 setImage(category, name);
-                
+
                 MekHqTableCellRenderer.setupTableColors(this, table, isSelected, hasFocus, row);
                 return this;
             }

--- a/MekHQ/src/mekhq/gui/dialog/ObjectiveEditPanel.java
+++ b/MekHQ/src/mekhq/gui/dialog/ObjectiveEditPanel.java
@@ -36,6 +36,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
+import javax.swing.UIManager;
 import javax.swing.border.LineBorder;
 
 import megamek.common.OffBoardDirection;
@@ -60,79 +61,79 @@ public class ObjectiveEditPanel extends JDialog {
     private JTextField txtPercentage;
     private JComboBox<String> cboCountType;
     private JComboBox<String> cboForceName;
-    
+
     private JLabel lblMagnitude;
     private JTextField txtAmount;
     private JComboBox<EffectScalingType> cboScalingType;
     private JComboBox<ObjectiveEffectType> cboEffectType;
     private JComboBox<ObjectiveEffectConditionType> cboEffectCondition;
-    
+
     private JList<ObjectiveEffect> successEffects;
     private JList<ObjectiveEffect> failureEffects;
     private JButton btnRemoveSuccess;
     private JButton btnRemoveFailure;
-    
+
     private JComboBox<String> cboTimeLimitDirection;
     private JComboBox<TimeLimitType> cboTimeScaling;
     private JTextField txtTimeLimit;
-    
+
     private JList<String> forceNames;
     JButton btnRemove;
-    
+
     private JList<String> lstDetails;
-        
+
     private ScenarioTemplate currentScenarioTemplate;
     private ScenarioObjective objective;
     private ScenarioTemplateEditorDialog parent;
-    
+
     public ObjectiveEditPanel(ScenarioTemplate template, ScenarioTemplateEditorDialog parent) {
         currentScenarioTemplate = template;
         objective = new ScenarioObjective();
         this.parent = parent;
-        
+
         initGUI();
         updateTimeLimitUI();
         validate();
         pack();
         setLocationRelativeTo(parent);
     }
-    
+
     public ObjectiveEditPanel(ScenarioTemplate template, ScenarioObjective objective, ScenarioTemplateEditorDialog parent) {
         currentScenarioTemplate = template;
         this.objective = objective;
         this.parent = parent;
-        
+
         initGUI();
         updateForceList();
-        
+
         txtShortDescription.setText(objective.getDescription());
         cboObjectiveType.setSelectedItem(objective.getObjectiveCriterion());
         cboCountType.setSelectedItem(objective.getAmountType());
         txtPercentage.setText(Integer.toString(objective.getAmount()));
         setDirectionDropdownVisibility();
-        
+
         cboDirection.setSelectedIndex(objective.getDestinationEdge().ordinal());
-        
+
         cboTimeScaling.setSelectedItem(objective.getTimeLimitType());
         updateTimeLimitUI();
         cboTimeLimitDirection.setSelectedIndex(objective.isTimeLimitAtMost() ? 0 : 1);
         if(objective.getTimeLimitType() == TimeLimitType.ScaledToPrimaryUnitCount) {
             txtTimeLimit.setText(objective.getTimeLimitScaleFactor().toString());
         } else {
-            if(objective.getTimeLimit() != null) { 
+            if(objective.getTimeLimit() != null) {
                 txtTimeLimit.setText(objective.getTimeLimit().toString());
             }
         }
-        
+
         updateEffectList(successEffects, objective.getSuccessEffects());
         updateEffectList(failureEffects, objective.getFailureEffects());
         updateDetailList();
-        
+
         validate();
         pack();
         setLocationRelativeTo(parent);
     }
-    
+
     private void initGUI() {
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridwidth = 1;
@@ -140,9 +141,9 @@ public class ObjectiveEditPanel extends JDialog {
         gbc.gridx = 0;
         gbc.gridy = 0;
         gbc.anchor = GridBagConstraints.WEST;
-        
+
         getContentPane().setLayout(new GridBagLayout());
-        
+
         addDescriptionUI(gbc);
         gbc.gridx = 0;
         gbc.gridy++;
@@ -150,27 +151,27 @@ public class ObjectiveEditPanel extends JDialog {
         addObjectiveTypeUI(gbc);
         gbc.gridx = 0;
         gbc.gridy++;
-        
+
         addSubjectForce(gbc);
         gbc.gridx = 0;
         gbc.gridy++;
-        
+
         addTimeLimitUI(gbc);
         gbc.gridx = 0;
         gbc.gridy++;
-        
+
         addEffectUI(gbc);
         gbc.gridx = 0;
         gbc.gridy++;
-        
+
         addObjectiveEffectUI(gbc);
-        
+
         gbc.gridx = 0;
         gbc.gridy++;
-        
+
         addSaveCloseButtons(gbc);
     }
-    
+
     /**
      * Handles the save/close buttons row.
      */
@@ -181,24 +182,24 @@ public class ObjectiveEditPanel extends JDialog {
         localGbc.gridx = 0;
         localGbc.gridy = 0;
         localGbc.insets = new Insets(0, 0, 0, 5);
-        
+
         JButton btnCancel = new JButton("Cancel");
         btnCancel.addActionListener(e -> this.setVisible(false));
         JButton btnSaveAndClose = new JButton("Save and Close");
         btnSaveAndClose.addActionListener(e -> this.saveObjectiveAndClose());
-        
+
         saveClosePanel.add(btnCancel);
         saveClosePanel.add(btnSaveAndClose);
-        
+
         getContentPane().add(saveClosePanel, gbc);
     }
-    
+
     /**
      * Handles the "description" row.
      */
     private void addDescriptionUI(GridBagConstraints gbc) {
         lblShortDescription = new JLabel("Short Description:");
-        
+
         JScrollPane txtScroll = new JScrollPane();
         txtShortDescription = new JTextArea();
         txtShortDescription.setColumns(40);
@@ -206,26 +207,26 @@ public class ObjectiveEditPanel extends JDialog {
         txtShortDescription.setLineWrap(true);
         txtShortDescription.setWrapStyleWord(true);
         txtScroll.setViewportView(txtShortDescription);
-        
+
         JTextField txtDetail = new JTextField();
         txtDetail.setColumns(40);
         JLabel lblDetail = new JLabel("Details (shows up after force/unit list):");
         lstDetails = new JList<>();
         JButton btnAddDetail = new JButton("Add");
         JButton btnRemoveDetail = new JButton("Remove");
-        
+
         lstDetails.addListSelectionListener(e -> btnRemoveDetail.setEnabled(lstDetails.getSelectedValuesList().size() > 0));
         lstDetails.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         btnRemoveDetail.addActionListener(e -> this.removeDetails());
         btnAddDetail.addActionListener(e -> this.addDetail(txtDetail));
-        
+
         JPanel descriptionPanel = new JPanel();
         descriptionPanel.setLayout(new GridBagLayout());
         GridBagConstraints localGbc = new GridBagConstraints();
         localGbc.gridx = 0;
         localGbc.gridy = 0;
         localGbc.insets = new Insets(5, 0, 5, 5);
-        
+
         descriptionPanel.add(lblShortDescription, localGbc);
         localGbc.gridx++;
         descriptionPanel.add(txtScroll, localGbc);
@@ -240,45 +241,45 @@ public class ObjectiveEditPanel extends JDialog {
         descriptionPanel.add(lstDetails, localGbc);
         localGbc.gridx++;
         descriptionPanel.add(btnRemoveDetail, localGbc);
-        
+
         getContentPane().add(descriptionPanel, gbc);
     }
-    
+
     /**
      * Handles the "objective type" row
      */
     private void addObjectiveTypeUI(GridBagConstraints gbc) {
         JPanel objectivePanel = new JPanel();
-        
-        lblObjectiveType = new JLabel("Objective Type:");        
+
+        lblObjectiveType = new JLabel("Objective Type:");
         cboObjectiveType = new JComboBox<>();
         for(ObjectiveCriterion objectiveType : ObjectiveCriterion.values()) {
             cboObjectiveType.addItem(objectiveType);
         }
         cboObjectiveType.addActionListener(e -> this.setDirectionDropdownVisibility());
-        
+
         txtPercentage = new JTextField();
         txtPercentage.setColumns(4);
-        
+
         cboCountType = new JComboBox<>();
         cboCountType.addItem("Percent");
         cboCountType.addItem("Fixed Amount");
-        
-        
+
+
         cboDirection = new JComboBox<>();
         cboDirection.addItem("Force Destination Edge");
         for(int x = 1; x < OffBoardDirection.values().length; x++) {
             cboDirection.addItem(OffBoardDirection.values()[x].toString());
         }
         cboDirection.setVisible(false);
-        
+
         objectivePanel.setLayout(new GridBagLayout());
         GridBagConstraints localGbc = new GridBagConstraints();
         localGbc.gridx = 0;
         localGbc.gridy = 0;
         localGbc.insets = new Insets(0, 0, 0, 5);
-        
-        
+
+
         objectivePanel.add(lblObjectiveType, localGbc);
         localGbc.gridx++;
         objectivePanel.add(cboObjectiveType, localGbc);
@@ -288,39 +289,39 @@ public class ObjectiveEditPanel extends JDialog {
         objectivePanel.add(txtPercentage, localGbc);
         localGbc.gridx++;
         objectivePanel.add(cboCountType, localGbc);
-        
+
         getContentPane().add(objectivePanel, gbc);
     }
-    
+
     /**
      * Handles the UI for adding objective effects
      */
     private void addObjectiveEffectUI(GridBagConstraints gbc) {
         JPanel effectPanel = new JPanel();
-        
-        
+
+
         JLabel lblSuccessEffects = new JLabel("Effects on completion:");
         JLabel lblFailureEffects = new JLabel("Effects on failure:");
-        
+
         successEffects = new JList<>();
         successEffects.addListSelectionListener(e -> btnRemoveSuccess.setEnabled(successEffects.getSelectedValuesList().size() > 0));
         failureEffects = new JList<>();
         failureEffects.addListSelectionListener(e -> btnRemoveFailure.setEnabled(failureEffects.getSelectedValuesList().size() > 0));
-        
+
         btnRemoveSuccess = new JButton("Remove");
         btnRemoveSuccess.addActionListener(e -> this.removeEffect(ObjectiveEffectConditionType.ObjectiveSuccess));
         btnRemoveSuccess.setEnabled(false);
-        
+
         btnRemoveFailure = new JButton("Remove");
         btnRemoveFailure.addActionListener(e -> this.removeEffect(ObjectiveEffectConditionType.ObjectiveFailure));
         btnRemoveFailure.setEnabled(false);
-        
+
         GridBagConstraints localGbc = new GridBagConstraints();
         effectPanel.setLayout(new GridBagLayout());
         localGbc.gridx = 0;
         localGbc.gridy = 0;
         localGbc.insets = new Insets(0, 0, 0, 5);
-        
+
         effectPanel.add(lblSuccessEffects, localGbc);
         localGbc.gridx++;
         effectPanel.add(successEffects, localGbc);
@@ -332,39 +333,39 @@ public class ObjectiveEditPanel extends JDialog {
         effectPanel.add(failureEffects, localGbc);
         localGbc.gridx++;
         effectPanel.add(btnRemoveFailure, localGbc);
-        
+
         getContentPane().add(effectPanel, gbc);
     }
-    
+
     /**
      * Handles the UI for adding/removing forces relevant to this objective
      */
     private void addSubjectForce(GridBagConstraints gbc) {
         JPanel forcePanel = new JPanel();
-        
+
         JLabel forcesLabel = new JLabel("Force Names:");
-        
+
         cboForceName = new JComboBox<String>();
         for(ScenarioForceTemplate forceTemplate : currentScenarioTemplate.getAllScenarioForces()) {
             cboForceName.addItem(forceTemplate.getForceName());
         }
-        
+
         forceNames = new JList<String>();
         forceNames.setVisibleRowCount(5);
         forceNames.addListSelectionListener(e -> btnRemove.setEnabled(forceNames.getSelectedValuesList().size() > 0));
-        
+
         JButton btnAdd = new JButton("Add");
         btnAdd.addActionListener(e -> this.addForce());
-        
+
         btnRemove = new JButton("Remove");
         btnRemove.addActionListener(e -> this.removeForce());
         btnRemove.setEnabled(false);
-        
+
         GridBagConstraints localGbc = new GridBagConstraints();
         localGbc.gridx = 0;
         localGbc.gridy = 0;
         localGbc.insets = new Insets(0, 0, 0, 5);
-        
+
         forcePanel.add(forcesLabel, localGbc);
         localGbc.gridx++;
         forcePanel.add(cboForceName, localGbc);
@@ -375,80 +376,80 @@ public class ObjectiveEditPanel extends JDialog {
         forcePanel.add(forceNames, localGbc);
         localGbc.gridx++;
         forcePanel.add(btnRemove, localGbc);
-        
-        
+
+
         getContentPane().add(forcePanel, gbc);
     }
-    
+
     private void addTimeLimitUI(GridBagConstraints gbc) {
         JPanel timeLimitPanel = new JPanel();
-        
+
         JLabel timeLimitLabel = new JLabel("Time Limit:");
-        
+
         cboTimeLimitDirection = new JComboBox<>();
         cboTimeLimitDirection.addItem("at most");
         cboTimeLimitDirection.addItem("at least");
-        
+
         cboTimeScaling = new JComboBox<>();
         for(TimeLimitType timeLimitType : TimeLimitType.values()) {
             cboTimeScaling.addItem(timeLimitType);
         }
         cboTimeScaling.addActionListener(e -> this.updateTimeLimitUI());
-        
+
         txtTimeLimit = new JTextField();
         txtTimeLimit.setColumns(5);
-        
+
         GridBagConstraints localGbc = new GridBagConstraints();
         localGbc.gridx = 0;
         localGbc.gridy = 0;
         localGbc.insets = new Insets(0, 0, 0, 5);
-        
+
         timeLimitPanel.add(cboTimeLimitDirection, localGbc);
         localGbc.gridx++;
         timeLimitPanel.add(cboTimeScaling, localGbc);
         localGbc.gridx++;
         timeLimitPanel.add(txtTimeLimit, localGbc);
-        
-        
+
+
         getContentPane().add(timeLimitPanel, gbc);
     }
-    
+
     /**
      * Handles the "add objective effect" row
      */
     private void addEffectUI(GridBagConstraints gbc) {
         JPanel effectPanel = new JPanel();
-                
+
         lblMagnitude = new JLabel("Amount:");
         txtAmount = new JTextField();
         txtAmount.setColumns(5);
-        
+
         JLabel lblScaling = new JLabel("Effect Scaling:");
         cboScalingType = new JComboBox<>();
         for(EffectScalingType scalingType : EffectScalingType.values()) {
             cboScalingType.addItem(scalingType);
         }
-        
+
         JLabel lblEffectType = new JLabel("Effect Type:");
         cboEffectType = new JComboBox<>();
         for(ObjectiveEffectType scalingType : ObjectiveEffectType.values()) {
             cboEffectType.addItem(scalingType);
         }
-        
+
         JLabel lblEffectCondition = new JLabel("Effect Condition:");
         cboEffectCondition = new JComboBox<>();
         cboEffectCondition.addItem(ObjectiveEffectConditionType.ObjectiveSuccess);
         cboEffectCondition.addItem(ObjectiveEffectConditionType.ObjectiveFailure);
-        
+
         JButton btnAdd = new JButton("Add");
         btnAdd.addActionListener(e -> this.addEffect());
-        
+
         GridBagConstraints localGbc = new GridBagConstraints();
         localGbc.gridx = 0;
         localGbc.gridy = 0;
         localGbc.insets = new Insets(0, 0, 0, 5);
         effectPanel.setLayout(new GridBagLayout());
-        
+
         effectPanel.add(lblMagnitude, localGbc);
         localGbc.gridx++;
         effectPanel.add(txtAmount, localGbc);
@@ -466,23 +467,23 @@ public class ObjectiveEditPanel extends JDialog {
         effectPanel.add(cboEffectCondition, localGbc);
         localGbc.gridx++;
         effectPanel.add(btnAdd, localGbc);
-        
+
         getContentPane().add(effectPanel, gbc);
     }
-    
+
     /**
      * Event handler for the 'add' button for scenario effects
      */
     private void addEffect() {
-        int amount = 0; 
+        int amount = 0;
         try {
             amount = Integer.parseInt(txtAmount.getText());
-            lblMagnitude.setForeground(Color.black);
+            lblMagnitude.setForeground(UIManager.getColor("text"));
         } catch(Exception e) {
             lblMagnitude.setForeground(Color.red);
             return;
         }
-        
+
         ObjectiveEffect effect = new ObjectiveEffect();
         effect.howMuch = amount;
         effect.effectScaling = (EffectScalingType) cboScalingType.getSelectedItem();
@@ -490,17 +491,17 @@ public class ObjectiveEditPanel extends JDialog {
 
         if(cboEffectCondition.getSelectedItem() == ObjectiveEffectConditionType.ObjectiveSuccess) {
             objective.addSuccessEffect(effect);
-            
+
             updateEffectList(successEffects, objective.getSuccessEffects());
         } else {
             objective.addFailureEffect(effect);
-            
+
             updateEffectList(failureEffects, objective.getFailureEffects());
         }
-        
+
         pack();
     }
-    
+
     /**
      * Worker function that updates an objective effects list with the given objective effects
      */
@@ -509,14 +510,14 @@ public class ObjectiveEditPanel extends JDialog {
         for(ObjectiveEffect currentEffect : objectiveEffects) {
             effectModel.addElement(currentEffect);
         }
-        
+
         listToUpdate.setModel(effectModel);
     }
-    
+
     private void removeEffect(ObjectiveEffectConditionType conditionType) {
         JList<ObjectiveEffect> listToUpdate;
         List<ObjectiveEffect> objectiveEffects;
-        
+
         if(conditionType == ObjectiveEffectConditionType.ObjectiveSuccess) {
             listToUpdate = successEffects;
             objectiveEffects = objective.getSuccessEffects();
@@ -526,84 +527,84 @@ public class ObjectiveEditPanel extends JDialog {
             objectiveEffects = objective.getFailureEffects();
             btnRemoveFailure.setEnabled(false);
         }
-        
+
         for(ObjectiveEffect effectToRemove : listToUpdate.getSelectedValuesList()) {
             objectiveEffects.remove(effectToRemove);
         }
-        
+
         updateEffectList(listToUpdate, objectiveEffects);
     }
-    
+
     private void addForce() {
         objective.addForce(cboForceName.getSelectedItem().toString());
-        
-        updateForceList();        
+
+        updateForceList();
         pack();
     }
-    
+
     private void removeForce() {
         for(String forceName : forceNames.getSelectedValuesList()) {
             objective.removeForce(forceName);
         }
-        
+
         updateForceList();
         btnRemove.setEnabled(false);
         pack();
     }
-    
+
     private void addDetail(JTextField field) {
         objective.addDetail(field.getText());
         updateDetailList();
     }
-    
+
     private void removeDetails() {
         for(int index : lstDetails.getSelectedIndices()) {
             objective.getDetails().remove(index);
         }
         updateDetailList();
     }
-    
+
     private void updateDetailList() {
         DefaultListModel<String> detailModel = new DefaultListModel<>();
         for(String detail : objective.getDetails()) {
             detailModel.addElement(detail);
         }
-        
+
         lstDetails.setModel(detailModel);
     }
-    
+
     private void updateForceList() {
         DefaultListModel<String> forceModel = new DefaultListModel<>();
         for(String forceName : objective.getAssociatedForceNames()) {
             forceModel.addElement(forceName);
         }
-        
+
         forceNames.setModel(forceModel);
     }
-    
+
     private void setDirectionDropdownVisibility() {
         switch((ObjectiveCriterion) cboObjectiveType.getSelectedItem()) {
         case PreventReachMapEdge:
         case ReachMapEdge:
             cboDirection.setVisible(true);
-            break;            
+            break;
         default:
             cboDirection.setVisible(false);
             break;
         }
     }
-    
+
     private void updateTimeLimitUI() {
         boolean enable = !cboTimeScaling.getSelectedItem().equals(TimeLimitType.None);
-        
+
         txtTimeLimit.setEnabled(enable);
         cboTimeLimitDirection.setEnabled(enable);
     }
-    
+
     private void saveObjectiveAndClose() {
         int number = 0;
         int timeLimit = 0;
-        
+
         try {
             number = Integer.parseInt(txtPercentage.getText());
             txtPercentage.setBorder(null);
@@ -611,7 +612,7 @@ public class ObjectiveEditPanel extends JDialog {
             txtPercentage.setBorder(new LineBorder(Color.red));
             return;
         }
-        
+
         try {
             if(txtTimeLimit.isEnabled()) {
                 timeLimit = Integer.parseInt(txtTimeLimit.getText());
@@ -621,7 +622,7 @@ public class ObjectiveEditPanel extends JDialog {
             txtTimeLimit.setBorder(new LineBorder(Color.red));
             return;
         }
-        
+
         objective.setObjectiveCriterion((ObjectiveCriterion) cboObjectiveType.getSelectedItem());
         objective.setDescription(txtShortDescription.getText());
         if(this.cboCountType.getSelectedIndex() == 0) {
@@ -629,13 +630,13 @@ public class ObjectiveEditPanel extends JDialog {
         } else {
             objective.setFixedAmount(number);
         }
-        
+
         if(cboDirection.isVisible() && cboDirection.getSelectedIndex() > 0) {
             objective.setDestinationEdge(OffBoardDirection.getDirection(cboDirection.getSelectedIndex() - 1));
         } else {
             objective.setDestinationEdge(OffBoardDirection.NONE);
         }
-             
+
         objective.setTimeLimitType((TimeLimitType) cboTimeScaling.getSelectedItem());
         if(txtTimeLimit.isEnabled()) {
             if(objective.getTimeLimitType() == TimeLimitType.ScaledToPrimaryUnitCount) {
@@ -644,15 +645,15 @@ public class ObjectiveEditPanel extends JDialog {
                 objective.setTimeLimit(timeLimit);
             }
         }
-        
+
         if(cboTimeLimitDirection.isEnabled()) {
             objective.setTimeLimitAtMost(cboTimeLimitDirection.getSelectedIndex() == 0);
         }
-            
+
         if(!currentScenarioTemplate.scenarioObjectives.contains(objective)) {
             currentScenarioTemplate.scenarioObjectives.add(objective);
         }
-        
+
         parent.updateObjectiveList();
         setVisible(false);
     }

--- a/MekHQ/src/mekhq/gui/model/DocTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/DocTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.util.ArrayList;
 
@@ -11,6 +10,7 @@ import mekhq.IconPackage;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.BasicInfo;
+import mekhq.gui.MekHqColors;
 
 /**
  * A table model for displaying doctors
@@ -18,8 +18,9 @@ import mekhq.gui.BasicInfo;
 public class DocTableModel extends DataTableModel {
     private static final long serialVersionUID = -6934834363013004894L;
 
-    private Campaign campaign;
-    
+    private final Campaign campaign;
+    private final MekHqColors colors = new MekHqColors();
+
     public DocTableModel(Campaign c) {
         columnNames = new String[] { "Doctors" };
         data = new ArrayList<Person>();
@@ -33,7 +34,7 @@ public class DocTableModel extends DataTableModel {
     public Person getDoctorAt(int row) {
         return (Person) data.get(row);
     }
-    
+
     public Campaign getCampaign() {
         return campaign;
     }
@@ -52,18 +53,18 @@ public class DocTableModel extends DataTableModel {
         public Component getTableCellRendererComponent(JTable table,
                 Object value, boolean isSelected, boolean hasFocus,
                 int row, int column) {
-            Component c = this;
             setOpaque(true);
             setPortrait(getDoctorAt(row));
-            setText(getValueAt(row, column).toString(), "black");
+            setText(getValueAt(row, column).toString());
             //setToolTipText(getCampaign().getTargetFor(getDoctorAt(row), getDoctorAt(row)).getDesc());
             if (isSelected) {
                 highlightBorder();
             } else {
                 unhighlightBorder();
             }
-            c.setBackground(new Color(220, 220, 220));
-            return c;
+            colors.getIconButton().getColor().ifPresent(c -> setBackground(c));
+            colors.getIconButton().getAlternateColor().ifPresent(c -> setForeground(c));
+            return this;
         }
 
     }

--- a/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
@@ -1,14 +1,11 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableCellRenderer;
 
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.Transaction;

--- a/MekHQ/src/mekhq/gui/model/LoanTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/LoanTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.text.DateFormat;
 import java.util.ArrayList;
@@ -12,6 +11,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.finances.Loan;
+import mekhq.gui.MekHqColors;
 
 /**
  * A table model for displaying active loans
@@ -30,11 +30,12 @@ public class LoanTableModel extends DataTableModel {
     public final static int COL_NEXT_PAY   =   8;
     public final static int N_COL            = 9;
 
+    private final MekHqColors colors = new MekHqColors();
 
     public LoanTableModel() {
         data = new ArrayList<Loan>();
     }
-    
+
     public int getRowCount() {
         return data.size();
     }
@@ -70,7 +71,7 @@ public class LoanTableModel extends DataTableModel {
     }
 
     public Object getValueAt(int row, int col) {
-        Loan loan = getLoan(row);           
+        Loan loan = getLoan(row);
         if(col == COL_DESC) {
             return loan.getDescription();
         }
@@ -162,7 +163,8 @@ public class LoanTableModel extends DataTableModel {
                 setForeground(UIManager.getColor("Table.selectionForeground"));
             } else {
                 if(loan.isOverdue()) {
-                    setBackground(Color.RED);
+                    colors.getLoanOverdue().getColor().ifPresent(c -> setBackground(c));
+                    colors.getLoanOverdue().getAlternateColor().ifPresent(c -> setForeground(c));
                 } else {
                     setBackground(UIManager.getColor("Table.background"));
                 }

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -19,7 +18,6 @@ import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
-import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
@@ -30,7 +28,7 @@ import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 public class PartsInUseTableModel extends DataTableModel {
     private static final long serialVersionUID = -7166100476703184175L;
-    
+
     private static final DecimalFormat FORMATTER = new DecimalFormat();
     static {
         FORMATTER.setMaximumFractionDigits(3);
@@ -54,7 +52,7 @@ public class PartsInUseTableModel extends DataTableModel {
         resourceMap = ResourceBundle.getBundle("mekhq.resources.PartsInUseTableModel", new EncodeControl()); //$NON-NLS-1$
         data = new ArrayList<PartInUse>();
     }
-    
+
     @Override
     public int getRowCount() {
         return data.size();
@@ -138,11 +136,11 @@ public class PartsInUseTableModel extends DataTableModel {
                 return false;
         }
     }
-    
+
     public void setData(Set<PartInUse> data) {
         setData(new ArrayList<>(data));
     }
-    
+
     @SuppressWarnings("unchecked")
     public void updateRow(int row, PartInUse piu) {
         ((ArrayList<PartInUse>) data).set(row, piu);
@@ -155,7 +153,7 @@ public class PartsInUseTableModel extends DataTableModel {
         }
         return (PartInUse) data.get(row);
     }
-    
+
     public boolean isBuyable(int row) {
         return (row >= 0) && (row < data.size())
             && (null != ((PartInUse) data.get(row)).getPartToBuy());
@@ -175,7 +173,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 return SwingConstants.CENTER;
         }
     }
-    
+
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_PART:
@@ -196,7 +194,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 return 100;
         }
     }
-    
+
     public boolean hasConstantWidth(int col) {
         switch(col) {
             case COL_BUTTON_BUY:
@@ -208,7 +206,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 return false;
         }
     }
-    
+
     public int getWidth(int col) {
         switch(col) {
             case COL_BUTTON_BUY:
@@ -222,7 +220,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 return Integer.MAX_VALUE;
         }
     }
-    
+
     public PartsInUseTableModel.Renderer getRenderer() {
         return new PartsInUseTableModel.Renderer();
     }
@@ -239,12 +237,12 @@ public class PartsInUseTableModel extends DataTableModel {
             return this;
         }
     }
-    
+
     public static class ButtonColumn extends AbstractCellEditor
         implements TableCellRenderer, TableCellEditor, ActionListener, MouseListener {
 
         private static final long serialVersionUID = 5632710519408125751L;
-        
+
         private JTable table;
         private Action action;
         private Border originalBorder;
@@ -272,7 +270,7 @@ public class PartsInUseTableModel extends DataTableModel {
             columnModel.getColumn(column).setCellEditor(this);
             table.addMouseListener(this);
         }
-        
+
         public Border getFocusBorder()
         {
             return focusBorder;
@@ -289,7 +287,7 @@ public class PartsInUseTableModel extends DataTableModel {
             editButton.setEnabled(enabled);
             renderButton.setEnabled(enabled);
         }
-        
+
         @Override
         public Object getCellEditorValue() {
             return editorValue;
@@ -327,7 +325,7 @@ public class PartsInUseTableModel extends DataTableModel {
         @Override
         public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
             boolean buyable = ((PartsInUseTableModel) table.getModel()).isBuyable(table.getRowSorter().convertRowIndexToModel(row));
-            
+
             if(value == null) {
                 editButton.setText(EMPTY_CELL);
                 editButton.setIcon(null);
@@ -339,7 +337,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 editButton.setIcon(null);
             }
             editButton.setEnabled(enabled && buyable);
-            
+
             this.editorValue = value;
             return editButton;
         }
@@ -347,7 +345,7 @@ public class PartsInUseTableModel extends DataTableModel {
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
             boolean buyable = ((PartsInUseTableModel) table.getModel()).isBuyable(table.getRowSorter().convertRowIndexToModel(row));
-            
+
             if(isSelected && enabled && buyable) {
                 renderButton.setForeground(table.getSelectionForeground());
                  renderButton.setBackground(table.getSelectionBackground());
@@ -374,7 +372,7 @@ public class PartsInUseTableModel extends DataTableModel {
                 renderButton.setIcon(null);
             }
             renderButton.setEnabled(enabled && buyable);
-            
+
             return renderButton;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/PatientTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PatientTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.util.ArrayList;
 
@@ -12,6 +11,7 @@ import mekhq.IconPackage;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.BasicInfo;
+import mekhq.gui.MekHqColors;
 
 /**
  * A table model for displaying personnel in the infirmary
@@ -19,9 +19,10 @@ import mekhq.gui.BasicInfo;
 public class PatientTableModel extends AbstractListModel<Person> {
     private static final long serialVersionUID = -1615929049408417297L;
 
-    ArrayList<Person> patients;
-    Campaign campaign;
-    
+    private ArrayList<Person> patients;
+    private final Campaign campaign;
+    private final MekHqColors colors = new MekHqColors();
+
     public PatientTableModel(Campaign c) {
         patients = new ArrayList<Person>();
         campaign = c;
@@ -46,11 +47,11 @@ public class PatientTableModel extends AbstractListModel<Person> {
     public int getSize() {
         return patients.size();
     }
-    
+
     private Campaign getCampaign() {
         return campaign;
     }
-    
+
     public PatientTableModel.Renderer getRenderer(IconPackage icons) {
         return new PatientTableModel.Renderer(icons);
     }
@@ -68,7 +69,6 @@ public class PatientTableModel extends AbstractListModel<Person> {
                 int index,
                 boolean isSelected,
                 boolean cellHasFocus) {
-            Component c = this;
             setOpaque(true);
             Person p = (Person)getElementAt(index);
             if (getCampaign().getCampaignOptions().useAdvancedMedical()) {
@@ -82,8 +82,10 @@ public class PatientTableModel extends AbstractListModel<Person> {
                 unhighlightBorder();
             }
             setPortrait(p);
-            c.setBackground(new Color(220, 220, 220));
-            return c;
+
+            colors.getIconButton().getColor().ifPresent(c -> setBackground(c));
+            colors.getIconButton().getAlternateColor().ifPresent(c -> setForeground(c));
+            return this;
         }
     }
 }

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.FontMetrics;
 import java.text.SimpleDateFormat;
@@ -38,7 +37,7 @@ public class PersonnelEventLogModel extends DataTableModel {
         data = new ArrayList<LogEntry>();
         dateTextWidth = getRenderer().metrics.stringWidth(shortDateFormat.format(new Date())) + 10;
     }
-   
+
     @Override
     public int getRowCount() {
         return data.size();
@@ -60,7 +59,7 @@ public class PersonnelEventLogModel extends DataTableModel {
                 return EMPTY_CELL;
         }
     }
-    
+
     @Override
     public Object getValueAt(int row, int column) {
         LogEntry event = getEvent(row);
@@ -73,24 +72,24 @@ public class PersonnelEventLogModel extends DataTableModel {
                 return EMPTY_CELL;
         }
     }
-    
+
     @Override
     public Class<?> getColumnClass(int c) {
         return String.class;
     }
-    
+
     @Override
     public boolean isCellEditable(int row, int col) {
         return false;
     }
-    
+
     public LogEntry getEvent(int row) {
         if((row < 0) || (row >= data.size())) {
             return null;
         }
         return (LogEntry) data.get(row);
     }
-    
+
     public int getAlignment(int column) {
         switch(column) {
             case COL_DATE:
@@ -101,7 +100,7 @@ public class PersonnelEventLogModel extends DataTableModel {
                 return StyleConstants.ALIGN_CENTER;
         }
     }
-    
+
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_DATE:
@@ -112,7 +111,7 @@ public class PersonnelEventLogModel extends DataTableModel {
                 return 100;
         }
     }
-    
+
     public boolean hasConstantWidth(int col) {
         switch(col) {
             case COL_DATE:
@@ -121,11 +120,11 @@ public class PersonnelEventLogModel extends DataTableModel {
                 return false;
         }
     }
-    
+
     public PersonnelEventLogModel.Renderer getRenderer() {
         return new PersonnelEventLogModel.Renderer();
     }
-    
+
     public static class Renderer extends JTextPane implements TableCellRenderer {
         private static final long serialVersionUID = -2201201114822098877L;
 

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.FontMetrics;
 import java.text.SimpleDateFormat;
@@ -38,7 +37,7 @@ public class PersonnelKillLogModel extends DataTableModel {
         data = new ArrayList<Kill>();
         dateTextWidth = getRenderer().metrics.stringWidth(shortDateFormat.format(new Date())) + 10;
     }
-   
+
     @Override
     public int getRowCount() {
         return data.size();
@@ -60,7 +59,7 @@ public class PersonnelKillLogModel extends DataTableModel {
                 return EMPTY_CELL;
         }
     }
-    
+
     @Override
     public Object getValueAt(int row, int column) {
         Kill kill = getKill(row);
@@ -75,24 +74,24 @@ public class PersonnelKillLogModel extends DataTableModel {
                 return EMPTY_CELL;
         }
     }
-    
+
     @Override
     public Class<?> getColumnClass(int c) {
         return String.class;
     }
-    
+
     @Override
     public boolean isCellEditable(int row, int col) {
         return false;
     }
-    
+
     public Kill getKill(int row) {
         if((row < 0) || (row >= data.size())) {
             return null;
         }
         return (Kill) data.get(row);
     }
-    
+
     public int getAlignment(int column) {
         switch(column) {
             case COL_DATE:
@@ -103,7 +102,7 @@ public class PersonnelKillLogModel extends DataTableModel {
                 return StyleConstants.ALIGN_CENTER;
         }
     }
-    
+
     public int getPreferredWidth(int column) {
         switch(column) {
             case COL_DATE:
@@ -114,7 +113,7 @@ public class PersonnelKillLogModel extends DataTableModel {
                 return 100;
         }
     }
-    
+
     public boolean hasConstantWidth(int col) {
         switch(col) {
             case COL_DATE:
@@ -123,11 +122,11 @@ public class PersonnelKillLogModel extends DataTableModel {
                 return false;
         }
     }
-    
+
     public PersonnelKillLogModel.Renderer getRenderer() {
         return new PersonnelKillLogModel.Renderer();
     }
-    
+
     public static class Renderer extends JTextPane implements TableCellRenderer  {
         private static final long serialVersionUID = -2201201114822098877L;
         private final SimpleAttributeSet attribs = new SimpleAttributeSet();

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
 import java.awt.Toolkit;
@@ -46,6 +45,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
 import mekhq.gui.BasicInfo;
+import mekhq.gui.MekHqColors;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 /**
@@ -60,6 +60,8 @@ public class PersonnelTableModel extends DataTableModel {
     private PersonnelMarket personnelMarket;
     private boolean loadAssignmentFromMarket;
     private boolean groupByUnit;
+
+    private final MekHqColors colors = new MekHqColors();
 
     public static final int COL_RANK            = 0;
     public static final int COL_NAME            = 1;
@@ -689,11 +691,14 @@ public class PersonnelTableModel extends DataTableModel {
                 setForeground(UIManager.getColor("Table.selectionForeground"));
             } else {
                 if (isDeployed(actualRow)) {
-                    setBackground(Color.LIGHT_GRAY);
+                    colors.getDeployed().getColor().ifPresent(c -> setBackground(c));
+                    colors.getDeployed().getAlternateColor().ifPresent(c -> setForeground(c));
                 } else if ((Integer.parseInt((String) getValueAt(actualRow,COL_HITS)) > 0) || getPerson(actualRow).hasInjuries(true)) {
-                    setBackground(Color.RED);
+                    colors.getInjured().getColor().ifPresent(c -> setBackground(c));
+                    colors.getInjured().getAlternateColor().ifPresent(c -> setForeground(c));
                 } else if (getPerson(actualRow).hasOnlyHealedPermanentInjuries()) {
-                    setBackground(new Color(0xee9a00));
+                    colors.getHealedInjuries().getColor().ifPresent(c -> setBackground(c));
+                    colors.getHealedInjuries().getAlternateColor().ifPresent(c -> setForeground(c));
                 } else {
                     setBackground(UIManager.getColor("Table.background"));
                 }

--- a/MekHQ/src/mekhq/gui/model/RankTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RankTableModel.java
@@ -1,11 +1,9 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
-import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 
@@ -28,7 +26,7 @@ public class RankTableModel extends DefaultTableModel {
     public RankTableModel(Object[][] ranksArray, String[] rankColNames) {
         super(ranksArray, rankColNames);
     }
-    
+
     @Override
     public boolean isCellEditable(int row, int column) {
     	return !(column == COL_NAME_RATE || column == COL_OFFICER);
@@ -53,7 +51,7 @@ public class RankTableModel extends DefaultTableModel {
     			return getValueAt(0, c).getClass();
     	}
     }
-    
+
     public int getColumnWidth(int c) {
     	switch (c) {
     		case COL_NAME_RATE:

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
 import java.util.ArrayList;
@@ -27,6 +26,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.RetirementDefectionTracker;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
+import mekhq.gui.MekHqColors;
 import mekhq.gui.dialog.RetirementDefectionDialog;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
 
@@ -55,7 +55,8 @@ public class RetirementTableModel extends AbstractTableModel {
         "Payout", "Recruit", "Unit"
     };
 
-    private Campaign campaign;
+    private final Campaign campaign;
+    private final MekHqColors colors = new MekHqColors();
     private ArrayList<UUID> data;
     private HashMap<UUID, TargetRoll> targets;
     private HashMap<UUID, Boolean> payBonus;
@@ -401,7 +402,8 @@ public class RetirementTableModel extends AbstractTableModel {
             if (!isSelected) {
                 if (null != campaign.getRetirementDefectionTracker().getPayout(p.getId()) &&
                     campaign.getRetirementDefectionTracker().getPayout(p.getId()).getWeightClass() > 0) {
-                    setBackground(Color.LIGHT_GRAY);
+                    colors.getPaidRetirement().getColor().ifPresent(c -> setBackground(c));
+                    colors.getPaidRetirement().getAlternateColor().ifPresent(c -> setForeground(c));
                 }
             }
             return this;
@@ -422,7 +424,6 @@ public class RetirementTableModel extends AbstractTableModel {
         public Component getTableCellRendererComponent(JTable table,
                 Object value, boolean isSelected, boolean hasFocus,
                 int row, int column) {
-            Component c = this;
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
             Person p = getPerson(actualRow);
@@ -479,15 +480,16 @@ public class RetirementTableModel extends AbstractTableModel {
                 }
             }
 
-            MekHqTableCellRenderer.setupTableColors(c, table, isSelected, hasFocus, row);
+            MekHqTableCellRenderer.setupTableColors(this, table, isSelected, hasFocus, row);
             if (!isSelected) {
                 if (null != campaign.getRetirementDefectionTracker().getPayout(p.getId()) &&
                         campaign.getRetirementDefectionTracker().getPayout(p.getId()).getWeightClass() > 0) {
-                    c.setBackground(Color.LIGHT_GRAY);
+                    colors.getPaidRetirement().getColor().ifPresent(c -> setBackground(c));
+                    colors.getPaidRetirement().getAlternateColor().ifPresent(c -> setForeground(c));
                 }
             }
-            
-            return c;
+
+            return this;
         }
     }
 }

--- a/MekHQ/src/mekhq/gui/model/TaskTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TaskTableModel.java
@@ -23,7 +23,6 @@ import mekhq.campaign.work.IPartWork;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.ITechWorkPanel;
 import mekhq.gui.RepairTaskInfo;
-import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 /**
  * A table model for displaying work items
@@ -31,10 +30,10 @@ import mekhq.gui.utilities.MekHqTableCellRenderer;
 public class TaskTableModel extends DataTableModel {
     private static final long serialVersionUID = -6256038046416893994L;
     private static Map<String, Person> techCache = new HashMap<String, Person>();
-    
+
     private CampaignGUI gui;
     private ITechWorkPanel panel;
-    
+
     private interface REPAIR_STATE {
     	public static final int AVAILABLE = 0;
     	public static final int NOT_AVAILABLE = 1;
@@ -42,14 +41,14 @@ public class TaskTableModel extends DataTableModel {
     	public static final int BLOCKED = 3;
     	public static final int SCHEDULED = 4;
     }
-    
+
     public TaskTableModel(CampaignGUI gui, ITechWorkPanel panel) {
         columnNames = new String[] { "Tasks" };
         data = new ArrayList<IPartWork>();
         this.gui = gui;
         this.panel = panel;
     }
-    
+
     public Object getValueAt(int row, int col) {
         return ((IPartWork) data.get(row)).getDesc();
     }
@@ -85,28 +84,28 @@ public class TaskTableModel extends DataTableModel {
             Component c = this;
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
-            
+
             setText("<html>" + getValueAt(actualRow, actualCol).toString() + "</html>");
             if (isSelected) {
                 highlightBorder();
             } else {
                 unhighlightBorder();
 			}
-			
+
             c.setBackground(table.getBackground());
             c.setForeground(table.getForeground());
-            
+
             IPartWork part = getTaskAt(actualRow);
-            
+
             int availableLevel = REPAIR_STATE.AVAILABLE;
-            
+
             if (null != part.getTeamId()) {
             	availableLevel = REPAIR_STATE.SCHEDULED;
-            } else {            	
+            } else {
             	if (part instanceof MissingPart) {
             		if (!((MissingPart)part).isReplacementAvailable()) {
 	            		PartInventory inventories = gui.getCampaign().getPartInventory(((MissingPart) part).getNewPart());
-	            		
+
 	            		if ((inventories.getTransit() > 0) || (inventories.getOrdered() > 0)) {
 	            			availableLevel = REPAIR_STATE.IN_TRANSIT;
 	            		} else {
@@ -128,72 +127,72 @@ public class TaskTableModel extends DataTableModel {
             	        }
             	    }
             	}
-            	
+
             	if (availableLevel == REPAIR_STATE.AVAILABLE) {
 	                Person tech = panel.getSelectedTech();
-	                
+
 	                if (null == tech) {
 	                	//Find a valid tech that we can copy their skill from
 	                	ArrayList<Person> techs = gui.getCampaign().getTechs(false);
-	                	
+
 	        			for (int i = techs.size() - 1; i >= 0; i--) {
 	        				Person techTemp = techs.get(i);
 
 	        				if ((null == techTemp) || (null == part) || (null == part.getUnit())) {
 	        					continue;
 	        				}
-	        				
+
 	        				if (techTemp.canTech(part.getUnit().getEntity())) {
 	        					tech = techTemp;
 	        					break;
 	        				}
 	        			}
-	        			
+
 	        			if (null != tech) {
 		        			Skill partSkill = tech.getSkillForWorkingOn(part);
 		        			String skillName = partSkill.getType().getName();
-		        			
+
 	        				//Find a tech in our placeholder cache
 	        				tech = techCache.get(skillName);
-	        				
+
 	        				if (null == tech) {
 			        			//Create a dummy elite tech with the proper skill and 1 minute and put it in our cache for later use
-			        			
+
 			        			tech = new Person(String.format("Temp Tech (%s)", skillName), gui.getCampaign());
 			        			tech.addSkill(skillName, partSkill.getType().getEliteLevel(), 1);
 			        			tech.setMinutesLeft(1);
-			        			
+
 			        			techCache.put(skillName, tech);
 	        				}
 	        			}
 	                }
-	                
+
 	                if (null != tech) {
 	                	TargetRoll roll = gui.getCampaign().getTargetFor(part, tech);
-	                	
+
 	                	if ((roll.getValue() == TargetRoll.IMPOSSIBLE) || (roll.getValue() == TargetRoll.AUTOMATIC_FAIL) || (roll.getValue() == TargetRoll.CHECK_FALSE)) {
 	                		availableLevel = REPAIR_STATE.BLOCKED;
 	                	}
 	                }
             	}
             }
-            
+
             String imgMod = "";
             boolean setSecondary = false;
-            
+
             switch (availableLevel) {
 	            case REPAIR_STATE.BLOCKED:
-	            	imgMod = "_impossible";	            	
+	            	imgMod = "_impossible";
 	            	break;
-	            	
+
 	            case REPAIR_STATE.IN_TRANSIT:
-	            	imgMod = "_transit";	            	
+	            	imgMod = "_transit";
 	            	break;
-	            	
+
 	            case REPAIR_STATE.NOT_AVAILABLE:
-	            	imgMod = "_na";	            	
+	            	imgMod = "_na";
 	            	break;
-	            	
+
 	            case REPAIR_STATE.SCHEDULED:
 	            	setSecondary = true;
 	            	break;
@@ -201,17 +200,17 @@ public class TaskTableModel extends DataTableModel {
 
         	String[] imgData = Part.findPartImage(part);
         	String imgPath = imgData[0] + imgData[1] + imgMod + ".png";
-            
+
             Image imgTool = getToolkit().getImage(imgPath); //$NON-NLS-1$
-            
+
             this.setImage(imgTool);
-            
+
             if (setSecondary) {
-            	this.setSecondaryImage(getToolkit().getImage("data/images/misc/repair/working.png"));	
+            	this.setSecondaryImage(getToolkit().getImage("data/images/misc/repair/working.png"));
             } else {
             	this.setSecondaryImage(null);
             }
-			
+
             return c;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/TechTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TechTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.util.ArrayList;
 

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -1,6 +1,5 @@
 package mekhq.gui.model;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
 import java.util.ArrayList;
@@ -18,15 +17,14 @@ import megamek.common.SmallCraft;
 import megamek.common.TechConstants;
 import megamek.common.UnitType;
 import mekhq.IconPackage;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
+import mekhq.gui.MekHqColors;
 import mekhq.gui.preferences.ColorPreference;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
-import mekhq.preferences.PreferencesNode;
 
 /**
  * A table Model for displaying information about units
@@ -59,44 +57,11 @@ public class UnitTableModel extends DataTableModel {
 
     private Campaign campaign;
 
-    public static ColorPreference normalColors;
-    public static ColorPreference selectedColors;
-    public static ColorPreference deployedColors;
-    public static ColorPreference inTransitColors;
-    public static ColorPreference refittingColors;
-    public static ColorPreference mothballingColors;
-    public static ColorPreference mothballedColors;
-    public static ColorPreference notRepairableColors;
-    public static ColorPreference nonfunctionalColors;
-    public static ColorPreference needsPartsFixedColors;
-    public static ColorPreference uncrewedColors;
+    private final MekHqColors colors = new MekHqColors();
 
     public UnitTableModel(Campaign c) {
         data = new ArrayList<Unit>();
         campaign = c;
-        setUserPreferences();
-    }
-
-    private synchronized void setUserPreferences() {
-        if (normalColors == null) {
-            PreferencesNode preferences = MekHQ.getPreferences().forClass(UnitTableModel.class);
-
-            normalColors = new ColorPreference("normal", UIManager.getColor("Table.background"), UIManager.getColor("Table.foreground"));
-            selectedColors = new ColorPreference("selected", UIManager.getColor("Table.selectionBackground"), UIManager.getColor("Table.selectionFackground"));
-            deployedColors = new ColorPreference("deployed", Color.LIGHT_GRAY, Color.BLACK);
-            inTransitColors = new ColorPreference("inTransit", Color.ORANGE, Color.BLACK);
-            refittingColors = new ColorPreference("refitting", Color.CYAN, Color.BLACK);
-            mothballingColors = new ColorPreference("mothballing", new Color(153,153,255), Color.BLACK);
-            mothballedColors = new ColorPreference("mothballed", new Color(204, 204, 255), Color.BLACK);
-            notRepairableColors = new ColorPreference("notRepairable", new Color(190, 150, 55), Color.BLACK);
-            nonfunctionalColors = new ColorPreference("nonfunctional", new Color(205, 92, 92), Color.BLACK);
-            needsPartsFixedColors = new ColorPreference("needsPartsFixed", new Color(238, 238, 0), Color.BLACK);
-            uncrewedColors = new ColorPreference("uncrewed", Color.RED, Color.BLACK);
-
-            preferences.manage(normalColors, selectedColors, deployedColors, inTransitColors, refittingColors,
-                mothballingColors, mothballedColors, notRepairableColors, nonfunctionalColors, needsPartsFixedColors,
-                uncrewedColors);
-        }
     }
 
     public int getRowCount() {
@@ -347,44 +312,42 @@ public class UnitTableModel extends DataTableModel {
             Unit u = getUnit(actualRow);
 
             if (isSelected) {
-                applyColors(selectedColors, isSelected);
+                setBackground(UIManager.getColor("Table.selectionBackground"));
+                setForeground(UIManager.getColor("Table.selectionForeground"));
             } else {
                 if (u.isDeployed()) {
-                    applyColors(deployedColors);
+                    applyColors(colors.getDeployed());
                 } else if(!u.isPresent()) {
-                    applyColors(inTransitColors);
+                    applyColors(colors.getInTransit());
                 } else if(u.isRefitting()) {
-                    applyColors(refittingColors);
+                    applyColors(colors.getRefitting());
                 } else if (u.isMothballing()) {
-                    applyColors(mothballingColors);
+                    applyColors(colors.getMothballing());
                 } else if (u.isMothballed()) {
-                    applyColors(mothballedColors);
+                    applyColors(colors.getMothballed());
                 } else if (!u.isRepairable()) {
-                    applyColors(notRepairableColors);
+                    applyColors(colors.getNotRepairable());
                 } else if (!u.isFunctional()) {
-                    applyColors(nonfunctionalColors);
+                    applyColors(colors.getNonFunctional());
                 } else if (u.hasPartsNeedingFixing()) {
-                    applyColors(needsPartsFixedColors);
+                    applyColors(colors.getNeedsPartsFixed());
                 } else if (u.getEntity() instanceof Infantry
                         && u.getActiveCrew().size() < u.getFullCrewSize()) {
-                    applyColors(uncrewedColors);
+                    applyColors(colors.getUncrewed());
                 } else {
-                    applyColors(normalColors);
+                    setBackground(UIManager.getColor("Table.background"));
+                    setForeground(UIManager.getColor("Table.foreground"));
                 }
             }
             return this;
         }
 
         private void applyColors(ColorPreference c) {
-            applyColors(c, false);
-        }
-
-        private void applyColors(ColorPreference c, boolean isSelected) {
             setBackground(c.getColor()
-                    .orElseGet(() -> UIManager.getColor(isSelected ? "Table.selectionBackground" : "Table.background")));
+                    .orElseGet(() -> UIManager.getColor("Table.background")));
 
             setForeground(c.getAlternateColor()
-                    .orElseGet(() -> UIManager.getColor(isSelected ? "Table.selectionForeground" : "Table.foreground")));
+                    .orElseGet(() -> UIManager.getColor("Table.foreground")));
         }
     }
 

--- a/MekHQ/src/mekhq/gui/preferences/ColorPreference.java
+++ b/MekHQ/src/mekhq/gui/preferences/ColorPreference.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2020 The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.preferences;
+
+import java.awt.Color;
+import java.util.Optional;
+
+import megamek.common.annotations.Nullable;
+import mekhq.preferences.PreferenceElement;
+
+/**
+ * Represents a preference which can manage a color and
+ * an optional alternate color.
+ */
+public class ColorPreference extends PreferenceElement {
+
+    private final Color defaultColor;
+    private final Color defaultAlternateColor;
+    private Optional<Color> color = Optional.empty();
+    private Optional<Color> alternateColor = Optional.empty();
+
+    /**
+     * Creates a new {@code ColorPreference} with a default {@link Color}.
+     */
+    public ColorPreference(String name, Color defaultColor) {
+        super(name);
+
+        this.defaultColor = defaultColor;
+        this.defaultAlternateColor = null;
+    }
+
+    /**
+     * Creates a new {@code ColorPreference} with a default {@link Color}
+     * and a default alternate color.
+     */
+    public ColorPreference(String name, Color defaultColor, Color defaultAlternateColor) {
+        super(name);
+
+        this.defaultColor = defaultColor;
+        this.defaultAlternateColor = defaultAlternateColor;
+    }
+
+    /**
+     * Gets the main color.
+     * @return The main color.
+     */
+    public Optional<Color> getColor() {
+        return Optional.ofNullable(color.orElse(defaultColor));
+    }
+
+    /**
+     * Sets the main color.
+     * @param color The main color.
+     */
+    public void setColor(Optional<Color> color) {
+        this.color = color;
+    }
+
+    /**
+     * Gets the alternate color.
+     * @param color The alternate color.
+     */
+    public Optional<Color> getAlternateColor() {
+        return Optional.ofNullable(alternateColor.orElse(defaultAlternateColor));
+    }
+
+    /**
+     * Sets the alternate color.
+     * @param color The alternate color.
+     */
+    public void setAlternateColor(Optional<Color> alternateColor) {
+        this.alternateColor = alternateColor;
+    }
+
+    @Override
+    protected String getValue() {
+        if (alternateColor.isPresent()) {
+            return String.format("%s|%s", format(color), format(alternateColor));
+        } else {
+            return format(color);
+        }
+    }
+
+    @Nullable
+    private static String format(Optional<Color> color) {
+        return color.isPresent() ? "#" + Integer.toHexString(color.get().getRGB()) : null;
+    }
+
+    @Override
+    protected void initialize(String value) {
+        if (value != null) {
+            String[] values = value.split("\\|");
+            if (values.length > 0) {
+                color = decode(values[0]);
+            }
+            if (values.length > 1) {
+                alternateColor = decode(values[1]);
+            }
+        }
+    }
+
+    private static Optional<Color> decode(String value) {
+        try {
+            return Optional.ofNullable(Color.decode(value));
+        } catch (NumberFormatException ex0) {
+            try {
+                return Optional.ofNullable(Color.getColor(value));
+            } catch (NumberFormatException ex1) {
+                // CAW: Ignored.
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected void dispose() {
+        // TODO Auto-generated method stub
+    }
+}

--- a/MekHQ/src/mekhq/gui/preferences/ColorPreference.java
+++ b/MekHQ/src/mekhq/gui/preferences/ColorPreference.java
@@ -74,7 +74,7 @@ public class ColorPreference extends PreferenceElement {
 
     /**
      * Gets the alternate color.
-     * @param color The alternate color.
+     * @return The alternate color.
      */
     public Optional<Color> getAlternateColor() {
         return Optional.ofNullable(alternateColor.orElse(defaultAlternateColor));
@@ -82,7 +82,7 @@ public class ColorPreference extends PreferenceElement {
 
     /**
      * Sets the alternate color.
-     * @param color The alternate color.
+     * @param alternateColor The alternate color.
      */
     public void setAlternateColor(Optional<Color> alternateColor) {
         this.alternateColor = alternateColor;
@@ -130,6 +130,5 @@ public class ColorPreference extends PreferenceElement {
 
     @Override
     protected void dispose() {
-        // TODO Auto-generated method stub
     }
 }

--- a/MekHQ/src/mekhq/gui/utilities/MarkdownEditorPanel.java
+++ b/MekHQ/src/mekhq/gui/utilities/MarkdownEditorPanel.java
@@ -20,7 +20,6 @@
 package mekhq.gui.utilities;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
@@ -48,18 +47,18 @@ import javax.swing.event.ChangeListener;
  *
  */
 public class MarkdownEditorPanel extends JPanel {
-    
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 7534667332172721918L;
-    
+
     private JTabbedPane tabPane;
     private JTextArea editor;
     private JScrollPane scrollEditor;
     private JScrollPane scrollViewer;
     private JTextPane viewer;
-    
+
     private JButton btnH1;
     private JButton btnH2;
     private JButton btnH3;
@@ -81,9 +80,9 @@ public class MarkdownEditorPanel extends JPanel {
      * @param title - a <code>String</code> to show up as the title of the editor at the top
      */
     public MarkdownEditorPanel(String title) {
-      
+
         tabPane = new JTabbedPane();
-        
+
         //set up editor
         setLayout(new BorderLayout());
         editor = new JTextArea();
@@ -92,7 +91,7 @@ public class MarkdownEditorPanel extends JPanel {
         editor.setWrapStyleWord(true);
         scrollEditor = new JScrollPane(editor);
         scrollEditor.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        
+
         //set up buttons
         JPanel pnlButtons = new JPanel(new WrapLayout(FlowLayout.LEFT));
         btnH1 = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_header_1608924.png"));
@@ -102,7 +101,7 @@ public class MarkdownEditorPanel extends JPanel {
             insertHeader(1);
         });
         pnlButtons.add(btnH1);
-        
+
         btnH2 = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_header_1608924_20px.png"));
         btnH2.setToolTipText("Header 2");
         btnH2.setPreferredSize(new Dimension(36, 36));
@@ -110,7 +109,7 @@ public class MarkdownEditorPanel extends JPanel {
             insertHeader(2);
         });
         pnlButtons.add(btnH2);
-        
+
         btnH3 = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_header_1608924_16px.png"));
         btnH3.setToolTipText("Header 3");
         btnH3.setPreferredSize(new Dimension(36, 36));
@@ -118,7 +117,7 @@ public class MarkdownEditorPanel extends JPanel {
             insertHeader(3);
         });
         pnlButtons.add(btnH3);
-        
+
         btnBold = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_ic_format_bold_48px_352381.png"));
         btnBold.setToolTipText("Bold");
         btnBold.setPreferredSize(new Dimension(36, 36));
@@ -126,7 +125,7 @@ public class MarkdownEditorPanel extends JPanel {
             boldText();
         });
         pnlButtons.add(btnBold);
-        
+
         btnItalic = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_ic_format_italic_48px_352387.png"));
         btnItalic.setToolTipText("Italicize");
         btnItalic.setPreferredSize(new Dimension(36, 36));
@@ -134,7 +133,7 @@ public class MarkdownEditorPanel extends JPanel {
             italicizeText();
         });
         pnlButtons.add(btnItalic);
-        
+
         btnHR = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_ic_remove_48px_352440.png"));
         btnHR.setToolTipText("Horizontal line");
         btnHR.setPreferredSize(new Dimension(36, 36));
@@ -142,7 +141,7 @@ public class MarkdownEditorPanel extends JPanel {
             insertHR();
         });
         pnlButtons.add(btnHR);
-        
+
         btnUL = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_ic_format_list_bulleted_48px_352389.png"));
         btnUL.setToolTipText("Unordered list");
         btnUL.setPreferredSize(new Dimension(36, 36));
@@ -150,7 +149,7 @@ public class MarkdownEditorPanel extends JPanel {
             insertBullet(false);
         });
         pnlButtons.add(btnUL);
-        
+
         btnOL = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_ic_format_list_numbered_48px_352390.png"));
         btnOL.setToolTipText("Ordered list");
         btnOL.setPreferredSize(new Dimension(36, 36));
@@ -158,7 +157,7 @@ public class MarkdownEditorPanel extends JPanel {
             insertBullet(true);
         });
         pnlButtons.add(btnOL);
-        
+
         btnQuestion = new JButton(new ImageIcon("data/images/misc/markdown_editor/iconfinder_ic_help_48px_352423.png"));
         btnQuestion.setToolTipText("More information");
         btnQuestion.setPreferredSize(new Dimension(36, 36));
@@ -167,9 +166,9 @@ public class MarkdownEditorPanel extends JPanel {
                     "<html>You can use the CommonMark markdown syntax to add rich text features such as bolding, heading, and italicizing.<br>To learn more about all of the features available go to https://commonmark.org/help/</html>");
         });
         pnlButtons.add(btnQuestion);
-        
-        
-        
+
+
+
         JPanel editorPanel = new JPanel(new BorderLayout());
         editorPanel.add(pnlButtons, BorderLayout.NORTH);
         editorPanel.add(scrollEditor, BorderLayout.CENTER);
@@ -181,7 +180,7 @@ public class MarkdownEditorPanel extends JPanel {
         scrollViewer = new JScrollPane(viewer);
         scrollViewer.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         tabPane.add("Preview", scrollViewer);
-        
+
         tabPane.addChangeListener(new ChangeListener() {
             public void stateChanged(ChangeEvent e) {
                 if(tabPane.getSelectedIndex()==1) {
@@ -196,7 +195,7 @@ public class MarkdownEditorPanel extends JPanel {
         if(null != title) {
             add(new JLabel("<html><h4>" + title + "</h4></html>"), BorderLayout.NORTH);
         }
-        
+
         //set up key bindings
         editor.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_B, KeyEvent.CTRL_DOWN_MASK), "bold");
         editor.getActionMap().put("bold", new AbstractAction() {
@@ -204,7 +203,7 @@ public class MarkdownEditorPanel extends JPanel {
                 boldText();
             }
         });
-        
+
         editor.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_I, KeyEvent.CTRL_DOWN_MASK), "italic");
         editor.getActionMap().put("italic", new AbstractAction() {
             public void actionPerformed(ActionEvent e) {
@@ -212,7 +211,7 @@ public class MarkdownEditorPanel extends JPanel {
             }
         });
     }
-    
+
     /**
      * Set the text for the editor. This can be used when called up on existing text to initially
      * fill the editor.
@@ -224,7 +223,7 @@ public class MarkdownEditorPanel extends JPanel {
             scrollEditor.getVerticalScrollBar().setValue(0);
         });
     }
-    
+
     /**
      * Get the text of the editor
      * @return <code>String</code> of the text in the editor
@@ -232,9 +231,9 @@ public class MarkdownEditorPanel extends JPanel {
     public String getText() {
         return editor.getText();
     }
-    
+
     /**
-     * Insert bold (**) markup on the selection. If an existing word or phrase is highlighted, this will put 
+     * Insert bold (**) markup on the selection. If an existing word or phrase is highlighted, this will put
      * the markup at either ends. Otherwise it will put an empty markup (****) with the cursor in the middle.
      */
     private void boldText() {
@@ -243,15 +242,15 @@ public class MarkdownEditorPanel extends JPanel {
         editor.insert("**", start);
         editor.insert("**", end+2);
         if(start==end) {
-            editor.setCaretPosition(start+2); 
+            editor.setCaretPosition(start+2);
         } else {
             editor.setCaretPosition(end+4);
         }
         editor.requestFocusInWindow();
     }
-    
+
     /**
-     * Insert italic (*) markup on the selection. If an existing word or phrase is highlighted, this will put 
+     * Insert italic (*) markup on the selection. If an existing word or phrase is highlighted, this will put
      * the markup at either ends. Otherwise it will put an empty markup (**) with the cursor in the middle.
      */
     private void italicizeText() {
@@ -260,13 +259,13 @@ public class MarkdownEditorPanel extends JPanel {
         editor.insert("*", start);
         editor.insert("*", end+1);
         if(start==end) {
-            editor.setCaretPosition(start+1); 
+            editor.setCaretPosition(start+1);
         } else {
             editor.setCaretPosition(end+2);
         }
         editor.requestFocusInWindow();
     }
-    
+
     /**
      * Insert a header (#) into the text at the currently selected start
      * @param level - the level of heading
@@ -282,7 +281,7 @@ public class MarkdownEditorPanel extends JPanel {
         editor.setCaretPosition(start+toInsert.length());
         editor.requestFocusInWindow();
     }
-    
+
     /**
      * Insert a horizontal rule (---) into the text at the currently selected start
      */
@@ -293,11 +292,11 @@ public class MarkdownEditorPanel extends JPanel {
         editor.setCaretPosition(start+toInsert.length());
         editor.requestFocusInWindow();
     }
-    
+
     /**
      * Insert a bullet point into the text. To ensure it looks correct, the bullet point is surrounded
      * by two carriage returns on either side.
-     * @param ordered - a <code>boolean</code> for whether the bullet point should be ordered or not. 
+     * @param ordered - a <code>boolean</code> for whether the bullet point should be ordered or not.
      */
     private void insertBullet(boolean ordered) {
         String toInsert = "\n\n- ";

--- a/MekHQ/src/mekhq/gui/utilities/MekHqTableCellRenderer.java
+++ b/MekHQ/src/mekhq/gui/utilities/MekHqTableCellRenderer.java
@@ -25,7 +25,6 @@ import java.awt.Component;
 import javax.swing.JTable;
 import javax.swing.UIManager;
 import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableCellRenderer;
 
 public class MekHqTableCellRenderer extends DefaultTableCellRenderer {
     private static final long serialVersionUID = -1L;
@@ -42,7 +41,7 @@ public class MekHqTableCellRenderer extends DefaultTableCellRenderer {
         return this;
     }
 
-    public static void setupTableColors(Component c, JTable table, boolean isSelected, 
+    public static void setupTableColors(Component c, JTable table, boolean isSelected,
             boolean hasFocus, int row) {
         if (isSelected) {
             c.setForeground(table.getSelectionForeground());

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -21,7 +21,6 @@
  */
 package mekhq.gui.view;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -320,7 +319,7 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
             if (null != scenario.getLance(campaign)) {
                 lblForceDesc.setText(campaign.getForce(scenario.getLanceForceId()).getFullName());
             } else if(scenario instanceof AtBDynamicScenario){
-            
+
                 StringBuilder forceBuilder = new StringBuilder();
                 forceBuilder.append("<html>");
                 boolean chop = false;
@@ -335,14 +334,14 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
                     }
                     chop = true;
                 }
-                
+
                 if(chop) {
                     forceBuilder.delete(forceBuilder.length() - 5, forceBuilder.length());
                 }
                 forceBuilder.append("</html>");
                 lblForceDesc.setText(forceBuilder.toString());
             }
-            
+
             gridBagConstraints.gridx = 2;
             gridBagConstraints.gridy = y++;
             gridBagConstraints.gridwidth = 1;
@@ -363,7 +362,7 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
             gridBagConstraints.gridy = y;
             gridBagConstraints.gridwidth = 1;
             panStats.add(lblPlayerStart, gridBagConstraints);
-    
+
             lblPlayerStartPos.setText(IStartingPositions.START_LOCATION_NAMES[scenario.getStart()]);
             gridBagConstraints.gridx = 2;
             gridBagConstraints.gridy = y++;
@@ -386,7 +385,7 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
                 }
             });
         }
-        
+
         txtDesc.setName("txtDesc");
         txtDesc.setText(scenario.getDescription());
         txtDesc.setEditable(false);
@@ -401,25 +400,25 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         panStats.add(txtDesc, gridBagConstraints);
-        
+
         StringBuilder objectiveBuilder = new StringBuilder();
         objectiveBuilder.append(scenario.getDeploymentInstructions());
-        
+
         for(ScenarioObjective objective : scenario.getScenarioObjectives()) {
             objectiveBuilder.append(objective.getDescription());
             objectiveBuilder.append("\n");
-            
+
             for(String forceName : objective.getAssociatedForceNames()) {
                 objectiveBuilder.append("\t");
                 objectiveBuilder.append(forceName);
                 objectiveBuilder.append("\n");
             }
-            
+
             for(String associatedUnitID : objective.getAssociatedUnitIDs()) {
                 String associatedUnitName = "";
                 UUID uid = UUID.fromString(associatedUnitID);
-                
-                // "logic": try to get a hold of the unit with the given UUID, 
+
+                // "logic": try to get a hold of the unit with the given UUID,
                 // either from the list of bot units or from the list of player units
                 if(scenario.getExternalIDLookup().containsKey(associatedUnitID)) {
                     associatedUnitName = scenario.getExternalIDLookup().get(associatedUnitID).getShortName();
@@ -434,27 +433,27 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
                 objectiveBuilder.append(associatedUnitName);
                 objectiveBuilder.append("\n");
             }
-            
+
             for(String detail : objective.getDetails()) {
                 objectiveBuilder.append("\t");
                 objectiveBuilder.append(detail);
                 objectiveBuilder.append("\n");
             }
-            
+
             objectiveBuilder.append("\t");
             objectiveBuilder.append(objective.getTimeLimitString());
             objectiveBuilder.append("\n");
-            
+
             objectiveBuilder.append("\n");
         }
-        
+
         objectiveBuilder.append(((AtBScenario) scenario).getBattlefieldControlDescription());
-        
+
         txtDetails.setText(objectiveBuilder.toString());
         txtDetails.setLineWrap(true);
         txtDetails.setWrapStyleWord(true);
         txtDetails.setEditable(false);
-        
+
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = y++;
         gridBagConstraints.gridwidth = 3;
@@ -658,10 +657,10 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
         panStats.add(lblAtmosphereDesc, gridBagConstraints);
         lblAtmosphere.setVisible(scenario.getAtmosphere() != PlanetaryConditions.ATMO_STANDARD);
         lblAtmosphereDesc.setVisible(scenario.getAtmosphere() != PlanetaryConditions.ATMO_STANDARD);
-        
+
         return y;
     }
-    
+
     /**
      * Worker function that generates UI elements appropriate for space scenarios
      * @param gridBagConstraints Current grid bag constraints in use
@@ -680,7 +679,7 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = y++;
         panStats.add(lblTerrainDesc, gridBagConstraints);
-        
+
         lblMapSize.setText(resourceMap.getString("lblMapSize.text"));
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = y;
@@ -701,10 +700,10 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = y++;
         panStats.add(lblMapSizeDesc, gridBagConstraints);
-        
+
         return y;
     }
-    
+
     /**
      * Worker function that generates UI elements appropriate for low atmosphere scenarios
      * @param gridBagConstraints Current grid bag constraints in use
@@ -723,7 +722,7 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = y++;
         panStats.add(lblTerrainDesc, gridBagConstraints);
-        
+
         lblMapSize.setText(resourceMap.getString("lblMapSize.text"));
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = y;
@@ -744,10 +743,10 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = y++;
         panStats.add(lblMapSizeDesc, gridBagConstraints);
-        
+
         return y;
     }
-    
+
     private ItemListener checkBoxListener = new ItemListener() {
         @Override
         public void itemStateChanged(ItemEvent e) {
@@ -766,7 +765,7 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
          * If the number falls below that, all are re-enabled.
          */
         for (int i = 0; i < REROLL_NUM; i++) {
-            if(chkReroll[i] != null) {            
+            if(chkReroll[i] != null) {
                 chkReroll[i].setEnabled(checkedBoxes < scenario.getRerollsRemaining() ||
                         chkReroll[i].isSelected());
             }

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -6,7 +6,6 @@
 
 package mekhq.gui.view;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
 import java.text.DecimalFormat;

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -6,7 +6,6 @@
 
 package mekhq.gui.view;
 
-import java.awt.Color;
 import java.util.ResourceBundle;
 
 import javax.swing.BorderFactory;
@@ -50,13 +49,13 @@ public class JumpPathViewPanel extends ScrollablePanel {
         this.campaign = c;
         initComponents();
     }
-    
+
     private void initComponents() {
         java.awt.GridBagConstraints gridBagConstraints;
 
         pnlStats = new javax.swing.JPanel();
         pnlPath = new javax.swing.JPanel();
-               
+
         setLayout(new java.awt.GridBagLayout());
 
 
@@ -70,9 +69,9 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;    
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         add(pnlStats, gridBagConstraints);
-        
+
         pnlPath.setName("pnlPath");
         pnlPath.setBorder(BorderFactory.createTitledBorder("Full Path"));
         getPath();
@@ -84,7 +83,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.weighty = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;    
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         add(pnlPath, gridBagConstraints);
     }
 
@@ -103,7 +102,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
             gridBagConstraints.weightx = 1.0;
             if(i >= (path.getSystems().size()-1)) {
                 gridBagConstraints.weighty = 1.0;
-            }        
+            }
             gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 0);
             gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
             gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
@@ -111,11 +110,11 @@ public class JumpPathViewPanel extends ScrollablePanel {
             i++;
         }
     }
-    
+
     private void fillStats() {
-        
+
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.JumpPathViewPanel", new EncodeControl()); //$NON-NLS-1$
-        
+
         lblJumps = new javax.swing.JLabel();
         txtJumps = new javax.swing.JLabel();
         lblTimeStart = new javax.swing.JLabel();
@@ -128,14 +127,14 @@ public class JumpPathViewPanel extends ScrollablePanel {
         txtTotalTime = new javax.swing.JLabel();
         lblCost = new javax.swing.JLabel();
         txtCost = new javax.swing.JLabel();
-        
+
         DateTime currentDate = Utilities.getDateTimeDay(campaign.getCalendar());
         String startName = (path.getFirstSystem() == null) ? "?" : path.getFirstSystem().getPrintableName(currentDate);
         String endName = (path.getLastSystem() == null) ? "?" : path.getLastSystem().getPrintableName(currentDate);
-        
+
         java.awt.GridBagConstraints gridBagConstraints;
         pnlStats.setLayout(new java.awt.GridBagLayout());
-        
+
         lblJumps.setName("lblJumps"); // NOI18N
         lblJumps.setText(resourceMap.getString("lblJumps1.text"));
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -144,7 +143,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(lblJumps, gridBagConstraints);
-        
+
         txtJumps.setName("lblJumps2"); // NOI18N
         txtJumps.setText("<html>" + path.getJumps() + " jumps" + "</html>");
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -155,7 +154,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(txtJumps, gridBagConstraints);
-        
+
         lblTimeStart.setName("lblTimeStart"); // NOI18N
         lblTimeStart.setText(resourceMap.getString("lblTimeStart1.text"));
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -164,7 +163,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(lblTimeStart, gridBagConstraints);
-        
+
         txtTimeStart.setName("lblTimeStart2"); // NOI18N
         txtTimeStart.setText("<html>" + Math.round(path.getStartTime(campaign.getLocation().getTransitTime())*100.0)/100.0 + " days from "+ startName + " to jump point" + "</html>");
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -175,7 +174,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(txtTimeStart, gridBagConstraints);
-        
+
         lblTimeEnd.setName("lblTimeEnd"); // NOI18N
         lblTimeEnd.setText(resourceMap.getString("lblTimeEnd1.text"));
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -184,7 +183,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(lblTimeEnd, gridBagConstraints);
-        
+
         txtTimeEnd.setName("lblTimeEnd2"); // NOI18N
         txtTimeEnd.setText("<html>" + Math.round(path.getEndTime()*100.0)/100.0 + " days from final jump point to " + endName + "</html>");
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -195,7 +194,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(txtTimeEnd, gridBagConstraints);
-        
+
         lblRechargeTime.setName("lblRechargeTime1"); // NOI18N
         lblRechargeTime.setText(resourceMap.getString("lblRechargeTime1.text"));
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -204,7 +203,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(lblRechargeTime, gridBagConstraints);
-        
+
         txtRechargeTime.setName("lblRechargeTime2"); // NOI18N
         txtRechargeTime.setText("<html>" + Math.round(path.getTotalRechargeTime(currentDate)*100.0)/100.0 + " days" + "</html>");
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -215,7 +214,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(txtRechargeTime, gridBagConstraints);
-        
+
         lblTotalTime.setName("lblTotalTime1"); // NOI18N
         lblTotalTime.setText(resourceMap.getString("lblTotalTime1.text"));
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -224,7 +223,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(lblTotalTime, gridBagConstraints);
-        
+
         txtTotalTime.setName("lblTotalTime2"); // NOI18N
         txtTotalTime.setText("<html>" + Math.round(path.getTotalTime(currentDate, campaign.getLocation().getTransitTime())*100.0)/100.0 + " days" + "</html>");
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -235,7 +234,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(txtTotalTime, gridBagConstraints);
-        
+
         if(campaign.getCampaignOptions().payForTransport()) {
             lblCost.setName("lblCost1"); // NOI18N
             lblCost.setText(resourceMap.getString("lblCost1.text"));
@@ -247,7 +246,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
             pnlStats.add(lblCost, gridBagConstraints);
 
             txtCost.setName("lblCost2"); // NOI18N
-            txtCost.setText("<html>" + 
+            txtCost.setText("<html>" +
                     campaign.calculateCostPerJump(
                                 true,
                                 campaign.getCampaignOptions().useEquipmentContractBase())

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -21,7 +21,6 @@
 
 package mekhq.gui.view;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.util.ArrayList;
@@ -40,10 +39,8 @@ import javax.swing.RowFilter;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 import javax.swing.SwingConstants;
-import javax.swing.UIManager;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
-import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
@@ -53,9 +50,11 @@ import mekhq.campaign.force.Lance;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.gui.MekHqColors;
 import mekhq.gui.model.DataTableModel;
 import mekhq.gui.model.UnitMarketTableModel;
 import mekhq.gui.model.XTableColumnModel;
+import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 /**
  * Against the Bot
@@ -79,7 +78,8 @@ public class LanceAssignmentView extends JPanel {
         public static final int ROLE_TRAINING = 4;
         public static final int ROLE_NUM = 5;
 
-        private Campaign campaign;
+        private final Campaign campaign;
+        private final MekHqColors colors = new MekHqColors();
 
         private JTable tblRequiredLances;
         private JTable tblAssignments;
@@ -119,7 +119,7 @@ public class LanceAssignmentView extends JPanel {
         for (int i = 0; i < UnitMarketTableModel.COL_NUM; i++) {
             column = ((XTableColumnModel)tblRequiredLances.getColumnModel()).getColumnByModelIndex(i);
             column.setPreferredWidth(rlModel.getColumnWidth(i));
-            column.setCellRenderer(new DefaultTableCellRenderer() {
+            column.setCellRenderer(new MekHqTableCellRenderer() {
                                 public Component getTableCellRendererComponent(JTable table,
                         Object value, boolean isSelected, boolean hasFocus,
                         int row, int column) {
@@ -129,9 +129,7 @@ public class LanceAssignmentView extends JPanel {
                                 getAlignment(table.convertColumnIndexToModel(column)));
                     if (table.convertColumnIndexToModel(column) > RequiredLancesTableModel.COL_CONTRACT) {
                         if (((String)value).indexOf('/') >= 0) {
-                                setForeground(Color.RED);
-                        } else {
-                                setForeground(UIManager.getColor(isSelected ? "Table.selectionForeground" : "Table.foreground"));
+                            colors.getBelowContractMinimum().getAlternateColor().ifPresent(c -> setForeground(c));
                         }
                     }
                     return this;
@@ -153,7 +151,7 @@ public class LanceAssignmentView extends JPanel {
         for (int i = 0; i < LanceAssignmentTableModel.COL_NUM; i++) {
             column = ((XTableColumnModel)tblAssignments.getColumnModel()).getColumnByModelIndex(i);
             column.setPreferredWidth(rlModel.getColumnWidth(i));
-            column.setCellRenderer(new DefaultTableCellRenderer() {
+            column.setCellRenderer(new MekHqTableCellRenderer() {
                                 public Component getTableCellRendererComponent(JTable table,
                         Object value, boolean isSelected, boolean hasFocus,
                         int row, int column) {

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -40,6 +40,7 @@ import javax.swing.RowFilter;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -59,16 +60,16 @@ import mekhq.gui.model.XTableColumnModel;
 /**
  * Against the Bot
  * Shows how many lances are required to be deployed on active contracts and
- * in what roles and allows the player to assign units to those roles. 
- * 
+ * in what roles and allows the player to assign units to those roles.
+ *
  * @author Neoancient
  *
  */
 public class LanceAssignmentView extends JPanel {
-        
-        
+
+
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = 7280552346074838142L;
         public static final int ROLE_NONE = 0;
@@ -77,9 +78,9 @@ public class LanceAssignmentView extends JPanel {
         public static final int ROLE_SCOUT = 3;
         public static final int ROLE_TRAINING = 4;
         public static final int ROLE_NUM = 5;
-        
+
         private Campaign campaign;
-        
+
         private JTable tblRequiredLances;
         private JTable tblAssignments;
         private JPanel panRequiredLances;
@@ -89,10 +90,10 @@ public class LanceAssignmentView extends JPanel {
 
         public LanceAssignmentView(Campaign c) {
                 campaign = c;
-                
+
                 initComponents();
         }
-        
+
         @SuppressWarnings("serial")
         private void initComponents() {
                 cbContract = new JComboBox<AtBContract>();
@@ -104,12 +105,12 @@ public class LanceAssignmentView extends JPanel {
                                 return new JLabel((null == value)?"None":((AtBContract)value).getName());
                         }
                 });
-                
+
                 cbRole = new JComboBox<String>(Lance.roleNames);
-                
+
                 setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-                
-                RequiredLancesTableModel rlModel = new RequiredLancesTableModel(campaign); 
+
+                RequiredLancesTableModel rlModel = new RequiredLancesTableModel(campaign);
                 tblRequiredLances = new JTable(rlModel);
         tblRequiredLances.setColumnModel(new XTableColumnModel());
         tblRequiredLances.createDefaultColumnsFromModel();
@@ -130,7 +131,7 @@ public class LanceAssignmentView extends JPanel {
                         if (((String)value).indexOf('/') >= 0) {
                                 setForeground(Color.RED);
                         } else {
-                                setForeground(Color.BLACK);
+                                setForeground(UIManager.getColor(isSelected ? "Table.selectionForeground" : "Table.foreground"));
                         }
                     }
                     return this;
@@ -139,11 +140,11 @@ public class LanceAssignmentView extends JPanel {
         }
         TableRowSorter<RequiredLancesTableModel>sorter = new TableRowSorter<RequiredLancesTableModel>(rlModel);
         tblRequiredLances.setRowSorter(sorter);
-        
+
         tblRequiredLances.setIntercellSpacing(new Dimension(0, 0));
         tblRequiredLances.setShowGrid(false);
-        
-                LanceAssignmentTableModel laModel = new LanceAssignmentTableModel(campaign); 
+
+                LanceAssignmentTableModel laModel = new LanceAssignmentTableModel(campaign);
                 tblAssignments = new JTable(laModel);
                 tblAssignments.setColumnModel(new XTableColumnModel());
                 tblAssignments.createDefaultColumnsFromModel();
@@ -198,7 +199,7 @@ public class LanceAssignmentView extends JPanel {
         sortKeys.add(new RowSorter.SortKey(LanceAssignmentTableModel.COL_FORCE, SortOrder.ASCENDING));
         sorter.setSortKeys(sortKeys);
         tblAssignments.setRowSorter(laSorter);
-        
+
         tblAssignments.setIntercellSpacing(new Dimension(0, 0));
         tblAssignments.setShowGrid(false);
 
@@ -215,7 +216,7 @@ public class LanceAssignmentView extends JPanel {
                 cmdrStrategy = campaign.getFlaggedCommander().
                                 getSkill(SkillType.S_STRATEGY).getLevel();
         }
-        int maxDeployedLances = 
+        int maxDeployedLances =
                         campaign.getCampaignOptions().getBaseStrategyDeployment() +
                         campaign.getCampaignOptions().getAdditionalStrategyDeployment() *
                         cmdrStrategy;
@@ -231,7 +232,7 @@ public class LanceAssignmentView extends JPanel {
         refresh();
         tblAssignments.getModel().addTableModelListener(assignmentTableListener);
         }
-        
+
         public void refresh() {
                 cbContract.removeAllItems();
                 ArrayList<AtBContract> activeContracts = new ArrayList<AtBContract>();
@@ -255,17 +256,17 @@ public class LanceAssignmentView extends JPanel {
                 ((DataTableModel)tblAssignments.getModel()).setData(campaign.getLanceList());
                 panRequiredLances.setVisible(tblRequiredLances.getRowCount() > 0);
         }
-        
+
         TableModelListener assignmentTableListener = new TableModelListener() {
                 public void tableChanged(TableModelEvent ev) {
                         ((RequiredLancesTableModel)tblRequiredLances.getModel()).fireTableDataChanged();
                 }
         };
-        
-        /** 
+
+        /**
          * Sorts Force objects according to where they appear on the TO&E
          */
-        
+
         public Comparator<Force> forceComparator = new Comparator<Force>() {
                 @Override
                 public int compare(Force f1, Force f2) {
@@ -299,15 +300,15 @@ public class LanceAssignmentView extends JPanel {
                         return 0;
                 }
         };
-        
+
 }
 
 class RequiredLancesTableModel extends DataTableModel {
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = -5007787884549927503L;
-        
+
         public static final int COL_CONTRACT = 0;
         public static final int COL_TOTAL = 1;
         public static final int COL_FIGHT = 2;
@@ -317,9 +318,9 @@ class RequiredLancesTableModel extends DataTableModel {
         public static final int COL_NUM = 6;
 
     protected String[] columnNames = {"Contract", "Total", "Fight", "Defend", "Scout", "Training"};
-    
+
     private Campaign campaign;
-    
+
     public RequiredLancesTableModel(Campaign campaign) {
         this.campaign = campaign;
         data = new ArrayList<AtBContract>();
@@ -334,7 +335,7 @@ class RequiredLancesTableModel extends DataTableModel {
     public String getColumnName(int column) {
         return columnNames[column];
     }
-        
+
     public int getColumnWidth(int col) {
         if (col == COL_CONTRACT) {
                 return 100;
@@ -361,11 +362,11 @@ class RequiredLancesTableModel extends DataTableModel {
     public boolean isCellEditable(int row, int col) {
         return false;
     }
-    
+
     public AtBContract getRow(int row) {
         return (AtBContract) data.get(row);
     }
-    
+
         @Override
         public Object getValueAt(int row, int column) {
                 if (row >= getRowCount()) {
@@ -406,16 +407,16 @@ class RequiredLancesTableModel extends DataTableModel {
                         }
                 }
                 return "";
-        }       
+        }
 }
 
 class LanceAssignmentTableModel extends DataTableModel {
-        
+
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = -2688617737510762878L;
-        
+
         public static final int COL_FORCE = 0;
         public static final int COL_WEIGHT_CLASS = 1;
         public static final int COL_CONTRACT = 2;
@@ -424,7 +425,7 @@ class LanceAssignmentTableModel extends DataTableModel {
 
     protected String[] columnNames = {"Force", "Wt", "Mission", "Role"};
     private Campaign campaign;
-    
+
     public LanceAssignmentTableModel(Campaign campaign) {
         this.campaign = campaign;
         data = new ArrayList<Lance>();
@@ -439,7 +440,7 @@ class LanceAssignmentTableModel extends DataTableModel {
     public String getColumnName(int column) {
         return columnNames[column];
     }
-        
+
     public int getColumnWidth(int col) {
         switch (col) {
         case COL_FORCE:
@@ -469,15 +470,15 @@ class LanceAssignmentTableModel extends DataTableModel {
     public boolean isCellEditable(int row, int col) {
         return col > COL_WEIGHT_CLASS;
     }
-    
+
     public Lance getRow(int row) {
         return (Lance) data.get(row);
     }
-    
+
         @Override
         public Object getValueAt(int row, int column) {
                 final String[] WEIGHT_CODES = {"UL", "L", "M", "H", "A", "SH"};
-                 
+
                 if (row >= getRowCount()) {
                         return "";
                 }

--- a/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
@@ -20,7 +20,6 @@
  */
 package mekhq.gui.view;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
 import java.util.LinkedHashMap;
@@ -57,15 +56,15 @@ public class ScenarioViewPanel extends ScrollablePanel {
     private Campaign campaign;
     private ForceStub forces;
     private IconPackage icons;
-    
+
     private javax.swing.JPanel pnlStats;
     private javax.swing.JTextPane txtDesc;
     private javax.swing.JTextPane txtReport;
     private javax.swing.JTree forceTree;
     private javax.swing.JLabel lblStatus;
-    
+
     private StubTreeModel forceModel;
-    
+
     public ScenarioViewPanel(Scenario s, Campaign c, IconPackage i) {
         this.scenario = s;
         this.campaign = c;
@@ -78,7 +77,7 @@ public class ScenarioViewPanel extends ScrollablePanel {
         forceModel = new StubTreeModel(forces);
         initComponents();
     }
-    
+
     private void initComponents() {
         java.awt.GridBagConstraints gridBagConstraints;
 
@@ -86,7 +85,7 @@ public class ScenarioViewPanel extends ScrollablePanel {
         txtDesc = new javax.swing.JTextPane();
         txtReport = new javax.swing.JTextPane();
         forceTree = new javax.swing.JTree();
-               
+
         setLayout(new java.awt.GridBagLayout());
 
         pnlStats.setName("pnlStats");
@@ -100,9 +99,9 @@ public class ScenarioViewPanel extends ScrollablePanel {
         gridBagConstraints.weighty = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;    
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         add(pnlStats, gridBagConstraints);
-        
+
         forceTree.setModel(forceModel);
         forceTree.setCellRenderer(new ForceStubRenderer());
         forceTree.setRowHeight(50);
@@ -115,9 +114,9 @@ public class ScenarioViewPanel extends ScrollablePanel {
         gridBagConstraints.weighty = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;    
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         add(forceTree, gridBagConstraints);
-        
+
         if(null != scenario.getReport() && !scenario.getReport().isEmpty()) {
             txtReport.setName("txtReport");
             txtReport.setEditable(false);
@@ -140,12 +139,12 @@ public class ScenarioViewPanel extends ScrollablePanel {
     }
 
     private void fillStats() {
-                
+
         lblStatus = new javax.swing.JLabel();
-        
+
         java.awt.GridBagConstraints gridBagConstraints;
         pnlStats.setLayout(new java.awt.GridBagLayout());
-        
+
         lblStatus.setName("lblOwner"); // NOI18N
         lblStatus.setText("<html><b>" + scenario.getStatusName() + "</b></html>");
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -158,7 +157,7 @@ public class ScenarioViewPanel extends ScrollablePanel {
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(lblStatus, gridBagConstraints);
-        
+
         if(null != scenario.getDescription() && !scenario.getDescription().isEmpty()) {
             txtDesc.setName("txtDesc");
             txtDesc.setEditable(false);
@@ -175,7 +174,7 @@ public class ScenarioViewPanel extends ScrollablePanel {
             gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
             pnlStats.add(txtDesc, gridBagConstraints);
         }
-        
+
         if(scenario.getLoot().size() > 0) {
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
@@ -187,7 +186,7 @@ public class ScenarioViewPanel extends ScrollablePanel {
             gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
             gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
             pnlStats.add(new JLabel("<html><b>Potential Rewards:</b></html>"), gridBagConstraints);
-            
+
             for(Loot loot : scenario.getLoot()) {
                 gridBagConstraints.gridx = 0;
                 gridBagConstraints.gridy++;
@@ -197,26 +196,26 @@ public class ScenarioViewPanel extends ScrollablePanel {
                 gridBagConstraints.insets = new java.awt.Insets(0, 10, 5, 0);
                 gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
                 gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
-                pnlStats.add(new JLabel(loot.getShortDescription()), gridBagConstraints);                
+                pnlStats.add(new JLabel(loot.getShortDescription()), gridBagConstraints);
             }
         }
-        
+
     }
-    
+
     protected class StubTreeModel implements TreeModel {
 
         private ForceStub rootForce;
         private Vector<TreeModelListener> listeners = new Vector<TreeModelListener>();
-        
+
         public StubTreeModel(ForceStub root) {
             rootForce = root;
         }
-    
+
         @Override
         public Object getChild(Object parent, int index) {
             if(parent instanceof ForceStub) {
                 return ((ForceStub)parent).getAllChildren().get(index);
-            } 
+            }
             return null;
         }
 
@@ -249,9 +248,9 @@ public class ScenarioViewPanel extends ScrollablePanel {
         @Override
         public void valueForPathChanged(TreePath arg0, Object arg1) {
             // TODO Auto-generated method stub
-            
+
         }
-        
+
         @Override
         public void addTreeModelListener( TreeModelListener listener ) {
               if ( listener != null && !listeners.contains( listener ) ) {
@@ -266,12 +265,12 @@ public class ScenarioViewPanel extends ScrollablePanel {
               }
            }
     }
-    
+
     protected class ForceStubRenderer extends DefaultTreeCellRenderer {
         private static final long serialVersionUID = 4076620029822185784L;
 
         public ForceStubRenderer() {
-            
+
         }
 
         @Override
@@ -293,9 +292,9 @@ public class ScenarioViewPanel extends ScrollablePanel {
 
             return this;
         }
-        
+
         protected Icon getIcon(Object node) {
-            
+
             if(node instanceof UnitStub) {
                 return getIconFrom((UnitStub)node);
             } else if(node instanceof ForceStub) {
@@ -304,15 +303,15 @@ public class ScenarioViewPanel extends ScrollablePanel {
                 return null;
             }
         }
-        
+
         protected Icon getIconFrom(UnitStub unit) {
             String category = unit.getPortraitCategory();
             String filename = unit.getPortraitFileName();
-            
+
             if(Crew.ROOT_PORTRAIT.equals(category)) {
                 category = "";
             }
-            
+
             // Return a null if the player has selected no portrait file.
             if ((null == category) || (null == filename) || Crew.PORTRAIT_NONE.equals(filename)) {
                 filename = "default.gif";
@@ -322,11 +321,11 @@ public class ScenarioViewPanel extends ScrollablePanel {
             try {
                 portrait = (Image) icons.getPortraits().getItem(category, filename);
                 if(null != portrait) {
-                    portrait = portrait.getScaledInstance(50, -1, Image.SCALE_DEFAULT);               
+                    portrait = portrait.getScaledInstance(50, -1, Image.SCALE_DEFAULT);
                 } else {
                     portrait = (Image) icons.getPortraits().getItem("", "default.gif");
                     if(null != portrait) {
-                        portrait = portrait.getScaledInstance(50, -1, Image.SCALE_DEFAULT);               
+                        portrait = portrait.getScaledInstance(50, -1, Image.SCALE_DEFAULT);
                     }
                 }
                 return new ImageIcon(portrait);
@@ -335,7 +334,7 @@ public class ScenarioViewPanel extends ScrollablePanel {
                 return null;
             }
         }
-        
+
         protected Icon getIconFrom(ForceStub force) {
             String category = force.getIconCategory();
             String filename = force.getIconFileName();
@@ -365,9 +364,9 @@ public class ScenarioViewPanel extends ScrollablePanel {
                 return new ImageIcon(portrait);
             } catch (Exception err) {
                 err.printStackTrace();
-                return null;         
+                return null;
             }
        }
-    }    
+    }
 
 }

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -6,11 +6,8 @@
 
 package mekhq.gui.view;
 
-import java.awt.Color;
 import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Graphics;
 import java.awt.Image;
 import java.util.ResourceBundle;
 
@@ -38,25 +35,25 @@ import mekhq.gui.utilities.MarkdownRenderer;
  * @author  Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class UnitViewPanel extends ScrollablePanel {
-	
+
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 7004741688464105277L;
 
 	private Unit unit;
 	private Entity entity;
 	private Campaign campaign;
-	
+
 	private MechTileset mt;
     private DirectoryItems camos;
-	
+
 	private JLabel lblImage;
 	//private javax.swing.JPanel pnlStats;
 	private javax.swing.JTextPane txtReadout;
-	private javax.swing.JTextPane txtFluff;	
+	private javax.swing.JTextPane txtFluff;
 	private javax.swing.JPanel pnlStats;
-	
+
 	private javax.swing.JLabel lblType;
 	private javax.swing.JLabel lblTech;
 	private javax.swing.JLabel txtTech;
@@ -68,7 +65,7 @@ public class UnitViewPanel extends ScrollablePanel {
 	private javax.swing.JLabel txtCost;
 	private javax.swing.JLabel lblQuirk;
 	private javax.swing.JLabel txtQuirk;
-	
+
 	public UnitViewPanel(Unit u, Campaign c, DirectoryItems camos, MechTileset mt) {
 		unit = u;
 		entity = u.getEntity();
@@ -78,14 +75,14 @@ public class UnitViewPanel extends ScrollablePanel {
 		initComponents();
 		//setMinimumSize(new Dimension(400, 200));
 	}
-	
+
 	private void initComponents() {
 		java.awt.GridBagConstraints gridBagConstraints;
 
 		txtReadout = new javax.swing.JTextPane();
 		txtFluff = new javax.swing.JTextPane();
 		pnlStats = new javax.swing.JPanel();
-		
+
     	ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.UnitViewPanel", new EncodeControl()); //$NON-NLS-1$
 
 		setLayout(new java.awt.GridBagLayout());
@@ -122,7 +119,7 @@ public class UnitViewPanel extends ScrollablePanel {
                 add(lblImage, gridBagConstraints);
             }
         }
-        
+
 		pnlStats.setName("pnlBasic");
 		pnlStats.setBorder(BorderFactory.createTitledBorder(unit.getName()));
 		fillStats(resourceMap);
@@ -133,10 +130,10 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.gridwidth = 1;
 		gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
 		gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;	
+		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		add(pnlStats, gridBagConstraints);
-		
-		
+
+
 		MechView mview = new MechView(entity, false, true);
 		txtReadout.setName("txtReadout");
 		txtReadout.setContentType(resourceMap.getString("txtReadout.contentType")); // NOI18N
@@ -158,7 +155,7 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		add(txtReadout, gridBagConstraints);
-		
+
 		if(unit.getHistory().length() > 0) {
 			txtFluff.setName("txtFluff");
 			txtFluff.setEditable(false);
@@ -179,9 +176,9 @@ public class UnitViewPanel extends ScrollablePanel {
 			add(txtFluff, gridBagConstraints);
 		}
 	}
-	
+
 	private void fillStats(ResourceBundle resourceMap) {
-		
+
 		lblType = new javax.swing.JLabel();
     	lblTech = new javax.swing.JLabel();
 		txtTech = new javax.swing.JLabel();
@@ -193,10 +190,10 @@ public class UnitViewPanel extends ScrollablePanel {
 		txtCost = new javax.swing.JLabel();
 		lblQuirk = new javax.swing.JLabel();
 		txtQuirk = new javax.swing.JLabel();
-		
+
 		java.awt.GridBagConstraints gridBagConstraints;
 		pnlStats.setLayout(new java.awt.GridBagLayout());
-		
+
 		lblType.setName("lblType"); // NOI18N
 		lblType.setText("<html><i>" + UnitType.getTypeDisplayableName(entity.getUnitType()) + "</i></html>");
 		gridBagConstraints = new java.awt.GridBagConstraints();
@@ -209,7 +206,7 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		pnlStats.add(lblType, gridBagConstraints);
-		
+
 		lblTech.setName("lblTech1"); // NOI18N
 		lblTech.setText(resourceMap.getString("lblTech1.text"));
 		gridBagConstraints = new java.awt.GridBagConstraints();
@@ -218,7 +215,7 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		pnlStats.add(lblTech, gridBagConstraints);
-		
+
 		txtTech.setName("lblTech2"); // NOI18N
 		txtTech.setText(TechConstants.getLevelDisplayableName(entity.getTechLevel()));
 		gridBagConstraints = new java.awt.GridBagConstraints();
@@ -238,7 +235,7 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		pnlStats.add(lblTonnage, gridBagConstraints);
-		
+
 		txtTonnage.setName("lblTonnage2"); // NOI18N
 		txtTonnage.setText(Double.toString(entity.getWeight()));
 		gridBagConstraints = new java.awt.GridBagConstraints();
@@ -258,7 +255,7 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		pnlStats.add(lblBV, gridBagConstraints);
-		
+
 		txtBV.setName("lblBV2"); // NOI18N
 		txtBV.setText(Integer.toString(entity.calculateBattleValue(true, true)));
 		gridBagConstraints = new java.awt.GridBagConstraints();
@@ -270,12 +267,12 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		pnlStats.add(txtBV, gridBagConstraints);
 
-		
+
 		double weight = 1.0;
 		if(campaign.getCampaignOptions().useQuirks() && entity.countQuirks() > 0) {
 			weight = 0.0;
 		}
-		
+
 		lblCost.setName("lblCost1"); // NOI18N
 		lblCost.setText(resourceMap.getString("lblCost1.text"));
 		gridBagConstraints = new java.awt.GridBagConstraints();
@@ -284,7 +281,7 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		pnlStats.add(lblCost, gridBagConstraints);
-		
+
 		txtCost.setName("lblCost2"); // NOI18N
 		txtCost.setText(unit.getSellValue().toAmountAndSymbolString());
 		gridBagConstraints = new java.awt.GridBagConstraints();
@@ -296,7 +293,7 @@ public class UnitViewPanel extends ScrollablePanel {
 		gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
 		gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 		pnlStats.add(txtCost, gridBagConstraints);
-		
+
 		if(campaign.getCampaignOptions().useQuirks() && entity.countQuirks() > 0) {
 			lblQuirk.setName("lblQuirk1"); // NOI18N
 			lblQuirk.setText(resourceMap.getString("lblQuirk1.text"));
@@ -306,7 +303,7 @@ public class UnitViewPanel extends ScrollablePanel {
 			gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
 			gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 			pnlStats.add(lblQuirk, gridBagConstraints);
-			
+
 			txtQuirk.setName("lblQuirk2"); // NOI18N
 			txtQuirk.setText(unit.getQuirksList());
 			gridBagConstraints = new java.awt.GridBagConstraints();
@@ -319,12 +316,12 @@ public class UnitViewPanel extends ScrollablePanel {
 			gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
 			pnlStats.add(txtQuirk, gridBagConstraints);
 		}
-		
+
 	}
-	
+
 	private Image getImageFor(Unit u, Component c) {
-        
-		if(null == mt) { 
+
+		if(null == mt) {
 			return null;
 		}
         Image base = mt.imageFor(u.getEntity(), c, -1);
@@ -332,7 +329,7 @@ public class UnitViewPanel extends ScrollablePanel {
         EntityImage entityImage = new EntityImage(base, tint, getCamo(u), c);
         return entityImage.loadPreviewImage();
     }
-    
+
     private Image getCamo(Unit unit) {
         // Try to get the player's camo file.
         Image camo = null;

--- a/MekHQ/src/mekhq/preferences/PreferencesNode.java
+++ b/MekHQ/src/mekhq/preferences/PreferencesNode.java
@@ -65,6 +65,18 @@ public class PreferencesNode {
     }
 
     /**
+     * Adds new elements to be managed by this node.
+     * If there are initial vales set for this node,
+     * we will try to set an initial value for each element.
+     * @param elements elements to manage.
+     */
+    public void manage(PreferenceElement... elements) {
+        for (PreferenceElement element : elements) {
+            manage(element);
+        }
+    }
+
+    /**
      * The class which preferences we are storing in this node.
      * @return the class stored in this node.
      */


### PR DESCRIPTION
This allows customization (without a UX at the moment) for colors throughout MekHQ, providing the backend work to #1480. Each property has a main and alternate color, currently used for backgrounds and foregrounds respectively. The values are saved in `mmconf/mekhq.preferences` as a pair of colors separated by a pipe, e.g. `#ff0000|#000000`. Each of the colors provides a default value based on our original colors.