### PR TITLE
Scale Unit sell values by their Entity's price multiplier

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1158,6 +1158,9 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             partsValue = partsValue.plus(2000.0 * sinks);
         }
 
+        // Scale the final value by the entity's price multiplier
+        partsValue = partsValue.multipliedBy(entity.getPriceMultiplier());
+
         return partsValue;
     }
 
@@ -1572,7 +1575,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             updateBayCapacity(unitType, unitWeight, false, bayNumber);
         }
     }
-    
+
     /**
      * Calculates transport bay space required by an infantry platoon,
      * which is not the same as the flat weight of that platoon
@@ -1848,7 +1851,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         } else {
             retVal.id = UUID.fromString(idNode.getTextContent());
         }
-        
+
         //Temp storage for used bay capacities
         boolean needsBayInitialization = true;
 
@@ -1980,7 +1983,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     retVal.mothballInfo = MothballInfo.generateInstanceFromXML(wn2, version);
                 }
                 // Set up bay space values after we've loaded everything from the unit record
-                // Used for older campaign 
+                // Used for older campaign
                 if (retVal.entity != null && retVal.getEntity().isLargeCraft() && needsBayInitialization) {
                     retVal.initializeBaySpace();
                 }


### PR DESCRIPTION
Fix #1497

When computing construction costs, the final cost of many units is scaled by a multiplier.
Generally this is related to the unit's weight class or type (e.g. aerodyne dropships cost 36 times
the sum of their components costs).

This change causes getSellValue() to take this into consideration, generally resulting in higher
sell prices. Ideally the sell value of a perfect condition, undamaged Unit would match it's buy cost.
This change doesn't get all the way there (things like SI are still not accounted for), but this is
a step towards that goal that doesn't require a major redesign of the Entity cost calculation methods.