### PR TITLE
relax bomb selection restrictions

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -94,7 +94,7 @@ public class AtBDynamicScenarioFactory {
      */
     public static int UNIT_WEIGHT_UNSPECIFIED = -1;
 
-    private static int[] validBotBombs = { BombType.B_HE, BombType.B_CLUSTER, BombType.B_RL, BombType.B_INFERNO, BombType.B_THUNDER };
+    private static int[] validBotBombs = { BombType.B_HE, BombType.B_CLUSTER, BombType.B_RL, BombType.B_INFERNO, BombType.B_THUNDER, BombType.B_FAE_SMALL, BombType.B_FAE_LARGE };
     private static int[] validBotAABombs = { BombType.B_RL };
 
     private static int[] minimumBVPercentage = { 50, 60, 70, 80, 90, 100 };

--- a/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
@@ -96,7 +96,7 @@ public class BombsDialog extends JDialog implements ActionListener {
         }
         
         bombPanel = new BombChoicePanel(bomber, campaign.getGameOptions().booleanOption("at2_nukes"),
-                campaign.getGameOptions().booleanOption("allow_advanced_ammo"), typeMax);
+                true, typeMax);
 
         //Set up the display of this dialog.
         JScrollPane scroller = new JScrollPane(bombPanel);


### PR DESCRIPTION
This allows users in MekHQ to load whatever bombs they want onto their aerospace fighters, limited only by availability. Previously, there was a restriction on that based on ... uh... a setting that's no longer present in MegaMek. ::shrug::