### PR TITLE
AtB: Adding SPA Generation for Generated Veteran and Elite Personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/DefaultSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/DefaultSpecialAbilityGenerator.java
@@ -30,23 +30,24 @@ public class DefaultSpecialAbilityGenerator extends AbstractSpecialAbilityGenera
             singleSpecialAbilityGenerator.setSkillPreferences(getSkillPreferences());
 
             // base number of special abilities is based on a random roll
-            int nabil = Utilities.rollSpecialAbilities(getSkillPreferences().getSpecialAbilBonus(expLvl));
+            int numAbilities = Utilities.rollSpecialAbilities(getSkillPreferences().getSpecialAbilBonus(expLvl));
 
             // Based on the AtB rules, recruits of veteran gain one and elites gain two
             // additional special abilities
             if (getCampaignOptions(person).getUseAtB()) {
                 switch (expLvl) {
                     case SkillType.EXP_VETERAN:
-                        nabil += 1;
+                        numAbilities += 1;
                         break;
                     case SkillType.EXP_ELITE:
-                        nabil += 2;
+                        numAbilities += 2;
                         break;
                 }
             }
 
-            while (nabil > 0 && singleSpecialAbilityGenerator.generateSpecialAbilities(person, expLvl)) {
-                nabil--;
+            while ((numAbilities > 0)
+                    && singleSpecialAbilityGenerator.generateSpecialAbilities(person, expLvl)) {
+                numAbilities--;
             }
 
             return true;

--- a/MekHQ/src/mekhq/campaign/personnel/DefaultSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/DefaultSpecialAbilityGenerator.java
@@ -26,11 +26,26 @@ public class DefaultSpecialAbilityGenerator extends AbstractSpecialAbilityGenera
     @Override
     public boolean generateSpecialAbilities(Person person, int expLvl) {
         if (getCampaignOptions(person).useAbilities()) {
-            SingleSpecialAbilityGenerator generator = new SingleSpecialAbilityGenerator();
-            generator.setSkillPreferences(getSkillPreferences());
+            SingleSpecialAbilityGenerator singleSpecialAbilityGenerator = new SingleSpecialAbilityGenerator();
+            singleSpecialAbilityGenerator.setSkillPreferences(getSkillPreferences());
 
+            // base number of special abilities is based on a random roll
             int nabil = Utilities.rollSpecialAbilities(getSkillPreferences().getSpecialAbilBonus(expLvl));
-            while (nabil > 0 && generator.generateSpecialAbilities(person, expLvl)) {
+
+            // Based on the AtB rules, recruits of veteran gain one and elites gain two
+            // additional special abilities
+            if (getCampaignOptions(person).getUseAtB()) {
+                switch (expLvl) {
+                    case SkillType.EXP_VETERAN:
+                        nabil += 1;
+                        break;
+                    case SkillType.EXP_ELITE:
+                        nabil += 2;
+                        break;
+                }
+            }
+
+            while (nabil > 0 && singleSpecialAbilityGenerator.generateSpecialAbilities(person, expLvl)) {
                 nabil--;
             }
 

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -307,7 +307,7 @@ public final class BatchXPDialog extends JDialog {
                 } else {
                     cost = SkillType.getType(skillName).getCost(0);
                 }
-                int experience = p.getExperienceLevel(false);
+                int startingExperienceLevel = p.getExperienceLevel(false);
 
                 // Improve the skill and deduce the cost
                 p.improveSkill(skillName);
@@ -315,12 +315,13 @@ public final class BatchXPDialog extends JDialog {
                 p.setXp(p.getXp() - cost);
 
                 // The next part is bollocks and doesn't belong here, but as long as we hardcode AtB ...
-                if(campaign.getCampaignOptions().getUseAtB()) {
-                    if((p.getPrimaryRole() > Person.T_NONE) && (p.getPrimaryRole() <= Person.T_CONV_PILOT)
-                        && (p.getExperienceLevel(false) > experience) && (experience >= SkillType.EXP_VETERAN)) {
+                if (campaign.getCampaignOptions().getUseAtB()) {
+                    if ((p.getPrimaryRole() > Person.T_NONE) && (p.getPrimaryRole() <= Person.T_CONV_PILOT)
+                            && (p.getExperienceLevel(false) > startingExperienceLevel)
+                            && (startingExperienceLevel >= SkillType.EXP_REGULAR)) {
                         SingleSpecialAbilityGenerator spaGenerator = new SingleSpecialAbilityGenerator();
                         String spa = spaGenerator.rollSPA(p);
-                        if(null == spa) {
+                        if (null == spa) {
                             if(campaign.getCampaignOptions().useEdge()) {
                                 p.getOptions().acquireAbility(PilotOptions.EDGE_ADVANTAGES, "edge", p.getEdge() + 1); //$NON-NLS-1$
                                 PersonalLogger.gainedEdge(p, campaign.getDate());

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -317,7 +317,7 @@ public final class BatchXPDialog extends JDialog {
                 // The next part is bollocks and doesn't belong here, but as long as we hardcode AtB ...
                 if(campaign.getCampaignOptions().getUseAtB()) {
                     if((p.getPrimaryRole() > Person.T_NONE) && (p.getPrimaryRole() <= Person.T_CONV_PILOT)
-                        && (p.getExperienceLevel(false) > experience) && (experience >= SkillType.EXP_REGULAR)) {
+                        && (p.getExperienceLevel(false) > experience) && (experience >= SkillType.EXP_VETERAN)) {
                         SingleSpecialAbilityGenerator spaGenerator = new SingleSpecialAbilityGenerator();
                         String spa = spaGenerator.rollSPA(p);
                         if(null == spa) {


### PR DESCRIPTION
This implements the SPA generation for newly generated veteran and elite personnel, and renames a confusingly named variable that I thought was another AtB issue.