### PR TITLE
Finishing Switch to MekHQ.getLogger() instead of System.out/err/printStackTrace

### DIFF
--- a/MekHQ/src/chat/ChatClient.java
+++ b/MekHQ/src/chat/ChatClient.java
@@ -4,6 +4,8 @@ package chat;
  * Code taken from http://introcs.cs.princeton.edu/java/84network/
  */
 
+import mekhq.MekHQ;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
@@ -18,7 +20,7 @@ import javax.swing.JTextField;
 public class ChatClient extends JPanel implements ActionListener {
 
     /**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -7447573101863923187L;
 
@@ -42,8 +44,9 @@ public class ChatClient extends JPanel implements ActionListener {
             socket = new Socket(hostName, 4444);
             out    = new Out(socket);
             in     = new In(socket);
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "ChatClient", e);
         }
-        catch (Exception ex) { ex.printStackTrace(); }
         this.screenName = screenName;
 
     /*    // close output stream  - this will cause listen() to stop and exit
@@ -53,7 +56,9 @@ public class ChatClient extends JPanel implements ActionListener {
                     out.close();
 //                    in.close();
 //                    try                   { socket.close();        }
-//                    catch (Exception ioe) { ioe.printStackTrace(); }
+//                    catch (Exception e) {
+//                        MekHQ.getLogger().error(getClass(), "windowClosing", e);
+//                    }
                 }
             }
         );
@@ -92,8 +97,11 @@ public class ChatClient extends JPanel implements ActionListener {
         }
         out.close();
         in.close();
-        try                 { socket.close();      }
-        catch (Exception e) { e.printStackTrace(); }
-        System.err.println("Closed client socket");
+        try {
+            socket.close();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "listen", e);
+        }
+        MekHQ.getLogger().error(getClass(), "listen", "Closed client socket");
     }
 }

--- a/MekHQ/src/chat/ChatServer.java
+++ b/MekHQ/src/chat/ChatServer.java
@@ -4,13 +4,15 @@ package chat;
  * Code taken from http://introcs.cs.princeton.edu/java/84network/
  */
 
+import mekhq.MekHQ;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Vector;
 
 public class ChatServer {
-	
+
 	// Moved this out here and added a die method just to make the warning shut the funk up
 	static ServerSocket serverSocket;
 
@@ -22,13 +24,12 @@ public class ChatServer {
         // thread that broadcasts messages to clients
         connectionListener.start();
 
-        System.err.println("ChatServer started");
+        MekHQ.getLogger().error(ChatServer.class, "main", "ChatServer started");
 
         while (true) {
-
             // wait for next client connection request
             Socket clientSocket = serverSocket.accept();
-            System.err.println("Created socket with client");
+            MekHQ.getLogger().error(ChatServer.class, "main", "Created socket with client");
 
             // listen to client in a separate thread
             Connection connection = new Connection(clientSocket);
@@ -36,12 +37,12 @@ public class ChatServer {
             connection.start();
         }
     }
-    
+
     public void die() {
     	// close socket
         try {
             serverSocket.close();
-        } catch (IOException ex) {
+        } catch (IOException ignored) {
         }
     }
 }

--- a/MekHQ/src/chat/Connection.java
+++ b/MekHQ/src/chat/Connection.java
@@ -4,6 +4,8 @@ package chat;
  * Code taken from http://introcs.cs.princeton.edu/java/84network/
  */
 
+import mekhq.MekHQ;
+
 import java.net.Socket;
 
 public class Connection extends Thread {
@@ -27,9 +29,12 @@ public class Connection extends Thread {
         }
         out.close();
         in.close();
-        try                 { socket.close();      }
-        catch (Exception e) { e.printStackTrace(); }
-        System.err.println("closing socket");
+        try {
+            socket.close();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "run", e);
+        }
+        MekHQ.getLogger().error(getClass(), "run", "closing socket");
     }
 
 
@@ -48,8 +53,11 @@ public class Connection extends Thread {
 
     public synchronized void setMessage(String s) {
         if (message != null) {
-            try                  { wait();               }
-            catch (Exception ex) { ex.printStackTrace(); }
+            try {
+                wait();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "setMessage", e);
+            }
         }
         message = s;
     }

--- a/MekHQ/src/chat/ConnectionListener.java
+++ b/MekHQ/src/chat/ConnectionListener.java
@@ -1,5 +1,7 @@
 package chat;
 
+import mekhq.MekHQ;
+
 import java.util.Vector;
 
 /*
@@ -32,9 +34,11 @@ public class ConnectionListener extends Thread {
             }
 
             // don't monopolize processor
-            try                 { Thread.sleep(100);   }
-            catch (Exception e) { e.printStackTrace(); }
+            try {
+                Thread.sleep(100);
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "run", e);
+            }
         }
     }
-
 }

--- a/MekHQ/src/chat/In.java
+++ b/MekHQ/src/chat/In.java
@@ -1,5 +1,7 @@
 package chat;
 
+import mekhq.MekHQ;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -55,9 +57,8 @@ public final class In {
             InputStream is = socket.getInputStream();
             scanner = new Scanner(new BufferedInputStream(is), charsetName);
             scanner.useLocale(usLocale);
-        }
-        catch (IOException ioe) {
-            System.err.println("Could not open " + socket);
+        } catch (IOException e) {
+            MekHQ.getLogger().error(getClass(), "In", "Could not open " + socket);
         }
     }
 
@@ -70,9 +71,8 @@ public final class In {
             InputStream is     = site.getInputStream();
             scanner            = new Scanner(new BufferedInputStream(is), charsetName);
             scanner.useLocale(usLocale);
-        }
-        catch (IOException ioe) {
-            System.err.println("Could not open " + url);
+        } catch (IOException e) {
+            MekHQ.getLogger().error(getClass(), "In", "Could not open " + url);
         }
     }
 
@@ -80,13 +80,11 @@ public final class In {
      * Create an input stream from a file.
      */
     public In(File file) {
-
         try {
             scanner = new Scanner(file, charsetName);
             scanner.useLocale(usLocale);
-        }
-        catch (IOException ioe) {
-            System.err.println("Could not open " + file);
+        } catch (IOException e) {
+            MekHQ.getLogger().error(getClass(), "In", "Could not open " + file);
         }
     }
 
@@ -115,9 +113,8 @@ public final class In {
             InputStream is     = site.getInputStream();
             scanner            = new Scanner(new BufferedInputStream(is), charsetName);
             scanner.useLocale(usLocale);
-        }
-        catch (IOException ioe) {
-            System.err.println("Could not open " + s);
+        } catch (IOException e) {
+            MekHQ.getLogger().error(getClass(), "In", "Could not open " + s);
         }
     }
 

--- a/MekHQ/src/chat/Out.java
+++ b/MekHQ/src/chat/Out.java
@@ -1,5 +1,7 @@
 package chat;
 
+import mekhq.MekHQ;
+
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -19,14 +21,20 @@ public class Out {
 
     // for Socket output
     public Out(Socket socket) {
-        try                     { out = new PrintWriter(socket.getOutputStream(), true); }
-        catch (IOException ioe) { ioe.printStackTrace();                                 }
+        try {
+            out = new PrintWriter(socket.getOutputStream(), true);
+        } catch (IOException e) {
+            MekHQ.getLogger().error(getClass(), "Out", e);
+        }
     }
 
     // for file output
     public Out(String s) {
-        try                     { out = new PrintWriter(new FileOutputStream(s), true);  }
-        catch(IOException ioe)  { ioe.printStackTrace();                                 }
+        try {
+            out = new PrintWriter(new FileOutputStream(s), true);
+        } catch (IOException e) {
+            MekHQ.getLogger().error(getClass(), "Out", e);
+        }
     }
 
     public void close() { out.close(); }

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -109,11 +109,11 @@ public class AtBGameThread extends GameThread {
             // phase
             for (int i = 0; (i < 1000) && (client.getGame().getPhase() == IGame.Phase.PHASE_UNKNOWN); i++) {
                 Thread.sleep(50);
-                System.out.println("Thread in unknown stage" );
+                MekHQ.getLogger().error(getClass(), "run", "Thread in unknown stage" );
             }
 
             if (((client.getGame() != null) && (client.getGame().getPhase() == IGame.Phase.PHASE_LOUNGE))) {
-                System.out.println("Thread in lounge" );
+                MekHQ.getLogger().info(getClass(), "run", "Thread in lounge" );
 
                 client.getLocalPlayer().setCamoCategory(app.getCampaign().getCamoCategory());
                 client.getLocalPlayer().setCamoFileName(app.getCampaign().getCamoFileName());

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -1,11 +1,11 @@
 /*
  * ClientThread - Copyright (C) 2011
- * 
- * Derived from MekWars (http://www.sourceforge.net/projects/mekwars) 
- * 
+ *
+ * Derived from MekWars (http://www.sourceforge.net/projects/mekwars)
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  */
@@ -44,12 +44,12 @@ class GameThread extends Thread implements CloseClientListener {
     protected ArrayList<Unit> units = new ArrayList<Unit>();
 
     protected volatile boolean stop = false;
-    
+
     // CONSTRUCTOR
     public GameThread(String name, Client c, MekHQ app, ArrayList<Unit> units) {
     	this(name, c, app, units, true);
     }
-    
+
     public GameThread(String name, Client c, MekHQ app, ArrayList<Unit> units, boolean started) {
         super(name);
         myname = name.trim();
@@ -97,27 +97,27 @@ class GameThread extends Thread implements CloseClientListener {
             // phase
             for (int i = 0; (i < 1000) && (client.getGame().getPhase() == IGame.Phase.PHASE_UNKNOWN); i++) {
                 Thread.sleep(50);
-            	System.out.println("Thread in unknown stage" );
+            	MekHQ.getLogger().error(getClass(), "run", "Thread in unknown stage" );
             }
 
             if (((client.getGame() != null) && (client.getGame().getPhase() == IGame.Phase.PHASE_LOUNGE))) {
-            	System.out.println("Thread in lounge" );
+                MekHQ.getLogger().info(getClass(), "run","Thread in lounge" );
             	client.getLocalPlayer().setCamoCategory(app.getCampaign().getCamoCategory());
                 client.getLocalPlayer().setCamoFileName(app.getCampaign().getCamoFileName());
-            	
+
                 if (started) {
                 	client.getGame().getOptions().loadOptions();
                 	client.sendGameOptions("", app.getCampaign().getGameOptionsVector());
     				Thread.sleep(campaign.getCampaignOptions().getStartGameDelay());
                 }
-                
+
                 for (Unit unit : units) {
                     // Get the Entity
                     Entity entity = unit.getEntity();
                     // Set the TempID for autoreporting
                     entity.setExternalIdAsString(unit.getId().toString());
                     // Set the owner
-                    entity.setOwner(client.getLocalPlayer()); 
+                    entity.setOwner(client.getLocalPlayer());
                     // Add Mek to game
                     client.sendAddEntity(entity);
                     // Wait a few secs to not overuse bandwith
@@ -126,7 +126,7 @@ class GameThread extends Thread implements CloseClientListener {
 
                 client.sendPlayerInfo();
             }
-            
+
             while(!stop) {
             	Thread.sleep(50);
             }
@@ -149,44 +149,44 @@ class GameThread extends Thread implements CloseClientListener {
     	requestStop();
     	app.stopHost();
     }
-    
+
     public void requestStop() {
     	PreferenceManager.getInstance().save();
     	try {
             WeaponOrderHandler.saveWeaponOrderFile();
         } catch (IOException e) {
-            System.out.println("Error saving custom weapon orders!");
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "requestStop",
+                    "Error saving custom weapon orders!", e);
         }
-    	
+
     	try {
             QuirksHandler.saveCustomQuirksList();
         } catch (IOException e) {
-            System.out.println("Error saving quirks override!");
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "requestStop",
+                    "Error saving quirks override!", e);
         }
-    	
+
     	stop = true;
     }
-    
+
     public boolean stopRequested() {
     	return stop;
     }
-    
+
     public void quit() {
     	client.die();
         client = null;// explicit null of the MM client. Wasn't/isn't being
         // GC'ed.
         System.gc();
     }
-    
+
     public void createController(){
     	controller = new MegaMekController();
-    	KeyboardFocusManager kbfm = 
+    	KeyboardFocusManager kbfm =
     			KeyboardFocusManager.getCurrentKeyboardFocusManager();
     	kbfm.addKeyEventDispatcher(controller);
-    	
+
     	KeyBindParser.parseKeyBindings(controller);
-    } 
+    }
 
 }

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -9,7 +9,6 @@
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  */
-
 package mekhq;
 
 import java.awt.KeyboardFocusManager;
@@ -31,8 +30,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
 
 class GameThread extends Thread implements CloseClientListener {
-
-    // VARIABLES
+    //region Variable Declarations
     protected String myname;
     protected Client client;
     protected ClientGUI swingGui;
@@ -41,13 +39,14 @@ class GameThread extends Thread implements CloseClientListener {
     protected Campaign campaign;
     protected boolean started;
 
-    protected ArrayList<Unit> units = new ArrayList<Unit>();
+    protected ArrayList<Unit> units;
 
     protected volatile boolean stop = false;
+    //endregion Variable Declarations
 
-    // CONSTRUCTOR
+    //region Constructors
     public GameThread(String name, Client c, MekHQ app, ArrayList<Unit> units) {
-    	this(name, c, app, units, true);
+        this(name, c, app, units, true);
     }
 
     public GameThread(String name, Client c, MekHQ app, ArrayList<Unit> units, boolean started) {
@@ -59,6 +58,7 @@ class GameThread extends Thread implements CloseClientListener {
         this.started = started;
         this.campaign = app.getCampaign();
     }
+    //endregion Constructors
 
     public Client getClient() {
         return client;
@@ -69,10 +69,10 @@ class GameThread extends Thread implements CloseClientListener {
         client.addCloseClientListener(this);
 
         if (swingGui != null) {
-        	for (Client client2 : swingGui.getBots().values()) {
-        		client2.die();
-        	}
-        	swingGui.getBots().clear();
+            for (Client client2 : swingGui.getBots().values()) {
+                client2.die();
+            }
+            swingGui.getBots().clear();
         }
         createController();
         swingGui = new ClientGUI(client, controller);
@@ -97,18 +97,18 @@ class GameThread extends Thread implements CloseClientListener {
             // phase
             for (int i = 0; (i < 1000) && (client.getGame().getPhase() == IGame.Phase.PHASE_UNKNOWN); i++) {
                 Thread.sleep(50);
-            	MekHQ.getLogger().error(getClass(), "run", "Thread in unknown stage" );
+                MekHQ.getLogger().error(getClass(), "run", "Thread in unknown stage" );
             }
 
             if (((client.getGame() != null) && (client.getGame().getPhase() == IGame.Phase.PHASE_LOUNGE))) {
                 MekHQ.getLogger().info(getClass(), "run","Thread in lounge" );
-            	client.getLocalPlayer().setCamoCategory(app.getCampaign().getCamoCategory());
+                client.getLocalPlayer().setCamoCategory(app.getCampaign().getCamoCategory());
                 client.getLocalPlayer().setCamoFileName(app.getCampaign().getCamoFileName());
 
                 if (started) {
-                	client.getGame().getOptions().loadOptions();
-                	client.sendGameOptions("", app.getCampaign().getGameOptionsVector());
-    				Thread.sleep(campaign.getCampaignOptions().getStartGameDelay());
+                    client.getGame().getOptions().loadOptions();
+                    client.sendGameOptions("", app.getCampaign().getGameOptionsVector());
+                    Thread.sleep(campaign.getCampaignOptions().getStartGameDelay());
                 }
 
                 for (Unit unit : units) {
@@ -128,16 +128,16 @@ class GameThread extends Thread implements CloseClientListener {
             }
 
             while(!stop) {
-            	Thread.sleep(50);
+                Thread.sleep(50);
             }
         } catch (Exception e) {
             MekHQ.getLogger().error(getClass(), "run()", e);
         }
         finally {
-	        client.die();
-	        client = null;
-	        swingGui = null;
-	        controller = null;
+            client.die();
+            client = null;
+            swingGui = null;
+            controller = null;
         }
     }
 
@@ -146,47 +146,46 @@ class GameThread extends Thread implements CloseClientListener {
      * adding the listener. And to MMNet for the poorly documented code change.
      */
     public void clientClosed() {
-    	requestStop();
-    	app.stopHost();
+        requestStop();
+        app.stopHost();
     }
 
     public void requestStop() {
-    	PreferenceManager.getInstance().save();
-    	try {
+        PreferenceManager.getInstance().save();
+        try {
             WeaponOrderHandler.saveWeaponOrderFile();
         } catch (IOException e) {
             MekHQ.getLogger().error(getClass(), "requestStop",
                     "Error saving custom weapon orders!", e);
         }
 
-    	try {
+        try {
             QuirksHandler.saveCustomQuirksList();
         } catch (IOException e) {
             MekHQ.getLogger().error(getClass(), "requestStop",
                     "Error saving quirks override!", e);
         }
 
-    	stop = true;
+        stop = true;
     }
 
     public boolean stopRequested() {
-    	return stop;
+        return stop;
     }
 
     public void quit() {
-    	client.die();
+        client.die();
         client = null;// explicit null of the MM client. Wasn't/isn't being
         // GC'ed.
         System.gc();
     }
 
     public void createController(){
-    	controller = new MegaMekController();
-    	KeyboardFocusManager kbfm =
-    			KeyboardFocusManager.getCurrentKeyboardFocusManager();
-    	kbfm.addKeyEventDispatcher(controller);
+        controller = new MegaMekController();
+        KeyboardFocusManager kbfm =
+                KeyboardFocusManager.getCurrentKeyboardFocusManager();
+        kbfm.addKeyEventDispatcher(controller);
 
-    	KeyBindParser.parseKeyBindings(controller);
+        KeyBindParser.parseKeyBindings(controller);
     }
-
 }

--- a/MekHQ/src/mekhq/IconPackage.java
+++ b/MekHQ/src/mekhq/IconPackage.java
@@ -23,7 +23,7 @@ import mekhq.campaign.force.Force;
 import mekhq.gui.utilities.PortraitFileFactory;
 
 /**
- * This is a convenience class that will keep all the various directories and tilesets 
+ * This is a convenience class that will keep all the various directories and tilesets
  * for tracking graphics and icons
  * @author Jay Lawson
  *
@@ -35,7 +35,7 @@ public class IconPackage {
     private DirectoryItems forceIcons;
     private DirectoryItems awardIcons;
     protected static MechTileset mt;
-    
+
     // Static defines for layered force icons
     public static String FORCE_FRAME                = "Pieces/Frames/"; //$NON-NLS-1$
     public static String FORCE_TYPE                 = "Pieces/Type/"; //$NON-NLS-1$
@@ -45,12 +45,12 @@ public class IconPackage {
     public static String FORCE_SPECIAL_MODIFIERS    = "Pieces/Special Modifiers/"; //$NON-NLS-1$
     public static String FORCE_BACKGROUNDS          = "Pieces/Backgrounds/"; //$NON-NLS-1$
     public static String FORCE_LOGOS                = "Pieces/Logos/"; //$NON-NLS-1$
-    
+
     public static String[] FORCE_DRAW_ORDER = {
-            FORCE_BACKGROUNDS, FORCE_FRAME, FORCE_TYPE, FORCE_FORMATIONS, 
+            FORCE_BACKGROUNDS, FORCE_FRAME, FORCE_TYPE, FORCE_FORMATIONS,
             FORCE_ADJUSTMENTS, FORCE_ALPHANUMERICS, FORCE_SPECIAL_MODIFIERS, FORCE_LOGOS
     };
-    
+
     /** A map of keys to various gui elements, for future skinning purposes */
     private final Map<String, String> guiElements = new HashMap<>();
     {
@@ -59,7 +59,7 @@ public class IconPackage {
         guiElements.put("default_male_paperdoll", "data/images/misc/paperdoll/default_male.xml");
         guiElements.put("default_female_paperdoll", "data/images/misc/paperdoll/default_female.xml");
     }
-    
+
     /** A map of resolution widths to file names for the startup screen */
     private final TreeMap<Integer, String> startupScreenImages = new TreeMap<>();
     {
@@ -67,7 +67,7 @@ public class IconPackage {
         startupScreenImages.put(1441, "data/images/misc/MekHQ Start_spooky_fhd.png");
         startupScreenImages.put(1921, "data/images/misc/MekHQ Start_spooky_uhd.png");
     }
-    
+
     /** A map of resolution widths to file names for the loading screen */
     private final TreeMap<Integer, String> loadingScreenImages = new TreeMap<>();
     {
@@ -75,11 +75,11 @@ public class IconPackage {
         loadingScreenImages.put(1441, "data/images/misc/MekHQ Load_spooky_fhd.png");
         loadingScreenImages.put(1921, "data/images/misc/MekHQ Load_spooky_uhd.png");
     }
-    
+
     public IconPackage() {
 
     }
-    
+
     public void loadDirectories() {
         if(null == portraits) {
             try {
@@ -123,15 +123,15 @@ public class IconPackage {
             }
         }
     }
-    
+
     public DirectoryItems getPortraits() {
         return portraits;
     }
-    
+
     public DirectoryItems getCamos() {
         return camos;
     }
-    
+
     public DirectoryItems getForceIcons() {
         return forceIcons;
     }
@@ -141,11 +141,11 @@ public class IconPackage {
     public MechTileset getMechTiles() {
         return mt;
     }
-    
+
     public String getGuiElement(String key) {
         return guiElements.get(key);
     }
-    
+
     /**
      * Gets the name of the startup screen image appropriate for the given horizontal resolution.
      * @param resolutionWidth Screen width
@@ -154,7 +154,7 @@ public class IconPackage {
     public String getStartupScreenImage(int resolutionWidth) {
         return startupScreenImages.floorEntry(resolutionWidth).getValue();
     }
-    
+
     /**
      * Gets the name of the loading screen image appropriate for the given horizontal resolution.
      * @param resolutionWidth Screen width
@@ -163,11 +163,11 @@ public class IconPackage {
     public String getLoadingScreenImage(int resolutionWidth) {
         return loadingScreenImages.floorEntry(resolutionWidth).getValue();
     }
-    
+
     public static Image buildForceIcon(String category, String filename, DirectoryItems items, LinkedHashMap<String, Vector<String>> iconMap) {
         final String METHOD_NAME = "buildForceIcon(String,String, DirectoryItems,LinkedHashMap<String,Vector<String>>)"; //$NON-NLS-1$
         Image retVal = null;
-        
+
         if(Crew.ROOT_PORTRAIT.equals(category)) {
             category = "";
         }
@@ -219,7 +219,7 @@ public class IconPackage {
                     try {
                         base = (BufferedImage) items.getItem("", "empty.png");
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        MekHQ.getLogger().error(IconPackage.class, "buildForceIcon", e);
                     }
                 }
                 retVal = base;
@@ -237,7 +237,7 @@ public class IconPackage {
                 MekHQ.getLogger().error(IconPackage.class, METHOD_NAME, err);
             }
         }
-        
+
         return retVal;
     }
 }

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -89,9 +89,9 @@ import mekhq.service.IAutosaveService;
  * The main class of the application.
  */
 public class MekHQ implements GameListener {
-	//TODO: This is intended as a debug/production type thing.
-	// So it should be backed down to 1 for releases...
-	// It's intended for 1 to be critical, 3 to be typical, and 5 to be debug/informational.
+	// TODO : This is intended as a debug/production type thing.
+	// TODO : So it should be backed down to 1 for releases...
+	// TODO : It's intended for 1 to be critical, 3 to be typical, and 5 to be debug/informational.
 	public static int VERBOSITY_LEVEL = 5;
 	public static String CAMPAIGN_DIRECTORY = "./campaigns/";
 	public static String PREFERENCES_FILE = "mmconf/mekhq.preferences";
@@ -365,15 +365,13 @@ public class MekHQ implements GameListener {
     	System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name","MekHQ");
 
-        SwingUtilities.invokeLater(() -> {
-            // TODO : logFileName should probably not be inline
-            String logFileName = "logs" + File.separator + "mekhqlog.txt";
-            // Reset the log file - TODO : Maybe move this to being a call to the logger?
-            MegaMek.resetLogFile(logFileName);
-            // redirect output to log file
-            redirectOutput(logFileName); // Deprecated call required for MegaMek usage
-            MekHQ.getInstance().startup();
-        });
+        // TODO : logFileName should probably not be inline
+        String logFileName = "logs" + File.separator + "mekhqlog.txt";
+        getLogger().resetLogFile(logFileName);
+        // redirect output to log file
+        redirectOutput(logFileName); // Deprecated call required for MegaMek usage
+
+        SwingUtilities.invokeLater(() -> MekHQ.getInstance().startup());
     }
 
     private void showInfo() {

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -279,7 +279,7 @@ public class MekHQ implements GameListener {
 	}
 
 	private MekHQ() {
-	    this.autosaveService = new AutosaveService(getLogger());
+	    this.autosaveService = new AutosaveService();
     }
 
     /**
@@ -367,7 +367,6 @@ public class MekHQ implements GameListener {
 
         SwingUtilities.invokeLater(() -> {
             //redirect output to log file
-            redirectOutput();
             MekHQ.getInstance().startup();
         });
     }
@@ -391,44 +390,16 @@ public class MekHQ implements GameListener {
         msg.append("\n\tJava vendor ").append(System.getProperty("java.vendor")); //$NON-NLS-1$ //$NON-NLS-2$
         msg.append("\n\tJava version ").append(System.getProperty("java.version")); //$NON-NLS-1$ //$NON-NLS-2$
         msg.append("\n\tPlatform ") //$NON-NLS-1$
-               .append(System.getProperty("os.name")) //$NON-NLS-1$
-               .append(" ") //$NON-NLS-1$
-               .append(System.getProperty("os.version")) //$NON-NLS-1$
-               .append(" (") //$NON-NLS-1$
-               .append(System.getProperty("os.arch")) //$NON-NLS-1$
-               .append(")"); //$NON-NLS-1$
+                .append(System.getProperty("os.name")) //$NON-NLS-1$
+                .append(" ") //$NON-NLS-1$
+                .append(System.getProperty("os.version")) //$NON-NLS-1$
+                .append(" (") //$NON-NLS-1$
+                .append(System.getProperty("os.arch")) //$NON-NLS-1$
+                .append(")"); //$NON-NLS-1$
         long maxMemory = Runtime.getRuntime().maxMemory() / 1024;
         msg.append("\n\tTotal memory available to MegaMek: ")
-            .append(NumberFormat.getInstance().format(maxMemory)).append(" kB"); //$NON-NLS-1$ //$NON-NLS-2$
+                .append(NumberFormat.getInstance().format(maxMemory)).append(" kB"); //$NON-NLS-1$ //$NON-NLS-2$
         getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, msg.toString());
-    }
-
-    /**
-     * This function redirects the standard error and output streams to the
-     * given File name.
-     *
-     */
-    private static void redirectOutput() {
-        try {
-            System.out.println("Redirecting output to mekhqlog.txt"); //$NON-NLS-1$
-            File logDir = new File("logs");
-            if (!logDir.exists()) {
-                logDir.mkdir();
-            }
-			final String logFilename = "logs" + File.separator + "mekhqlog.txt";
-			MegaMek.resetLogFile(logFilename);
-            OutputStream os = new FileOutputStream(logFilename, true);
-            BufferedOutputStream bos = new BufferedOutputStream(os, 64);
-			PrintStream ps = new PrintStream(bos);
-            System.setOut(ps);
-            System.setErr(ps);
-            ps.close();
-            bos.close();
-            os.close();
-        } catch (Exception e) {
-            System.err.println("Unable to redirect output to mekhqlog.txt"); //$NON-NLS-1$
-            e.printStackTrace();
-        }
     }
 
     public Server getMyServer() {

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -366,7 +366,12 @@ public class MekHQ implements GameListener {
         System.setProperty("com.apple.mrj.application.apple.menu.about.name","MekHQ");
 
         SwingUtilities.invokeLater(() -> {
-            //redirect output to log file
+            // TODO : logFileName should probably not be inline
+            String logFileName = "logs" + File.separator + "mekhqlog.txt";
+            // Reset the log file - TODO : Maybe move this to being a call to the logger?
+            MegaMek.resetLogFile(logFileName);
+            // redirect output to log file
+            redirectOutput(logFileName); // Deprecated call required for MegaMek usage
             MekHQ.getInstance().startup();
         });
     }
@@ -390,16 +395,42 @@ public class MekHQ implements GameListener {
         msg.append("\n\tJava vendor ").append(System.getProperty("java.vendor")); //$NON-NLS-1$ //$NON-NLS-2$
         msg.append("\n\tJava version ").append(System.getProperty("java.version")); //$NON-NLS-1$ //$NON-NLS-2$
         msg.append("\n\tPlatform ") //$NON-NLS-1$
-                .append(System.getProperty("os.name")) //$NON-NLS-1$
-                .append(" ") //$NON-NLS-1$
-                .append(System.getProperty("os.version")) //$NON-NLS-1$
-                .append(" (") //$NON-NLS-1$
-                .append(System.getProperty("os.arch")) //$NON-NLS-1$
-                .append(")"); //$NON-NLS-1$
+               .append(System.getProperty("os.name")) //$NON-NLS-1$
+               .append(" ") //$NON-NLS-1$
+               .append(System.getProperty("os.version")) //$NON-NLS-1$
+               .append(" (") //$NON-NLS-1$
+               .append(System.getProperty("os.arch")) //$NON-NLS-1$
+               .append(")"); //$NON-NLS-1$
         long maxMemory = Runtime.getRuntime().maxMemory() / 1024;
         msg.append("\n\tTotal memory available to MegaMek: ")
-                .append(NumberFormat.getInstance().format(maxMemory)).append(" kB"); //$NON-NLS-1$ //$NON-NLS-2$
+            .append(NumberFormat.getInstance().format(maxMemory)).append(" kB"); //$NON-NLS-1$ //$NON-NLS-2$
         getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO, msg.toString());
+    }
+
+    /**
+     * This function redirects the standard error and output streams to the
+     * given File name.
+     */
+    @Deprecated // March 12th, 2020. This is no longer used by MekHQ, but is required to hide MegaMek's
+    // output to the console for dev builds
+    private static void redirectOutput(String logFilename) {
+        try {
+            System.out.println("Redirecting output to mekhqlog.txt"); //$NON-NLS-1$
+            File logDir = new File("logs");
+            if (!logDir.exists()) {
+                logDir.mkdir();
+            }
+
+            // Note: these are not closed on purpose
+            OutputStream os = new FileOutputStream(logFilename, true);
+            BufferedOutputStream bos = new BufferedOutputStream(os, 64);
+			PrintStream ps = new PrintStream(bos);
+            System.setOut(ps);
+            System.setErr(ps);
+        } catch (Exception e) {
+            MekHQ.getLogger().error(MekHQ.class, "redirectOutput",
+                    "Unable to redirect output to mekhqlog.txt", e);
+        }
     }
 
     public Server getMyServer() {

--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -1033,13 +1033,12 @@ public class Utilities {
             }
             in.close();
             out.close();
-            System.out.println("File copied."); //$NON-NLS-1$
-        }
-        catch(FileNotFoundException ex){
-            System.out.println(ex.getMessage() + " in the specified directory."); //$NON-NLS-1$
-        }
-        catch(IOException e){
-            System.out.println(e.getMessage());
+            MekHQ.getLogger().info(Utilities.class, "copyFile", "File copied."); //$NON-NLS-1$
+        } catch (FileNotFoundException e) {
+            MekHQ.getLogger().error(Utilities.class, "copyFile",
+                    e.getMessage() + " in the specified directory."); //$NON-NLS-1$
+        } catch (IOException e) {
+            MekHQ.getLogger().error(Utilities.class, "copyFile", e.getMessage());
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -350,7 +350,7 @@ public class Campaign implements Serializable, ITechManager {
         retirementDefectionTracker = new RetirementDefectionTracker();
         fatigueLevel = 0;
         atbConfig = null;
-        autosaveService = new AutosaveService(MekHQ.getLogger());
+        autosaveService = new AutosaveService();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -573,7 +573,7 @@ public class Campaign implements Serializable, ITechManager {
                 try {
                     Thread.sleep(50);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    MekHQ.getLogger().error(getClass(), "initUnitGenerator", e);
                 }
             }
             rm.setSelectedRATs(campaignOptions.getRATs());

--- a/MekHQ/src/mekhq/campaign/GamePreset.java
+++ b/MekHQ/src/mekhq/campaign/GamePreset.java
@@ -271,17 +271,10 @@ public class GamePreset implements MekHqXmlSerializable {
     				presets.add(preset);
     			}
     			fis.close();
-    		} catch (Exception ex) {
-    			ex.printStackTrace();
-    			/*	JOptionPane.showMessageDialog(null,
-					"The campaign file could not be loaded.\nPlease check the log file for details.",
-					"Campaign Loading Error",
-				    JOptionPane.ERROR_MESSAGE);*/
+    		} catch (Exception e) {
+                MekHQ.getLogger().error(GamePreset.class, "getGamePresetsIn", e);
     		}
     	}
     	return presets;
 	}
-
-
-
 }

--- a/MekHQ/src/mekhq/campaign/MercRosterAccess.java
+++ b/MekHQ/src/mekhq/campaign/MercRosterAccess.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import javax.swing.SwingWorker;
 
 import megamek.common.UnitType;
+import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Rank;
@@ -86,17 +87,16 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
         } catch (SQLException e) {
             throw e;
         } catch (ClassNotFoundException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "connect", e);
         }
     }
 
     public void writeCampaignData() {
-
         //TODO throw all SQLExceptions - but then where do they go from doInBackground?
         try {
             statement = connect.createStatement();
-        } catch (SQLException e2) {
-            e2.printStackTrace();
+        } catch (SQLException e) {
+            MekHQ.getLogger().error(getClass(), "writeCampaignData", e);
         };
 
         writeBasicData();
@@ -108,17 +108,15 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
 
         // Needed because otherwise progress isn't reaching 100 and the progress meter stays open
         setProgress(100);
-
     }
 
     private void writeBasicData() {
-
         try {
             preparedStatement = connect.prepareStatement("UPDATE " + table + ".command SET name=? where id=1");
             preparedStatement.setString(1, truncateString(campaign.getName(), 100));
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "writeBasicData", e);
         }
 
         progressNote = "Uploading dates";
@@ -129,7 +127,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             preparedStatement.setDate(1, new java.sql.Date(campaign.getCalendar().getTimeInMillis()));
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "writeBasicData", e);
         }
         progressTicker++;
         progressNote = "Uploading ranks";
@@ -149,7 +147,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "writeBasicData", e);
         }
         //write skill types
         progressNote = "Uploading skill types";
@@ -166,7 +164,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "writeBasicData", e);
         }
         //write crewtypes
         progressNote = "Uploading personnel types";
@@ -340,7 +338,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "writeBasicData", e);
         }
 
         //write equipment types
@@ -370,7 +368,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "writeBasicData", e);
         }
     }
 
@@ -386,8 +384,8 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             preparedStatement.setInt(4, 0);
             preparedStatement.setString(5, campaign.getForces().getDescription());
             preparedStatement.executeUpdate();
-        } catch (SQLException e1) {
-            e1.printStackTrace();
+        } catch (SQLException e) {
+            MekHQ.getLogger().error(getClass(), "writeForceData", e);
         }
 
         progressNote = "Uploading force data";
@@ -406,7 +404,6 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
     }
 
     private void writeForce(Force force, int parent) {
-
         try {
             preparedStatement = connect.prepareStatement("INSERT INTO " + table + ".unit (type, name, parent, prefpos, text) VALUES (?, ?, ?, ?, ?)");
             preparedStatement.setString(1, "1");
@@ -416,7 +413,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             preparedStatement.setString(5, force.getDescription());
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "writeForce", e);
         }
         //retrieve the MercRoster id of this force
         int id = parent;
@@ -424,7 +421,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             rs.next();
             id = rs.getInt("id");
         } catch (SQLException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "writeForce", e);
         }
 
         progressTicker += 2;
@@ -441,7 +438,6 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 forceHash.put(u.getCommander().getId(), id);
             }
         }
-
     }
 
     private void writePersonnelData() {
@@ -455,8 +451,8 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             statement.execute("TRUNCATE TABLE " + table + ".personnelpositions");
             statement.execute("TRUNCATE TABLE " + table + ".skills");
             statement.execute("TRUNCATE TABLE " + table + ".kills");
-        } catch (SQLException e1) {
-            e1.printStackTrace();
+        } catch (SQLException e) {
+            MekHQ.getLogger().error(getClass(), "writePersonnelData", e);
         }
 
         progressNote = "Uploading personnel data";
@@ -537,7 +533,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 progressTicker += 4;
                 determineProgress();
             } catch (SQLException e) {
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "writePersonnelData", e);
             }
         }
     }
@@ -553,8 +549,8 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 statement.execute("ALTER TABLE " + table + ".equipment ADD uuid VARCHAR(40)");
             }
             rs.close();
-        } catch (SQLException e1) {
-            e1.printStackTrace();
+        } catch (SQLException e) {
+            MekHQ.getLogger().error(getClass(), "writeEquipmentData", e);
         }
 
         progressNote = "Uploading equipment data";
@@ -595,7 +591,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 progressTicker += 1;
                 determineProgress();
             } catch (SQLException e) {
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "writeEquipmentData", e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -137,13 +137,11 @@ public class ResolveScenarioTracker {
     }
 
     public void processMulFiles() {
-        //File salvageFile = salvageList.getSelectedFile();
-        if(unitList.isPresent()) {
+        if (unitList.isPresent()) {
             try {
                 loadUnitsAndPilots(unitList.get());
             } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "processMulFiles", e);
             }
         } else {
             initUnitsAndPilotsWithoutBattle();
@@ -860,15 +858,11 @@ public class ResolveScenarioTracker {
             MULParser parser = new MULParser();
 
             // Open up the file.
-            InputStream listStream = new FileInputStream(unitFile);
-            // Read a Vector from the file.
-            try {
+            try (InputStream listStream = new FileInputStream(unitFile)) {
+                // Read a Vector from the file.
                 parser.parse(listStream);
-                listStream.close();
-            } catch (Exception excep) {
-                excep.printStackTrace(System.err);
-                // throw new IOException("Unable to read from: " +
-                // unitFile.getName());
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "loadUnitsAndPilots", e);
             }
 
             // Was there any error in parsing?
@@ -1621,7 +1615,7 @@ public class ResolveScenarioTracker {
                             : unit.getEntity();
                     baseEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
                 } catch (EntityLoadingException e) {
-                    e.printStackTrace();
+                    MekHQ.getLogger().error(getClass(), "Unit Status", e);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -221,7 +221,7 @@ public class Finances implements Serializable {
                 try {
                     retVal.wentIntoDebt = df.parse(wn2.getTextContent().trim());
                 } catch (DOMException | ParseException e) {
-                    e.printStackTrace();
+                    MekHQ.getLogger().error(Finances.class, "generateInstanceFromXML", e);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/finances/Loan.java
+++ b/MekHQ/src/mekhq/campaign/finances/Loan.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Objects;
 
 import megamek.common.Compute;
+import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
@@ -424,8 +425,7 @@ public class Loan implements MekHqXmlSerializable {
                 try {
                     retVal.nextPayment.setTime(df.parse(wn2.getTextContent().trim()));
                 } catch (DOMException | ParseException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                    MekHQ.getLogger().error(Loan.class, "generateInstanceFromXML", e);
                 }
             } else if (wn2.getNodeName().equalsIgnoreCase("overdue")) {
                 retVal.overdue = wn2.getTextContent().equalsIgnoreCase("true");

--- a/MekHQ/src/mekhq/campaign/finances/Transaction.java
+++ b/MekHQ/src/mekhq/campaign/finances/Transaction.java
@@ -18,7 +18,6 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.finances;
 
 import java.io.PrintWriter;
@@ -42,24 +41,23 @@ import org.w3c.dom.NodeList;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class Transaction implements Serializable {
+    private static final long serialVersionUID = -8772148858528954672L;
 
-	private static final long serialVersionUID = -8772148858528954672L;
-
-	public final static int C_MISC            = 0;
-	public final static int C_EQUIP           = 1;
-	public final static int C_UNIT            = 2;
-	public final static int C_SALARY          = 3;
-	public final static int C_OVERHEAD        = 4;
-	public final static int C_MAINTAIN        = 5;
-	public final static int C_UNIT_SALE       = 6;
-	public final static int C_EQUIP_SALE      = 7;
-	public final static int C_START           = 8;
-	public final static int C_TRANSPORT       = 9;
-	public final static int C_CONTRACT       = 10;
-	public final static int C_BLC            = 11;
-	public final static int C_SALVAGE        = 12;
-	public final static int C_LOAN_PRINCIPAL = 13;
-	public final static int C_LOAN_PAYMENT   = 14;
+    public final static int C_MISC            = 0;
+    public final static int C_EQUIP           = 1;
+    public final static int C_UNIT            = 2;
+    public final static int C_SALARY          = 3;
+    public final static int C_OVERHEAD        = 4;
+    public final static int C_MAINTAIN        = 5;
+    public final static int C_UNIT_SALE       = 6;
+    public final static int C_EQUIP_SALE      = 7;
+    public final static int C_START           = 8;
+    public final static int C_TRANSPORT       = 9;
+    public final static int C_CONTRACT       = 10;
+    public final static int C_BLC            = 11;
+    public final static int C_SALVAGE        = 12;
+    public final static int C_LOAN_PRINCIPAL = 13;
+    public final static int C_LOAN_PAYMENT   = 14;
     public final static int C_REPAIRS        = 15;
     public final static int C_NUM            = 16;
 
@@ -73,68 +71,68 @@ public class Transaction implements Serializable {
         return out;
     }
 
-	public static String getCategoryName(int cat) {
-		switch(cat) {
-		case C_MISC:
-			return "Miscellaneous";
-		case C_EQUIP:
-			return "Equipment Purchases";
-		case C_UNIT:
-			return "Unit Purchases";
-		case C_SALARY:
-			return "Salary Payments";
-		case C_OVERHEAD:
-			return "Overhead Expenses";
-		case C_MAINTAIN:
-			return "Maintenance Expenses";
-		case C_UNIT_SALE:
-			return "Unit Sales";
-		case C_EQUIP_SALE:
-			return "Equipment Sales";
-		case C_CONTRACT:
-			return "Contract payments";
-		case C_BLC:
-			return "Battle Loss Compensation";
-		case C_SALVAGE:
-			return "Salvage Exchange";
-		case C_START:
-			return "Starting Capital";
-		case C_TRANSPORT:
-			return "Transportation";
-		case C_LOAN_PRINCIPAL:
-		    return "Loan Principal";
-		case C_LOAN_PAYMENT:
-		    return "Loan Payment";
-		case C_REPAIRS:
+    public static String getCategoryName(int cat) {
+        switch(cat) {
+        case C_MISC:
+            return "Miscellaneous";
+        case C_EQUIP:
+            return "Equipment Purchases";
+        case C_UNIT:
+            return "Unit Purchases";
+        case C_SALARY:
+            return "Salary Payments";
+        case C_OVERHEAD:
+            return "Overhead Expenses";
+        case C_MAINTAIN:
+            return "Maintenance Expenses";
+        case C_UNIT_SALE:
+            return "Unit Sales";
+        case C_EQUIP_SALE:
+            return "Equipment Sales";
+        case C_CONTRACT:
+            return "Contract payments";
+        case C_BLC:
+            return "Battle Loss Compensation";
+        case C_SALVAGE:
+            return "Salvage Exchange";
+        case C_START:
+            return "Starting Capital";
+        case C_TRANSPORT:
+            return "Transportation";
+        case C_LOAN_PRINCIPAL:
+            return "Loan Principal";
+        case C_LOAN_PAYMENT:
+            return "Loan Payment";
+        case C_REPAIRS:
             return "Repairs";
-		default:
-			return "Unknown category";
-		}
-	}
+        default:
+            return "Unknown category";
+        }
+    }
 
-	private Money amount;
-	private String description;
-	private Date date;
-	private int category;
+    private Money amount;
+    private String description;
+    private Date date;
+    private int category;
 
-	public Transaction() {
-		this(Money.zero(),-1,"",null);
-	}
+    public Transaction() {
+        this(Money.zero(),-1,"",null);
+    }
 
-	public Transaction(Money a, int c, String d, Date dt) {
-		amount = a;
-		category = c;
-		description = d;
-		date = dt;
-	}
+    public Transaction(Money a, int c, String d, Date dt) {
+        amount = a;
+        category = c;
+        description = d;
+        date = dt;
+    }
 
-	public Transaction(Transaction t) {
-	    //copy constructor
-	    this.amount = t.amount;
-	    this.category = t.category;
-	    this.description = t.description;
-	    this.date = t.date;
-	}
+    public Transaction(Transaction t) {
+        //copy constructor
+        this.amount = t.amount;
+        this.category = t.category;
+        this.description = t.description;
+        this.date = t.date;
+    }
 
     public static int getCategoryIndex(String name) {
         for (int i = 0; i < getCategoryList().size(); i++) {
@@ -180,86 +178,86 @@ public class Transaction implements Serializable {
     }
 
     public Money getAmount() {
-		return amount;
-	}
+        return amount;
+    }
 
-	public void setAmount(Money a) {
-		this.amount = a;
-	}
+    public void setAmount(Money a) {
+        this.amount = a;
+    }
 
-	public String getDescription() {
-		return description;
-	}
+    public String getDescription() {
+        return description;
+    }
 
-	public void setDescription(String s) {
-		this.description = s;
-	}
+    public void setDescription(String s) {
+        this.description = s;
+    }
 
-	public int getCategory() {
-		return category;
-	}
+    public int getCategory() {
+        return category;
+    }
 
-	public void setCategory(int c) {
-		this.category = c;
-	}
+    public void setCategory(int c) {
+        this.category = c;
+    }
 
-	public String getCategoryName() {
-		return getCategoryName(getCategory());
-	}
+    public String getCategoryName() {
+        return getCategoryName(getCategory());
+    }
 
-	public Date getDate() {
-		return date;
-	}
+    public Date getDate() {
+        return date;
+    }
 
     public void setDate(Date date) {
         this.date = date;
     }
 
-	protected void writeToXml(PrintWriter pw1, int indent) {
-		pw1.println(MekHqXmlUtil.indentStr(indent) + "<transaction>");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<amount>"
-				+amount.toXmlString()
-				+"</amount>");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<description>"
-				+MekHqXmlUtil.escape(description)
-				+"</description>");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<category>"
-				+category
-				+"</category>");
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<date>"
-				+df.format(date)
-				+"</date>");
-		pw1.println(MekHqXmlUtil.indentStr(indent) + "</transaction>");
-	}
+    protected void writeToXml(PrintWriter pw1, int indent) {
+        pw1.println(MekHqXmlUtil.indentStr(indent) + "<transaction>");
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<amount>"
+                +amount.toXmlString()
+                +"</amount>");
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<description>"
+                +MekHqXmlUtil.escape(description)
+                +"</description>");
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<category>"
+                +category
+                +"</category>");
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<date>"
+                +df.format(date)
+                +"</date>");
+        pw1.println(MekHqXmlUtil.indentStr(indent) + "</transaction>");
+    }
 
-	public static Transaction generateInstanceFromXML(Node wn) {
-		Transaction retVal = new Transaction();
+    public static Transaction generateInstanceFromXML(Node wn) {
+        Transaction retVal = new Transaction();
 
-		NodeList nl = wn.getChildNodes();
-		for (int x=0; x<nl.getLength(); x++) {
-			Node wn2 = nl.item(x);
-			if (wn2.getNodeName().equalsIgnoreCase("amount")) {
-			    retVal.amount = Money.fromXmlString(wn2.getTextContent().trim());
-			} else if (wn2.getNodeName().equalsIgnoreCase("category")) {
-				retVal.category = Integer.parseInt(wn2.getTextContent().trim());
-			} else if (wn2.getNodeName().equalsIgnoreCase("description")) {
-				retVal.description = wn2.getTextContent();
-			} else if (wn2.getNodeName().equalsIgnoreCase("date")) {
-				SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-				try {
-					retVal.date = df.parse(wn2.getTextContent().trim());
-				} catch (DOMException | ParseException e) {
+        NodeList nl = wn.getChildNodes();
+        for (int x=0; x<nl.getLength(); x++) {
+            Node wn2 = nl.item(x);
+            if (wn2.getNodeName().equalsIgnoreCase("amount")) {
+                retVal.amount = Money.fromXmlString(wn2.getTextContent().trim());
+            } else if (wn2.getNodeName().equalsIgnoreCase("category")) {
+                retVal.category = Integer.parseInt(wn2.getTextContent().trim());
+            } else if (wn2.getNodeName().equalsIgnoreCase("description")) {
+                retVal.description = wn2.getTextContent();
+            } else if (wn2.getNodeName().equalsIgnoreCase("date")) {
+                SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+                try {
+                    retVal.date = df.parse(wn2.getTextContent().trim());
+                } catch (DOMException | ParseException e) {
                     MekHQ.getLogger().error(Transaction.class, "generateInstanceFromXml", e);
-				}
+                }
             }
-		}
-		return retVal;
-	}
+        }
+        return retVal;
+    }
 
     public String updateTransaction(Transaction previousTransaction) {
         return  "Edited Transaction: {" +

--- a/MekHQ/src/mekhq/campaign/finances/Transaction.java
+++ b/MekHQ/src/mekhq/campaign/finances/Transaction.java
@@ -1,20 +1,20 @@
 /*
  * Transaction.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.Vector;
 
+import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 
 import org.w3c.dom.DOMException;
@@ -41,9 +42,9 @@ import org.w3c.dom.NodeList;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class Transaction implements Serializable {
-	
+
 	private static final long serialVersionUID = -8772148858528954672L;
-	
+
 	public final static int C_MISC            = 0;
 	public final static int C_EQUIP           = 1;
 	public final static int C_UNIT            = 2;
@@ -71,7 +72,7 @@ public class Transaction implements Serializable {
         Collections.sort(out);
         return out;
     }
-	
+
 	public static String getCategoryName(int cat) {
 		switch(cat) {
 		case C_MISC:
@@ -115,18 +116,18 @@ public class Transaction implements Serializable {
 	private String description;
 	private Date date;
 	private int category;
-	
+
 	public Transaction() {
 		this(Money.zero(),-1,"",null);
 	}
-	
+
 	public Transaction(Money a, int c, String d, Date dt) {
 		amount = a;
 		category = c;
 		description = d;
 		date = dt;
 	}
-	
+
 	public Transaction(Transaction t) {
 	    //copy constructor
 	    this.amount = t.amount;
@@ -134,7 +135,7 @@ public class Transaction implements Serializable {
 	    this.description = t.description;
 	    this.date = t.date;
 	}
-	
+
     public static int getCategoryIndex(String name) {
         for (int i = 0; i < getCategoryList().size(); i++) {
             if (getCategoryName(i).equalsIgnoreCase(name)) {
@@ -181,31 +182,31 @@ public class Transaction implements Serializable {
     public Money getAmount() {
 		return amount;
 	}
-	
+
 	public void setAmount(Money a) {
 		this.amount = a;
 	}
-	
+
 	public String getDescription() {
 		return description;
 	}
-	
+
 	public void setDescription(String s) {
 		this.description = s;
 	}
-	
+
 	public int getCategory() {
 		return category;
 	}
-	
+
 	public void setCategory(int c) {
 		this.category = c;
 	}
-	
+
 	public String getCategoryName() {
 		return getCategoryName(getCategory());
 	}
-	
+
 	public Date getDate() {
 		return date;
 	}
@@ -238,7 +239,7 @@ public class Transaction implements Serializable {
 
 	public static Transaction generateInstanceFromXML(Node wn) {
 		Transaction retVal = new Transaction();
-		
+
 		NodeList nl = wn.getChildNodes();
 		for (int x=0; x<nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
@@ -253,8 +254,7 @@ public class Transaction implements Serializable {
 				try {
 					retVal.date = df.parse(wn2.getTextContent().trim());
 				} catch (DOMException | ParseException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+                    MekHQ.getLogger().error(Transaction.class, "generateInstanceFromXml", e);
 				}
             }
 		}

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -50,6 +50,7 @@ import megamek.common.verifier.TestEntity;
 import megamek.common.weapons.InfantryAttack;
 import megamek.common.weapons.Weapon;
 import megamek.common.weapons.bayweapons.BayWeapon;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.AeroHeatSink;
@@ -172,7 +173,7 @@ public class PartsStore implements Serializable {
             try {
                 newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
             } catch (EntityLoadingException e) {
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "stockBattleArmorSuits", e);
             }
             if(null != newEntity) {
                 BattleArmorSuit ba = new BattleArmorSuit(summary.getChassis(), summary.getModel(), (int)summary.getTons(), 1, summary.getWeightClass(), summary.getWalkMp(), summary.getJumpMp(), newEntity.entityIsQuad(), summary.isClan(), newEntity.getMovementMode(), c);

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -110,7 +110,7 @@ public class AtBScenarioFactory {
 
             return s;
         } catch (InstantiationException | IllegalAccessException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(AtBScenarioFactory.class, "createScenario", e);
         }
 
         return null;

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
@@ -27,6 +27,7 @@ import megamek.common.Board;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.OffBoardDirection;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
@@ -113,7 +114,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
                 botForce.setDestinationEdge(getEnemyHome());
             }
         } catch (PrincessException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "setExtraMissionForces", e);
         }
 
         addBotForce(botForce);
@@ -142,7 +143,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
 
         getScenarioObjectives().add(destroyHostiles);
     }
-    
+
     @Override
     public String getBattlefieldControlDescription() {
         return getResourceBundle().getString("battleDetails.common.defenderControlsBattlefield");

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -28,6 +28,7 @@ import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import megamek.common.OffBoardDirection;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
@@ -109,7 +110,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
                 botForce.setDestinationEdge(destinationEdge);
             }
         } catch (PrincessException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "setExtraMissionForces", e);
         }
 
         addBotForce(botForce);
@@ -164,7 +165,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
 
         getScenarioObjectives().add(destroyHostiles);
     }
-    
+
     @Override
     public String getBattlefieldControlDescription() {
         return getResourceBundle().getString("battleDetails.common.defenderControlsBattlefield");

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
@@ -27,6 +27,7 @@ import megamek.client.bot.princess.PrincessException;
 import megamek.common.Board;
 import megamek.common.Compute;
 import megamek.common.Entity;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBScenario;
@@ -128,7 +129,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
                 addBotForce(bf);
             }
         } catch (PrincessException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "setExtraMissionForces", e);
         }
     }
 
@@ -145,15 +146,15 @@ public class ExtractionBuiltInScenario extends AtBScenario {
         if (isAttacker()) {
             civilianObjective = CommonObjectiveFactory.getPreserveSpecificFriendlies(CIVILIAN_FORCE_ID, 50, false);
             keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 66, false);
-            
+
             civilianObjective.setTimeLimit(12);
             civilianObjective.setTimeLimitAtMost(false);
             civilianObjective.setTimeLimitType(TimeLimitType.Fixed);
-            
+
             keepFriendliesAlive.setTimeLimit(12);
             keepFriendliesAlive.setTimeLimitAtMost(false);
             keepFriendliesAlive.setTimeLimitType(TimeLimitType.Fixed);
-            
+
             // not losing the scenario also gets you a "bonus"
             ObjectiveEffect bonusEffect = new ObjectiveEffect();
             bonusEffect.effectType = ObjectiveEffectType.AtBBonus;
@@ -184,10 +185,10 @@ public class ExtractionBuiltInScenario extends AtBScenario {
         if (keepFriendliesAlive != null) {
             getScenarioObjectives().add(keepFriendliesAlive);
         }
-        
+
         getScenarioObjectives().add(civilianObjective);
     }
-    
+
     @Override
     public String getBattlefieldControlDescription() {
         return getResourceBundle().getString("battleDetails.common.defenderControlsBattlefield");

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -24,6 +24,7 @@ package mekhq.campaign.parts;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 
+import mekhq.MekHQ;
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -485,8 +486,9 @@ public class BattleArmorSuit extends Part {
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         if(null != unit) {
-            if(trooper < 0) {
-                System.err.println("Trooper location -1 found on BattleArmorSuit attached to unit");
+            if (trooper < 0) {
+                MekHQ.getLogger().error(getClass(), "updateConditionFromEntity",
+                        "Trooper location -1 found on BattleArmorSuit attached to unit");
                 return;
             }
             if(unit.getEntity().getInternal(trooper) == IArmorState.ARMOR_DESTROYED) {
@@ -615,7 +617,7 @@ public class BattleArmorSuit extends Part {
         try {
             newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
         } catch (EntityLoadingException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "addSubParts", e);
         }
         Unit newUnit = null;
         if (null != newEntity) {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1497,24 +1497,19 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                 }
                 BLKFile.encode(fileNameCampaign, newEntity);
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "saveCustomization", e);
         }
         oldUnit.getCampaign().addCustom(newEntity.getChassis() + " " + newEntity.getModel());
         MechSummaryCache.getInstance().loadMechData();
         //I need to change the new entity to the one from the mtf file now, so that equip
         //numbers will match
         MechSummary summary = MechSummaryCache.getInstance().getMech(newEntity.getChassis() + " " + newEntity.getModel());
-        if(null == summary) {
+        if (null == summary) {
             throw(new EntityLoadingException());
         }
-        //try {
-            newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
-        /*} catch (EntityLoadingException ex) {
-            Logger.getLogger(CampaignGUI.class.getName())
-                    .log(Level.SEVERE, null, ex);
-        }*/
 
+        newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
     }
 
     private int getTimeMultiplier() {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -1,20 +1,20 @@
 /*
  * BattleArmorAmmoBin.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -41,44 +41,44 @@ import mekhq.campaign.work.IAcquisitionWork;
 public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
 
     /**
-     * Battle Armor ammo bins need to look for shots for all the remaining troopers in the 
-     * squad. 
-     * TODO: Think about how to handle the case of understrength squads. Right now they 
+     * Battle Armor ammo bins need to look for shots for all the remaining troopers in the
+     * squad.
+     * TODO: Think about how to handle the case of understrength squads. Right now they
      * pay for more ammo than they need, but this is easier than trying to track ammo per suit
      * and adjust for different ammo types when suits are added and removed from squads.
      */
     private static final long serialVersionUID = 2421186617583650648L;
-    
+
     public BattleArmorAmmoBin() {
         this(0, null, -1, 0, false, null);
     }
-    
+
     public BattleArmorAmmoBin(int tonnage, EquipmentType et, int equipNum, int shots, boolean singleShot, Campaign c) {
         super(tonnage, et, equipNum, shots, singleShot, false, c);
     }
-    
+
     public int getNumTroopers() {
         if(null != unit && unit.getEntity() instanceof BattleArmor) {
             //we are going to base this on the full squad size, even though this makes understrength
             //squads overpay for their ammo - that way suits can be moved around without having to adjust
-            //ammo - Tech: "oh you finally got here. Check in the back corner, we stockpiled some ammo for 
+            //ammo - Tech: "oh you finally got here. Check in the back corner, we stockpiled some ammo for
             //you."
             return ((BattleArmor)unit.getEntity()).getSquadSize();
         }
         return 0;
     }
-    
+
     //no salvaging of BA parts
     @Override
     public boolean isSalvaging() {
         return false;
     }
-    
+
     /*@Override
     public int getFullShots() {
     	return super.getFullShots() * getNumTroopers();
     }*/
-    
+
     @Override
     protected int getCurrentShots() {
     	int shots = getFullShots() * getNumTroopers() - shotsNeeded;
@@ -92,13 +92,13 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
     	}
     	return shots;
     }
-    
+
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if(null != mounted) {
-            	long currentMuniType = 0;			
+            	long currentMuniType = 0;
 				if(mounted.getType() instanceof AmmoType) {
 					currentMuniType = ((AmmoType)mounted.getType()).getMunitionType();
 				}
@@ -111,8 +111,8 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
             }
         }
     }
-    
-    @Override 
+
+    @Override
 	public int getBaseTime() {
 		if(null != unit) {
 			Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
@@ -124,12 +124,12 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
 		}
 		return 15;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return 0;
 	}
-    
+
     @Override
     public void updateConditionFromPart() {
         if(null != unit) {
@@ -143,7 +143,7 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
             }
         }
     }
-    
+
     @Override
     public void loadBin() {
         int shots = Math.min(getAmountAvailable(), shotsNeeded);
@@ -152,12 +152,12 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if(null != mounted) {
-            	if(mounted.getType().equals(type) 						
+            	if(mounted.getType().equals(type)
 						&& ((AmmoType)mounted.getType()).getMunitionType() == getMunitionType()) {
                     //just a simple reload
                     mounted.setShotsLeft(mounted.getBaseShotsLeft() + shotsPerTrooper);
                 } else {
-                    //loading a new type of ammo                
+                    //loading a new type of ammo
                     unload();
                     mounted.changeAmmoType((AmmoType)type);
                     mounted.setShotsLeft(shotsPerTrooper);
@@ -167,13 +167,13 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
         changeAmountAvailable(-1 * shots, (AmmoType)type);
         shotsNeeded -= shots;
     }
-    
+
     @Override
     public void unload() {
         int shots = 0;
         AmmoType curType = (AmmoType)type;
         if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);      
+            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if(null != mounted) {
                 shots = mounted.getBaseShotsLeft() * getNumTroopers();
                 mounted.setShotsLeft(0);
@@ -183,9 +183,9 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
         shotsNeeded = getFullShots() * getNumTroopers();
         if(shots > 0) {
             changeAmountAvailable(shots, curType);
-        }   
+        }
     }
-    
+
     @Override
     public String checkFixable() {
     	int amountAvailable = getAmountAvailable();
@@ -193,14 +193,14 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
     		return "Cannot do a partial reload of Battle Armor ammo less than the number of troopers";
     	}
     	return super.checkFixable();
-    	
+
     }
 
     @Override
     public void remove(boolean salvage) {
         //shouldn't be here
     }
-    
+
     @Override
     public Part getNewPart() {
     	int shots = (int) Math.floor(1000/((AmmoType)type).getKgPerShot());
@@ -211,7 +211,7 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
 		}
         return new AmmoStorage(1,type,shots,campaign);
     }
-    
+
     @Override
     public IAcquisitionWork getAcquisitionWork() {
     	int shots = (int) Math.floor(1000/((AmmoType)type).getKgPerShot());
@@ -226,21 +226,21 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
     @Override
     public String getAcquisitionDesc() {
         String toReturn = "<html><font size='2'";
-        
+
         toReturn += ">";
         toReturn += "<b>" + getAcquisitionDisplayName() + "</b> " + getAcquisitionBonus() + "<br/>";
         toReturn += getAcquisitionExtraDesc() + "<br/>";
         PartInventory inventories = campaign.getPartInventory(getAcquisitionPart());
-        toReturn += inventories.getTransitOrderedDetails() + "<br/>"; 
+        toReturn += inventories.getTransitOrderedDetails() + "<br/>";
         toReturn += getBuyCost().toAmountAndSymbolString() + "<br/>";
         toReturn += "</font></html>";
         return toReturn;
     }
-	
+
     @Override
     public String getAcquisitionDisplayName() {
     	return type.getDesc();
-    }    
+    }
 
     private int calculateShots() {
         int shots = (int) Math.floor(1000/((AmmoType)type).getKgPerShot());
@@ -249,10 +249,10 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
 			//because presumably this is happening because KgperShot is -1 or 0
 			shots = 20;
 		}
-		
+
 		return shots;
     }
-    
+
 	@Override
 	public String getAcquisitionExtraDesc() {
 		return calculateShots() + " shots";
@@ -276,11 +276,11 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
     public boolean needsMaintenance() {
         return false;
     }
-    
+
     public boolean canNeverScrap() {
     	return true;
 	}
-    
+
     /**
      * Restores the equipment from the name
      */
@@ -290,12 +290,12 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
         } else {
             type = EquipmentType.get(typeName);
         }
-        
-        
+
+
         //FIXME, this is a crappy hack, but we want something along these lines
         //to make sure that BA ammo gets removed from all parts - It might be better to run
         //a check on the XML loading after restore - we also will need to to the same for proto
-        //ammo but we can only do this if we have all the correct ammo rack sizes for the 
+        //ammo but we can only do this if we have all the correct ammo rack sizes for the
         //generics (e.g. LRM1, LRM2, LRM3, etc)
         /*if(typeName.contains("BA-")) {
         	String newTypeName = "IS" + typeName.split("BA-")[1];
@@ -305,12 +305,11 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
         		type = newType;
         	}
         }*/
-        
+
 
         if (type == null) {
-            System.err
-            .println("Mounted.restore: could not restore equipment type \""
-                    + typeName + "\"");
+            MekHQ.getLogger().error(BattleArmorAmmoBin.class, "restore",
+                    "Mounted.restore: could not restore equipment type \"" + typeName + "\"");
             return;
         }
         try {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -51,7 +51,7 @@ import mekhq.campaign.unit.Unit;
  * needs to be subclassed. Some examples of equipment that needs to be
  * subclasses: - MASC (depends on engine rating) - AES (depends on location and
  * cost is by unit tonnage)
- * 
+ *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class EquipmentPart extends Part {
@@ -141,7 +141,8 @@ public class EquipmentPart extends Part {
         }
 
         if (type == null) {
-            System.err.println("Mounted.restore: could not restore equipment type \"" + typeName + "\"");
+            MekHQ.getLogger().error(getClass(), "restore",
+                    "Mounted.restore: could not restore equipment type \"" + typeName + "\"");
         }
     }
 
@@ -408,7 +409,7 @@ public class EquipmentPart extends Part {
          * unit.getEntity().locations(); loc++) { for (int i = 0; i <
          * unit.getEntity().getNumberOfCriticals(loc); i++) { CriticalSlot slot =
          * unit.getEntity().getCritical(loc, i);
-         * 
+         *
          * // ignore empty & system slots if ((slot == null) || (slot.getType() !=
          * CriticalSlot.TYPE_EQUIPMENT)) { continue; } Mounted equip =
          * unit.getEntity().getEquipment(equipmentNum); Mounted m1 = slot.getMount();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
@@ -23,6 +23,7 @@ package mekhq.campaign.parts.equipment;
 
 import java.io.PrintWriter;
 
+import mekhq.MekHQ;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -67,7 +68,7 @@ public class MissingEquipmentPart extends MissingPart {
     public MissingEquipmentPart() {
     	this(0, null, -1, null, 0, false);
     }
-    
+
     public MissingEquipmentPart(int tonnage, EquipmentType et, int equipNum, Campaign c, double eTonnage) {
         this(tonnage, et, equipNum, c, eTonnage, false);
     }
@@ -110,9 +111,8 @@ public class MissingEquipmentPart extends MissingPart {
         }
 
         if (type == null) {
-            System.err
-            .println("Mounted.restore: could not restore equipment type \""
-                    + name + "\"");
+            MekHQ.getLogger().error(getClass(), "restore",
+                    "Mounted.restore: could not restore equipment type \"" + name + "\"");
         }
     }
 
@@ -155,7 +155,7 @@ public class MissingEquipmentPart extends MissingPart {
 		}
 		restore();
 	}
-	
+
 	@Override
 	public TechAdvancement getTechAdvancement() {
 	    return type.getTechAdvancement();

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
@@ -226,8 +226,8 @@ public class Bloodname implements Serializable {
 					retVal.phenotype = P_NAVAL;
 					break;
 				default:
-					System.err.println("Unknown phenotype " +
-							wn.getTextContent() + " in " + retVal.name);
+					MekHQ.getLogger().error(Bloodname.class, "loadFromXml",
+                            "Unknown phenotype " + wn.getTextContent() + " in " + retVal.name);
 				}
 			} else if (wn.getNodeName().equalsIgnoreCase("postReaving")) {
 				String[] clans = wn.getTextContent().trim().split(",");

--- a/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
@@ -145,14 +145,13 @@ public class PersonAwardController {
      * @param stringDate is the date it was awarded
      */
     public void removeAward(String setName, String awardName, String stringDate){
-
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd"); // TODO : remove inline date format
 
         Date date = null;
         try {
             date = df.parse(stringDate);
         } catch (ParseException e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "removeAward", e);
         }
 
         for(Award award : awards){

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -39,40 +39,37 @@ import mekhq.MekHQ;
  * Provides access to RATGenerator through IUnitGenerator interface.
  *
  * @author Neoancient
- *
  */
-
 public class RATGeneratorConnector extends AbstractUnitGenerator implements IUnitGenerator {
-
-	/* Initialize RATGenerator and load the data for the current game year */
-	public RATGeneratorConnector(int year) {
-		while (!RATGenerator.getInstance().isInitialized()) {
-			try {
-				Thread.sleep(50);
-			} catch (InterruptedException e) {
+    /* Initialize RATGenerator and load the data for the current game year */
+    public RATGeneratorConnector(int year) {
+        while (!RATGenerator.getInstance().isInitialized()) {
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
                 MekHQ.getLogger().error(getClass(), "RATGeneratorConnector", e);
-			}
-		}
-		RATGenerator.getInstance().loadYear(year);
-	}
+            }
+        }
+        RATGenerator.getInstance().loadYear(year);
+    }
 
-	private UnitTable findTable(String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes) {
-		FactionRecord fRec = Faction.getFactionRecordOrFallback(faction);
-		if(fRec == null) {
-		    return null;
-		}
+    private UnitTable findTable(String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes) {
+        FactionRecord fRec = Faction.getFactionRecordOrFallback(faction);
+        if(fRec == null) {
+            return null;
+        }
 
-		String rating = getFactionSpecificRating(fRec, quality);
+        String rating = getFactionSpecificRating(fRec, quality);
 
-		ArrayList<Integer> wcs = new ArrayList<>();
-		if (weightClass >= 0) {
-			wcs.add(weightClass);
-		}
+        ArrayList<Integer> wcs = new ArrayList<>();
+        if (weightClass >= 0) {
+            wcs.add(weightClass);
+        }
 
-		return UnitTable.findTable(fRec, unitType, year, rating, wcs, ModelRecord.NETWORK_NONE, movementModes, new ArrayList<>(), 2, fRec);
-	}
+        return UnitTable.findTable(fRec, unitType, year, rating, wcs, ModelRecord.NETWORK_NONE, movementModes, new ArrayList<>(), 2, fRec);
+    }
 
-	/**
+    /**
      * Helper function that extracts the string-based unit rating from the given int-based unit-rating
      * for the given faction.
      * @param fRec Faction record
@@ -89,28 +86,28 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
         return rating;
     }
 
-	/* (non-Javadoc)
-	 * @see mekhq.campaign.universe.IUnitGenerator#isSupportedUnitType(int)
-	 */
-	@Override
-	public boolean isSupportedUnitType(int unitType) {
-		return unitType != UnitType.GUN_EMPLACEMENT
-				&& unitType != UnitType.SPACE_STATION;
-	}
+    /* (non-Javadoc)
+     * @see mekhq.campaign.universe.IUnitGenerator#isSupportedUnitType(int)
+     */
+    @Override
+    public boolean isSupportedUnitType(int unitType) {
+        return unitType != UnitType.GUN_EMPLACEMENT
+                && unitType != UnitType.SPACE_STATION;
+    }
 
-	/* (non-Javadoc)
-	 * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int)
-	 */
-	@Override
-	public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality) {
-		UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
+    /* (non-Javadoc)
+     * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int)
+     */
+    @Override
+    public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality) {
+        UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
                 EnumSet.noneOf(EntityMovementMode.class));
-		return (ut == null)? null : ut.generateUnit();
-	}
+        return (ut == null)? null : ut.generateUnit();
+    }
 
-	/* (non-Javadoc)
-	 * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int, java.util.function.Predicate)
-	 */
+    /* (non-Javadoc)
+     * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int, java.util.function.Predicate)
+     */
     @Override
     public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality, Predicate<MechSummary> filter) {
         UnitTable ut = findTable(faction, unitType, weightClass, year, quality, EnumSet.noneOf(EntityMovementMode.class));
@@ -123,27 +120,27 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
         return (ut == null)? null : ut.generateUnit(filter == null?null : filter::test);
     }
 
-	/* (non-Javadoc)
-	 * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int)
-	 */
-	@Override
-	public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality) {
-		UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
+    /* (non-Javadoc)
+     * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int)
+     */
+    @Override
+    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality) {
+        UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
                 EnumSet.noneOf(EntityMovementMode.class));
-		return ut == null? new ArrayList<>() : ut.generateUnits(count);
-	}
+        return ut == null? new ArrayList<>() : ut.generateUnits(count);
+    }
 
-	/* (non-Javadoc)
-	 * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int, java.util.function.Predicate)
-	 */
-	@Override
-	public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality,
-			Predicate<MechSummary> filter) {
-		UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
+    /* (non-Javadoc)
+     * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int, java.util.function.Predicate)
+     */
+    @Override
+    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality,
+            Predicate<MechSummary> filter) {
+        UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
                 EnumSet.noneOf(EntityMovementMode.class));
-		return ut == null? new ArrayList<>() : ut.generateUnits(count,
-		        filter == null? null : filter::test);
-	}
+        return ut == null? new ArrayList<>() : ut.generateUnits(count,
+                filter == null? null : filter::test);
+    }
 
     @Override
     public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Predicate<MechSummary> filter) {

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -33,6 +33,7 @@ import megamek.client.ratgenerator.UnitTable;
 import megamek.common.EntityMovementMode;
 import megamek.common.MechSummary;
 import megamek.common.UnitType;
+import mekhq.MekHQ;
 
 /**
  * Provides access to RATGenerator through IUnitGenerator interface.
@@ -49,7 +50,7 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
 			try {
 				Thread.sleep(50);
 			} catch (InterruptedException e) {
-				e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "RATGeneratorConnector", e);
 			}
 		}
 		RATGenerator.getInstance().loadYear(year);

--- a/MekHQ/src/mekhq/campaign/universe/RATManager.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATManager.java
@@ -146,7 +146,7 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
             try {
                 Thread.sleep(50);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
             }
         }
         File f = new File(RATINFO_DIR, fileNames.get(name));
@@ -161,7 +161,6 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
             xmlDoc = db.parse(fis);
             fis.close();
         } catch (Exception ex) {
-            ex.printStackTrace();
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR, "While loading RAT info from " + f.getName() + ": "); //$NON-NLS-1$
             MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             return false;

--- a/MekHQ/src/mekhq/gui/BasicInfo.java
+++ b/MekHQ/src/mekhq/gui/BasicInfo.java
@@ -17,6 +17,7 @@ import javax.swing.border.LineBorder;
 import megamek.client.ui.swing.util.PlayerColors;
 import megamek.common.Crew;
 import mekhq.IconPackage;
+import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
@@ -137,8 +138,8 @@ public class BasicInfo extends JPanel {
         Image camo = null;
         try {
             camo = (Image) icons.getCamos().getItem(unit.getCamoCategory(), unit.getCamoFileName());
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "getCamo", e);
         }
         return camo;
     }
@@ -178,8 +179,8 @@ public class BasicInfo extends JPanel {
                 portrait = portrait.getScaledInstance(-1, 58, Image.SCALE_SMOOTH);
                 setImage(portrait);
             }
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "setPortrait", e);
         }
     }
 
@@ -211,8 +212,8 @@ public class BasicInfo extends JPanel {
                 }
             }
             return portrait;
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "getImageFor", e);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -795,15 +795,14 @@ public final class BriefingTab extends CampaignGuiTab {
             // Save the player's entities to the file.
             // FIXME: this is not working
             EntityListFile.saveTo(unitFile, chosen);
-
-        } catch (IOException ex) {
-            ex.printStackTrace(System.err);
+        } catch (IOException e) {
+            MekHQ.getLogger().error(getClass(), "deployListFile", e);
         }
 
         if (undeployed.length() > 0) {
             JOptionPane.showMessageDialog(getFrame(),
-                    "The following units could not be deployed:" + undeployed.toString(), "Could not deploy some units",
-                    JOptionPane.WARNING_MESSAGE);
+                    "The following units could not be deployed:" + undeployed.toString(),
+                    "Could not deploy some units", JOptionPane.WARNING_MESSAGE);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1056,8 +1056,8 @@ public class CampaignGUI extends JPanel {
             Method method = clazz.getMethod(methodName, Window.class, boolean.class);
             method.invoke(null, window, true);
         } catch (Throwable t) {
-            System.err.println("Full screen mode is not supported");
-            t.printStackTrace();
+            MekHQ.getLogger().error(CampaignGUI.class, "enableFullScreenMode",
+                    "Full screen mode is not supported", t);
         }
     }
 
@@ -1918,8 +1918,8 @@ public class CampaignGUI extends JPanel {
             // Open up the file.
             try (InputStream is = new FileInputStream(unitFile)) {
                 parser.parse(is);
-            } catch (Exception excep) {
-                excep.printStackTrace(System.err);
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "loadListFile", e);
             }
 
             // Was there any error in parsing?
@@ -2483,8 +2483,8 @@ public class CampaignGUI extends JPanel {
             // other stuff
             try {
                 lab.refreshRefitSummary();
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "refreshLab", e);
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1468,7 +1468,7 @@ public class CampaignGUI extends JPanel {
     }
 
     private void menuMekHqOptionsActionPerformed(ActionEvent evt) {
-        MekHqOptionsDialog dialog = new MekHqOptionsDialog(getFrame(), MekHQ.getLogger());
+        MekHqOptionsDialog dialog = new MekHqOptionsDialog(getFrame());
         dialog.setVisible(true);
     }
 

--- a/MekHQ/src/mekhq/gui/EntityImage.java
+++ b/MekHQ/src/mekhq/gui/EntityImage.java
@@ -1,5 +1,7 @@
 package mekhq.gui;
 
+import mekhq.MekHQ;
+
 import java.awt.Component;
 import java.awt.Image;
 import java.awt.image.ImageObserver;
@@ -60,13 +62,13 @@ import java.awt.image.PixelGrabber;
             try {
                 pgMech.grabPixels();
             } catch (InterruptedException e) {
-                System.err
-                        .println("EntityImage.applyColor(): Failed to grab pixels for mech image." + e.getMessage()); //$NON-NLS-1$
+                MekHQ.getLogger().error(getClass(), "applyColor",
+                        "EntityImage.applyColor(): Failed to grab pixels for mech image." + e.getMessage()); //$NON-NLS-1$
                 return image;
             }
             if ((pgMech.getStatus() & ImageObserver.ABORT) != 0) {
-                System.err
-                        .println("EntityImage.applyColor(): Failed to grab pixels for mech image. ImageObserver aborted."); //$NON-NLS-1$
+                MekHQ.getLogger().error(getClass(), "applyColor",
+                        "EntityImage.applyColor(): Failed to grab pixels for mech image. ImageObserver aborted."); //$NON-NLS-1$
                 return image;
             }
 
@@ -76,13 +78,13 @@ import java.awt.image.PixelGrabber;
                 try {
                     pgCamo.grabPixels();
                 } catch (InterruptedException e) {
-                    System.err
-                            .println("EntityImage.applyColor(): Failed to grab pixels for camo image." + e.getMessage()); //$NON-NLS-1$
+                    MekHQ.getLogger().error(getClass(), "applyColor",
+                            "EntityImage.applyColor(): Failed to grab pixels for camo image." + e.getMessage()); //$NON-NLS-1$
                     return image;
                 }
                 if ((pgCamo.getStatus() & ImageObserver.ABORT) != 0) {
-                    System.err
-                            .println("EntityImage.applyColor(): Failed to grab pixels for mech image. ImageObserver aborted."); //$NON-NLS-1$
+                    MekHQ.getLogger().error(getClass(), "applyColor",
+                            "EntityImage.applyColor(): Failed to grab pixels for mech image. ImageObserver aborted."); //$NON-NLS-1$
                     return image;
                 }
             }
@@ -112,4 +114,4 @@ import java.awt.image.PixelGrabber;
                     IMG_HEIGHT, pMech, 0, IMG_WIDTH));
             return image;
         }
-    }	
+    }

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -15,6 +15,7 @@ import megamek.common.Crew;
 import megamek.common.Entity;
 import megamek.common.GunEmplacement;
 import mekhq.IconPackage;
+import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
@@ -194,8 +195,8 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
                 }
             }
             return new ImageIcon(portrait);
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "getIconFrom", e);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -77,6 +77,7 @@ import javax.swing.JViewport;
 import javax.swing.Timer;
 import javax.vecmath.Vector2d;
 
+import mekhq.MekHQ;
 import org.joda.time.DateTime;
 
 import megamek.common.EquipmentType;
@@ -322,7 +323,7 @@ public class InterstellarMapPanel extends JPanel {
                                     ImageIO.write(img, "png", file.get());
                                 }
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                MekHQ.getLogger().error(getClass(), "maybeShowPopup", e);
                             }
                             conf.centerX = originalX;
                             conf.centerY = originalY;

--- a/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
+++ b/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
@@ -596,8 +596,8 @@ public class PlanetarySystemMapPanel extends JPanel {
         Image camo = null;
         try {
             camo = (Image) camos.getItem(campaign.getCamoCategory(), campaign.getCamoFileName());
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "getCamo", e);
         }
         return camo;
     }

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -289,8 +289,8 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements
                         }
                         BLKFile.encode(fileNameCampaign, unit.getEntity());
                     }
-                } catch (Exception ex) {
-                    ex.printStackTrace();
+                } catch (Exception e) {
+                    MekHQ.getLogger().error(getClass(), "actionPerformed", e);
                 }
                 gui.getCampaign().addCustom(
                         unit.getEntity().getChassis() + " "

--- a/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
@@ -48,19 +48,16 @@ import java.util.ResourceBundle;
  * - cancelButton.text -> text for the cancel button
  */
 public abstract class BaseDialog extends JDialog implements WindowListener {
-    private final MMLogger logger;
     private ResourceBundle resources;
     private DialogResult result;
 
-    protected BaseDialog(JFrame parent, MMLogger logger) {
-        this(parent, logger, false);
+    protected BaseDialog(JFrame parent) {
+        this(parent, false);
     }
 
-    protected BaseDialog(JFrame parent, MMLogger logger, boolean isModal) {
+    protected BaseDialog(JFrame parent, boolean isModal) {
         super(parent);
-        assert logger != null;
 
-        this.logger = logger;
         this.addWindowListener(this);
         this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         this.setModal(isModal);
@@ -162,9 +159,8 @@ public abstract class BaseDialog extends JDialog implements WindowListener {
     private void cancelButtonActionPerformed(ActionEvent evt) {
         try {
             this.cancelAction();
-        }
-        catch (Exception ex) {
-            this.logger.error(this.getClass(), "cancelButtonActionPerformed", ex);
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "cancelButtonActionPerformed", e);
         }
         finally {
             this.result = DialogResult.CANCEL;
@@ -179,9 +175,8 @@ public abstract class BaseDialog extends JDialog implements WindowListener {
     public void windowClosing(WindowEvent e) {
         try {
             this.cancelAction();
-        }
-        catch (Exception ex) {
-            this.logger.error(this.getClass(), "windowClosing", ex);
+        } catch (Exception ex) {
+            MekHQ.getLogger().error(getClass(), "windowClosing", ex);
         }
         finally {
             this.result = DialogResult.CANCEL;

--- a/MekHQ/src/mekhq/gui/dialog/CamoChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CamoChoiceDialog.java
@@ -148,7 +148,7 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.weightx = 1.0;
         getContentPane().add(comboCategories, gridBagConstraints);
-        
+
         btnSelect.setText(resourceMap.getString("btnSelect.text")); // NOI18N
         btnSelect.setName("btnSelect"); // NOI18N
         btnSelect.addActionListener(new java.awt.event.ActionListener() {
@@ -219,7 +219,7 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
     public int getColorIndex() {
         return colorIndex;
     }
-    
+
     public boolean clickedSelect() {
         return clickedSelect;
     }
@@ -322,7 +322,7 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
         }
 
         public class Renderer extends CamoPanel implements TableCellRenderer {
-			
+
         	public Renderer(DirectoryItems camos) {
 				super(camos);
 			}
@@ -333,7 +333,7 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
                 String name = getValueAt(row, column).toString();
                 setText(getValueAt(row, column).toString());
                 setImage(category, name, row);
-                
+
                 MekHqTableCellRenderer.setupTableColors(this, table, isSelected, hasFocus, row);
                 return this;
             }
@@ -359,11 +359,11 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
             }
         }
     }
-    
+
     public class CamoPanel extends javax.swing.JPanel {
     	private static final long serialVersionUID = -4106360800407452822L;
     	private DirectoryItems camos;
-        
+
         /** Creates new form CamoPanel */
         public CamoPanel(DirectoryItems camos) {
             this.camos = camos;
@@ -392,17 +392,17 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
         public void setText(String text) {
             lblImage.setText(text);
         }
-        
+
         //public void setImage(Image image) {
           //  lblImage.setIcon(new ImageIcon(image));
         //}
-        
+
         public void setImage(String category, String name, int colorInd) {
 
             if (null == category) {
                 return;
             }
-            
+
             if(Player.NO_CAMO.equals(category)) {
                 if (colorInd == -1) {
                     colorInd = 0;
@@ -424,8 +424,8 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
                     category = ""; //$NON-NLS-1$
                 Image camo = (Image) camos.getItem(category, name);
                 lblImage.setIcon(new ImageIcon(camo));
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "setImage", e);
             }
         }
         // Variables declaration - do not modify//GEN-BEGIN:variables
@@ -442,6 +442,6 @@ public class CamoChoiceDialog extends javax.swing.JDialog {
     private javax.swing.JTable tableCamo;
     // End of variables declaration//GEN-END:variables
 
-    
-    
+
+
 }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -5109,7 +5109,6 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
             Image camo = (Image) camos.getItem(camoCategory, camoFileName);
             btnCamo.setIcon(new ImageIcon(camo));
         } catch (Exception err) {
-            //err.printStackTrace();
         	JOptionPane.showMessageDialog(
         			this,
         			"Cannot find your camo file.\n"
@@ -5302,9 +5301,6 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
     }
 
     public static class SpinnerEditor extends DefaultCellEditor {
-        /**
-		 *
-		 */
 		private static final long serialVersionUID = -2711422398394960413L;
 		JSpinner spinner;
         JSpinner.NumberEditor editor;
@@ -5320,9 +5316,6 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
             textField.addFocusListener(new FocusListener() {
                 @Override
                 public void focusGained(FocusEvent fe) {
-                    System.err.println("Got focus");
-                    //textField.setSelectionStart(0);
-                    //textField.setSelectionEnd(1);
                     SwingUtilities.invokeLater(() -> {
                         if (valueSet) {
                             textField.setCaretPosition(1);
@@ -5339,9 +5332,8 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
         // Prepares the spinner component and returns it.
         @Override
-        public Component getTableCellEditorComponent(
-                JTable table, Object value, boolean isSelected, int row, int column
-                                                    ) {
+        public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected,
+                                                     int row, int column) {
             if (!valueSet) {
                 spinner.setValue(value);
             }
@@ -5351,14 +5343,9 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
         @Override
         public boolean isCellEditable(EventObject eo) {
-            System.err.println("isCellEditable");
             if (eo instanceof KeyEvent) {
                 KeyEvent ke = (KeyEvent) eo;
-                System.err.println("key event: " + ke.getKeyChar());
                 textField.setText(String.valueOf(ke.getKeyChar()));
-                //textField.select(1,1);
-                //textField.setCaretPosition(1);
-                //textField.moveCaretPosition(1);
                 valueSet = true;
             } else {
                 valueSet = false;
@@ -5374,13 +5361,11 @@ public class CampaignOptionsDialog extends javax.swing.JDialog {
 
         @Override
         public boolean stopCellEditing() {
-            System.err.println("Stopping edit");
             try {
                 editor.commitEdit();
                 spinner.commitEdit();
             } catch (java.text.ParseException e) {
-                JOptionPane.showMessageDialog(null,
-                                              "Invalid value, discarding.");
+                JOptionPane.showMessageDialog(null, "Invalid value, discarding.");
             }
             return super.stopCellEditing();
         }

--- a/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
@@ -18,7 +18,6 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
 import java.awt.Component;
@@ -26,6 +25,7 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.text.DecimalFormat;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.ResourceBundle;
@@ -65,7 +65,7 @@ import mekhq.preferences.PreferencesNode;
  * @author  Taharqa
  */
 public class ChooseRefitDialog extends javax.swing.JDialog {
-	private static final long serialVersionUID = -8038099101234445018L;
+    private static final long serialVersionUID = -8038099101234445018L;
     private Campaign campaign;
     private Unit unit;
     private RefitTableModel refitModel;
@@ -101,11 +101,11 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 
         setTitle(resourceMap.getString("title.text") + " " + unit.getName());
 
-    	GridBagConstraints gridBagConstraints;
-    	getContentPane().setLayout(new GridBagLayout());
+        GridBagConstraints gridBagConstraints;
+        getContentPane().setLayout(new GridBagLayout());
 
-    	refitTable = new JTable(refitModel);
-		TableColumn column = null;
+        refitTable = new JTable(refitModel);
+        TableColumn column = null;
         for (int i = 0; i < RefitTableModel.N_COL; i++) {
             column = refitTable.getColumnModel().getColumn(i);
             column.setPreferredWidth(refitModel.getColumnWidth(i));
@@ -115,20 +115,20 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         refitTable.setShowGrid(false);
         refitTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         refitTable.getSelectionModel().addListSelectionListener(
-				new javax.swing.event.ListSelectionListener() {
-					public void valueChanged(
-							javax.swing.event.ListSelectionEvent evt) {
-						refitTableValueChanged();
-					}
-				});
+                new javax.swing.event.ListSelectionListener() {
+                    public void valueChanged(
+                            javax.swing.event.ListSelectionEvent evt) {
+                        refitTableValueChanged();
+                    }
+                });
         TableRowSorter<RefitTableModel> refitSorter = new TableRowSorter<RefitTableModel>(refitModel);
         refitSorter.setComparator(RefitTableModel.COL_CLASS, new ClassSorter());
         refitSorter.setComparator(RefitTableModel.COL_COST, new FormattedNumberSorter());
         refitTable.setRowSorter(refitSorter);
-		scrRefitTable = new JScrollPane();
-		scrRefitTable.setViewportView(refitTable);
-		scrRefitTable.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("refitTable.title")));
-		gridBagConstraints = new java.awt.GridBagConstraints();
+        scrRefitTable = new JScrollPane();
+        scrRefitTable.setViewportView(refitTable);
+        scrRefitTable.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("refitTable.title")));
+        gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.weightx = 1.0;
@@ -140,8 +140,8 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 
         scrShoppingList = new JScrollPane();
         scrShoppingList.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder(resourceMap.getString("shoppingList.title")),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                 BorderFactory.createTitledBorder(resourceMap.getString("shoppingList.title")),
+                 BorderFactory.createEmptyBorder(5,5,5,5)));
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
@@ -151,26 +151,26 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         scrShoppingList.setMinimumSize(new java.awt.Dimension(300, 200));
-		scrShoppingList.setPreferredSize(new java.awt.Dimension(300, 200));
+        scrShoppingList.setPreferredSize(new java.awt.Dimension(300, 200));
         getContentPane().add(scrShoppingList, gridBagConstraints);
 
         txtOldUnit = new JTextPane();
         txtOldUnit.setEditable(false);
         txtOldUnit.setContentType("text/html");
         txtOldUnit.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder(resourceMap.getString("txtOldUnit.title")),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                 BorderFactory.createTitledBorder(resourceMap.getString("txtOldUnit.title")),
+                 BorderFactory.createEmptyBorder(5,5,5,5)));
         MechView mv = new MechView(unit.getEntity(), false, true);
-		txtOldUnit.setText("<div style='font: 12pt monospaced'>" + mv.getMechReadout() + "</div>");
+        txtOldUnit.setText("<div style='font: 12pt monospaced'>" + mv.getMechReadout() + "</div>");
         scrOldUnit = new JScrollPane(txtOldUnit);
         scrOldUnit.setMinimumSize(new java.awt.Dimension(300, 400));
-		scrOldUnit.setPreferredSize(new java.awt.Dimension(300, 400));
-		javax.swing.SwingUtilities.invokeLater(new Runnable() {
-			public void run() {
-				scrOldUnit.getVerticalScrollBar().setValue(0);
-			}
-		});
-		gridBagConstraints = new java.awt.GridBagConstraints();
+        scrOldUnit.setPreferredSize(new java.awt.Dimension(300, 400));
+        javax.swing.SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                scrOldUnit.getVerticalScrollBar().setValue(0);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.gridheight = 2;
@@ -185,8 +185,8 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         txtNewUnit.setEditable(false);
         txtNewUnit.setContentType("text/html");
         txtNewUnit.setBorder(BorderFactory.createCompoundBorder(
-	   			 BorderFactory.createTitledBorder(resourceMap.getString("txtNewUnit.title")),
-	   			 BorderFactory.createEmptyBorder(5,5,5,5)));
+                 BorderFactory.createTitledBorder(resourceMap.getString("txtNewUnit.title")),
+                 BorderFactory.createEmptyBorder(5,5,5,5)));
         scrNewUnit = new JScrollPane(txtNewUnit);
         scrNewUnit.setMinimumSize(new java.awt.Dimension(300, 400));
         scrNewUnit.setPreferredSize(new java.awt.Dimension(300, 400));
@@ -201,8 +201,8 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
                 beginRefit();
             }
         });
-		gridBagConstraints = new java.awt.GridBagConstraints();
-		gridBagConstraints.gridx = 0;
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
@@ -217,7 +217,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
             }
         });
         gridBagConstraints = new java.awt.GridBagConstraints();
-		gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
@@ -247,89 +247,89 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
     }
 
     private void beginRefit() {
-    	setVisible(false);
-    	gui.refitUnit(getSelectedRefit(), false);
+        setVisible(false);
+        gui.refitUnit(getSelectedRefit(), false);
     }
 
     private void cancel() {
-    	setVisible(false);
+        setVisible(false);
     }
 
     private Refit getSelectedRefit() {
-    	int selectedRow = refitTable.getSelectedRow();
-    	if(selectedRow < 0) {
-    		return null;
-    	}
-    	return refitModel.getRefitAt(refitTable.convertRowIndexToModel(selectedRow));
+        int selectedRow = refitTable.getSelectedRow();
+        if(selectedRow < 0) {
+            return null;
+        }
+        return refitModel.getRefitAt(refitTable.convertRowIndexToModel(selectedRow));
     }
 
     private void refitTableValueChanged() {
-    	Refit r = getSelectedRefit();
-    	if(null == r) {
-    		scrShoppingList.setViewportView(null);
-    		txtNewUnit.setText("");
-    		btnOK.setEnabled(false);
-    		return;
-    	}
-    	btnOK.setEnabled(true);
-    	lstShopping = new JList<String>(r.getShoppingListDescription());
-    	scrShoppingList.setViewportView(lstShopping);
+        Refit r = getSelectedRefit();
+        if(null == r) {
+            scrShoppingList.setViewportView(null);
+            txtNewUnit.setText("");
+            btnOK.setEnabled(false);
+            return;
+        }
+        btnOK.setEnabled(true);
+        lstShopping = new JList<String>(r.getShoppingListDescription());
+        scrShoppingList.setViewportView(lstShopping);
         MechView mv = new MechView(r.getNewEntity(), false, true);
-		txtNewUnit.setText("<div style='font: 12pt monospaced'>" + mv.getMechReadout() + "</div>");
-		javax.swing.SwingUtilities.invokeLater(new Runnable() {
-			public void run() {
-				scrNewUnit.getVerticalScrollBar().setValue(0);
-			}
-		});
+        txtNewUnit.setText("<div style='font: 12pt monospaced'>" + mv.getMechReadout() + "</div>");
+        javax.swing.SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                scrNewUnit.getVerticalScrollBar().setValue(0);
+            }
+        });
     }
 
 
     private void populateRefits() {
-    	ArrayList<Refit> refits = new ArrayList<Refit>();
+        ArrayList<Refit> refits = new ArrayList<Refit>();
         for(String model : Utilities.getAllVariants(unit.getEntity(), campaign)) {
-			MechSummary summary = MechSummaryCache.getInstance().getMech(unit.getEntity().getChassis() + " " + model);
-			if(null == summary) {
-				continue;
-			}
-			try {
+            MechSummary summary = MechSummaryCache.getInstance().getMech(unit.getEntity().getChassis() + " " + model);
+            if(null == summary) {
+                continue;
+            }
+            try {
                 Entity refitEn = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
-				if(null != refitEn) {
-					Refit r = new Refit(unit, refitEn, false, false);
-					if(null == r.checkFixable()) {
-						refits.add(r);
-					}
-				}
-			} catch (EntityLoadingException ex) {
-			    MekHQ.getLogger().error(getClass(), "populateRefits()", ex); //$NON-NLS-1$
-			}
-		}
+                if(null != refitEn) {
+                    Refit r = new Refit(unit, refitEn, false, false);
+                    if(null == r.checkFixable()) {
+                        refits.add(r);
+                    }
+                }
+            } catch (EntityLoadingException ex) {
+                MekHQ.getLogger().error(getClass(), "populateRefits()", ex); //$NON-NLS-1$
+            }
+        }
         refitModel = new RefitTableModel(refits);
     }
 
     /**
-	 * A table model for displaying parts - similar to the one in CampaignGUI, but not exactly
-	 */
-	public class RefitTableModel extends AbstractTableModel {
-		private static final long serialVersionUID = 534443424190075264L;
+     * A table model for displaying parts - similar to the one in CampaignGUI, but not exactly
+     */
+    public class RefitTableModel extends AbstractTableModel {
+        private static final long serialVersionUID = 534443424190075264L;
 
-		protected String[] columnNames;
-		protected ArrayList<Refit> data;
+        protected String[] columnNames;
+        protected ArrayList<Refit> data;
 
-		public final static int COL_MODEL    =   0;
-		public final static int COL_CLASS    =   1;
-		public final static int COL_BV       =   2;
-		public final static int COL_TIME     =   3;
-		public final static int COL_NPART    =   4;
-		public final static int COL_TARGET   =   5;
-		public final static int COL_COST     =   6;
+        public final static int COL_MODEL    =   0;
+        public final static int COL_CLASS    =   1;
+        public final static int COL_BV       =   2;
+        public final static int COL_TIME     =   3;
+        public final static int COL_NPART    =   4;
+        public final static int COL_TARGET   =   5;
+        public final static int COL_COST     =   6;
 
         public final static int N_COL          = 7;
 
-		public RefitTableModel(ArrayList<Refit> refits) {
-			data = refits;
-		}
+        public RefitTableModel(ArrayList<Refit> refits) {
+            data = refits;
+        }
 
-		public int getRowCount() {
+        public int getRowCount() {
             return data.size();
         }
 
@@ -340,220 +340,205 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         @Override
         public String getColumnName(int column) {
             switch(column) {
-            	case COL_MODEL:
-            		return "Model";
-            	case COL_CLASS:
+                case COL_MODEL:
+                    return "Model";
+                case COL_CLASS:
                     return "Class";
-            	case COL_BV:
+                case COL_BV:
                     return "BV";
-            	case COL_TIME:
+                case COL_TIME:
                     return "Time";
-            	case COL_NPART:
+                case COL_NPART:
                     return "# Parts";
-            	case COL_COST:
+                case COL_COST:
                     return "Cost";
-            	case COL_TARGET:
-            	    return "Kit TN";
+                case COL_TARGET:
+                    return "Kit TN";
                 default:
                     return "?";
             }
         }
 
-		public Object getValueAt(int row, int col) {
-	        Refit r;
-	        if(data.isEmpty()) {
-	        	return "";
-	        } else {
-	        	r = (Refit)data.get(row);
-	        }
-			if(col == COL_MODEL) {
-				return r.getNewEntity().getModel();
-			}
-			if(col == COL_CLASS) {
-				return r.getRefitClassName();
-			}
-			if(col == COL_BV) {
-				return r.getNewEntity().calculateBattleValue(true, true);
-			}
-			if(col == COL_TIME) {
-				return r.getTime();
-			}
-			if(col == COL_NPART) {
-				return r.getShoppingList().size();
-			}
-			if(col == COL_COST) {
-				return r.getCost().toAmountAndSymbolString();
-			}
-			if(col == COL_TARGET) {
-			    return campaign.getTargetForAcquisition(r, campaign.getLogisticsPerson(), false).getValueAsString();
-			}
-			return "?";
-		}
+        public Object getValueAt(int row, int col) {
+            Refit r;
+            if(data.isEmpty()) {
+                return "";
+            } else {
+                r = (Refit)data.get(row);
+            }
+            if(col == COL_MODEL) {
+                return r.getNewEntity().getModel();
+            }
+            if(col == COL_CLASS) {
+                return r.getRefitClassName();
+            }
+            if(col == COL_BV) {
+                return r.getNewEntity().calculateBattleValue(true, true);
+            }
+            if(col == COL_TIME) {
+                return r.getTime();
+            }
+            if(col == COL_NPART) {
+                return r.getShoppingList().size();
+            }
+            if(col == COL_COST) {
+                return r.getCost().toAmountAndSymbolString();
+            }
+            if(col == COL_TARGET) {
+                return campaign.getTargetForAcquisition(r, campaign.getLogisticsPerson(), false).getValueAsString();
+            }
+            return "?";
+        }
 
-		@Override
-		public boolean isCellEditable(int row, int col) {
-			return false;
-		}
+        @Override
+        public boolean isCellEditable(int row, int col) {
+            return false;
+        }
 
-		@Override
-		public Class<?> getColumnClass(int c) {
-			return getValueAt(0, c).getClass();
-		}
+        @Override
+        public Class<?> getColumnClass(int c) {
+            return getValueAt(0, c).getClass();
+        }
 
-		public Refit getRefitAt(int row) {
-			return (Refit) data.get(row);
-		}
+        public Refit getRefitAt(int row) {
+            return (Refit) data.get(row);
+        }
 
-		 public int getColumnWidth(int c) {
-	            switch(c) {
-	            case COL_MODEL:
-	            	return 75;
-	            case COL_CLASS:
-	            	return 110;
-	            case COL_COST:
-	            	return 40;
-	            default:
-	                return 10;
-	            }
-		 }
+         public int getColumnWidth(int c) {
+                switch(c) {
+                case COL_MODEL:
+                    return 75;
+                case COL_CLASS:
+                    return 110;
+                case COL_COST:
+                    return 40;
+                default:
+                    return 10;
+                }
+         }
 
-		 public int getAlignment(int col) {
-			 switch(col) {
-			 case COL_MODEL:
-			 case COL_CLASS:
-				 return SwingConstants.LEFT;
-			 default:
-				 return SwingConstants.RIGHT;
-			 }
-		 }
+         public int getAlignment(int col) {
+             switch(col) {
+             case COL_MODEL:
+             case COL_CLASS:
+                 return SwingConstants.LEFT;
+             default:
+                 return SwingConstants.RIGHT;
+             }
+         }
 
-		 public String getTooltip(int row, int col) {
-		     Refit r;
-		     if(data.isEmpty()) {
-		         return "";
-		     } else {
-		         r = (Refit)data.get(row);
-		     }
-			 switch(col) {
-			 case COL_TARGET:
-			     return campaign.getTargetForAcquisition(r, campaign.getLogisticsPerson(), false).getDesc();
-			 default:
-				 return null;
-			 }
-		 }
+         public String getTooltip(int row, int col) {
+             Refit r;
+             if(data.isEmpty()) {
+                 return "";
+             } else {
+                 r = (Refit)data.get(row);
+             }
+             switch(col) {
+             case COL_TARGET:
+                 return campaign.getTargetForAcquisition(r, campaign.getLogisticsPerson(), false).getDesc();
+             default:
+                 return null;
+             }
+         }
 
-		 //fill table with values
-		 public void setData(ArrayList<Refit> refits) {
-			 data = refits;
-			 fireTableDataChanged();
-		 }
+         //fill table with values
+         public void setData(ArrayList<Refit> refits) {
+             data = refits;
+             fireTableDataChanged();
+         }
 
-		 public RefitTableModel.Renderer getRenderer() {
-			 return new RefitTableModel.Renderer();
-		 }
+         public RefitTableModel.Renderer getRenderer() {
+             return new RefitTableModel.Renderer();
+         }
 
-		 public class Renderer extends DefaultTableCellRenderer {
+         public class Renderer extends DefaultTableCellRenderer {
 
-			private static final long serialVersionUID = -6655108546652975061L;
+            private static final long serialVersionUID = -6655108546652975061L;
 
-			public Component getTableCellRendererComponent(JTable table,
-					Object value, boolean isSelected, boolean hasFocus,
-					int row, int column) {
-				super.getTableCellRendererComponent(table, value, isSelected,
-						hasFocus, row, column);
-				setOpaque(true);
-				int actualCol = table.convertColumnIndexToModel(column);
-				int actualRow = table.convertRowIndexToModel(row);
-				setHorizontalAlignment(getAlignment(actualCol));
-				setToolTipText(getTooltip(actualRow, actualCol));
+            public Component getTableCellRendererComponent(JTable table,
+                    Object value, boolean isSelected, boolean hasFocus,
+                    int row, int column) {
+                super.getTableCellRendererComponent(table, value, isSelected,
+                        hasFocus, row, column);
+                setOpaque(true);
+                int actualCol = table.convertColumnIndexToModel(column);
+                int actualRow = table.convertRowIndexToModel(row);
+                setHorizontalAlignment(getAlignment(actualCol));
+                setToolTipText(getTooltip(actualRow, actualCol));
 
-				return this;
-			}
+                return this;
+            }
 
-		 }
-	}
+         }
+    }
 
-	/**
-	 * A comparator for numbers that have been formatted with DecimalFormat
-	 * @author Jay Lawson
-	 *
-	 */
-	public class FormattedNumberSorter implements Comparator<String> {
-
-		@Override
-		public int compare(String s0, String s1) {
-			//lets find the weight class integer for each name
-			DecimalFormat format = new DecimalFormat();
-			int l0 = 0;
-			try {
-				l0 = format.parse(s0).intValue();
-			} catch (java.text.ParseException e) {
+    /**
+     * A comparator for numbers that have been formatted with DecimalFormat
+     * @author Jay Lawson
+     */
+    public static class FormattedNumberSorter implements Comparator<String> {
+        @Override
+        public int compare(String s0, String s1) {
+            //lets find the weight class integer for each name
+            DecimalFormat format = new DecimalFormat();
+            int l0 = 0;
+            try {
+                l0 = format.parse(s0).intValue();
+            } catch (ParseException e) {
                 MekHQ.getLogger().error(getClass(), "compare", e);
-			}
-			int l1 = 0;
-			try {
-				l1 = format.parse(s1).intValue();
-			} catch (java.text.ParseException e) {
+            }
+            int l1 = 0;
+            try {
+                l1 = format.parse(s1).intValue();
+            } catch (ParseException e) {
                 MekHQ.getLogger().error(getClass(), "compare", e);
-			}
-			return ((Comparable<Integer>)l0).compareTo(l1);
-		}
-	}
+            }
+            return ((Comparable<Integer>) l0).compareTo(l1);
+        }
+    }
 
-	/**
-	 * A comparator for refit classes
-	 * @author Jay Lawson
-	 *
-	 */
-	public class ClassSorter implements Comparator<String> {
-
-		@Override
-		public int compare(String s0, String s1) {
-			int r0 = Refit.NO_CHANGE;
-			int r1 = Refit.NO_CHANGE;
-			if(s0.contains("Omni")) {
-				r0 = Refit.CLASS_OMNI;
-			}
-			else if(s0.contains("Class A")) {
-				r0 = Refit.CLASS_A;
-			}
-			else if(s0.contains("Class B")) {
-				r0 = Refit.CLASS_B;
-			}
-			else if(s0.contains("Class C")) {
-				r0 = Refit.CLASS_C;
-			}
-			else if(s0.contains("Class D")) {
-				r0 = Refit.CLASS_D;
-			}
-			else if(s0.contains("Class E")) {
-				r0 = Refit.CLASS_E;
-			}
-			else if(s0.contains("Class F")) {
-				r0 = Refit.CLASS_F;
-			}
-			if(s1.contains("Omni")) {
-				r1 = Refit.CLASS_OMNI;
-			}
-			else if(s1.contains("Class A")) {
-				r1 = Refit.CLASS_A;
-			}
-			else if(s1.contains("Class B")) {
-				r1 = Refit.CLASS_B;
-			}
-			else if(s1.contains("Class C")) {
-				r1 = Refit.CLASS_C;
-			}
-			else if(s1.contains("Class D")) {
-				r1 = Refit.CLASS_D;
-			}
-			else if(s1.contains("Class E")) {
-				r1 = Refit.CLASS_E;
-			}
-			else if(s1.contains("Class F")) {
-				r1 = Refit.CLASS_F;
-			}
-			return ((Comparable<Integer>)r0).compareTo(r1);
-		}
-	}
+    /**
+     * A comparator for refit classes
+     * @author Jay Lawson
+     *
+     */
+    public static class ClassSorter implements Comparator<String> {
+        @Override
+        public int compare(String s0, String s1) {
+            int r0 = Refit.NO_CHANGE;
+            int r1 = Refit.NO_CHANGE;
+            if (s0.contains("Omni")) {
+                r0 = Refit.CLASS_OMNI;
+            } else if (s0.contains("Class A")) {
+                r0 = Refit.CLASS_A;
+            } else if (s0.contains("Class B")) {
+                r0 = Refit.CLASS_B;
+            } else if (s0.contains("Class C")) {
+                r0 = Refit.CLASS_C;
+            } else if (s0.contains("Class D")) {
+                r0 = Refit.CLASS_D;
+            } else if (s0.contains("Class E")) {
+                r0 = Refit.CLASS_E;
+            } else if (s0.contains("Class F")) {
+                r0 = Refit.CLASS_F;
+            }
+            if (s1.contains("Omni")) {
+                r1 = Refit.CLASS_OMNI;
+            } else if (s1.contains("Class A")) {
+                r1 = Refit.CLASS_A;
+            } else if (s1.contains("Class B")) {
+                r1 = Refit.CLASS_B;
+            } else if (s1.contains("Class C")) {
+                r1 = Refit.CLASS_C;
+            } else if (s1.contains("Class D")) {
+                r1 = Refit.CLASS_D;
+            } else if (s1.contains("Class E")) {
+                r1 = Refit.CLASS_E;
+            } else if (s1.contains("Class F")) {
+                r1 = Refit.CLASS_F;
+            }
+            return ((Comparable<Integer>) r0).compareTo(r1);
+        }
+    }
 }

--- a/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
@@ -1,20 +1,20 @@
 /*
  * ChooseRefitDialog.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -70,7 +70,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
     private Unit unit;
     private RefitTableModel refitModel;
     private CampaignGUI gui;
-    
+
     private javax.swing.JButton btnClose;
     private javax.swing.JButton btnOK;
     private JTable refitTable;
@@ -81,7 +81,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
     private JTextPane txtNewUnit;
     private JScrollPane scrOldUnit;
     private JScrollPane scrNewUnit;
-    
+
     /** Creates new form EditPersonnelLogDialog */
     public ChooseRefitDialog(java.awt.Frame parent, boolean modal, Campaign c, Unit u, CampaignGUI gui) {
         super(parent, modal);
@@ -93,17 +93,17 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         setLocationRelativeTo(parent);
         setUserPreferences();
     }
-    
+
     private void initComponents() {
-    	
+
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ChooseRefitDialog", new EncodeControl()); //$NON-NLS-1$
 
         setTitle(resourceMap.getString("title.text") + " " + unit.getName());
-        
+
     	GridBagConstraints gridBagConstraints;
     	getContentPane().setLayout(new GridBagLayout());
-    	
+
     	refitTable = new JTable(refitModel);
 		TableColumn column = null;
         for (int i = 0; i < RefitTableModel.N_COL; i++) {
@@ -120,7 +120,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 							javax.swing.event.ListSelectionEvent evt) {
 						refitTableValueChanged();
 					}
-				});       
+				});
         TableRowSorter<RefitTableModel> refitSorter = new TableRowSorter<RefitTableModel>(refitModel);
         refitSorter.setComparator(RefitTableModel.COL_CLASS, new ClassSorter());
         refitSorter.setComparator(RefitTableModel.COL_COST, new FormattedNumberSorter());
@@ -137,7 +137,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         getContentPane().add(scrRefitTable, gridBagConstraints);
-        
+
         scrShoppingList = new JScrollPane();
         scrShoppingList.setBorder(BorderFactory.createCompoundBorder(
 	   			 BorderFactory.createTitledBorder(resourceMap.getString("shoppingList.title")),
@@ -153,7 +153,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         scrShoppingList.setMinimumSize(new java.awt.Dimension(300, 200));
 		scrShoppingList.setPreferredSize(new java.awt.Dimension(300, 200));
         getContentPane().add(scrShoppingList, gridBagConstraints);
-        
+
         txtOldUnit = new JTextPane();
         txtOldUnit.setEditable(false);
         txtOldUnit.setContentType("text/html");
@@ -166,7 +166,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         scrOldUnit.setMinimumSize(new java.awt.Dimension(300, 400));
 		scrOldUnit.setPreferredSize(new java.awt.Dimension(300, 400));
 		javax.swing.SwingUtilities.invokeLater(new Runnable() {
-			public void run() { 
+			public void run() {
 				scrOldUnit.getVerticalScrollBar().setValue(0);
 			}
 		});
@@ -180,7 +180,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         getContentPane().add(scrOldUnit, gridBagConstraints);
-        
+
         txtNewUnit = new JTextPane();
         txtNewUnit.setEditable(false);
         txtNewUnit.setContentType("text/html");
@@ -192,7 +192,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         scrNewUnit.setPreferredSize(new java.awt.Dimension(300, 400));
         gridBagConstraints.gridx = 2;
         getContentPane().add(scrNewUnit, gridBagConstraints);
-        
+
         JPanel panBtn = new JPanel(new GridBagLayout());
         btnOK = new JButton(resourceMap.getString("btnOK.text")); // NOI18N
         btnOK.setEnabled(false);
@@ -209,7 +209,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panBtn.add(btnOK, gridBagConstraints);
-        
+
         btnClose = new JButton(resourceMap.getString("btnClose.text")); // NOI18N
         btnClose.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -224,7 +224,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panBtn.add(btnClose, gridBagConstraints);
-        
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 2;
@@ -235,7 +235,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         getContentPane().add(panBtn, gridBagConstraints);
-        
+
         pack();
     }
 
@@ -250,11 +250,11 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
     	setVisible(false);
     	gui.refitUnit(getSelectedRefit(), false);
     }
-    
+
     private void cancel() {
     	setVisible(false);
     }
-    
+
     private Refit getSelectedRefit() {
     	int selectedRow = refitTable.getSelectedRow();
     	if(selectedRow < 0) {
@@ -262,7 +262,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
     	}
     	return refitModel.getRefitAt(refitTable.convertRowIndexToModel(selectedRow));
     }
-    
+
     private void refitTableValueChanged() {
     	Refit r = getSelectedRefit();
     	if(null == r) {
@@ -277,13 +277,13 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
         MechView mv = new MechView(r.getNewEntity(), false, true);
 		txtNewUnit.setText("<div style='font: 12pt monospaced'>" + mv.getMechReadout() + "</div>");
 		javax.swing.SwingUtilities.invokeLater(new Runnable() {
-			public void run() { 
+			public void run() {
 				scrNewUnit.getVerticalScrollBar().setValue(0);
 			}
 		});
     }
-    
-    
+
+
     private void populateRefits() {
     	ArrayList<Refit> refits = new ArrayList<Refit>();
         for(String model : Utilities.getAllVariants(unit.getEntity(), campaign)) {
@@ -301,11 +301,11 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 				}
 			} catch (EntityLoadingException ex) {
 			    MekHQ.getLogger().error(getClass(), "populateRefits()", ex); //$NON-NLS-1$
-			}		
+			}
 		}
         refitModel = new RefitTableModel(refits);
     }
-    
+
     /**
 	 * A table model for displaying parts - similar to the one in CampaignGUI, but not exactly
 	 */
@@ -324,11 +324,11 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 		public final static int COL_COST     =   6;
 
         public final static int N_COL          = 7;
-		
+
 		public RefitTableModel(ArrayList<Refit> refits) {
 			data = refits;
 		}
-		
+
 		public int getRowCount() {
             return data.size();
         }
@@ -389,12 +389,12 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 			}
 			return "?";
 		}
-		
+
 		@Override
 		public boolean isCellEditable(int row, int col) {
 			return false;
 		}
-		
+
 		@Override
 		public Class<?> getColumnClass(int c) {
 			return getValueAt(0, c).getClass();
@@ -403,7 +403,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 		public Refit getRefitAt(int row) {
 			return (Refit) data.get(row);
 		}
-		
+
 		 public int getColumnWidth(int c) {
 	            switch(c) {
 	            case COL_MODEL:
@@ -416,7 +416,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 	                return 10;
 	            }
 		 }
-	        
+
 		 public int getAlignment(int col) {
 			 switch(col) {
 			 case COL_MODEL:
@@ -441,13 +441,13 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 				 return null;
 			 }
 		 }
-	        
+
 		 //fill table with values
 		 public void setData(ArrayList<Refit> refits) {
 			 data = refits;
 			 fireTableDataChanged();
 		 }
-	        
+
 		 public RefitTableModel.Renderer getRenderer() {
 			 return new RefitTableModel.Renderer();
 		 }
@@ -466,13 +466,13 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 				int actualRow = table.convertRowIndexToModel(row);
 				setHorizontalAlignment(getAlignment(actualCol));
 				setToolTipText(getTooltip(actualRow, actualCol));
-					
+
 				return this;
 			}
 
 		 }
 	}
-	
+
 	/**
 	 * A comparator for numbers that have been formatted with DecimalFormat
 	 * @author Jay Lawson
@@ -481,41 +481,39 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 	public class FormattedNumberSorter implements Comparator<String> {
 
 		@Override
-		public int compare(String s0, String s1) {	
+		public int compare(String s0, String s1) {
 			//lets find the weight class integer for each name
 			DecimalFormat format = new DecimalFormat();
 			int l0 = 0;
 			try {
 				l0 = format.parse(s0).intValue();
 			} catch (java.text.ParseException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "compare", e);
 			}
 			int l1 = 0;
 			try {
 				l1 = format.parse(s1).intValue();
 			} catch (java.text.ParseException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "compare", e);
 			}
-			return ((Comparable<Integer>)l0).compareTo(l1);		
+			return ((Comparable<Integer>)l0).compareTo(l1);
 		}
 	}
-	
+
 	/**
-	 * A comparator for refit classes 
+	 * A comparator for refit classes
 	 * @author Jay Lawson
 	 *
 	 */
 	public class ClassSorter implements Comparator<String> {
 
 		@Override
-		public int compare(String s0, String s1) {	
+		public int compare(String s0, String s1) {
 			int r0 = Refit.NO_CHANGE;
 			int r1 = Refit.NO_CHANGE;
 			if(s0.contains("Omni")) {
 				r0 = Refit.CLASS_OMNI;
-			} 
+			}
 			else if(s0.contains("Class A")) {
 				r0 = Refit.CLASS_A;
 			}
@@ -536,7 +534,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 			}
 			if(s1.contains("Omni")) {
 				r1 = Refit.CLASS_OMNI;
-			} 
+			}
 			else if(s1.contains("Class A")) {
 				r1 = Refit.CLASS_A;
 			}
@@ -555,7 +553,7 @@ public class ChooseRefitDialog extends javax.swing.JDialog {
 			else if(s1.contains("Class F")) {
 				r1 = Refit.CLASS_F;
 			}
-			return ((Comparable<Integer>)r0).compareTo(r1);		
+			return ((Comparable<Integer>)r0).compareTo(r1);
 		}
 	}
 }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -589,7 +589,6 @@ public class CustomizeAtBContractDialog extends JDialog {
             Image camo = (Image) camos.getItem(camoCategory, camoFileName);
             btnCamo.setIcon(new ImageIcon(camo));
         } catch (Exception err) {
-            //err.printStackTrace();
         	JOptionPane.showMessageDialog(
         			this,
         			"Cannot find your camo file.\n"

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -139,30 +139,30 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
             setProgress(0);
             try {
                 Faction.generateFactions();
-            } catch (Exception ex) {
-                ex.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
             }
             try{
                 CurrencyManager.getInstance().loadCurrencies();
-            } catch (Exception ex) {
-                MekHQ.getLogger().error(DataLoadingDialog.class, METHOD_NAME, ex);
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
             }
             try {
                 Bloodname.loadBloodnameData();
-            } catch (Exception ex) {
-                ex.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
             }
             try {
                 //Load values needed for CampaignOptionsDialog
                 RATManager.populateCollectionNames();
-            } catch (Exception ex) {
-                ex.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
             }
             while (!Systems.getInstance().isInitialized()) {
                 //Sleep for up to one second.
                 try {
                     Thread.sleep(50);
-                } catch (InterruptedException ignore) {
+                } catch (InterruptedException ignored) {
 
                 }
             }
@@ -171,14 +171,14 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
             try {
                 QuirksHandler.initQuirksList();
             } catch (IOException e) {
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
             }
             while (!MechSummaryCache.getInstance().isInitialized()) {
                 //Sleep for up to one second.
                 try {
                     Thread.sleep(50);
-                } catch (InterruptedException ignore) {
-                    ignore.printStackTrace();
+                } catch (InterruptedException e) {
+                    MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                 }
             }
             setProgress(2);
@@ -194,8 +194,7 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
                     InjuryTypes.registerAll();
                     campaign.setApp(app);
                 } catch (Exception e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                    MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                 }
             } else {
                 MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO,
@@ -211,28 +210,35 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
                     campaign.restore();
                     campaign.cleanUp();
                     fis.close();
-                } catch (NullEntityException ex) {
+                } catch (NullEntityException e) {
                     JOptionPane.showMessageDialog(null,
-                            "The following units could not be loaded by the campaign:\n" + ex.getError() + "\n\nPlease be sure to copy over any custom units before starting a new version of MekHQ.\nIf you believe the units listed are not customs, then try deleting the file data/mechfiles/units.cache and restarting MekHQ.\nIt is also possible that unit chassi and model names have changed across versions of MegaMek. You can check this by\nopening up MegaMek and searching for the units. Chassis and models can be edited in your MekHQ save file with a text editor." ,
+                            "The following units could not be loaded by the campaign:\n"
+                                    + e.getError() + "\n\nPlease be sure to copy over any custom units"
+                                    + "before starting a new version of MekHQ.\nIf you believe the units"
+                                    + "listed are not customs, then try deleting the file data/mechfiles/units.cache"
+                                    + "and restarting MekHQ.\nIt is also possible that unit chassi"
+                                    + "and model names have changed across versions of MegaMek."
+                                    + "You can check this by\nopening up MegaMek and searching for the units."
+                                    + "Chassis and models can be edited in your MekHQ save file with a text editor.",
                             "Unit Loading Error",
                             JOptionPane.ERROR_MESSAGE);
                     cancelled = true;
                     cancel(true);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
+                } catch (Exception e) {
+                    MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
                     JOptionPane.showMessageDialog(null,
                             "The campaign file could not be loaded.\nPlease check the log file for details.",
                             "Campaign Loading Error",
                             JOptionPane.ERROR_MESSAGE);
-                    //setVisible(false);
                     cancelled = true;
                     cancel(true);
-                } catch(OutOfMemoryError e) {
+                } catch (OutOfMemoryError e) {
                     JOptionPane.showMessageDialog(null,
-                            "MekHQ ran out of memory attempting to load the campaign file. \nTry increasing the memory allocated to MekHQ and reloading.\nSee the FAQ at http://megamek.org for details.",
+                            "MekHQ ran out of memory attempting to load the campaign file."
+                                    + "\nTry increasing the memory allocated to MekHQ and reloading."
+                                    + "\nSee the FAQ at http://megamek.org for details.",
                             "Not Enough Memory",
                             JOptionPane.ERROR_MESSAGE);
-                    //setVisible(false);
                     cancelled = true;
                     cancel(true);
                 }

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -43,26 +43,26 @@ import mekhq.preferences.PreferencesNode;
 /**
  * Hovanes Gambaryan Henry Demirchian CSUN, CS 585 Professor Mike Barnes
  * December 06, 2000
- * 
+ *
  * DateChooser class is a general GUI based date chooser. It allows the user to
  * select an instance of GregorianCalendar defined in java.util package.
- * 
+ *
  * Programming API is similar to JFC's JColorChooser or JFileChooser. This class
  * can be used in any application to enable the user to select a date from a
  * visually displayed calendar.
- * 
+ *
  * There is a lot of improvements that can be done over this class in areas of
  * functionality, usability, and appearance. But as is, the class can be easily
  * used from within any Java program.
- * 
+ *
  * Typical usage is like:
- * 
+ *
  * // initial date GregorianCalendar date = new GregorianCalendar()
- * 
+ *
  * // The owner is the JFrame of the application ("AppClass.this")
- * 
+ *
  * // show the date chooser DateChooser dc = new DateChooser(owner, date);
- * 
+ *
  * // user can eiter choose a date or cancel by closing if (dc.showDateChooser()
  * == DateChooser.OK_OPTION) { date = dc.getDate(); }
  */
@@ -72,8 +72,8 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
     public static final int OK_OPTION = 1;
     public static final int CANCEL_OPTION = 2;
 
-    private final DateFormat MMDDYYYY = new SimpleDateFormat("MM/dd/yyyy");
-    private final DateFormat ISO8601 = new SimpleDateFormat("yyyy-MM-dd");
+    private final DateFormat MMDDYYYY = new SimpleDateFormat("MM/dd/yyyy"); // TODO : remove inline date
+    private final DateFormat ISO8601 = new SimpleDateFormat("yyyy-MM-dd"); // TODO : remove inline date
 
     private static final ArrayList<String> monthNames;
     static {
@@ -101,10 +101,10 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
 
     // Stores the user-input date.
     private JFormattedTextField dateField = null;
-    
+
     /**
      * Constructor for DateChooser
-     * 
+     *
      * @param owner
      *            JFrame instance, owner of DateChooser dialog
      * @param d
@@ -115,7 +115,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         super(owner, "Date Chooser", true);
         date = d;
         workingDate = date;
-        
+
         // Ensure the dialog isn't hidden
         setAlwaysOnTop(true);
 
@@ -231,7 +231,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
 
     /**
      * Action handler for this dialog, which handles all the button presses.
-     * 
+     *
      * @param evt
      *            ActionEvent
      */
@@ -254,7 +254,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
             try {
                 y = Integer.parseInt(yearLabel.getText());
             } catch (NumberFormatException e) {
-                System.err.println(e.toString());
+                MekHQ.getLogger().error(getClass(), "actionPerformed", e);
             }
             yearLabel.setText(String.valueOf(--y));
             updateDayGrid(false);
@@ -263,7 +263,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
             try {
                 y = Integer.parseInt(yearLabel.getText());
             } catch (NumberFormatException e) {
-                System.err.println(e.toString());
+                MekHQ.getLogger().error(getClass(), "actionPerformed", e);
             }
             yearLabel.setText(String.valueOf(++y));
             updateDayGrid(false);
@@ -275,7 +275,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
                 y = Integer.parseInt(yearLabel.getText());
                 d = Integer.parseInt(label);
             } catch (NumberFormatException e) {
-                System.err.println(e.toString());
+                MekHQ.getLogger().error(getClass(), "actionPerformed", e);
             }
             date = new GregorianCalendar(y, m, d);
             date.setLenient(false);
@@ -329,7 +329,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         try {
             y = Integer.parseInt(yearLabel.getText());
         } catch (NumberFormatException e) {
-            System.err.println(e.toString());
+            MekHQ.getLogger().error(getClass(), "updateDayGrid", e);
         }
 
         // look at the first day of the month for this month
@@ -411,7 +411,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
     /**
      * Return the month following the one passed in as an argument. If the
      * argument is the las month of the year, return the first month.
-     * 
+     *
      * @param month
      *            Current month expressed as an integer (0 to 11).
      */
@@ -425,7 +425,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
     /**
      * Return the month preceding the one passed in as an argument. If the
      * argument is the first month of the year, return the last month.
-     * 
+     *
      * @param month
      *            Current month expressed as an integer (0 to 11).
      */
@@ -445,7 +445,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         try {
             y = Integer.parseInt(yearLabel.getText());
         } catch (NumberFormatException e) {
-            System.err.println(e.toString());
+            MekHQ.getLogger().error(getClass(), "getLastDay", e);
         }
 
         if ((m == 4) || (m == 6) || (m == 9) || (m == 11)) {

--- a/MekHQ/src/mekhq/gui/dialog/EditTransactionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditTransactionDialog.java
@@ -36,7 +36,7 @@ import mekhq.preferences.PreferencesNode;
 public class EditTransactionDialog extends JDialog implements ActionListener, FocusListener, MouseListener {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -8742160448355293487L;
 
@@ -192,8 +192,8 @@ public class EditTransactionDialog extends JDialog implements ActionListener, Fo
             newTransaction.setDescription(descriptionField.getText());
             try {
                 newTransaction.setDate(LONG_DATE.parse(dateButton.getText()));
-            } catch (ParseException e1) {
-                e1.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
+            } catch (ParseException ex) {
+                MekHQ.getLogger().error(getClass(), "actionPerformed", ex);
             }
             setVisible(false);
         } else if (cancelButton.equals(e.getSource())) {

--- a/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
@@ -777,13 +777,12 @@ public class ImageChoiceDialog extends JDialog {
                     }
                 }
                 lblImage.setIcon(new ImageIcon(image));
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "setImage", e);
             }
         }
         // Variables declaration - do not modify//GEN-BEGIN:variables
         private JLabel lblImage;
         // End of variables declaration//GEN-END:variables
-
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/LaunchGameDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LaunchGameDialog.java
@@ -53,7 +53,7 @@ public class LaunchGameDialog extends JDialog implements ActionListener {
         initComponents();
         setUserPreferences();
     }
-    
+
     public void initComponents() {
     	yourNameL = new JLabel(
                 Messages.getString("MegaMek.yourNameL"), SwingConstants.RIGHT); //$NON-NLS-1$
@@ -145,9 +145,9 @@ public class LaunchGameDialog extends JDialog implements ActionListener {
                 if (!server) {
                 	serverAddr = serverAddrF.getText();
                 }
-                port = Integer.decode(portF.getText().trim()).intValue();
+                port = Integer.decode(portF.getText().trim());
             } catch (NumberFormatException ex) {
-                System.err.println(ex.getMessage());
+                MekHQ.getLogger().error(getClass(), "actionPerformed", ex.getMessage());
             }
         } else {
             cancelled = true;

--- a/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
@@ -41,8 +41,8 @@ public class MekHqOptionsDialog extends BaseDialog {
     private JCheckBox checkSaveBeforeMissions;
     private JSpinner spinnerSavedGamesCount;
 
-    public MekHqOptionsDialog(JFrame parent, MMLogger logger) {
-        super(parent, logger);
+    public MekHqOptionsDialog(JFrame parent) {
+        super(parent);
 
         this.initialize(resources);
         this.setInitialState();

--- a/MekHQ/src/mekhq/gui/dialog/MercRosterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MercRosterDialog.java
@@ -47,17 +47,17 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
     private JPasswordField txtPasswd;
     private JButton btnUpload;
     private JButton btnCancel;
-    
+
     private ProgressMonitor progressMonitor;
     private MercRosterAccess access;
-    
+
     private static final long serialVersionUID = 8376874926997734492L;
     /** Creates new form */
     public MercRosterDialog(java.awt.Frame parent, boolean modal, Campaign c) {
         super(parent, modal);
         frame = parent;
         this.campaign = c;
-        initComponents();      
+        initComponents();
         this.setLocationRelativeTo(parent);
         setUserPreferences();
     }
@@ -78,11 +78,11 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form"); // NOI18N
         setTitle(resourceMap.getString("Form.title"));
-        
+
         getContentPane().setLayout(new GridBagLayout());
-      
+
         GridBagConstraints gbc = new GridBagConstraints();
-        
+
         gbc.gridx = 0;
         gbc.gridy = 0;
         gbc.fill = GridBagConstraints.NONE;
@@ -91,12 +91,12 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
         gbc.insets = new Insets(5,5,5,5);
         gbc.anchor = GridBagConstraints.WEST;
         getContentPane().add(new JLabel(resourceMap.getString("lblAddress.text")), gbc);
-        
+
         gbc.gridx = 1;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         getContentPane().add(txtAddress, gbc);
-        
+
         gbc.gridx = 0;
         gbc.gridy = 1;
         gbc.fill = GridBagConstraints.NONE;
@@ -107,7 +107,7 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         getContentPane().add(txtPort, gbc);
-        
+
         gbc.gridx = 0;
         gbc.gridy = 2;
         gbc.fill = GridBagConstraints.NONE;
@@ -118,7 +118,7 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         getContentPane().add(txtTable, gbc);
-        
+
         gbc.gridx = 0;
         gbc.gridy = 3;
         gbc.fill = GridBagConstraints.NONE;
@@ -129,7 +129,7 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         getContentPane().add(txtUser, gbc);
-        
+
         gbc.gridx = 0;
         gbc.gridy = 4;
         gbc.fill = GridBagConstraints.NONE;
@@ -140,23 +140,23 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         getContentPane().add(txtPasswd, gbc);
-        
+
         JPanel panButtons = new JPanel(new GridLayout(0,2));
         panButtons.add(btnUpload);
         panButtons.add(btnCancel);
-        
+
         btnUpload.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 upload();
             }
         });
-        
+
         btnCancel.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 setVisible(false);
             }
         });
-        
+
         gbc.gridx = 0;
         gbc.gridy = 5;
         gbc.gridwidth = 2;
@@ -165,7 +165,7 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
         gbc.weighty = 1.0;
         gbc.anchor = GridBagConstraints.NORTH;
         getContentPane().add(panButtons, gbc);
-        
+
         pack();
     }
 
@@ -193,15 +193,15 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
                     "Could not connect to the mysql database. Check your entries and confirm\n" +
                     "that you can connect to the database remotely.",
                     "Could not connect",
-                    JOptionPane.ERROR_MESSAGE); 
-            e.printStackTrace();
+                    JOptionPane.ERROR_MESSAGE);
+            MekHQ.getLogger().error(getClass(), "upload", e);
             return;
-        }       
+        }
         access.addPropertyChangeListener(this);
         access.execute();
         setVisible(false);
     }
-    
+
     @Override
     public void propertyChange(PropertyChangeEvent arg0) {
         progressMonitor.setProgress(access.getProgress());
@@ -209,7 +209,7 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
         if (progressMonitor.isCanceled()) {
             access.cancel(true);
             access.close();
-        } 
+        }
         if (access.isDone()) {
             //nothing
         }

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -562,16 +562,20 @@ public class NewAtBContractDialog extends NewContractDialog {
             contract.setStartDate(null);
             needUpdatePayment = true;
         } else if (source.equals(cbEmployer)) {
-        	System.out.println("Setting employer code to " + getCurrentEmployerCode());
+        	MekHQ.getLogger().info(getClass(), "doUpdateContract",
+                    "Setting employer code to " + getCurrentEmployerCode());
         	long time = System.currentTimeMillis();
     		contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
-    		System.out.println("to set employer code: " + (System.currentTimeMillis() - time));
+            MekHQ.getLogger().info(getClass(), "doUpdateContract",
+                    "to set employer code: " + (System.currentTimeMillis() - time));
         	time = System.currentTimeMillis();
     		updateEnemies();
-    		System.out.println("to update enemies: " + (System.currentTimeMillis() - time));
+            MekHQ.getLogger().info(getClass(), "doUpdateContract",
+                    "to update enemies: " + (System.currentTimeMillis() - time));
         	time = System.currentTimeMillis();
     		updatePlanets();
-    		System.out.println("to update planets: " + (System.currentTimeMillis() - time));
+            MekHQ.getLogger().info(getClass(), "doUpdateContract",
+                    "to update planets: " + (System.currentTimeMillis() - time));
     		needUpdatePayment = true;
      	} else if (source.equals(cbEnemy)) {
     		contract.setEnemyCode(getCurrentEnemyCode());

--- a/MekHQ/src/mekhq/gui/dialog/UnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnitSelectorDialog.java
@@ -546,7 +546,7 @@ public class UnitSelectorDialog extends JDialog {
         try {
             mechView = new MechView(selectedUnit.getEntity(), false, true);
         } catch (Exception e) {
-            e.printStackTrace();
+            MekHQ.getLogger().error(getClass(), "refreshUnitView", e);
             // error unit didn't load right. this is bad news.
             populateTextFields = false;
         }
@@ -582,7 +582,7 @@ public class UnitSelectorDialog extends JDialog {
 
         // break out if there are no units to filter
         if (mechs == null) {
-            System.err.println("No units to filter!");
+            MekHQ.getLogger().error(getClass(), "setMechs", "No units to filter!");
         } else {
             unitModel.setData(mechs);
         }
@@ -751,7 +751,7 @@ public class UnitSelectorDialog extends JDialog {
      * @author Jay Lawson
      *
      */
-    public class FormattedNumberSorter implements Comparator<String> {
+    public static class FormattedNumberSorter implements Comparator<String> {
         @Override
         public int compare(String s0, String s1) {
             DecimalFormat format = new DecimalFormat();
@@ -759,13 +759,13 @@ public class UnitSelectorDialog extends JDialog {
             try {
                 l0 = format.parse(s0).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "FormattedNumberSorter", e);
             }
             double l1 = 0;
             try {
                 l1 = format.parse(s1).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "FormattedNumberSorter", e);
             }
             return ((Comparable<Double>)l0).compareTo(l1);
         }

--- a/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
+++ b/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
@@ -4,6 +4,7 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
 import java.util.StringTokenizer;
 import java.util.UUID;
 
@@ -89,9 +90,9 @@ public class TOETransferHandler extends TransferHandler {
                 force = gui.getCampaign().getForce(Integer.parseInt(id));
             }
         } catch (UnsupportedFlavorException ufe) {
-            System.out.println("UnsupportedFlavor: " + ufe.getMessage());
-        } catch (java.io.IOException ioe) {
-            System.out.println("I/O error: " + ioe.getMessage());
+            MekHQ.getLogger().error(getClass(), "canImport", "UnsupportedFlavor: " + ufe.getMessage());
+        } catch (IOException ioe) {
+            MekHQ.getLogger().error(getClass(), "canImport", "I/O error: " + ioe.getMessage());
         }
         // Do not allow a drop on the drag source selections.
         JTree.DropLocation dl = (JTree.DropLocation) support
@@ -142,9 +143,9 @@ public class TOETransferHandler extends TransferHandler {
                 force = gui.getCampaign().getForce(Integer.parseInt(id));
             }
         } catch (UnsupportedFlavorException ufe) {
-            System.out.println("UnsupportedFlavor: " + ufe.getMessage());
-        } catch (java.io.IOException ioe) {
-            System.out.println("I/O error: " + ioe.getMessage());
+            MekHQ.getLogger().error(getClass(), "importData", "UnsupportedFlavor: " + ufe.getMessage());
+        } catch (IOException ioe) {
+            MekHQ.getLogger().error(getClass(), "importData", "I/O error: " + ioe.getMessage());
         }
         // Get drop location info.
         JTree.DropLocation dl = (JTree.DropLocation) support

--- a/MekHQ/src/mekhq/gui/sorter/FormattedNumberSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/FormattedNumberSorter.java
@@ -1,5 +1,7 @@
 package mekhq.gui.sorter;
 
+import mekhq.MekHQ;
+
 import java.text.DecimalFormat;
 import java.util.Comparator;
 
@@ -38,15 +40,13 @@ import java.util.Comparator;
             try {
                 l0 = FORMAT.parse(s0).longValue();
             } catch (java.text.ParseException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "compare", e);
             }
             long l1 = 0;
             try {
                 l1 = FORMAT.parse(s1).longValue();
             } catch (java.text.ParseException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                MekHQ.getLogger().error(getClass(), "compare", e);
             }
             return Long.compare(l0, l1);
         }

--- a/MekHQ/src/mekhq/gui/sorter/FormattedNumberSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/FormattedNumberSorter.java
@@ -3,51 +3,49 @@ package mekhq.gui.sorter;
 import mekhq.MekHQ;
 
 import java.text.DecimalFormat;
+import java.text.ParseException;
 import java.util.Comparator;
 
+/**
+ * A comparator for numbers that have been formatted with DecimalFormat
+ * @author Jay Lawson
+ */
+public class FormattedNumberSorter implements Comparator<String> {
+    private static final String PLUS_SIGN = "+"; //$NON-NLS-1$
+    private static final DecimalFormat FORMAT = new DecimalFormat();
 
-
-    /**
-     * A comparator for numbers that have been formatted with DecimalFormat
-     * @author Jay Lawson
-     *
-     */
-    public class FormattedNumberSorter implements Comparator<String> {
-        private static final String PLUS_SIGN = "+"; //$NON-NLS-1$
-        private static final DecimalFormat FORMAT = new DecimalFormat();
-
-        @Override
-        public int compare(String s0, String s1) {
-            // Cut off leading "+" sign if there
-            if(s0.startsWith(PLUS_SIGN)) {
-                s0 = s0.substring(1);
-            }
-            if(s1.startsWith(PLUS_SIGN)) {
-                s1 = s1.substring(1);
-            }
-            // Empty cells are smaller than all numbers
-            if((s0.length() == 0) && (s1.length() == 0)) {
-                return 0;
-            }
-            if(s0.length() == 0) {
-                return -1;
-            }
-            if(s1.length() == 0) {
-                return 1;
-            }
-            //lets find the weight class integer for each name
-            long l0 = 0;
-            try {
-                l0 = FORMAT.parse(s0).longValue();
-            } catch (java.text.ParseException e) {
-                MekHQ.getLogger().error(getClass(), "compare", e);
-            }
-            long l1 = 0;
-            try {
-                l1 = FORMAT.parse(s1).longValue();
-            } catch (java.text.ParseException e) {
-                MekHQ.getLogger().error(getClass(), "compare", e);
-            }
-            return Long.compare(l0, l1);
+    @Override
+    public int compare(String s0, String s1) {
+        // Cut off leading "+" sign if there
+        if (s0.startsWith(PLUS_SIGN)) {
+            s0 = s0.substring(1);
         }
+        if (s1.startsWith(PLUS_SIGN)) {
+            s1 = s1.substring(1);
+        }
+        // Empty cells are smaller than all numbers
+        if ((s0.length() == 0) && (s1.length() == 0)) {
+            return 0;
+        }
+        if (s0.length() == 0) {
+            return -1;
+        }
+        if (s1.length() == 0) {
+            return 1;
+        }
+        //lets find the weight class integer for each name
+        long l0 = 0;
+        try {
+            l0 = FORMAT.parse(s0).longValue();
+        } catch (ParseException e) {
+            MekHQ.getLogger().error(getClass(), "compare", e);
+        }
+        long l1 = 0;
+        try {
+            l1 = FORMAT.parse(s1).longValue();
+        } catch (ParseException e) {
+            MekHQ.getLogger().error(getClass(), "compare", e);
+        }
+        return Long.compare(l0, l1);
     }
+}

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -63,6 +63,7 @@ import megamek.common.IStartingPositions;
 import megamek.common.PlanetaryConditions;
 import megamek.common.util.EncodeControl;
 import mekhq.IconPackage;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.ForceStub;
@@ -941,8 +942,8 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
                     }
                 }
                 return new ImageIcon(portrait);
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "getIconFrom", e);
                 return null;
             }
         }
@@ -974,8 +975,8 @@ public class AtBScenarioViewPanel extends ScrollablePanel {
                 }
                 }
                 return new ImageIcon(portrait);
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "getIconFrom", e);
                 return null;
             }
        }

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -28,6 +28,7 @@ import megamek.common.Entity;
 import megamek.common.UnitType;
 import megamek.common.util.EncodeControl;
 import mekhq.IconPackage;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.Force;
@@ -170,8 +171,8 @@ public class ForceViewPanel extends ScrollablePanel {
         	portrait = portrait.getScaledInstance(scale, -1, Image.SCALE_SMOOTH);
             ImageIcon icon = new ImageIcon(portrait);
         	lbl.setIcon(icon);
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "setIcon", e);
         }
 	}
 
@@ -520,8 +521,8 @@ public class ForceViewPanel extends ScrollablePanel {
             	}
             }
             lbl.setIcon(new ImageIcon(portrait));
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "setPortrait", e);
         }
     }
 
@@ -541,8 +542,8 @@ public class ForceViewPanel extends ScrollablePanel {
         Image camo = null;
         try {
             camo = (Image) icons.getCamos().getItem(unit.getCamoCategory(), unit.getCamoFileName());
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "getCamo", e);
         }
         return camo;
     }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -311,8 +311,8 @@ public class PersonViewPanel extends ScrollablePanel {
                 ribbonLabel.setIcon(new ImageIcon(ribbon));
                 ribbonLabel.setToolTipText(award.getTooltip());
                 rowRibbonsBox.add(ribbonLabel, 0);
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "drawRibbons", e);
             }
 
             i++;
@@ -355,8 +355,8 @@ public class PersonViewPanel extends ScrollablePanel {
                 medalLabel.setIcon(new ImageIcon(medal));
                 medalLabel.setToolTipText(award.getTooltip());
                 pnlMedals.add(medalLabel);
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "drawMedals", e);
             }
         }
 
@@ -386,8 +386,8 @@ public class PersonViewPanel extends ScrollablePanel {
                 miscLabel.setIcon(new ImageIcon(miscAward));
                 miscLabel.setToolTipText(award.getTooltip());
                 pnlMiscAwards.add(miscLabel);
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "drawMiscAwards", e);
             }
         }
         return pnlMiscAwards;
@@ -436,8 +436,8 @@ public class PersonViewPanel extends ScrollablePanel {
                 }
             }
             lblPortrait.setIcon(new ImageIcon(portrait));
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "setPortrait", e);
         }
 
         GridBagConstraints gbc_lblPortrait = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
@@ -37,6 +37,7 @@ import javax.swing.tree.TreePath;
 
 import megamek.common.Crew;
 import mekhq.IconPackage;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.ForceStub;
@@ -329,8 +330,8 @@ public class ScenarioViewPanel extends ScrollablePanel {
                     }
                 }
                 return new ImageIcon(portrait);
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "getIconFrom", e);
                 return null;
             }
         }
@@ -362,11 +363,10 @@ public class ScenarioViewPanel extends ScrollablePanel {
                 }
                 }
                 return new ImageIcon(portrait);
-            } catch (Exception err) {
-                err.printStackTrace();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(getClass(), "getIconFrom", e);
                 return null;
             }
        }
     }
-
 }

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -24,6 +24,7 @@ import megamek.common.TechConstants;
 import megamek.common.UnitType;
 import megamek.common.util.DirectoryItems;
 import megamek.common.util.EncodeControl;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.EntityImage;
@@ -335,8 +336,8 @@ public class UnitViewPanel extends ScrollablePanel {
         Image camo = null;
         try {
             camo = (Image) camos.getItem(unit.getCamoCategory(), unit.getCamoFileName());
-        } catch (Exception err) {
-            err.printStackTrace();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(getClass(), "getCamo", e);
         }
         return camo;
     }

--- a/MekHQ/src/mekhq/module/ScriptPluginManager.java
+++ b/MekHQ/src/mekhq/module/ScriptPluginManager.java
@@ -103,11 +103,14 @@ public class ScriptPluginManager {
     private static void listEngines() {
         ScriptEngineManager mgr = new ScriptEngineManager(PluginManager.getInstance().getClassLoader());
         for (ScriptEngineFactory engine : mgr.getEngineFactories()) {
-            System.out.println("Engine: " + engine.getEngineName());
-            System.out.println("\tVersion: " + engine.getEngineVersion());
-            System.out.println("\tAlias: " + engine.getNames());
-            System.out.println("\tLanguage name: " + engine.getLanguageName());
-            System.out.println();
+            MekHQ.getLogger().info(ScriptPluginManager.class, "listEngines",
+                    "Engine: " + engine.getEngineName());
+            MekHQ.getLogger().info(ScriptPluginManager.class, "listEngines",
+                    "\tVersion: " + engine.getEngineVersion());
+            MekHQ.getLogger().info(ScriptPluginManager.class, "listEngines",
+                    "\tAlias: " + engine.getNames());
+            MekHQ.getLogger().info(ScriptPluginManager.class, "listEngines",
+                    "\tLanguage name: " + engine.getLanguageName() + "\n");
         }
     }
 }

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -51,23 +51,23 @@ import mekhq.campaign.universe.UnitGeneratorParameters;
 
 /**
  * Main engine of the Against the Bot campaign system.
- * 
+ *
  * @author Neoancient
  *
  */
 public class AtBEventProcessor {
-    
+
     private final Campaign campaign;
-    
+
     public AtBEventProcessor(Campaign campaign) {
         this.campaign = campaign;
         MekHQ.registerHandler(this);
     }
-    
+
     public void shutdown() {
         MekHQ.unregisterHandler(this);
     }
-    
+
     @Subscribe
     public void handleNewDay(NewDayEvent ev) {
         // TODO: move code from Campaign here
@@ -144,11 +144,11 @@ public class AtBEventProcessor {
             addRecruitUnit(p);
         }
     }
-    
+
     private void addRecruitUnit(Person p) {
         final String METHOD_NAME = "addRecruitUnit(Person)"; //$NON-NLS-1$
         UnitGeneratorParameters params = new UnitGeneratorParameters();
-        
+
         int unitType;
         switch (p.getPrimaryRole()) {
             case Person.T_MECHWARRIOR:
@@ -166,13 +166,13 @@ public class AtBEventProcessor {
                 break;
             case Person.T_INFANTRY:
                 unitType = UnitType.INFANTRY;
-                
+
                 // infantry will have a 1/3 chance of being field guns
                 if(Compute.d6() <= 2) {
                     params.getMissionRoles().add(MissionRole.FIELD_GUN);
                     params.getMovementModes().addAll(IUnitGenerator.ALL_INFANTRY_MODES);
                 }
-                
+
                 break;
             case Person.T_BA:
                 unitType = UnitType.BATTLE_ARMOR;
@@ -203,19 +203,19 @@ public class AtBEventProcessor {
         Entity en;
 
         String faction = getRecruitFaction(campaign);
-        
+
         params.setFaction(faction);
         params.setUnitType(unitType);
         params.setWeightClass(weight);
         params.setYear(campaign.getCalendar().get(Calendar.YEAR));
         params.setQuality(IUnitRating.DRAGOON_F);
-        
+
         MechSummary ms = campaign.getUnitGenerator().generate(params);
         if (null != ms) {
             if (Faction.getFaction(faction).isClan() && ms.getName().matches(".*Platoon.*")) {
                 String name = "Clan " + ms.getName().replaceAll("Platoon", "Point");
                 ms = MechSummaryCache.getInstance().getMech(name);
-                System.out.println("looking for Clan infantry " + name);
+                MekHQ.getLogger().info(getClass(), METHOD_NAME, "looking for Clan infantry " + name);
             }
             try {
                 en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
@@ -288,7 +288,7 @@ public class AtBEventProcessor {
             p.removeSkill(skill2);
         }
     }
-    
+
     public static String getRecruitFaction(Campaign c) {
         if (c.getFactionCode().equals("MERC")) {
             if (c.getCalendar().get(Calendar.YEAR) > 3055 && Compute.randomInt(20) == 0) {

--- a/MekHQ/src/mekhq/service/AutosaveService.java
+++ b/MekHQ/src/mekhq/service/AutosaveService.java
@@ -20,7 +20,6 @@
  */
 package mekhq.service;
 
-import megamek.common.logging.MMLogger;
 import megamek.common.util.StringUtil;
 import mekhq.MekHQ;
 import mekhq.MekHqConstants;
@@ -39,13 +38,8 @@ import java.util.zip.GZIPOutputStream;
 
 public class AutosaveService implements IAutosaveService {
     private final Preferences userPreferences = Preferences.userRoot().node(MekHqConstants.AUTOSAVE_NODE);
-    private final MMLogger logger;
 
-    public AutosaveService(MMLogger logger) {
-        assert logger != null;
-
-        this.logger = logger;
-    }
+    public AutosaveService() { }
 
     @Override
     public void requestDayAdvanceAutosave(Campaign campaign, Calendar calendar) {
@@ -106,12 +100,11 @@ public class AutosaveService implements IAutosaveService {
                     writer.close();
                 }
             } else {
-                this.logger.error(this.getClass(), "performAutosave",
+                MekHQ.getLogger().error(getClass(), "performAutosave",
                         "Unable to perform an autosave because of a null or empty file name");
             }
-        }
-        catch (Exception ex) {
-            this.logger.error(this.getClass(), "performAutosave", ex);
+        } catch (Exception ex) {
+            MekHQ.getLogger().error(getClass(), "performAutosave", ex);
         }
     }
 
@@ -135,7 +128,7 @@ public class AutosaveService implements IAutosaveService {
                 if (autosaveFiles.get(index).delete()) {
                     autosaveFiles.remove(index);
                 } else {
-                    this.logger.error(this.getClass(), "getAutosaveFilename",
+                    MekHQ.getLogger().error(getClass(), "getAutosaveFilename",
                             "Unable to delete file " + autosaveFiles.get(index).getName());
                     index++;
                 }


### PR DESCRIPTION
This should fix the logger not working in current nightly builds, and completely moves MekHQ to use DefaultMMLogger instead of System.out, System.err, and e.printStackTrace.

To review:
Hide whitespace differences should be on (a bunch of these files have not been opened recently, and it was an automatic thing by my IDE)
View the first three commits together, as they are the same thing (switching to using the getLogger()). Commit four consists of whitespace changes (mostly relating to tabs) that I discovered when reviewing this story.
Only logical change is commented, as are the main questions.