### PR TITLE
Quick fix for logger

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -409,22 +409,19 @@ public class MekHQ implements GameListener {
      *
      */
     private static void redirectOutput() {
+        System.out.println("Redirecting output to mekhqlog.txt"); //$NON-NLS-1$
+        File logDir = new File("logs");
+        if (!logDir.exists()) {
+            logDir.mkdir();
+        }
+        final String logFileName = "logs" + File.separator + "mekhqlog.txt";
+        getLogger().resetLogFile(logFileName);
         try {
-            System.out.println("Redirecting output to mekhqlog.txt"); //$NON-NLS-1$
-            File logDir = new File("logs");
-            if (!logDir.exists()) {
-                logDir.mkdir();
-            }
-			final String logFilename = "logs" + File.separator + "mekhqlog.txt";
-			MegaMek.resetLogFile(logFilename);
-            OutputStream os = new FileOutputStream(logFilename, true);
+            OutputStream os = new FileOutputStream(logFileName, true);
             BufferedOutputStream bos = new BufferedOutputStream(os, 64);
 			PrintStream ps = new PrintStream(bos);
             System.setOut(ps);
             System.setErr(ps);
-            ps.close();
-            bos.close();
-            os.close();
         } catch (Exception e) {
             System.err.println("Unable to redirect output to mekhqlog.txt"); //$NON-NLS-1$
             e.printStackTrace();


### PR DESCRIPTION
The only real change here is that we no longer remove the close() calls for the logger (the other changes are just moving calls outside of the try{} catch), which seems to have broken the logger in MekHQ. As it works on my local branch, I think we should merge this ASAP and then test on the nightly build to ensure this fixes the issue. If it does not, I will take another look into the problem.
This will cause an LGTM issue, as I'm removing a potential resource link.