### PR TITLE
Fixing FMM(r) Unit Rating Medic Pool Hour Calculation and Unit Test

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5914,8 +5914,11 @@ public class Campaign implements Serializable, ITechManager {
         return Math.min(nmedics / ndocs, 4);
     }
 
+    /**
+     * @return the number of medics in the campaign including any in the temporary medic pool
+     */
     public int getNumberMedics() {
-        int medics = medicPool;
+        int medics = getMedicPool(); // this uses a getter for unit testing
         for (Person p : getPersonnel()) {
             if (p.isMedic() && p.isActive() && !p.isDeployed()) {
                 medics++;

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -539,8 +539,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
     }
 
     private int getMedicPoolHours() {
-        return (getCampaign().getMedicPool() +
-                getCampaign().getNumberMedics()) * 20;
+        return getCampaign().getNumberMedics() * 20;
     }
 
     int getMedicalSupportAvailable() {

--- a/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
@@ -42,9 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Vector;
+import java.util.*;
 
 import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
@@ -316,7 +314,6 @@ public class FieldManualMercRevDragoonsRatingTest {
 
     @Test
     public void testGetMedSupportAvailable() {
-
         // Test having 1 regular doctor with 4 temp medics.
         // Expected available support should be:
         // Regular Doctor = 40 hours.
@@ -350,6 +347,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         Person mockMedic = mock(Person.class);
         when(mockMedic.getPrimaryRole()).thenReturn(Person.T_MEDIC);
         when(mockMedic.isDoctor()).thenReturn(false);
+        when(mockMedic.isMedic()).thenReturn(true);
         when(mockMedic.isActive()).thenReturn(true);
         when(mockMedic.isDeployed()).thenReturn(false);
         when(mockMedic.getSkill(eq(SkillType.S_MEDTECH))).thenReturn(mockMedicSkill);


### PR DESCRIPTION
This fixes two related bugs in FMM(r) unit rating, namely that we were double counting medic pool personnel, which was being hidden by how we unit tested. That should no longer be the case.