### PR TITLE
Adding a market table refresh to the PersonnelMarketDialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -276,7 +276,10 @@ public class PersonnelMarketDialog extends JDialog {
 
         JButton btnAdvDay = new JButton("Advance Day");
         btnAdvDay.setName("buttonAdvanceDay");
-        btnAdvDay.addActionListener(evt -> hqView.getCampaignController().advanceDay());
+        btnAdvDay.addActionListener(evt -> {
+            hqView.getCampaignController().advanceDay();
+            personnelModel.setData(personnelMarket.getPersonnel());
+        });
         btnAdvDay.setEnabled(hqView.getCampaignController().isHost());
         panelOKBtns.add(btnAdvDay, new GridBagConstraints());
 


### PR DESCRIPTION
This fixes a bug I discovered while testing my personnel dialog changes.