### PR TITLE
Moving Personnel Enums to their own folder

### DIFF
--- a/MekHQ/src/mekhq/campaign/log/MedicalLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/MedicalLogger.java
@@ -21,6 +21,7 @@ package mekhq.campaign.log;
 import megamek.common.util.EncodeControl;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 
 import java.text.MessageFormat;
 import java.util.Collection;
@@ -38,8 +39,8 @@ public class MedicalLogger {
     public static MedicalLogEntry severedSpine(Person person, Date date) {
         String message = logEntriesResourceMap.getString("severedSpine.text");
         MedicalLogEntry medicalLogEntry = new MedicalLogEntry(date, MessageFormat.format(message,
-                        person.getGenderString(Person.GENDER_DESCRIPTOR.HIS_HER),
-                        person.getGenderString(Person.GENDER_DESCRIPTOR.HIM_HER)));
+                        person.getGenderString(GenderDescriptors.HIS_HER),
+                        person.getGenderString(GenderDescriptors.HIM_HER)));
         person.addLogEntry(medicalLogEntry);
         return medicalLogEntry;
     }
@@ -47,7 +48,7 @@ public class MedicalLogger {
     public static MedicalLogEntry brokenRibPunctureDead(Person person, Date date) {
         String message = logEntriesResourceMap.getString("brokenRibPunctureDead.text");
         MedicalLogEntry medicalLogEntry = new MedicalLogEntry(date, MessageFormat.format(message,
-                person.getGenderString(Person.GENDER_DESCRIPTOR.HIS_HER)));
+                person.getGenderString(GenderDescriptors.HIS_HER)));
         person.addLogEntry(medicalLogEntry);
         return medicalLogEntry;
     }
@@ -55,7 +56,7 @@ public class MedicalLogger {
     public static MedicalLogEntry brokenRibPuncture(Person person, Date date) {
         String message = logEntriesResourceMap.getString("brokenRibPuncture.text");
         MedicalLogEntry medicalLogEntry = new MedicalLogEntry(date, MessageFormat.format(message,
-                person.getGenderString(Person.GENDER_DESCRIPTOR.HIS_HER)));
+                person.getGenderString(GenderDescriptors.HIS_HER)));
         person.addLogEntry(medicalLogEntry);
         return medicalLogEntry;
     }
@@ -161,7 +162,7 @@ public class MedicalLogger {
     public static void deliveredBaby(Person patient, Person baby, Date date) {
         String message = logEntriesResourceMap.getString("deliveredBaby.text");
         MedicalLogEntry medicalLogEntry = new MedicalLogEntry(date, MessageFormat.format(message,
-                baby.getGenderString(Person.GENDER_DESCRIPTOR.BOY_GIRL)));
+                baby.getGenderString(GenderDescriptors.BOY_GIRL)));
         patient.addLogEntry(medicalLogEntry);
     }
 
@@ -178,7 +179,7 @@ public class MedicalLogger {
     public static void diedFromWounds(Person patient, Date date) {
         String message = logEntriesResourceMap.getString("diedFromWounds.text");
         MedicalLogEntry medicalLogEntry = new MedicalLogEntry(date, MessageFormat.format(message,
-                patient.getGenderString(Person.GENDER_DESCRIPTOR.HIS_HER)));
+                patient.getGenderString(GenderDescriptors.HIS_HER)));
         patient.addLogEntry(medicalLogEntry);
     }
 }

--- a/MekHQ/src/mekhq/campaign/log/PersonalLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/PersonalLogger.java
@@ -21,6 +21,7 @@ package mekhq.campaign.log;
 
 import megamek.common.util.EncodeControl;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 
 import java.text.MessageFormat;
 import java.util.Date;
@@ -71,6 +72,6 @@ public class PersonalLogger {
     public static void ourChildBorn(Person person, Person baby, String spouseName, Date date) {
         person.addLogEntry(new PersonalLogEntry(date,
                 MessageFormat.format(logEntriesResourceMap.getString("ourChildBorn.text"),
-                        spouseName, baby.getGenderString(Person.GENDER_DESCRIPTOR.BOY_GIRL))));
+                        spouseName, baby.getGenderString(GenderDescriptors.BOY_GIRL))));
     }
 }

--- a/MekHQ/src/mekhq/campaign/log/ServiceLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/ServiceLogger.java
@@ -21,6 +21,7 @@ package mekhq.campaign.log;
 
 import megamek.common.util.EncodeControl;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 
 import java.text.MessageFormat;
 import java.util.Date;
@@ -37,7 +38,7 @@ public class ServiceLogger {
     public static void retireDueToWounds(Person person, Date date){
         String message = logEntriesResourceMap.getString("retiredDueToWounds.text");
         person.addLogEntry(new ServiceLogEntry(date, MessageFormat.format(message,
-                person.getGenderString(Person.GENDER_DESCRIPTOR.HIS_HER))));
+                person.getGenderString(GenderDescriptors.HIS_HER))));
     }
 
     public static void madeBondsman(Person person, Date date, String name, String rankEntry){

--- a/MekHQ/src/mekhq/campaign/mod/am/HitLocationGen.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/HitLocationGen.java
@@ -7,12 +7,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
 
 import mekhq.Utilities;
-import mekhq.campaign.personnel.BodyLocation;
+import mekhq.campaign.personnel.enums.BodyLocation;
 
 /**
  * Home to static methods returning a random hit location given a random integer value generator
@@ -83,11 +83,11 @@ public class HitLocationGen {
         } while((null == entry) || !validCheck.apply(entry.getValue()));
         return entry.getValue();
     }
-    
+
     public static BodyLocation generic(IntUnaryOperator rnd, Function<BodyLocation, Boolean> validCheck) {
         return queryRandomTable(GENERIC_RANDOM_HIT_TABLE, rnd, validCheck);
     }
-    
+
     public static BodyLocation mechAndAsf(IntUnaryOperator rnd, Function<BodyLocation, Boolean> validCheck) {
         return queryRandomTable(MECH_RANDOM_HIT_TABLE, rnd, validCheck);
     }

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
@@ -30,7 +30,7 @@ import mekhq.Utilities;
 import mekhq.campaign.*;
 import mekhq.campaign.log.MedicalLogEntry;
 import mekhq.campaign.log.MedicalLogger;
-import mekhq.campaign.personnel.BodyLocation;
+import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.InjuryLevel;
 import mekhq.campaign.personnel.InjuryType;

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
@@ -37,6 +37,7 @@ import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Modifier;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.GenderDescriptors;
+import mekhq.campaign.personnel.enums.ModifierValue;
 
 /** Advanced Medical sub-system injury types */
 public final class InjuryTypes {
@@ -122,7 +123,7 @@ public final class InjuryTypes {
 
         @Override
         public Collection<Modifier> getModifiers(Injury inj) {
-            return Arrays.asList(new Modifier(Modifier.Value.PILOTING, Integer.MAX_VALUE,
+            return Arrays.asList(new Modifier(ModifierValue.PILOTING, Integer.MAX_VALUE,
                 null, InjuryType.MODTAG_INJURY));
         }
     }
@@ -156,8 +157,8 @@ public final class InjuryTypes {
         @Override
         public Collection<Modifier> getModifiers(Injury inj) {
             return Arrays.asList(
-                new Modifier(Modifier.Value.GUNNERY, 3, null, InjuryType.MODTAG_INJURY),
-                new Modifier(Modifier.Value.PILOTING, 3, null, InjuryType.MODTAG_INJURY));
+                new Modifier(ModifierValue.GUNNERY, 3, null, InjuryType.MODTAG_INJURY),
+                new Modifier(ModifierValue.PILOTING, 3, null, InjuryType.MODTAG_INJURY));
         }
     }
 
@@ -203,7 +204,7 @@ public final class InjuryTypes {
 
         @Override
         public Collection<Modifier> getModifiers(Injury inj) {
-            return Arrays.asList(new Modifier(Modifier.Value.PILOTING, Integer.MAX_VALUE, null, InjuryType.MODTAG_INJURY));
+            return Arrays.asList(new Modifier(ModifierValue.PILOTING, Integer.MAX_VALUE, null, InjuryType.MODTAG_INJURY));
         }
     }
 
@@ -258,7 +259,7 @@ public final class InjuryTypes {
 
         @Override
         public Collection<Modifier> getModifiers(Injury inj) {
-            return Arrays.asList(new Modifier(Modifier.Value.PILOTING, 2, null, InjuryType.MODTAG_INJURY));
+            return Arrays.asList(new Modifier(ModifierValue.PILOTING, 2, null, InjuryType.MODTAG_INJURY));
         }
     }
 
@@ -296,9 +297,9 @@ public final class InjuryTypes {
             BodyLocation loc = inj.getLocation();
             switch(loc) {
                 case LEFT_ARM: case LEFT_HAND: case RIGHT_ARM: case RIGHT_HAND:
-                    return Arrays.asList(new Modifier(Modifier.Value.GUNNERY, 3, null, InjuryType.MODTAG_INJURY));
+                    return Arrays.asList(new Modifier(ModifierValue.GUNNERY, 3, null, InjuryType.MODTAG_INJURY));
                 case LEFT_LEG: case LEFT_FOOT: case RIGHT_LEG: case RIGHT_FOOT:
-                    return Arrays.asList(new Modifier(Modifier.Value.PILOTING, 3, null, InjuryType.MODTAG_INJURY));
+                    return Arrays.asList(new Modifier(ModifierValue.PILOTING, 3, null, InjuryType.MODTAG_INJURY));
                 default:
                     return Arrays.asList();
             }
@@ -438,10 +439,10 @@ public final class InjuryTypes {
             BodyLocation loc = inj.getLocation();
             switch(loc) {
                 case LEFT_ARM: case LEFT_HAND: case RIGHT_ARM: case RIGHT_HAND:
-                    return Arrays.asList(new Modifier(Modifier.Value.GUNNERY, inj.isPermanent() ? 1 : 2,
+                    return Arrays.asList(new Modifier(ModifierValue.GUNNERY, inj.isPermanent() ? 1 : 2,
                         null, InjuryType.MODTAG_INJURY));
                 case LEFT_LEG: case LEFT_FOOT: case RIGHT_LEG: case RIGHT_FOOT:
-                    return Arrays.asList(new Modifier(Modifier.Value.PILOTING, inj.isPermanent() ? 1 : 2,
+                    return Arrays.asList(new Modifier(ModifierValue.PILOTING, inj.isPermanent() ? 1 : 2,
                         null, InjuryType.MODTAG_INJURY));
                 default:
                     return Arrays.asList();
@@ -563,7 +564,7 @@ public final class InjuryTypes {
 
         @Override
         public Collection<Modifier> getModifiers(Injury inj) {
-            return Arrays.asList(new Modifier(Modifier.Value.PILOTING, 1, null, InjuryType.MODTAG_INJURY));
+            return Arrays.asList(new Modifier(ModifierValue.PILOTING, 1, null, InjuryType.MODTAG_INJURY));
         }
     }
 
@@ -594,9 +595,9 @@ public final class InjuryTypes {
             BodyLocation loc = inj.getLocation();
             switch(loc) {
                 case LEFT_ARM: case LEFT_HAND: case RIGHT_ARM: case RIGHT_HAND:
-                    return Arrays.asList(new Modifier(Modifier.Value.GUNNERY, 1, null, InjuryType.MODTAG_INJURY));
+                    return Arrays.asList(new Modifier(ModifierValue.GUNNERY, 1, null, InjuryType.MODTAG_INJURY));
                 case LEFT_LEG: case LEFT_FOOT: case RIGHT_LEG: case RIGHT_FOOT:
-                    return Arrays.asList(new Modifier(Modifier.Value.PILOTING, 1, null, InjuryType.MODTAG_INJURY));
+                    return Arrays.asList(new Modifier(ModifierValue.PILOTING, 1, null, InjuryType.MODTAG_INJURY));
                 default:
                     return Arrays.asList();
             }

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
@@ -32,7 +32,7 @@ import mekhq.campaign.log.MedicalLogEntry;
 import mekhq.campaign.log.MedicalLogger;
 import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.Injury;
-import mekhq.campaign.personnel.InjuryLevel;
+import mekhq.campaign.personnel.enums.InjuryLevel;
 import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Modifier;
 import mekhq.campaign.personnel.Person;

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
@@ -36,6 +36,7 @@ import mekhq.campaign.personnel.InjuryLevel;
 import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Modifier;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 
 /** Advanced Medical sub-system injury types */
 public final class InjuryTypes {
@@ -286,7 +287,7 @@ public final class InjuryTypes {
 
         @Override
         public String getFluffText(BodyLocation loc, int severity, int gender) {
-            return "Lost " + Person.getGenderString(gender, Person.GENDER_DESCRIPTOR.HIS_HER) + " "
+            return "Lost " + Person.getGenderString(gender, GenderDescriptors.HIS_HER) + " "
                 + loc.readableName;
         }
 
@@ -616,7 +617,7 @@ public final class InjuryTypes {
 
         @Override
         public String getFluffText(BodyLocation loc, int severity, int gender) {
-            return "A laceration on " + Person.getGenderString(gender, Person.GENDER_DESCRIPTOR.HIS_HER) + " head";
+            return "A laceration on " + Person.getGenderString(gender, GenderDescriptors.HIS_HER) + " head";
         }
 
         @Override
@@ -644,7 +645,7 @@ public final class InjuryTypes {
 
         @Override
         public String getFluffText(BodyLocation loc, int severity, int gender) {
-            return "A bruise on " + Person.getGenderString(gender, Person.GENDER_DESCRIPTOR.HIS_HER)
+            return "A bruise on " + Person.getGenderString(gender, GenderDescriptors.HIS_HER)
                     + " " + loc.readableName;
         }
 
@@ -673,7 +674,7 @@ public final class InjuryTypes {
 
         @Override
         public String getFluffText(BodyLocation loc, int severity, int gender) {
-            return "Some cuts on " + Person.getGenderString(gender, Person.GENDER_DESCRIPTOR.HIS_HER)
+            return "Some cuts on " + Person.getGenderString(gender, GenderDescriptors.HIS_HER)
                     + " " + loc.readableName;
         }
 

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
@@ -31,7 +31,7 @@ import megamek.common.Mech;
 import mekhq.campaign.*;
 import mekhq.campaign.log.MedicalLogger;
 import mekhq.campaign.log.ServiceLogger;
-import mekhq.campaign.personnel.BodyLocation;
+import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Person;

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
@@ -38,6 +38,7 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.Skill;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 import mekhq.campaign.unit.Unit;
 
 /**
@@ -284,7 +285,7 @@ public final class InjuryUtil {
                     result.add(new GameEffect(
                         String.format("%s made a mistake in the treatment of %s and caused %s %s to worsen.",
                             doc.getHyperlinkedFullTitle(), p.getHyperlinkedName(),
-                            p.getGenderString(Person.GENDER_DESCRIPTOR.HIS_HER), i.getName()),
+                            p.getGenderString(GenderDescriptors.HIS_HER), i.getName()),
                         rnd -> {
                             int time = i.getTime();
                             i.setTime((int) Math.max(Math.ceil(time * 1.2), time + 5));
@@ -338,7 +339,7 @@ public final class InjuryUtil {
             } else {
                 result.add(new GameEffect(
                     String.format("%s spent time resting to heal %s %s.",
-                        p.getHyperlinkedName(), p.getGenderString(Person.GENDER_DESCRIPTOR.HIS_HER), i.getName()),
+                        p.getHyperlinkedName(), p.getGenderString(GenderDescriptors.HIS_HER), i.getName()),
                     rnd -> {
 
                     }));

--- a/MekHQ/src/mekhq/campaign/personnel/Injury.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Injury.java
@@ -39,6 +39,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import mekhq.campaign.personnel.enums.BodyLocation;
+import mekhq.campaign.personnel.enums.InjuryLevel;
 import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 

--- a/MekHQ/src/mekhq/campaign/personnel/Injury.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Injury.java
@@ -38,6 +38,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import mekhq.campaign.personnel.enums.BodyLocation;
 import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 

--- a/MekHQ/src/mekhq/campaign/personnel/Injury.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Injury.java
@@ -1,6 +1,4 @@
 /*
- * java
- *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  *
  * This file is part of MekHQ.
@@ -39,6 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import mekhq.campaign.personnel.enums.BodyLocation;
+import mekhq.campaign.personnel.enums.InjuryHiding;
 import mekhq.campaign.personnel.enums.InjuryLevel;
 import org.joda.time.DateTime;
 import org.w3c.dom.Node;
@@ -99,7 +98,7 @@ public class Injury {
     /** Flag to indicate someone capable successfully treated this injury. */
     private boolean workedOn;
     private boolean extended;
-    private Hiding hidingState = Hiding.DEFAULT;
+    private InjuryHiding hidingState = InjuryHiding.DEFAULT;
     @XmlElement(name="InjuryUUID")
     private UUID id;
     /** Generic extra data, for use with plugins and mods */
@@ -261,10 +260,10 @@ public class Injury {
     }
 
     public boolean isHidden() {
-        return (hidingState != Hiding.NO) && ((hidingState == Hiding.YES) || type.isHidden(this));
+        return (hidingState != InjuryHiding.NO) && ((hidingState == InjuryHiding.YES) || type.isHidden(this));
     }
 
-    public void setHidingState(Hiding hidingState) {
+    public void setHidingState(InjuryHiding hidingState) {
         this.hidingState = Objects.requireNonNull(hidingState);
     }
 
@@ -335,10 +334,8 @@ public class Injury {
             extraData = new ExtraData();
         }
 
-        hidingState = Utilities.nonNull(hidingState, Hiding.DEFAULT);
+        hidingState = Utilities.nonNull(hidingState, InjuryHiding.DEFAULT);
 
         version = Injury.VERSION;
     }
-
-    public static enum Hiding { YES, NO, DEFAULT }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/InjuryType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/InjuryType.java
@@ -23,6 +23,7 @@ import java.util.*;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import mekhq.campaign.personnel.enums.BodyLocation;
 import org.joda.time.DateTime;
 
 import mekhq.Utilities;

--- a/MekHQ/src/mekhq/campaign/personnel/InjuryType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/InjuryType.java
@@ -24,6 +24,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import mekhq.campaign.personnel.enums.BodyLocation;
+import mekhq.campaign.personnel.enums.InjuryLevel;
 import org.joda.time.DateTime;
 
 import mekhq.Utilities;

--- a/MekHQ/src/mekhq/campaign/personnel/Modifier.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Modifier.java
@@ -7,16 +7,18 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.personnel;
+
+import mekhq.campaign.personnel.enums.ModifierValue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,16 +42,16 @@ import java.util.stream.Stream;
  * In addition, modifiers can have a set of string tags, used for filtering and searching in them.
  */
 public class Modifier {
-    public final Value value;
+    public final ModifierValue value;
     public final int mod;
     public final String type;
     public final Set<String> tags;
-    
-    public static int calcTotalModifier(Collection<Modifier> mods, Value val) {
+
+    public static int calcTotalModifier(Collection<Modifier> mods, ModifierValue val) {
         return calcTotalModifier(mods.stream(), val);
     }
-    
-    public static int calcTotalModifier(Stream<Modifier> mods, Value val) {
+
+    public static int calcTotalModifier(Stream<Modifier> mods, ModifierValue val) {
         final Map<String, Integer> posMods = new HashMap<>();
         final Map<String, Integer> negMods = new HashMap<>();
         final Collection<Integer> untypedMods = new ArrayList<>();
@@ -84,19 +86,15 @@ public class Modifier {
         }
         return (int) result;
     }
-    
-    public Modifier(Value value, int mod) {
+
+    public Modifier(ModifierValue value, int mod) {
         this(value, mod, null);
     }
-    
-    public Modifier(Value value, int mod, String type, String ... tags) {
+
+    public Modifier(ModifierValue value, int mod, String type, String ... tags) {
         this.value = Objects.requireNonNull(value);
         this.mod = mod;
         this.type = type;
         this.tags = (null != tags) ? Arrays.stream(tags).collect(Collectors.toSet()) : new HashSet<>();
-    }
-    
-    public static enum Value {
-        PILOTING, GUNNERY
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -35,6 +35,7 @@ import megamek.common.util.WeightedMap;
 import mekhq.campaign.*;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.*;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -105,15 +106,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public static final int S_KIA = 2;
     public static final int S_MIA = 3;
     public static final int S_NUM = 4;
-
-    public enum GENDER_DESCRIPTOR {
-        MALE_FEMALE,
-        HE_SHE,
-        HIM_HER,
-        HIS_HER,
-        HIS_HERS,
-        BOY_GIRL
-    }
 
     // Prisoners, Bondsmen, and Normal Personnel
     public static final int PRISONER_NOT = 0;
@@ -590,11 +582,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
 
     //region Text Getters
     //TODO : Rename and Localize region
-    public String getGenderString(GENDER_DESCRIPTOR variant) {
+    public String getGenderString(GenderDescriptors variant) {
         return getGenderString(gender, variant);
     }
 
-    public static String getGenderString(int gender, GENDER_DESCRIPTOR variant) {
+    public static String getGenderString(int gender, GenderDescriptors variant) {
         switch (variant) {
             case MALE_FEMALE: {
                 switch (gender) {
@@ -1325,7 +1317,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
             baby.setAncestorsId(ancId);
 
             campaign.addReport(String.format("%s has given birth to %s, a baby %s!", getHyperlinkedName(),
-                    baby.getHyperlinkedName(), baby.getGenderString(GENDER_DESCRIPTOR.BOY_GIRL)));
+                    baby.getHyperlinkedName(), baby.getGenderString(GenderDescriptors.BOY_GIRL)));
             if (campaign.getCampaignOptions().logConception()) {
                 MedicalLogger.deliveredBaby(this, baby, campaign.getDate());
                 if (fatherId != null) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -37,6 +37,7 @@ import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.*;
 import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.enums.GenderDescriptors;
+import mekhq.campaign.personnel.enums.ModifierValue;
 import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -4142,11 +4143,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
     }
 
     public int getPilotingInjuryMod() {
-        return Modifier.calcTotalModifier(injuries.stream().flatMap(i -> i.getModifiers().stream()), Modifier.Value.PILOTING);
+        return Modifier.calcTotalModifier(injuries.stream().flatMap(i -> i.getModifiers().stream()), ModifierValue.PILOTING);
     }
 
     public int getGunneryInjuryMod() {
-        return Modifier.calcTotalModifier(injuries.stream().flatMap(i -> i.getModifiers().stream()), Modifier.Value.GUNNERY);
+        return Modifier.calcTotalModifier(injuries.stream().flatMap(i -> i.getModifiers().stream()), ModifierValue.GUNNERY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -35,6 +35,7 @@ import megamek.common.util.WeightedMap;
 import mekhq.campaign.*;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.*;
+import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.enums.GenderDescriptors;
 import org.joda.time.DateTime;
 import org.w3c.dom.Node;

--- a/MekHQ/src/mekhq/campaign/personnel/enums/BodyLocation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/BodyLocation.java
@@ -7,16 +7,16 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
-package mekhq.campaign.personnel;
+package mekhq.campaign.personnel.enums;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -59,12 +59,12 @@ public enum BodyLocation {
             }
         }
     }
-    
+
     /** @return the body location corresponding to the (old) ID */
     public static BodyLocation of(int id) {
         return ((id > 0) && (id < idMap.length)) ? idMap[id] : GENERIC;
     }
-    
+
     /** @return the body location corresponding to the given string */
     public static BodyLocation of(String str) {
         try {
@@ -74,7 +74,7 @@ public enum BodyLocation {
         }
         return valueOf(str.toUpperCase(Locale.ROOT));
     }
-    
+
     public final int id;
     // Includes everything attached to a limb
     public final boolean isLimb;
@@ -87,11 +87,11 @@ public enum BodyLocation {
     private BodyLocation(int id, String readableName) {
         this(id, readableName, false, null);
     }
-    
+
     private BodyLocation(int id, String readableName, boolean isLimb) {
         this(id, readableName, isLimb, null);
     }
-    
+
     private BodyLocation(int id, String readableName, boolean isLimb, BodyLocation parent) {
         this.id = id;
         this.readableName = readableName;
@@ -106,7 +106,7 @@ public enum BodyLocation {
     private void addChildLocation(BodyLocation child) {
         children.add(child);
     }
-    
+
     public boolean isParentOf(BodyLocation child) {
         if(children.contains(child)) {
             return true;
@@ -118,11 +118,11 @@ public enum BodyLocation {
         }
         return false;
     }
-    
+
     public boolean isChildOf(BodyLocation parent) {
         return (null != this.parent) ? (this.parent == parent) || this.parent.isChildOf(parent) : false;
     }
-    
+
     public static final class XMLAdapter extends XmlAdapter<String, BodyLocation> {
         @Override
         public BodyLocation unmarshal(String v) throws Exception {

--- a/MekHQ/src/mekhq/campaign/personnel/enums/GenderDescriptors.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/GenderDescriptors.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.personnel.enums;
+
+/**
+ * This is used to determine which gender descriptor to use based on the following specified format
+ */
+public enum GenderDescriptors {
+    /**
+     * Descriptor: Male or Female
+     */
+    MALE_FEMALE,
+    /**
+     * Descriptor: He or She
+     */
+    HE_SHE,
+    /**
+     * Descriptor: Him or Her
+     */
+    HIM_HER,
+    /**
+     * Descriptor: His or Her
+     */
+    HIS_HER,
+    /**
+     * Descriptor: His or Hers
+     */
+    HIS_HERS,
+    /**
+     * Descriptor: Boy or Girl
+     */
+    BOY_GIRL
+}

--- a/MekHQ/src/mekhq/campaign/personnel/enums/InjuryHiding.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/InjuryHiding.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.personnel.enums;
+
+public enum InjuryHiding {
+    YES,
+    NO,
+    DEFAULT
+}

--- a/MekHQ/src/mekhq/campaign/personnel/enums/InjuryLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/InjuryLevel.java
@@ -7,16 +7,16 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
-package mekhq.campaign.personnel;
+package mekhq.campaign.personnel.enums;
 
 /**
  * Injury levels are simple categorization values used in the display and prioritization of injuries.

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ModifierValue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ModifierValue.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.personnel.enums;
+
+public enum ModifierValue {
+    PILOTING,
+    GUNNERY
+}

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import javax.swing.*;
 
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 import org.joda.time.DateTime;
 
 import megamek.client.ui.swing.DialogOptionComponent;
@@ -282,8 +283,8 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
         panDemog.add(lblGender, gridBagConstraints);
 
         DefaultComboBoxModel<String> genderModel = new DefaultComboBoxModel<>();
-        genderModel.addElement(Person.getGenderString(Crew.G_MALE, Person.GENDER_DESCRIPTOR.MALE_FEMALE));
-        genderModel.addElement(Person.getGenderString(Crew.G_FEMALE, Person.GENDER_DESCRIPTOR.MALE_FEMALE));
+        genderModel.addElement(Person.getGenderString(Crew.G_MALE, GenderDescriptors.MALE_FEMALE));
+        genderModel.addElement(Person.getGenderString(Crew.G_FEMALE, GenderDescriptors.MALE_FEMALE));
         choiceGender.setModel(genderModel);
         choiceGender.setName("choiceGender"); // NOI18N
         choiceGender.setSelectedIndex(person.getGender());

--- a/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
@@ -1,21 +1,21 @@
 /*
  * EditInjuryEntryDialog.java
- * 
+ *
  * Copyright (C) 2018 MegaMek team
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,7 +45,7 @@ import javax.swing.WindowConstants;
 
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
-import mekhq.campaign.personnel.BodyLocation;
+import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.InjuryType;
 import mekhq.gui.model.FilterableComboBoxModel;
@@ -61,7 +61,7 @@ public class EditInjuryEntryDialog extends JDialog {
     @SuppressWarnings("unused")
     private Frame frame; // FIXME: Unusued => Unneeded?
     private Injury injury;
-    
+
     private JButton btnClose;
     private JButton btnOK;
     private JTextArea txtDays;
@@ -74,11 +74,11 @@ public class EditInjuryEntryDialog extends JDialog {
     private JComboBox<String> ddExtended;
     private JPanel panBtn;
     private JPanel panMain;
-    
+
     private BodyLocationChoice[] locations;
     private InjuryTypeChoice[] types;
     private FilterableComboBoxModel<InjuryTypeChoice> ddTypeModel;
-    
+
     /** Creates new form EditInjuryEntryDialog */
     public EditInjuryEntryDialog(Frame parent, boolean modal, Injury e) {
         super(parent, modal);
@@ -125,7 +125,7 @@ public class EditInjuryEntryDialog extends JDialog {
                 break;
             }
         }
-        
+
         txtDays = new JTextArea();
         txtFluff = new JTextArea();
         txtHits = new JTextArea();
@@ -137,7 +137,7 @@ public class EditInjuryEntryDialog extends JDialog {
         btnClose = new JButton();
         panBtn = new JPanel();
         panMain = new JPanel();
-        
+
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditInjuryEntryDialog", new EncodeControl()); //$NON-NLS-1$
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form"); // NOI18N
@@ -145,7 +145,7 @@ public class EditInjuryEntryDialog extends JDialog {
         getContentPane().setLayout(new BorderLayout());
         panBtn.setLayout(new GridLayout(0,2));
         panMain.setLayout(new GridBagLayout());
-        
+
         txtDays.setText(Integer.toString(injury.getTime()));
         txtDays.setName("txtDays");
         txtDays.setEditable(true);
@@ -165,7 +165,7 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         panMain.add(txtDays, gridBagConstraints);
-        
+
         ddLocation.setName("ddLocation");
         ddLocation.setEditable(false);
         ddLocation.setBorder(BorderFactory.createCompoundBorder(
@@ -212,7 +212,7 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panMain.add(ddType, gridBagConstraints);
-        
+
         txtFluff.setText(injury.getFluff());
         txtFluff.setName("txtFluff");
         txtFluff.setEditable(true);
@@ -232,7 +232,7 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panMain.add(txtFluff, gridBagConstraints);
-        
+
         txtHits.setText(Integer.toString(injury.getHits()));
         txtHits.setName("txtHits");
         txtHits.setEditable(true);
@@ -252,7 +252,7 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panMain.add(txtHits, gridBagConstraints);
-        
+
         ddPermanent.setSelectedIndex(injury.isPermanent() ? 0 : 1);
         ddPermanent.setName("ddPermanent");
         ddPermanent.setEditable(false);
@@ -270,7 +270,7 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panMain.add(ddPermanent, gridBagConstraints);
-        
+
         ddWorkedOn.setSelectedIndex(injury.isWorkedOn() ? 0 : 1);
         ddWorkedOn.setName("ddWorkedOn");
         ddWorkedOn.setEditable(false);
@@ -288,7 +288,7 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panMain.add(ddWorkedOn, gridBagConstraints);
-        
+
         ddExtended.setSelectedIndex(injury.getExtended() ? 0 : 1);
         ddExtended.setName("ddExtended");
         ddExtended.setEditable(true);
@@ -306,7 +306,7 @@ public class EditInjuryEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         panMain.add(ddExtended, gridBagConstraints);
-        
+
         btnOK.setText(resourceMap.getString("btnOkay.text")); // NOI18N
         btnOK.setName("btnOK"); // NOI18N
         btnOK.addActionListener(new ActionListener() {
@@ -368,31 +368,31 @@ public class EditInjuryEntryDialog extends JDialog {
         injury = null;
         this.setVisible(false);
     }
-    
+
     public Injury getEntry() {
         return injury;
     }
-    
+
     private static class BodyLocationChoice {
         public final BodyLocation loc;
-        
+
         public BodyLocationChoice(BodyLocation loc) {
             this.loc = loc;
         }
-        
+
         @Override
         public String toString() {
             return loc.readableName;
         }
     }
-    
+
     private static class InjuryTypeChoice {
         public final InjuryType type;
-        
+
         public InjuryTypeChoice(InjuryType type) {
             this.type = type;
         }
-        
+
         @Override
         public String toString() {
             return type.getName(BodyLocation.GENERIC, 1);

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -75,7 +75,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.ExtraData;
 import mekhq.campaign.log.LogEntry;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.personnel.BodyLocation;
+import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.InjuryLevel;
 import mekhq.campaign.personnel.InjuryType;

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -77,7 +77,7 @@ import mekhq.campaign.log.LogEntry;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.Injury;
-import mekhq.campaign.personnel.InjuryLevel;
+import mekhq.campaign.personnel.enums.InjuryLevel;
 import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Person;
 

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -45,6 +45,7 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
 import mekhq.gui.BasicInfo;
@@ -404,7 +405,7 @@ public class PersonnelTableModel extends DataTableModel {
                     return "";
                 }
             case COL_GENDER:
-                return p.getGenderString(Person.GENDER_DESCRIPTOR.MALE_FEMALE);
+                return p.getGenderString(GenderDescriptors.MALE_FEMALE);
             case COL_AGE:
                 return Integer.toString(p.getAge(getCampaign().getCalendar()));
             case COL_TYPE:

--- a/MekHQ/src/mekhq/gui/view/Paperdoll.java
+++ b/MekHQ/src/mekhq/gui/view/Paperdoll.java
@@ -7,12 +7,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -67,7 +67,7 @@ import org.xml.sax.SAXException;
 
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
-import mekhq.campaign.personnel.BodyLocation;
+import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.gui.utilities.MultiplyComposite;
 
 /**
@@ -76,12 +76,12 @@ import mekhq.gui.utilities.MultiplyComposite;
  */
 public class Paperdoll extends Component {
     private static final long serialVersionUID = 2427542264332728643L;
-    
+
     public static final int DEFAULT_WIDTH = 256;
     public static final int DEFAULT_HEIGHT = 768;
-    
+
     private transient ActionListener listener;
-    
+
     private Image base;
     private Map<BodyLocation, Path2D> locShapes;
     private Map<BodyLocation, Color> locColors;
@@ -91,28 +91,28 @@ public class Paperdoll extends Component {
 
     private transient BodyLocation hoverLoc;
     private transient double scale;
-    
+
     // TODO: Make this work with any enum, not just BodyLocation
     public Paperdoll(InputStream is) {
         locShapes = new EnumMap<>(BodyLocation.class);
         locColors = new EnumMap<>(BodyLocation.class);
         locOverlays = new EnumMap<>(BodyLocation.class);
         locTags = new EnumMap<>(BodyLocation.class);
-        
+
         try {
             loadShapeData(is);
         } catch(Exception ex) {
             MekHQ.getLogger().error(getClass(), "<init>(InputStream)", ex);
         }
-        
+
         highlightColor = null;
-        
+
         enableEvents(AWTEvent.MOUSE_EVENT_MASK | AWTEvent.MOUSE_MOTION_EVENT_MASK);
     }
-    
+
     public void loadShapeData(InputStream is) throws JAXBException, SAXException, ParserConfigurationException {
         final String METHOD_NAME = "loadShapeData(InputStream)"; //$NON-NLS-1$
-        
+
         JAXBContext context = JAXBContext.newInstance(OverlayLocDataList.class, OverlayLocData.class);
         Unmarshaller unmarshaller = context.createUnmarshaller();
         Source inputSource = MekHqXmlUtil.createSafeXmlSource(is);
@@ -147,7 +147,7 @@ public class Paperdoll extends Component {
         }
         setSize(base.getWidth(null), base.getHeight(null));
     }
-    
+
     public void setLocShape(BodyLocation loc, Path2D path) {
         Objects.requireNonNull(loc);
         if(null != path) {
@@ -157,7 +157,7 @@ public class Paperdoll extends Component {
         }
         invalidate();
     }
-    
+
     public void setLocColor(BodyLocation loc, Color color) {
         Objects.requireNonNull(loc);
         Color oldColor = locColors.get(loc);
@@ -166,7 +166,7 @@ public class Paperdoll extends Component {
             invalidate();
         }
     }
-    
+
     public void setLocTag(BodyLocation loc, String tag) {
         Objects.requireNonNull(loc);
         String oldTag = locTags.get(loc);
@@ -179,26 +179,26 @@ public class Paperdoll extends Component {
             invalidate();
         }
     }
-    
+
     public void clearLocColors() {
         locColors.clear();
     }
-    
+
     public void clearLocTags() {
         locTags.clear();
     }
-    
+
     public Color getHighlightColor() {
         return highlightColor;
     }
-    
+
     public void setHighlightColor(Color highlightColor) {
         if(!Objects.equals(this.highlightColor, highlightColor)) {
             invalidate();
         }
         this.highlightColor = highlightColor;
     }
-    
+
     @Override
     public void paint(Graphics g) {
         final Graphics2D g2 = (Graphics2D) g;
@@ -232,14 +232,14 @@ public class Paperdoll extends Component {
                 g2.fill(overlay);
             });
         g2.setComposite(AlphaComposite.SrcOver);
-        
+
         if((null != highlightColor) && (null != hoverLoc) && locShapes.containsKey(hoverLoc)) {
             g2.setPaint(highlightColor);
             g2.setStroke(new BasicStroke(5f));
             g2.draw(locShapes.get(hoverLoc));
         }
     }
-    
+
     public BodyLocation locationUnderPoint(double x, double y) {
         final double scaledX = x / scale;
         final double scaledY = y / scale;
@@ -247,20 +247,20 @@ public class Paperdoll extends Component {
             .filter(entry -> entry.getValue().contains(scaledX, scaledY)).findAny()
             .map(entry -> entry.getKey()).orElse(BodyLocation.GENERIC);
     }
-    
+
     @Override
     public Dimension getPreferredSize() {
         return new Dimension(base.getWidth(null), base.getHeight(null));
     }
-    
+
     public void addActionListener(ActionListener al) {
         listener = AWTEventMulticaster.add(listener, al);
     }
-    
+
     public void removeActionListener(ActionListener al) {
         listener = AWTEventMulticaster.remove(listener, al);
     }
-    
+
     @Override
     public void processEvent(AWTEvent e) {
         if(e instanceof MouseEvent) {
@@ -286,7 +286,7 @@ public class Paperdoll extends Component {
             }
         }
     }
-    
+
     // XML serialization classes
     @XmlRootElement(name="overlays")
     @XmlAccessorType(XmlAccessType.FIELD)
@@ -295,7 +295,7 @@ public class Paperdoll extends Component {
         @XmlElement(name="loc")
         public List<OverlayLocData> locs;
     }
-    
+
     @XmlRootElement(name="loc")
     @XmlAccessorType(XmlAccessType.FIELD)
     public static class OverlayLocData {
@@ -307,7 +307,7 @@ public class Paperdoll extends Component {
         public List<Point2D> path;
         @XmlElement(name="image")
         public List<OverlayLocImage> overlayImages;
-        
+
         public Path2D genPath() {
             Path2D result = new Path2D.Float();
             if((null != path) && !path.isEmpty()) {
@@ -319,14 +319,14 @@ public class Paperdoll extends Component {
             return result;
         }
     }
-    
+
     public static class OverlayLocImage {
         @XmlAttribute
         public String tag;
         @XmlValue
         public String image;
     }
-    
+
     private static class XMLPoint2DAdapter extends XmlAdapter<String, Point2D> {
         @Override
         public Point2D unmarshal(String v) throws Exception {
@@ -349,6 +349,6 @@ public class Paperdoll extends Component {
         public String marshal(Point2D v) throws Exception {
             return (null != v) ? String.format(Locale.ROOT, "%.3f,%.3f", v.getX(), v.getY()) : null;
         }
-        
+
     }
 }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -30,6 +30,7 @@ import javax.swing.table.TableColumn;
 
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.FormerSpouse;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
 import org.joda.time.DateTime;
 
 import megamek.common.Crew;
@@ -614,7 +615,7 @@ public class PersonViewPanel extends ScrollablePanel {
         pnlInfo.add(lblGender1, gridBagConstraints);
 
         lblGender2.setName("lblGender2"); // NOI18N
-        lblGender2.setText(person.getGenderString(Person.GENDER_DESCRIPTOR.MALE_FEMALE));
+        lblGender2.setText(person.getGenderString(GenderDescriptors.MALE_FEMALE));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = firsty;


### PR DESCRIPTION
This is the first of two organizational changes that I'm doing to make it easier to parse through the Personnel folder. 

To review this: whitespace differences off (automatic changes), and the changes are almost entirely due to locating enums. The one exception is that I've added comments to GenderDescriptors to explain what each one means