### PR TITLE
MegaMek Log File is Reset on MekHQ load

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -96,6 +96,7 @@ public class MekHQ implements GameListener {
 	public static String CAMPAIGN_DIRECTORY = "./campaigns/";
 	public static String PREFERENCES_FILE = "mmconf/mekhq.preferences";
 	public static String PRESET_DIR = "./mmconf/mhqPresets/";
+	private static String DEFAULT_LOG_FILE_NAME = "mekhqlog.txt";
 
 	private static final EventBus EVENT_BUS = new EventBus();
 
@@ -365,11 +366,16 @@ public class MekHQ implements GameListener {
     	System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name","MekHQ");
 
-        // TODO : logFileName should probably not be inline
-        String logFileName = "logs" + File.separator + "mekhqlog.txt";
-        getLogger().resetLogFile(logFileName);
+        // We need to reset both the MekHQ and MegaMek log files for now, as we route output to them
+        // both
+        String logFileNameMHQ = PreferenceManager.getClientPreferences().getLogDirectory()
+                + File.separator + DEFAULT_LOG_FILE_NAME;
+        String logFileNameMM = PreferenceManager.getClientPreferences().getLogDirectory()
+                + File.separator + MegaMek.DEFAULT_LOG_FILE_NAME;
+        getLogger().resetLogFile(logFileNameMHQ);
+        getLogger().resetLogFile(logFileNameMM);
         // redirect output to log file
-        redirectOutput(logFileName); // Deprecated call required for MegaMek usage
+        redirectOutput(logFileNameMHQ); // Deprecated call required for MegaMek usage
 
         SwingUtilities.invokeLater(() -> MekHQ.getInstance().startup());
     }

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -96,7 +96,7 @@ public class MekHQ implements GameListener {
 	public static String CAMPAIGN_DIRECTORY = "./campaigns/";
 	public static String PREFERENCES_FILE = "mmconf/mekhq.preferences";
 	public static String PRESET_DIR = "./mmconf/mhqPresets/";
-	private static String DEFAULT_LOG_FILE_NAME = "mekhqlog.txt";
+	public static String DEFAULT_LOG_FILE_NAME = "mekhqlog.txt";
 
 	private static final EventBus EVENT_BUS = new EventBus();
 


### PR DESCRIPTION
This prevents the case where you end up with a huge log file because you never start MegaMek. I also removed the inline Strings and moved it to instead use the preference manager.