### PR TITLE
Creating JMenuHelpers class

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -59,7 +59,6 @@ import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.Skill;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.actions.StripUnitAction;
@@ -77,6 +76,7 @@ import mekhq.gui.dialog.LargeCraftAmmoSwapDialog;
 import mekhq.gui.dialog.MarkdownEditorDialog;
 import mekhq.gui.dialog.QuirksDialog;
 import mekhq.gui.model.UnitTableModel;
+import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.StaticChecks;
 
 public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionListener {
@@ -872,11 +872,11 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionLi
                         }
                     }
                     if (techsFound > 0) {
-                        addMenuIfNonEmpty(menu, menuElite, 20);
-                        addMenuIfNonEmpty(menu, menuVeteran, 20);
-                        addMenuIfNonEmpty(menu, menuRegular, 20);
-                        addMenuIfNonEmpty(menu, menuGreen, 20);
-                        addMenuIfNonEmpty(menu, menuUltraGreen, 20);
+                        JMenuHelpers.addMenuIfNonEmpty(menu, menuElite, 20);
+                        JMenuHelpers.addMenuIfNonEmpty(menu, menuVeteran, 20);
+                        JMenuHelpers.addMenuIfNonEmpty(menu, menuRegular, 20);
+                        JMenuHelpers.addMenuIfNonEmpty(menu, menuGreen, 20);
+                        JMenuHelpers.addMenuIfNonEmpty(menu, menuUltraGreen, 20);
 
                         popup.add(menu);
                     }
@@ -1148,14 +1148,5 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionLi
                     + unit.getEntity().getModel());
         }
         MechSummaryCache.getInstance().loadMechData();
-    }
-
-    private static void addMenuIfNonEmpty(JMenu menu, JMenu child, int scrollerThreshold) {
-        if (child.getItemCount() > 0) {
-            menu.add(child);
-            if (child.getItemCount() > scrollerThreshold) {
-                MenuScroller.setScrollerFor(child, scrollerThreshold);
-            }
-        }
     }
 }

--- a/MekHQ/src/mekhq/gui/utilities/JMenuHelpers.java
+++ b/MekHQ/src/mekhq/gui/utilities/JMenuHelpers.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 - The MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.utilities;
+
+import megamek.client.ui.swing.util.MenuScroller;
+
+import javax.swing.*;
+
+public class JMenuHelpers {
+    public static void addMenuIfNonEmpty(JMenu menu, JMenu child, int scrollerThreshold) {
+        if (child.getItemCount() > 0) {
+            menu.add(child);
+            if (child.getItemCount() > scrollerThreshold) {
+                MenuScroller.setScrollerFor(child, scrollerThreshold);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This moves the addMenuIfNonEmpty method to a new JMenuHelpers class, which allows it to be easily reused in the code (two implementation PRs will be opened soon after this is merged)