### PR TITLE
Campaign Options: Fixing Default Edge Cost

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -409,7 +409,7 @@ public class CampaignOptions implements Serializable {
         contractNegotiationXP = 0;
         adminXP = 0;
         adminXPPeriod = 1;
-        edgeCost = 1;
+        edgeCost = 10;
         unitRatingMethod = UnitRatingMethod.CAMPAIGN_OPS;
         waitingPeriod = 7;
         acquisitionSkill = S_TECH;


### PR DESCRIPTION
The default should be 10, not 1. This fixes that issue, which was raised by Algebro on discord.