### PR TITLE
#1611: just reset maintenance when we do maintenance

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8146,8 +8146,9 @@ public class Campaign implements Serializable, ITechManager {
             addReport(techNameLinked + " performs maintenance on " + u.getHyperlinkedName() + ". " + paidString
                     + qualityString + ". " + damageString + " [<a href='MAINTENANCE|" + u.getId()
                     + "'>Get details</a>]");
+            
+            u.resetDaysSinceMaintenance();
         }
-        u.resetDaysSinceMaintenance();
     }
 
     public void initTimeInService() {


### PR DESCRIPTION
This fixes the behavior described in issue #1611 - for some reason the 'days since maintenance' count was being reset every day, rather than every maintenance check.