### PR TITLE
Prisoners Marriage Logic Fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1285,7 +1285,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 !this.equals(p)
                 && !p.hasSpouse()
                 && p.oldEnoughToMarry()
-                && (!p.isPrisoner() || (p.isPrisoner() && isPrisoner()))
+                && (!p.isPrisoner() || isPrisoner())
                 && !p.isDeadOrMIA()
                 && p.isActive()
                 && ((getAncestorsId() == null)


### PR DESCRIPTION
This is a bug I found when asked about a workaround as part of #1612 . Prisoners were supposed to be able to marry whomever (specifically that a prisoner can marry anyone, but nobody else can marry a prisoner), however they are currently only able to marry other prisoners.