### PR TITLE
1632: Fixing ternary mistake that makes all random marriages same sex

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1316,7 +1316,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
 
     public void addRandomSpouse(boolean sameSex) {
         List<Person> potentials = new ArrayList<>();
-        int gender = sameSex ? getGender() : (isMale() ? Crew.G_MALE : Crew.G_FEMALE);
+        int gender = sameSex ? getGender() : (isMale() ? Crew.G_FEMALE : Crew.G_MALE);
         for (Person p : campaign.getPersonnel()) {
             if (isPotentialRandomSpouse(p, gender)) {
                 potentials.add(p);


### PR DESCRIPTION
This fixes #1632.