### PR TITLE
Fixing Activate/Mothball Display Text

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -1038,13 +1038,13 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionLi
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
                     if (oneActive) {
-                        menuItem = new JMenuItem(oneSelected ? "Mass Mothball Units" : "Mothball Unit");
+                        menuItem = new JMenuItem(oneSelected ? "Mothball Units" : "Mass Mothball Unit");
                         menuItem.setActionCommand(COMMAND_GM_MOTHBALL);
                         menuItem.addActionListener(this);
                         menu.add(menuItem);
                     }
                     if (oneMothballed) {
-                        menuItem = new JMenuItem(oneSelected ? "Mass Activate Units" : "Activate Unit");
+                        menuItem = new JMenuItem(oneSelected ? "Activate Units" : "Mass Activate Unit");
                         menuItem.setActionCommand(COMMAND_GM_ACTIVATE);
                         menuItem.addActionListener(this);
                         menu.add(menuItem);


### PR DESCRIPTION
This fixes an issue where I flipped the sides of a ternary, which then displays the wrong values.