### PR TITLE
Fix undesirable deployment zone for reinforcements

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
@@ -598,6 +598,8 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
         rft.setForceName(REINFORCEMENT_TEMPLATE_ID);
         rft.setGenerationMethod(ForceGenerationMethod.PlayerSupplied.ordinal());
         rft.setGenerationOrder(1);
+        rft.setActualDeploymentZone(Board.START_NONE);
+        rft.setSyncDeploymentType(SynchronizedDeploymentType.None);
 
         return rft;
     }


### PR DESCRIPTION
This small change fixes a behavior where any forces assigned to most AtB scenarios (especially ones generated from templates) as reinforcements would default to ANY as a deployment zone, which makes very little sense.