### PR TITLE
Avoid NPE in Person::isMothballing

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3635,8 +3635,9 @@ public class Person implements Serializable, MekHqXmlSerializable {
         if (!isTech()) {
             return false;
         }
-        for (Unit u : campaign.getUnits()) {
-            if (u.isMothballing() && u.getTech().getId().equals(id)) {
+        for (UUID unitId : techUnitIds) {
+            Unit u = campaign.getUnit(unitId);
+            if (u != null && u.isMothballing()) {
                 return true;
             }
         }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3637,7 +3637,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         }
         for (UUID unitId : techUnitIds) {
             Unit u = campaign.getUnit(unitId);
-            if (u != null && u.isMothballing()) {
+            if ((u != null) && u.isMothballing()) {
                 return true;
             }
         }


### PR DESCRIPTION
Sometimes a unit would be marked as mothballing but the tech would be cleared, leading to an NPE when checking if the IDs matched. This switches the logic to only search the units the person is tech'ing.