### PR TITLE
Remove UI-only code from Person

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3011,13 +3011,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
         }
     }
 
-    public String getPatientDesc() {
-        String toReturn = "<html><font size='2'><b>" + getFullTitle() + "</b><br/>";
-        toReturn += getHits() + " hit(s)<br>[next check in " + getDaysToWaitForHealing() + " days]";
-        toReturn += "</font></html>";
-        return toReturn;
-    }
-
     /**
      * returns a full description in HTML format that will be used for the graphical display in the
      * personnel table among other places
@@ -3987,22 +3980,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public void removeInjury(Injury i) {
         injuries.remove(i);
         MekHQ.triggerEvent(new PersonChangedEvent(this));
-    }
-
-    public String getInjuriesDesc() {
-        StringBuilder toReturn = new StringBuilder("<html><font size='2'><b>").append(getFullTitle())
-                .append("</b><br/>").append("&nbsp;&nbsp;&nbsp;Injuries:");
-        String sep = "<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
-        for (Injury injury : injuries) {
-            toReturn.append(sep).append(injury.getFluff());
-            if (sep.contains("<br/>")) {
-                sep = ", ";
-            } else {
-                sep = ",<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
-            }
-        }
-        toReturn.append("</font></html>");
-        return toReturn.toString();
     }
 
     public void diagnose(int hits) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4085,29 +4085,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return Modifier.calcTotalModifier(injuries.stream().flatMap(i -> i.getModifiers().stream()), ModifierValue.GUNNERY);
     }
 
-    /**
-     * @return an HTML encoded string of effects
-     */
-    public String getEffectString() {
-        StringBuilder sb = new StringBuilder("<html>");
-        final int pilotingMod = getPilotingInjuryMod();
-        final int gunneryMod = getGunneryInjuryMod();
-        if((pilotingMod != 0) && (pilotingMod < Integer.MAX_VALUE)) {
-            sb.append(String.format("  Piloting %+d <br>", pilotingMod));
-        } else if(pilotingMod == Integer.MAX_VALUE) {
-            sb.append("  Piloting: <i>Impossible</i>  <br>");
-        }
-        if((gunneryMod != 0) && (gunneryMod < Integer.MAX_VALUE)) {
-            sb.append(String.format("  Gunnery: %+d <br>", gunneryMod));
-        } else if(gunneryMod == Integer.MAX_VALUE) {
-            sb.append("  Gunnery: <i>Impossible</i>  <br>");
-        }
-        if(gunneryMod == 0 && pilotingMod == 0) {
-            sb.append("None");
-        }
-        return sb.append("</html>").toString();
-    }
-
     public boolean hasInjuries(boolean permCheck) {
         boolean tf = false;
         if (injuries.size() > 0) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -212,15 +212,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
     //endregion Divorce Variables
     //endregion Family Variables
 
-    /** Contains the skill levels to be displayed in a tech's description */
-    private static final String[] DISPLAYED_SKILL_LEVELS = new String[] {
-        SkillType.S_TECH_MECH,
-        SkillType.S_TECH_MECHANIC,
-        SkillType.S_TECH_BA,
-        SkillType.S_TECH_AERO,
-        SkillType.S_TECH_VESSEL,
-    };
-
     protected UUID id;
     protected int oldId;
 
@@ -3890,40 +3881,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
             lvl = aeroSkill.getLevel();
         }
         return lvl;
-    }
-
-    public String getTechDesc(boolean overtimeAllowed, IPartWork part) {
-        StringBuilder toReturn = new StringBuilder(128);
-        toReturn.append("<html><font size='2'");
-        if (null != part && null != part.getUnit() && getTechUnitIDs().contains(part.getUnit().getId())) {
-            toReturn.append(" color='green'><b>@");
-        }
-        else {
-            toReturn.append("><b>");
-        }
-        toReturn.append(getFullTitle()).append("</b><br/>");
-
-        boolean first = true;
-        for (String skillName : DISPLAYED_SKILL_LEVELS) {
-            Skill skill = getSkill(skillName);
-            if (null == skill) {
-                continue;
-            } else if (!first) {
-                toReturn.append("; ");
-            }
-
-            toReturn.append(SkillType.getExperienceLevelName(skill.getExperienceLevel()));
-            toReturn.append(" ").append(skillName);
-            first = false;
-        }
-
-        toReturn.append(String.format(" (%d XP)<br/>", getXp()))
-                .append(String.format("%d minutes left", getMinutesLeft()));
-        if (overtimeAllowed) {
-            toReturn.append(String.format(" + (%d overtime)", getOvertimeLeft()));
-        }
-        toReturn.append("</font></html>");
-        return toReturn.toString();
     }
 
     public boolean isRightTechTypeFor(IPartWork part) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3871,31 +3871,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return null;
     }
 
-    public String getDocDesc() {
-        StringBuilder toReturn = new StringBuilder(128);
-        toReturn.append("<html><font size='2'><b>").append(getFullTitle()).append("</b><br/>");
-
-        Skill skill = getSkill(SkillType.S_DOCTOR);
-        if (null != skill) {
-            toReturn.append(SkillType.getExperienceLevelName(skill.getExperienceLevel()))
-                    .append(" " + SkillType.S_DOCTOR);
-        }
-
-        toReturn.append(String.format(" (%d XP)", getXp()));
-
-        if (campaign.getMedicsPerDoctor() < 4) {
-            toReturn.append("</font><font size='2' color='red'>, ")
-                    .append(campaign.getMedicsPerDoctor())
-                    .append(" medics</font><font size='2'><br/>");
-        } else {
-            toReturn.append(String.format(", %d medics<br />", campaign.getMedicsPerDoctor()));
-        }
-
-        toReturn.append(String.format("%d patient(s)</font></html>", campaign.getPatientsFor(this)));
-
-        return toReturn.toString();
-    }
-
     public int getBestTechLevel() {
         int lvl = -1;
         Skill mechSkill = getSkill(SkillType.S_TECH_MECH);

--- a/MekHQ/src/mekhq/gui/model/DocTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/DocTableModel.java
@@ -9,6 +9,8 @@ import javax.swing.table.TableCellRenderer;
 import mekhq.IconPackage;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.Skill;
+import mekhq.campaign.personnel.SkillType;
 import mekhq.gui.BasicInfo;
 
 /**
@@ -26,7 +28,32 @@ public class DocTableModel extends DataTableModel {
     }
 
     public Object getValueAt(int row, int col) {
-        return ((Person) data.get(row)).getDocDesc();
+        return getDocDesc((Person) data.get(row));
+    }
+
+    private String getDocDesc(Person doc) {
+        StringBuilder toReturn = new StringBuilder(128);
+        toReturn.append("<html><font size='2'><b>").append(doc.getFullTitle()).append("</b><br/>");
+
+        Skill skill = doc.getSkill(SkillType.S_DOCTOR);
+        if (null != skill) {
+            toReturn.append(SkillType.getExperienceLevelName(skill.getExperienceLevel()))
+                    .append(" " + SkillType.S_DOCTOR);
+        }
+
+        toReturn.append(String.format(" (%d XP)", doc.getXp()));
+
+        if (campaign.getMedicsPerDoctor() < 4) {
+            toReturn.append("</font><font size='2' color='red'>, ")
+                    .append(campaign.getMedicsPerDoctor())
+                    .append(" medics</font><font size='2'><br/>");
+        } else {
+            toReturn.append(String.format(", %d medics<br />", campaign.getMedicsPerDoctor()));
+        }
+
+        toReturn.append(String.format("%d patient(s)</font></html>", campaign.getPatientsFor(doc)));
+
+        return toReturn.toString();
     }
 
     public Person getDoctorAt(int row) {

--- a/MekHQ/src/mekhq/gui/model/PatientTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PatientTableModel.java
@@ -9,6 +9,7 @@ import javax.swing.ListCellRenderer;
 
 import mekhq.IconPackage;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.BasicInfo;
 
@@ -70,9 +71,9 @@ public class PatientTableModel extends AbstractListModel<Person> {
             Person p = (Person)getElementAt(index);
             setPortrait(p);
             if (getCampaign().getCampaignOptions().useAdvancedMedical()) {
-                setHtmlText(p.getInjuriesDesc());
+                setHtmlText(getInjuriesDesc(p));
             } else {
-                setHtmlText(p.getPatientDesc());
+                setHtmlText(getPatientDesc(p));
             }
             if (isSelected) {
                 highlightBorder();
@@ -83,5 +84,28 @@ public class PatientTableModel extends AbstractListModel<Person> {
             setForeground(list.getForeground());
             return this;
         }
+    }
+
+    private String getInjuriesDesc(Person p) {
+        StringBuilder toReturn = new StringBuilder("<html><font size='2'><b>").append(p.getFullTitle())
+                .append("</b><br/>").append("&nbsp;&nbsp;&nbsp;Injuries:");
+        String sep = "<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+        for (Injury injury : p.getInjuries()) {
+            toReturn.append(sep).append(injury.getFluff());
+            if (sep.contains("<br/>")) {
+                sep = ", ";
+            } else {
+                sep = ",<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+            }
+        }
+        toReturn.append("</font></html>");
+        return toReturn.toString();
+    }
+
+    private String getPatientDesc(Person p) {
+        String toReturn = "<html><font size='2'><b>" + p.getFullTitle() + "</b><br/>";
+        toReturn += p.getHits() + " hit(s)<br>[next check in " + p.getDaysToWaitForHealing() + " days]";
+        toReturn += "</font></html>";
+        return toReturn;
     }
 }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1436,7 +1436,7 @@ public class PersonViewPanel extends ScrollablePanel {
         }
 
         lblAdvancedMedical2.setName("lblAdvancedMedical2"); // NOI18N
-        lblAdvancedMedical2.setText(person.getEffectString());
+        lblAdvancedMedical2.setText(getAdvancedMedalEffectString(person));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
@@ -1483,6 +1483,30 @@ public class PersonViewPanel extends ScrollablePanel {
         pnlInjuries.add(pnlInjuryDetails, BorderLayout.CENTER);
 
         return pnlInjuries;
+    }
+
+    /**
+     * Gets the advanced medical effects active for the person.
+     * @return an HTML encoded string of effects
+     */
+    private String getAdvancedMedalEffectString(Person p) {
+        StringBuilder sb = new StringBuilder("<html>");
+        final int pilotingMod = p.getPilotingInjuryMod();
+        final int gunneryMod = p.getGunneryInjuryMod();
+        if((pilotingMod != 0) && (pilotingMod < Integer.MAX_VALUE)) {
+            sb.append(String.format("  Piloting %+d <br>", pilotingMod));
+        } else if(pilotingMod == Integer.MAX_VALUE) {
+            sb.append("  Piloting: <i>Impossible</i>  <br>");
+        }
+        if((gunneryMod != 0) && (gunneryMod < Integer.MAX_VALUE)) {
+            sb.append(String.format("  Gunnery: %+d <br>", gunneryMod));
+        } else if(gunneryMod == Integer.MAX_VALUE) {
+            sb.append("  Gunnery: <i>Impossible</i>  <br>");
+        }
+        if(gunneryMod == 0 && pilotingMod == 0) {
+            sb.append("None");
+        }
+        return sb.append("</html>").toString();
     }
 
     private JPanel fillKillRecord() {


### PR DESCRIPTION
The cognitive burden of reading Person.java is getting Too Damn High. This PR simply moves five UI-only descriptor methods to their respective UI classes. A 2.3% win, but a win nonetheless.