### PR TITLE
Do not add TECH_CLAN to originalUnitTech

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4035,7 +4035,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public void setOriginalUnit(Unit unit) {
         originalUnitId = unit.getId();
         if (unit.getEntity().isClan()) {
-            originalUnitTech += TECH_CLAN;
+            originalUnitTech = TECH_CLAN;
         } else if (unit.getEntity().getTechLevel() > megamek.common.TechConstants.T_INTRO_BOXSET) {
             originalUnitTech = TECH_IS2;
         } else {

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -4,9 +4,15 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.spy;
 
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import megamek.MegaMek;
+import megamek.common.Entity;
+import mekhq.campaign.unit.Unit;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.UUID;
 
 public class PersonTest {
     private Person mockPerson;
@@ -84,6 +90,79 @@ public class PersonTest {
         mockPerson.awardController.removeAward("TestSet", "Test Award 1", "3000-01-02");
 
         assertEquals(0, mockPerson.awardController.getNumberOfAwards(PersonnelTestUtilities.getTestAward1()));
+    }
+
+    @Test
+    public void testSetOriginalUnit() {
+        initPerson();
+
+        UUID is1Id = UUID.randomUUID();
+        int is1WeightClass = megamek.common.EntityWeightClass.WEIGHT_LIGHT;
+
+        Unit is1 = Mockito.mock(Unit.class);
+        Mockito.when(is1.getId()).thenReturn(is1Id);
+
+        Entity is1Entity = Mockito.mock(Entity.class);
+        Mockito.when(is1Entity.isClan()).thenReturn(false);
+        Mockito.when(is1Entity.getTechLevel()).thenReturn(megamek.common.TechConstants.T_INTRO_BOXSET);
+        Mockito.when(is1Entity.getWeightClass()).thenReturn(is1WeightClass);
+        Mockito.when(is1.getEntity()).thenReturn(is1Entity);
+
+        mockPerson.setOriginalUnit(is1);
+        assertEquals(Person.TECH_IS1, mockPerson.getOriginalUnitTech());
+        assertEquals(is1WeightClass, mockPerson.getOriginalUnitWeight());
+        assertEquals(is1Id, mockPerson.getOriginalUnitId());
+
+        int[] is2Techs = new int[] {
+            megamek.common.TechConstants.T_IS_TW_NON_BOX,
+            megamek.common.TechConstants.T_IS_TW_ALL,
+            megamek.common.TechConstants.T_IS_ADVANCED,
+            megamek.common.TechConstants.T_IS_EXPERIMENTAL,
+            megamek.common.TechConstants.T_IS_UNOFFICIAL,
+        };
+        for (int is2TechLevel : is2Techs) {
+            UUID is2Id = UUID.randomUUID();
+            int is2WeightClass = megamek.common.EntityWeightClass.WEIGHT_HEAVY;
+
+            Unit is2 = Mockito.mock(Unit.class);
+            Mockito.when(is2.getId()).thenReturn(is2Id);
+
+            Entity is2Entity = Mockito.mock(Entity.class);
+            Mockito.when(is2Entity.isClan()).thenReturn(false);
+            Mockito.when(is2Entity.getTechLevel()).thenReturn(is2TechLevel);
+            Mockito.when(is2Entity.getWeightClass()).thenReturn(is2WeightClass);
+            Mockito.when(is2.getEntity()).thenReturn(is2Entity);
+
+            mockPerson.setOriginalUnit(is2);
+            assertEquals(Person.TECH_IS2, mockPerson.getOriginalUnitTech());
+            assertEquals(is2WeightClass, mockPerson.getOriginalUnitWeight());
+            assertEquals(is2Id, mockPerson.getOriginalUnitId());
+        }
+
+        int[] clanTechs = new int[] {
+            megamek.common.TechConstants.T_CLAN_TW,
+            megamek.common.TechConstants.T_CLAN_ADVANCED,
+            megamek.common.TechConstants.T_CLAN_EXPERIMENTAL,
+            megamek.common.TechConstants.T_CLAN_UNOFFICIAL,
+        };
+        for (int clanTech : clanTechs) {
+            UUID clanId = UUID.randomUUID();
+            int clanWeightClass = megamek.common.EntityWeightClass.WEIGHT_MEDIUM;
+
+            Unit clan = Mockito.mock(Unit.class);
+            Mockito.when(clan.getId()).thenReturn(clanId);
+
+            Entity clanEntity = Mockito.mock(Entity.class);
+            Mockito.when(clanEntity.isClan()).thenReturn(true);
+            Mockito.when(clanEntity.getTechLevel()).thenReturn(clanTech);
+            Mockito.when(clanEntity.getWeightClass()).thenReturn(clanWeightClass);
+            Mockito.when(clan.getEntity()).thenReturn(clanEntity);
+
+            mockPerson.setOriginalUnit(clan);
+            assertEquals(Person.TECH_CLAN, mockPerson.getOriginalUnitTech());
+            assertEquals(clanWeightClass, mockPerson.getOriginalUnitWeight());
+            assertEquals(clanId, mockPerson.getOriginalUnitId());
+        }
     }
 
     private void initPerson(){


### PR DESCRIPTION
This fixes a bug introduced in the refactoring commit d59fa1f85b3fb673cbb0b766be34a28409c24bc7. The old code set `originalUnitTech` to 0 before adding either 2 for clan tech or using postfix increment for IS2. The new code did not reset `originalUnitTech` to 0.