### PR TITLE
Change refit model weight calculation to work with BA

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -369,17 +369,29 @@ public class Utilities {
         CampaignOptions options = campaign.getCampaignOptions();
         ArrayList<String> variants = new ArrayList<>();
         for(MechSummary summary : MechSummaryCache.getInstance().getAllMechs()) {
-            // If this isn't the same chassis, is our current unit, or is a different weight we continue
-            if(!en.getChassis().equalsIgnoreCase(summary.getChassis())
+            // If this isn't the same chassis, is our current unit, we continue
+            if (!en.getChassis().equalsIgnoreCase(summary.getChassis())
                     || en.getModel().equalsIgnoreCase(summary.getModel())
-                    || summary.getTons() != en.getWeight()
                     || !summary.getUnitType().equals(UnitType.determineUnitType(en))) {
                 continue;
             }
             // If we only allow canon units and this isn't canon we continue
-            if(!summary.isCanon() && options.allowCanonRefitOnly()) {
+            if (!summary.isCanon() && options.allowCanonRefitOnly()) {
                 continue;
             }
+            
+            // Weight of the two units must match or we continue, but BA weight gets
+            // checked differently
+            if (en instanceof BattleArmor) {
+                if (((BattleArmor)en).getTroopers() != (int) summary.getTWweight()) {
+                    continue;
+                }
+            } else {
+                if (summary.getTons() != en.getWeight()) {
+                    continue;
+                }
+            }
+            
             // If the unit doesn't meet the tech filter criteria we continue
             ITechnology techProg = UnitTechProgression.getProgression(summary, campaign.getTechFaction(), true);
             if (null == techProg) {

--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -372,14 +372,14 @@ public class Utilities {
             // If this isn't the same chassis, is our current unit, we continue
             if (!en.getChassis().equalsIgnoreCase(summary.getChassis())
                     || en.getModel().equalsIgnoreCase(summary.getModel())
-                    || !summary.getUnitType().equals(UnitType.determineUnitType(en))) {
+                    || !summary.getUnitType().equals(UnitType.getTypeName(en.getUnitType()))) {
                 continue;
             }
             
             // Weight of the two units must match or we continue, but BA weight gets
             // checked differently
             if (en instanceof BattleArmor) {
-                if (((BattleArmor)en).getTroopers() != (int) summary.getTWweight()) {
+                if (((BattleArmor) en).getTroopers() != (int) summary.getTWweight()) {
                     continue;
                 }
             } else {

--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -375,10 +375,6 @@ public class Utilities {
                     || !summary.getUnitType().equals(UnitType.determineUnitType(en))) {
                 continue;
             }
-            // If we only allow canon units and this isn't canon we continue
-            if (!summary.isCanon() && options.allowCanonRefitOnly()) {
-                continue;
-            }
             
             // Weight of the two units must match or we continue, but BA weight gets
             // checked differently
@@ -390,6 +386,11 @@ public class Utilities {
                 if (summary.getTons() != en.getWeight()) {
                     continue;
                 }
+            }
+            
+            // If we only allow canon units and this isn't canon we continue
+            if (!summary.isCanon() && options.allowCanonRefitOnly()) {
+                continue;
             }
             
             // If the unit doesn't meet the tech filter criteria we continue


### PR DESCRIPTION
Fixes an undocumented bug where the available refit dialog won't appear due to an index out of bounds exception. This happens when refitting squads that have models with different numbers of troopers, such as IS/WoB versions of the Phalanx.