### PR TITLE
fix phantom scenario assignment npe

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4235,7 +4235,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         
         // clean up units that are assigned to non-existing scenarios
-        for(Unit unit : this.getUnits()) {
+        for (Unit unit : this.getUnits()) {
             if(this.getScenario(unit.getScenarioId()) == null) {
                 unit.setScenarioId(Scenario.S_DEFAULT_ID);
             }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4236,7 +4236,7 @@ public class Campaign implements Serializable, ITechManager {
         
         // clean up units that are assigned to non-existing scenarios
         for (Unit unit : this.getUnits()) {
-            if(this.getScenario(unit.getScenarioId()) == null) {
+            if (this.getScenario(unit.getScenarioId()) == null) {
                 unit.setScenarioId(Scenario.S_DEFAULT_ID);
             }
         }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4233,6 +4233,13 @@ public class Campaign implements Serializable, ITechManager {
                 force.removeUnit(unitID);
             }
         }
+        
+        // clean up units that are assigned to non-existing scenarios
+        for(Unit unit : this.getUnits()) {
+            if(this.getScenario(unit.getScenarioId()) == null) {
+                unit.setScenarioId(Scenario.S_DEFAULT_ID);
+            }
+        }
     }
 
     public boolean isOvertimeAllowed() {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -31,6 +31,7 @@ import megamek.common.*;
 import megamek.common.InfantryBay.PlatoonType;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.ServiceLogger;
+import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.parts.*;
 
 import org.w3c.dom.NamedNodeMap;
@@ -197,7 +198,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         this.oldGunners = new ArrayList<>();
         this.oldVesselCrew = new ArrayList<>();
         this.oldNavigator = -1;
-        scenarioId = -1;
+        scenarioId = Scenario.S_DEFAULT_ID;
         this.refit = null;
         this.engineer = null;
         this.history = "";


### PR DESCRIPTION
This PR fixes an issue which prevents the personnel tab from displaying when one of the units involved has been assigned to a scenario but has somehow not been properly unassigned.