### PR TITLE
1691: Personnel are now filtered by primary and secondary roles in the Personnel Tab

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2375,8 +2375,7 @@ public class Campaign implements Serializable, ITechManager {
             return admin;
         } else if (skill.equals(CampaignOptions.S_TECH)) {
             for (Person p : getPersonnel()) {
-                if (getCampaignOptions().isAcquisitionSupportStaffOnly()
-                        && !p.isSupport()) {
+                if (getCampaignOptions().isAcquisitionSupportStaffOnly() && !p.hasSupportRole(false)) {
                     continue;
                 }
                 if (maxAcquisitions > 0 && p.getAcquisitions() >= maxAcquisitions) {
@@ -2390,8 +2389,7 @@ public class Campaign implements Serializable, ITechManager {
             }
         } else {
             for (Person p : getPersonnel()) {
-                if (getCampaignOptions().isAcquisitionSupportStaffOnly()
-                        && !p.isSupport()) {
+                if (getCampaignOptions().isAcquisitionSupportStaffOnly() && !p.hasSupportRole(false)) {
                     continue;
                 }
                 if (maxAcquisitions > 0 && p.getAcquisitions() >= maxAcquisitions) {
@@ -2423,8 +2421,7 @@ public class Campaign implements Serializable, ITechManager {
                 if (!p.isActive()) {
                     continue;
                 }
-                if (getCampaignOptions().isAcquisitionSupportStaffOnly()
-                        && !p.isSupport()) {
+                if (getCampaignOptions().isAcquisitionSupportStaffOnly() && !p.hasSupportRole(false)) {
                     continue;
                 }
                 if (maxAcquisitions > 0 && p.getAcquisitions() >= maxAcquisitions) {
@@ -4577,7 +4574,6 @@ public class Campaign implements Serializable, ITechManager {
         campaignOptions = options;
     }
 
-
     public void writeToXml(PrintWriter pw1) {
         // File header
         pw1.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
@@ -6437,7 +6433,7 @@ public class Campaign implements Serializable, ITechManager {
             searchCat_RoleGroup = "Vessel Crew/";
         }
 
-        if (p.isSupport()) {
+        if (p.hasPrimarySupportRole(true)) {
             searchCat_CombatSupport = "Support/";
         } else {
             searchCat_CombatSupport = "Combat/";
@@ -7822,8 +7818,7 @@ public class Campaign implements Serializable, ITechManager {
 
         for (Person p : getPersonnel()) {
             // Add them to the total count
-            if (Person.isCombatRole(p.getPrimaryRole()) && !p.isPrisoner()
-                    && !p.isBondsman() && p.isActive()) {
+            if (p.hasPrimaryCombatRole() && p.isFree() && p.isActive()) {
                 countPersonByType[p.getPrimaryRole()]++;
                 countTotal++;
                 if (getCampaignOptions().useAdvancedMedical() && p.getInjuries().size() > 0) {
@@ -7832,11 +7827,11 @@ public class Campaign implements Serializable, ITechManager {
                     countInjured++;
                 }
                 salary = salary.plus(p.getSalary());
-            } else if (Person.isCombatRole(p.getPrimaryRole()) && (p.getStatus() == PersonnelStatus.RETIRED)) {
+            } else if (p.hasPrimaryCombatRole() && (p.getStatus() == PersonnelStatus.RETIRED)) {
                 countRetired++;
-            } else if (Person.isCombatRole(p.getPrimaryRole()) && (p.getStatus() == PersonnelStatus.MIA)) {
+            } else if (p.hasPrimaryCombatRole() && (p.getStatus() == PersonnelStatus.MIA)) {
                 countMIA++;
-            } else if (Person.isCombatRole(p.getPrimaryRole()) && (p.getStatus() == PersonnelStatus.KIA)) {
+            } else if (p.hasPrimaryCombatRole() && (p.getStatus() == PersonnelStatus.KIA)) {
                 countKIA++;
             }
         }
@@ -7886,8 +7881,7 @@ public class Campaign implements Serializable, ITechManager {
 
         for (Person p : getPersonnel()) {
             // Add them to the total count
-            if (Person.isSupportRole(p.getPrimaryRole()) && !p.isPrisoner()
-                    && !p.isBondsman() && p.isActive()) {
+            if (p.hasPrimarySupportRole(false) && p.isFree() && p.isActive()) {
                 countPersonByType[p.getPrimaryRole()]++;
                 countTotal++;
                 if (p.getInjuries().size() > 0 || p.getHits() > 0) {
@@ -7904,14 +7898,11 @@ public class Campaign implements Serializable, ITechManager {
                 if (p.getInjuries().size() > 0 || p.getHits() > 0) {
                     countInjured++;
                 }
-            } else if (Person.isSupportRole(p.getPrimaryRole())
-                    && (p.getStatus() == PersonnelStatus.RETIRED)) {
+            } else if (p.hasPrimarySupportRole(false) && (p.getStatus() == PersonnelStatus.RETIRED)) {
                 countRetired++;
-            } else if (Person.isSupportRole(p.getPrimaryRole())
-                    && (p.getStatus() == PersonnelStatus.MIA)) {
+            } else if (p.hasPrimarySupportRole(false) && (p.getStatus() == PersonnelStatus.MIA)) {
                 countMIA++;
-            } else if (Person.isSupportRole(p.getPrimaryRole())
-                    && (p.getStatus() == PersonnelStatus.KIA)) {
+            } else if (p.hasPrimarySupportRole(false) && (p.getStatus() == PersonnelStatus.KIA)) {
                 countKIA++;
             }
         }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -76,8 +76,8 @@ public class Person implements Serializable, MekHqXmlSerializable {
      * in isCombatRole(int) or isSupportRole(int). You should also increase the value of T_NUM
      * if you add new roles.
      */
-    public static final int T_NONE = 0;
-    public static final int T_MECHWARRIOR = 1;
+    public static final int T_NONE = 0; // Support Role
+    public static final int T_MECHWARRIOR = 1; // Start of Combat Roles
     public static final int T_AERO_PILOT = 2;
     public static final int T_GVEE_DRIVER = 3;
     public static final int T_NVEE_DRIVER = 4;
@@ -90,8 +90,8 @@ public class Person implements Serializable, MekHqXmlSerializable {
     public static final int T_SPACE_PILOT = 11;
     public static final int T_SPACE_CREW = 12;
     public static final int T_SPACE_GUNNER = 13;
-    public static final int T_NAVIGATOR = 14; // End of combat roles
-    public static final int T_MECH_TECH = 15;
+    public static final int T_NAVIGATOR = 14; // End of Combat Roles
+    public static final int T_MECH_TECH = 15; // Start of Support Roles
     public static final int T_MECHANIC = 16;
     public static final int T_AERO_TECH = 17;
     public static final int T_BA_TECH = 18;
@@ -829,6 +829,47 @@ public class Person implements Serializable, MekHqXmlSerializable {
      */
     public boolean hasRole(int role) {
         return (getPrimaryRole() == role) || (getSecondaryRole() == role);
+    }
+
+    public boolean hasRoleWithin(int minimumRole, int maximumRole) {
+        return (((getPrimaryRole() >= minimumRole) && (getPrimaryRole() <= maximumRole))
+                || ((getSecondaryRole() >= minimumRole) && (getSecondaryRole() <= maximumRole)));
+    }
+
+    /**
+     * @return true if this person has either a primary or a secondary role that is considered a combat
+     *         role
+     */
+    public boolean isCombat() {
+        return isCombatRole(primaryRole) || isCombatRole(secondaryRole);
+    }
+
+    /**
+     * @return true if this person has either a primary or a secondary role that is considered a support
+     *         role
+     */
+    public boolean isSupport() {
+        return isSupportRole(primaryRole) || isSupportRole(secondaryRole);
+    }
+
+    /**
+     * Determines whether a role is considered a combat role. Note that T_LAM_PILOT is a special
+     * placeholder which is not used for either primary or secondary role and will return false.
+     *
+     * @param role A value that can be used for a person's primary or secondary role.
+     * @return     Whether the role is considered a combat role
+     */
+    public static boolean isCombatRole(int role) {
+        return ((role > T_NONE) && (role <= T_NAVIGATOR))
+                || (role == T_VEHICLE_CREW);
+    }
+
+    /**
+     * @param role A value that can be used for a person's primary or secondary role.
+     * @return     Whether the role is considered a support role
+     */
+    public static boolean isSupportRole(int role) {
+        return (role >= T_MECH_TECH) && (role < T_LAM_PILOT);
     }
 
     public PersonnelStatus getStatus() {
@@ -3339,42 +3380,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
             return null;
         }
         return "<html>" + abilityString + "</html>";
-    }
-
-    /**
-     * @return true if this person has either a primary or a secondary role that is considered a combat
-     *         role
-     */
-    public boolean isCombat() {
-        return isCombatRole(primaryRole) || isCombatRole(secondaryRole);
-    }
-
-    /**
-     * @return true if this person has either a primary or a secondary role that is considered a support
-     *         role
-     */
-    public boolean isSupport() {
-        return isSupportRole(primaryRole) || isSupportRole(secondaryRole);
-    }
-
-    /**
-     * Determines whether a role is considered a combat role. Note that T_LAM_PILOT is a special
-     * placeholder which is not used for either primary or secondary role and will return false.
-     *
-     * @param role A value that can be used for a person's primary or secondary role.
-     * @return     Whether the role is considered a combat role
-     */
-    public static boolean isCombatRole(int role) {
-        return ((role > T_NONE) && (role <= T_NAVIGATOR))
-                || (role == T_VEHICLE_CREW);
-    }
-
-    /**
-     * @param role A value that can be used for a person's primary or secondary role.
-     * @return     Whether the role is considered a support role
-     */
-    public static boolean isSupportRole(int role) {
-        return (role >= T_MECH_TECH) && (role < T_LAM_PILOT);
     }
 
     public boolean canDrive(Entity ent) {

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 The MegaMek Team. All rights reserved.
+ * Copyright (c) 2017 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -71,7 +71,6 @@ import mekhq.preferences.PreferencesNode;
 
 /**
  * Tab for interacting with all personnel
- *
  */
 public final class PersonnelTab extends CampaignGuiTab {
 
@@ -398,27 +397,22 @@ public final class PersonnelTab extends CampaignGuiTab {
             public boolean include(Entry<? extends PersonnelTableModel, ? extends Integer> entry) {
                 PersonnelTableModel personModel = entry.getModel();
                 Person person = personModel.getPerson(entry.getIdentifier());
-                int type = person.getPrimaryRole();
                 if (((nGroup == PG_ACTIVE)
-                        || ((nGroup == PG_COMBAT)
-                                && ((type <= Person.T_SPACE_GUNNER) && (type > Person.T_NONE)))
-                        || ((nGroup == PG_SUPPORT)
-                                && ((type > Person.T_SPACE_GUNNER) || (type == Person.T_NONE)))
-                        || ((nGroup == PG_MW) && (type == Person.T_MECHWARRIOR))
-                        || ((nGroup == PG_CREW) && ((type == Person.T_GVEE_DRIVER)
-                                || (type == Person.T_NVEE_DRIVER) || (type == Person.T_VTOL_PILOT)
-                                || (type == Person.T_VEE_GUNNER) || (type == Person.T_VEHICLE_CREW)))
-                        || ((nGroup == PG_PILOT) && (type == Person.T_AERO_PILOT))
-                        || ((nGroup == PG_CPILOT) && (type == Person.T_CONV_PILOT))
-                        || ((nGroup == PG_PROTO) && (type == Person.T_PROTO_PILOT))
-                        || ((nGroup == PG_BA) && (type == Person.T_BA))
-                        || ((nGroup == PG_SOLDIER) && (type == Person.T_INFANTRY))
-                        || ((nGroup == PG_VESSEL) && ((type == Person.T_SPACE_PILOT)
-                                || (type == Person.T_SPACE_CREW) || (type == Person.T_SPACE_GUNNER)
-                                || (type == Person.T_NAVIGATOR)))
-                        || ((nGroup == PG_TECH) && (type >= Person.T_MECH_TECH) && (type < Person.T_DOCTOR))
-                        || ((nGroup == PG_DOC) && ((type == Person.T_DOCTOR) || (type == Person.T_MEDIC)))
-                        || ((nGroup == PG_ADMIN) && (type > Person.T_MEDIC)))
+                        || ((nGroup == PG_COMBAT) && person.hasCombatRole())
+                        || ((nGroup == PG_SUPPORT) && person.hasSupportRole(true))
+                        || ((nGroup == PG_MW) && person.hasRole(Person.T_MECHWARRIOR))
+                        || ((nGroup == PG_CREW)
+                                && (person.hasRoleWithin(Person.T_GVEE_DRIVER, Person.T_VEE_GUNNER)
+                                        || person.hasRole(Person.T_VEHICLE_CREW)))
+                        || ((nGroup == PG_PILOT) && person.hasRole(Person.T_AERO_PILOT))
+                        || ((nGroup == PG_CPILOT) && person.hasRole(Person.T_CONV_PILOT))
+                        || ((nGroup == PG_PROTO) && person.hasRole(Person.T_PROTO_PILOT))
+                        || ((nGroup == PG_BA) && person.hasRole(Person.T_BA))
+                        || ((nGroup == PG_SOLDIER) && person.hasRole(Person.T_INFANTRY))
+                        || ((nGroup == PG_VESSEL) && person.hasRoleWithin(Person.T_SPACE_PILOT, Person.T_NAVIGATOR))
+                        || ((nGroup == PG_TECH) && person.hasRoleWithin(Person.T_MECH_TECH, Person.T_ASTECH))
+                        || ((nGroup == PG_DOC) && person.hasRoleWithin(Person.T_DOCTOR, Person.T_MEDIC))
+                        || ((nGroup == PG_ADMIN) && person.hasRoleWithin(Person.T_ADMIN_COM, Person.T_ADMIN_HR)))
                         && !person.isPrisoner()) {
                     return person.isActive();
                 } else if (nGroup == PG_DEPENDENT) {

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1271,7 +1271,7 @@ public class PersonViewPanel extends ScrollablePanel {
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
             pnlSkills.add(lblEdge2, gridBagConstraints);
 
-            if (campaign.getCampaignOptions().useSupportEdge() && person.isSupport()) {
+            if (campaign.getCampaignOptions().useSupportEdge() && person.hasSupportRole(false)) {
                 //Add the Edge Available field for support personnel only
                 lblEdgeAvail1.setName("lblEdgeAvail1"); // NOI18N //$NON-NLS-1$
                 lblEdgeAvail1.setText(resourceMap.getString("lblEdgeAvail1.text")); //$NON-NLS-1$


### PR DESCRIPTION
This fixes #1691, and implements fixes for a few missing roles in the sorting for the Personnel Tab.