### PR TITLE
1718: Refit configuration change does not look for multiple qualities…

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -170,7 +170,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		}
 		// don't just return with the first part if it is damaged
 		for(Part part : campaign.getSpareParts()) {
-			if(part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart()) {
+			if(part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart() || part.isUsedForRefitPlanning()) {
 				continue;
 			}
 
@@ -179,7 +179,9 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 					bestPart = part;
 				} else if(bestPart.needsFixing() && !part.needsFixing()) {
 					bestPart = part;
-				}
+				} else if(bestPart.getQuality() < part.getQuality()) {
+				    bestPart = part;
+                }
 			}
 		}
 		return bestPart;

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -170,7 +170,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 		}
 		// don't just return with the first part if it is damaged
 		for(Part part : campaign.getSpareParts()) {
-			if(part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart() || part.isUsedForRefitPlanning()) {
+			if (part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart() || part.isUsedForRefitPlanning()) {
 				continue;
 			}
 
@@ -179,7 +179,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 					bestPart = part;
 				} else if(bestPart.needsFixing() && !part.needsFixing()) {
 					bestPart = part;
-				} else if(bestPart.getQuality() < part.getQuality()) {
+				} else if (bestPart.getQuality() < part.getQuality()) {
 				    bestPart = part;
                 }
 			}
@@ -448,4 +448,3 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
         return isExtinct(year, clan, techFaction);
     }
 }
-

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1236,9 +1236,13 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         return reserveId != null;
     }
 
-    public boolean isUsedForRefitPlanning() { return usedForRefitPlanning; }
+    public boolean isUsedForRefitPlanning() {
+        return usedForRefitPlanning;
+    }
 
-    public void setUsedForRefitPlanning(boolean flag) { usedForRefitPlanning = flag; }
+    public void setUsedForRefitPlanning(boolean flag) {
+        usedForRefitPlanning = flag;
+    }
 
     public void setDaysToArrival(int days) {
         daysToArrival = days;

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -184,6 +184,8 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     //this tracks whether the part is reserved for a refit
     protected UUID refitId;
     protected UUID reserveId;
+    //temporarily mark the part used by current refit planning
+    protected boolean usedForRefitPlanning;
 
     //for delivery
     protected int daysToArrival;
@@ -235,6 +237,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         this.workingOvertime = false;
         this.shorthandedMod = 0;
         this.refitId = null;
+        this.usedForRefitPlanning = false;
         this.daysToArrival = 0;
         this.campaign = c;
         this.brandNew = true;
@@ -1232,6 +1235,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     public boolean isReservedForReplacement() {
         return reserveId != null;
     }
+
+    public boolean isUsedForRefitPlanning() { return usedForRefitPlanning; }
+
+    public void setUsedForRefitPlanning(boolean flag) { usedForRefitPlanning = flag; }
 
     public void setDaysToArrival(int days) {
         daysToArrival = days;

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -495,6 +495,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         int atype = 0;
         boolean aclan = false;
         HashMap<Integer,Integer> partQuantity = new HashMap<>();
+        List<Part> plannedReplacementParts = new ArrayList<>();
         for(Part nPart : newPartList) {
             //TODO: I don't think we need this here anymore
             nPart.setUnit(oldUnit);
@@ -518,6 +519,11 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                     newUnitParts.add(replacement.getId());
                     //adjust quantity
                     partQuantity.put(replacement.getId(), partQuantity.get(replacement.getId())-1);
+                    //If the quantity is now 0 set usedForRefitPlanning flag so findReplacement ignores this item
+                    if (partQuantity.get(replacement.getId()) == 0) {
+                        replacement.setUsedForRefitPlanning(true);
+                        plannedReplacementParts.add(replacement);
+                    }
                 } else {
                     replacement = ((MissingPart)nPart).getNewPart();
                     //set entity for variable cost items
@@ -559,6 +565,11 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                         newUnitParts.add(replacement.getId());
                         //adjust quantity
                         partQuantity.put(replacement.getId(), partQuantity.get(replacement.getId())-1);
+                        //If the quantity is now 0 set usedForRefitPlanning flag so findReplacement ignores this item
+                        if (partQuantity.get(replacement.getId()) == 0) {
+                            replacement.setUsedForRefitPlanning(true);
+                            plannedReplacementParts.add(replacement);
+                        }
                     } else {
                         shoppingList.add(nPart);
                     }
@@ -689,6 +700,10 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                     }
                 }
             }
+        }
+        //clear any planned replacement flags
+        for (Part rPart: plannedReplacementParts) {
+            rPart.setUsedForRefitPlanning(false);
         }
 
         //if oldUnitParts is not empty we are removing some stuff and so this should
@@ -1088,9 +1103,11 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             Part newPart = oldUnit.getCampaign().getPart(id);
             if(newPart.isSpare()) {
                 if(newPart.getQuantity() > 1) {
+                    int quality = newPart.getQuality();
                     newPart.decrementQuantity();
                     newPart = newPart.clone();
                     newPart.setRefitId(oldUnit.getId());
+                    newPart.setQuality(quality);
                     oldUnit.getCampaign().addPart(newPart, 0);
                     newNewUnitParts.add(newPart.getId());
                 } else {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1103,11 +1103,9 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             Part newPart = oldUnit.getCampaign().getPart(id);
             if(newPart.isSpare()) {
                 if(newPart.getQuantity() > 1) {
-                    int quality = newPart.getQuality();
                     newPart.decrementQuantity();
                     newPart = newPart.clone();
                     newPart.setRefitId(oldUnit.getId());
-                    newPart.setQuality(quality);
                     oldUnit.getCampaign().addPart(newPart, 0);
                     newNewUnitParts.add(newPart.getId());
                 } else {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -702,7 +702,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             }
         }
         //clear any planned replacement flags
-        for (Part rPart: plannedReplacementParts) {
+        for (Part rPart : plannedReplacementParts) {
             rPart.setUsedForRefitPlanning(false);
         }
 


### PR DESCRIPTION
… in warehouse

This change fixes the problem of refits not taking all available items into account while planning a refit. The change also prioritizes higher quality items.

One other fix in this pull request is that I noticed in testing that the current system does not retain the original quality of an item when it is cloned for a refit. All cloned items use the default QUALITY_D for a new part. I have added a small fix to retain the original quality of the item through the cloning process.

This fixes #1718 