### PR TITLE
1725: Refit does not save original part quality when part is cloned

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1215,6 +1215,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         this.hits = part.hits;
         this.brandNew = part.brandNew;
         this.omniPodded = part.omniPodded;
+        this.quality = part.quality;
     }
 
     public void setRefitId(UUID rid) {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1088,11 +1088,9 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             Part newPart = oldUnit.getCampaign().getPart(id);
             if(newPart.isSpare()) {
                 if(newPart.getQuantity() > 1) {
-                    int quality = newPart.getQuality();
                     newPart.decrementQuantity();
                     newPart = newPart.clone();
                     newPart.setRefitId(oldUnit.getId());
-                    newPart.setQuality(quality);
                     oldUnit.getCampaign().addPart(newPart, 0);
                     newNewUnitParts.add(newPart.getId());
                 } else {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1088,9 +1088,11 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             Part newPart = oldUnit.getCampaign().getPart(id);
             if(newPart.isSpare()) {
                 if(newPart.getQuantity() > 1) {
+                    int quality = newPart.getQuality();
                     newPart.decrementQuantity();
                     newPart = newPart.clone();
                     newPart.setRefitId(oldUnit.getId());
+                    newPart.setQuality(quality);
                     oldUnit.getCampaign().addPart(newPart, 0);
                     newNewUnitParts.add(newPart.getId());
                 } else {


### PR DESCRIPTION
The change to save the original part quality while items are cloned during a refit.

This fixes #1725 