### PR TITLE
Implement Quick Skip for createScenariosForNewWeek

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3793,15 +3793,15 @@ public class Campaign implements Serializable, ITechManager {
      */
     public List<Contract> getActiveContracts() {
         List<Contract> active = new ArrayList<>();
-        for (Mission m : getMissions()) {
-            if (!(m instanceof Contract)) {
+        for (Mission mission : getMissions()) {
+            if (!(mission instanceof Contract)) {
                 continue;
             }
-            Contract c = (Contract) m;
-            if (c.isActive()
-                    && !getCalendar().getTime().after(c.getEndingDate())
-                    && !getCalendar().getTime().before(c.getStartDate())) {
-                active.add(c);
+            Contract contract = (Contract) mission;
+            if (contract.isActive()
+                    && !getCalendar().getTime().after(contract.getEndingDate())
+                    && !getCalendar().getTime().before(contract.getStartDate())) {
+                active.add(contract);
             }
         }
         return active;
@@ -4307,7 +4307,7 @@ public class Campaign implements Serializable, ITechManager {
                 force.removeUnit(unitID);
             }
         }
-        
+
         // clean up units that are assigned to non-existing scenarios
         for (Unit unit : this.getUnits()) {
             if (this.getScenario(unit.getScenarioId()) == null) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -18,19 +18,14 @@
  */
 package mekhq.campaign.mission.atb;
 
-import java.awt.event.ActionListener;
 import java.util.*;
 
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Lance;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.Mission;
-import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.scenario.AceDuelBuiltInScenario;
 import mekhq.campaign.mission.atb.scenario.AlliedTraitorsBuiltInScenario;
 import mekhq.campaign.mission.atb.scenario.AllyRescueBuiltInScenario;
@@ -158,14 +153,14 @@ public class AtBScenarioFactory {
         boolean hasBaseAttack;
         boolean hasBaseAttackAttacker;
 
-        // Determine active missions
-        for (Mission mission : c.getMissions()) {
-            if (!mission.isActive() || !(mission instanceof AtBContract) ) {
-                continue; //if not active or an AtBContract, we don't care about the mission
+        // We only need to process active contracts
+        for (Mission contract : c.getActiveContracts()) {
+            if (!(contract instanceof AtBContract) ) {
+                continue; //if not an AtBContract, we don't care about the mission
             }
 
             //region Value Initialization
-            atbContract = (AtBContract) mission;
+            atbContract = (AtBContract) contract;
             sList = new ArrayList<>();
             dontGenerateForces = new ArrayList<>();
             hasBaseAttack = false;

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -118,17 +118,17 @@ public class AtBScenarioFactory {
 
     @SuppressWarnings("unchecked")
     public static void registerScenario(IAtBScenario scenario) {
-    final String METHOD_NAME = "registerScenario(IAtBScenario)"; //$NON-NLS-1$
+        final String METHOD_NAME = "registerScenario(IAtBScenario)"; //$NON-NLS-1$
 
-    if (!scenario.getClass().isAnnotationPresent(AtBScenarioEnabled.class)) {
-        MekHQ.getLogger().log(AtBScenarioFactory.class, METHOD_NAME, LogLevel.ERROR,
-                String.format("Unable to register an AtBScenario of class '%s' because is does not have the '%s' annotation.", //$NON-NLS-1$
-        scenario.getClass().getName(), AtBScenarioEnabled.class.getName()));
-    } else {
-        int type = scenario.getScenarioType();
-        List<Class<IAtBScenario>> list = scenarioMap.computeIfAbsent(type, k -> new ArrayList<>());
+        if (!scenario.getClass().isAnnotationPresent(AtBScenarioEnabled.class)) {
+            MekHQ.getLogger().log(AtBScenarioFactory.class, METHOD_NAME, LogLevel.ERROR,
+                    String.format("Unable to register an AtBScenario of class '%s' because is does not have the '%s' annotation.", //$NON-NLS-1$
+            scenario.getClass().getName(), AtBScenarioEnabled.class.getName()));
+        } else {
+            int type = scenario.getScenarioType();
+            List<Class<IAtBScenario>> list = scenarioMap.computeIfAbsent(type, k -> new ArrayList<>());
 
-        list.add((Class<IAtBScenario>) scenario.getClass());
+            list.add((Class<IAtBScenario>) scenario.getClass());
         }
     }
 
@@ -143,6 +143,12 @@ public class AtBScenarioFactory {
      * @param c the campaign for which to generate scenarios
      */
     public static void createScenariosForNewWeek(Campaign c) {
+        // First, we only want to generate if we have an active contract
+        if (!c.hasActiveContract()) {
+            return;
+        }
+
+        // If we have an active contract, then we can progress with generation
         Hashtable<Integer, Lance> lances = c.getLances();
 
         AtBContract atbContract;


### PR DESCRIPTION
This is a little performance saver for calls to createScenariosForNewWeek, based on the new active contract tracing added in #1695