### PR TITLE
fix sandblaster issues

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -114,6 +114,10 @@ public class CrewSkillUpgrader {
         // that cost less XP than the remaining cap
         for(int x = 0; (x < spaCap) && (xpCap > minAbilityCost); x++) {
             int spaCost = addSingleSPA(entity, xpCap);
+            // if we didn't assign an SPA, let's reroll it.
+            if (spaCost == 0) {
+                x--;
+            }
             xpCap -= spaCost;
         }
     }
@@ -176,6 +180,11 @@ public class CrewSkillUpgrader {
         default:
             entity.getCrew().getOptions().getOption(spa.getName()).setValue(true);
             return spa.getCost();
+        }
+        
+        // if we fail to pick a random weapon/specialization for whatever reason, don't assign the SPA
+        if (spaValue.equals(Crew.SPECIAL_NONE)) {
+            return 0;
         }
         
         entity.getCrew().getOptions().getOption(spa.getName()).setValue(spaValue);

--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -231,8 +231,8 @@ public class CrewSkillUpgrader {
             }
         }
         
-        int weaponIndex = Compute.randomInt(entity.getIndividualWeaponList().size());
-        return entity.getIndividualWeaponList().get(weaponIndex).getName();
+        int weaponIndex = Compute.randomInt(eligibleWeapons.size());
+        return eligibleWeapons.get(weaponIndex).getName();
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -231,6 +231,10 @@ public class CrewSkillUpgrader {
             }
         }
         
+        if(eligibleWeapons.size() == 0) {
+            return Crew.SPECIAL_NONE;
+        }
+        
         int weaponIndex = Compute.randomInt(eligibleWeapons.size());
         return eligibleWeapons.get(weaponIndex).getName();
     }

--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -23,10 +23,12 @@ import java.util.Map;
 import megamek.common.Compute;
 import megamek.common.Crew;
 import megamek.common.Entity;
+import megamek.common.Mounted;
 import megamek.common.UnitType;
 import megamek.common.WeaponType;
 import megamek.common.options.OptionsConstants;
 import mekhq.Utilities;
+import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SpecialAbility;
 
 /**
@@ -166,7 +168,10 @@ public class CrewSkillUpgrader {
             spaValue = pickRandomGunnerySpecialization(entity);
             break;
         case OptionsConstants.GUNNERY_WEAPON_SPECIALIST:
-            spaValue = pickRandomWeapon(entity);
+            spaValue = pickRandomWeapon(entity, false);
+            break;
+        case OptionsConstants.GUNNERY_SANDBLASTER:
+            spaValue = pickRandomWeapon(entity, true);
             break;
         default:
             entity.getCrew().getOptions().getOption(spa.getName()).setValue(true);
@@ -216,7 +221,16 @@ public class CrewSkillUpgrader {
      * @param entity The entity being manipulated
      * @return Weapon name
      */
-    private String pickRandomWeapon(Entity entity) {
+    private String pickRandomWeapon(Entity entity, boolean clusterOnly) {
+        List<Mounted> weapons = entity.getIndividualWeaponList();
+        List<Mounted> eligibleWeapons = new ArrayList<>();
+        
+        for(Mounted weapon : weapons) {
+            if(SpecialAbility.isWeaponEligibleForSPA(weapon.getType(), Person.T_NONE, clusterOnly)) {
+                eligibleWeapons.add(weapon);
+            }
+        }
+        
         int weaponIndex = Compute.randomInt(entity.getIndividualWeaponList().size());
         return entity.getIndividualWeaponList().get(weaponIndex).getName();
     }

--- a/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
@@ -108,7 +108,12 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
             person.getOptions()
                 .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name,
                     SpecialAbility.chooseWeaponSpecialization(person.getPrimaryRole(), person.getOriginFaction().isClan(),
-                            getCampaignOptions(person).getTechLevel(), person.getCampaign().getGameYear()));
+                            getCampaignOptions(person).getTechLevel(), person.getCampaign().getGameYear(), false));
+        } else if (name.equals(OptionsConstants.GUNNERY_SANDBLASTER)) {
+            person.getOptions()
+                .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name,
+                    SpecialAbility.chooseWeaponSpecialization(person.getPrimaryRole(), person.getOriginFaction().isClan(),
+                            getCampaignOptions(person).getTechLevel(), person.getCampaign().getGameYear(), true));
         } else {
             person.getOptions()
                 .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, true);

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -22,6 +22,7 @@ import mekhq.campaign.personnel.enums.GenderDescriptors;
 
 import megamek.client.ui.swing.DialogOptionComponent;
 import megamek.client.ui.swing.DialogOptionListener;
+import megamek.common.AmmoType;
 import megamek.common.Crew;
 import megamek.common.EquipmentType;
 import megamek.common.WeaponType;
@@ -1126,11 +1127,21 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
         DialogOptionComponent optionComp = new DialogOptionComponent(this, option, editable);
 
         if (OptionsConstants.GUNNERY_WEAPON_SPECIALIST.equals(option.getName())) { //$NON-NLS-1$
-            optionComp.addValue("None"); //$NON-NLS-1$
+            optionComp.addValue(Crew.SPECIAL_NONE);
             //holy crap, do we really need to add every weapon?
             for (Enumeration<EquipmentType> i = EquipmentType.getAllTypes(); i.hasMoreElements();) {
                 EquipmentType etype = i.nextElement();
-                if (etype instanceof WeaponType) {
+                if (SpecialAbility.isWeaponEligibleForSPA(etype, person.getPrimaryRole(), false)) {
+                    optionComp.addValue(etype.getName());
+                }
+            }
+            optionComp.setSelected(option.stringValue());
+        } else if (OptionsConstants.GUNNERY_SANDBLASTER.equals(option.getName())) { //$NON-NLS-1$
+            optionComp.addValue(Crew.SPECIAL_NONE);
+            //holy crap, do we really need to add every weapon?
+            for (Enumeration<EquipmentType> i = EquipmentType.getAllTypes(); i.hasMoreElements();) {
+                EquipmentType etype = i.nextElement();
+                if (SpecialAbility.isWeaponEligibleForSPA(etype, person.getPrimaryRole(), true)) {
                     optionComp.addValue(etype.getName());
                 }
             }


### PR DESCRIPTION
A recent MegaMek PR changed the Sandblaster SPA so that it points to a particular weapon, but caused a bunch of issues in MekHQ with personnel generation, in multiple areas. This PR fixes those errors, and also limits randomly generated personnel with Sandblaster to just weapons that can potentially use cluster tables.