### PR TITLE
acquisition tables are not refreshing on new day

### DIFF
--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -345,6 +345,7 @@ public final class HangarTab extends CampaignGuiTab {
     @Override
     public void refreshAll() {
         refreshUnitList();
+        refreshAcquisitionList();
     }
 
     public void filterUnits() {

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -473,6 +473,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     public void refreshAll() {
         refreshTechsList();
         refreshPartsList();
+        refreshProcurementList();
     }
 
     /*
@@ -792,7 +793,6 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     @Subscribe
     public void handle(UnitRefitEvent ev) {
         partsScheduler.schedule();
-        procurementScheduler.schedule();
     }
 
     @Subscribe

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -793,6 +793,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     @Subscribe
     public void handle(UnitRefitEvent ev) {
         partsScheduler.schedule();
+        procurementScheduler.schedule();
     }
 
     @Subscribe


### PR DESCRIPTION
I noticed that the acquisition tables were not properly refreshing when you moved to a new day and were on the same tab for both the warehouse and hangar. They should be counting down the days until the next procurement check. The problem seemed to be that the refresh method in each tab for the acquisition table were not part of the refreshAll() method. 