### PR TITLE
Changing PersonnelStatus to use ParseFromString

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2003,25 +2003,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                         }
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("status")) {
-                    // TODO : remove inline migration
-                    if (version.isLowerThan("0.47.6")) {
-                        switch (Integer.parseInt(wn2.getTextContent())) {
-                            case 1:
-                                retVal.status = PersonnelStatus.RETIRED;
-                                break;
-                            case 2:
-                                retVal.status = PersonnelStatus.KIA;
-                                break;
-                            case 3:
-                                retVal.status = PersonnelStatus.MIA;
-                                break;
-                            default:
-                                retVal.status = PersonnelStatus.ACTIVE;
-                                break;
-                        }
-                    } else {
-                        retVal.status = PersonnelStatus.valueOf(wn2.getTextContent());
-                    }
+                    retVal.status = PersonnelStatus.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("prisonerStatus")) {
                     retVal.prisonerStatus = PrisonerStatus.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("willingToDefect")) { // Legacy

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
@@ -48,4 +48,33 @@ public enum PersonnelStatus {
     public String getStatusName() {
         return statusName;
     }
+
+    /**
+     * @param text containing the PersonnelStatus
+     * @return the saved PersonnelStatus
+     */
+    public static PersonnelStatus parseFromString(String text) {
+        try {
+            return valueOf(text);
+        } catch (Exception ignored) {
+
+        }
+
+        try {
+            switch (Integer.parseInt(text)) {
+                case 1:
+                    return RETIRED;
+                case 2:
+                    return KIA;
+                case 3:
+                    return MIA;
+                default:
+                    return ACTIVE;
+            }
+        } catch (Exception ignored) {
+
+        }
+
+        return ACTIVE;
+    }
 }


### PR DESCRIPTION
This cleans up how PersonnelStatus is loaded, and was something I noticed while merging stories today.