### PR TITLE
Removing inline display date from Person

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -313,8 +313,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
         OTHER_RANSOM_VALUES.put(SkillType.EXP_ELITE, Money.of(50000));
     }
 
-    private final static String DATE_DISPLAY_FORMAT = "yyyy-MM-dd";
-
     //region Reverse Compatibility
     private int oldUnitId = -1;
     private int oldDoctorId = -1;
@@ -1169,11 +1167,12 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return recruitment;
     }
 
-    public String getRecruitmentAsString() {
+    public String getRecruitmentAsString(Campaign campaign) {
         if (getRecruitment() == null) {
             return null;
         } else {
-            return getRecruitment().format(DateTimeFormatter.ofPattern(DATE_DISPLAY_FORMAT));
+            return getRecruitment().format(DateTimeFormatter.ofPattern(
+                    campaign.getCampaignOptions().getDisplayDateFormat()));
         }
     }
 
@@ -1185,11 +1184,12 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return lastRankChangeDate;
     }
 
-    public String getLastRankChangeDateAsString() {
+    public String getLastRankChangeDateAsString(Campaign campaign) {
         if (getLastRankChangeDate() == null) {
             return null;
         } else {
-            return getLastRankChangeDate().format(DateTimeFormatter.ofPattern(DATE_DISPLAY_FORMAT));
+            return getRecruitment().format(DateTimeFormatter.ofPattern(
+                    campaign.getCampaignOptions().getDisplayDateFormat()));
         }
     }
 

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -695,7 +695,7 @@ public class PersonViewPanel extends ScrollablePanel {
                 pnlInfo.add(lblRecruited1, gridBagConstraints);
 
                 lblRecruited2.setName("lblRecruited2");
-                lblRecruited2.setText(person.getRecruitmentAsString());
+                lblRecruited2.setText(person.getRecruitmentAsString(campaign));
                 gridBagConstraints = new GridBagConstraints();
                 gridBagConstraints.gridx = 3;
                 gridBagConstraints.gridy = secondy;
@@ -740,7 +740,7 @@ public class PersonViewPanel extends ScrollablePanel {
                 gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
                 pnlInfo.add(lblLastRankChangeDate1, gridBagConstraints);
 
-                JLabel lblLastRankChangeDate2 = new JLabel(person.getLastRankChangeDateAsString());
+                JLabel lblLastRankChangeDate2 = new JLabel(person.getLastRankChangeDateAsString(campaign));
                 lblLastRankChangeDate2.setName("lblLastRankChangeDate2");
                 gridBagConstraints = new GridBagConstraints();
                 gridBagConstraints.gridx = 3;


### PR DESCRIPTION
This removes a temporary method to get a standard display format and replaces it with a call to CampaignOptions::getDisplayDateFormat