### PR TITLE
Fixing GuiTabType Accessibility Spacing Issue

### DIFF
--- a/MekHQ/src/mekhq/gui/GuiTabType.java
+++ b/MekHQ/src/mekhq/gui/GuiTabType.java
@@ -33,8 +33,8 @@ import megamek.common.util.EncodeControl;
  */
 public enum GuiTabType {
     //region Enum Declaration
-    COMMAND(0,  "panCommand.TabConstraints.tabTitle", KeyEvent.VK_O),
-    TOE(1,  "panOrganization.TabConstraints.tabTitle", KeyEvent.VK_T),
+    COMMAND(0, "panCommand.TabConstraints.tabTitle", KeyEvent.VK_O),
+    TOE(1, "panOrganization.TabConstraints.tabTitle", KeyEvent.VK_T),
     BRIEFING(2, "panBriefing.TabConstraints.tabTitle", KeyEvent.VK_B),
     MAP(3, "panMap.TabConstraints.tabTitle", KeyEvent.VK_S),
     PERSONNEL(4, "panPersonnel.TabConstraints.tabTitle", KeyEvent.VK_P),


### PR DESCRIPTION
This fixes a dumb mistake I made, namely a double space typo. That is an accessibility issue, so I'm fixing it here.

This PR is entirely whitespace changes.