### PR TITLE
Two new unofficial special abilities for techs

### DIFF
--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -4,7 +4,7 @@
 
 	<!-- PILOTING SPA -->
 	<ability>
-		<lookupName>animal_mimic</lookupName>	
+		<lookupName>animal_mimic</lookupName>
 		<xpCost>5</xpCost>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
@@ -12,7 +12,7 @@
 	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>dodge_maneuver</lookupName>	
+		<lookupName>dodge_maneuver</lookupName>
 		<xpCost>10</xpCost>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
@@ -20,7 +20,7 @@
 	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>hot_dog</lookupName>	
+		<lookupName>hot_dog</lookupName>
 		<xpCost>5</xpCost>
 		<weight>2</weight>
 		<skillPrereq>
@@ -35,21 +35,21 @@
 		<invalidAbilities>jumping_jack</invalidAbilities>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>jumping_jack</lookupName>	
+		<lookupName>jumping_jack</lookupName>
 		<xpCost>10</xpCost>
-		<!-- the extra weight on this one helps increase its likelihood if hopping 
+		<!-- the extra weight on this one helps increase its likelihood if hopping
 		     jack was already selected -->
 		<weight>6</weight>
 		<prereqAbilities>hopping_jack</prereqAbilities>
 	    <removeAbilities>hopping_jack</removeAbilities>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>maneuvering_ace</lookupName>
@@ -63,35 +63,35 @@
 	    	<skill>Piloting/Aerospace::Regular</skill>
 	        <skill>Piloting/Aircraft::Regular</skill>
 	        <skill>Piloting/Naval::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>melee_specialist</lookupName>	
+		<lookupName>melee_specialist</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>melee_master</lookupName>	
+		<lookupName>melee_master</lookupName>
 		<xpCost>15</xpCost>
 		<weight>6</weight>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>shaky_stick</lookupName>	
+		<lookupName>shaky_stick</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
 	    	<skill>Piloting/VTOL::Regular</skill>
 	    	<skill>Piloting/Aerospace::Regular</skill>
 	        <skill>Piloting/Aircraft::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>tm_forest_ranger</lookupName>
@@ -101,7 +101,7 @@
 	    	<skill>Piloting/Mech::Veteran</skill>
 	        <skill>Gunnery/Protomech::Veteran</skill>
 			<skill>Piloting/Ground Vehicle::Veteran</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>tm_frogman</lookupName>
@@ -110,7 +110,7 @@
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Veteran</skill>
 	        <skill>Gunnery/Protomech::Veteran</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>tm_mountaineer</lookupName>
@@ -135,7 +135,7 @@
 
 	<!-- GUNNERY SPA -->
 	<ability>
-		<lookupName>cluster_hitter</lookupName>	
+		<lookupName>cluster_hitter</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
@@ -145,12 +145,12 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 		<invalidAbilities>cluster_master</invalidAbilities>
 	</ability>
 	<ability>
-		<lookupName>cluster_master</lookupName>	
+		<lookupName>cluster_master</lookupName>
 		<weight>6</weight>
 		<xpCost>5</xpCost>
 		<prereqAbilities>cluster_hitter</prereqAbilities>
@@ -163,19 +163,19 @@
 	        <skill>Gunnery/Spacecraft::Veteran</skill>
 	        <skill>Gunnery/Battlesuit::Veteran</skill>
 	        <skill>Gunnery/Protomech::Veteran</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>golden_goose</lookupName>	
+		<lookupName>golden_goose</lookupName>
 		<weight>3</weight>
 		<xpCost>10</xpCost>
 	    <skillPrereq>
 	        <skill>Gunnery/Aerospace::Regular</skill>
 	        <skill>Gunnery/Aircraft::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>multi_tasker</lookupName>	
+		<lookupName>multi_tasker</lookupName>
 		<xpCost>5</xpCost>
 		<weight>2</weight>
 		<skillPrereq>
@@ -185,11 +185,11 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>oblique_attacker</lookupName>	
+		<lookupName>oblique_attacker</lookupName>
 		<xpCost>5</xpCost>
 		<weight>2</weight>
 		<skillPrereq>
@@ -198,11 +198,11 @@
 	        <skill>Gunnery/Aircraft::Regular</skill>
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>oblique_artillery</lookupName>	
+		<lookupName>oblique_artillery</lookupName>
 		<xpCost>10</xpCost>
 		<weight>2</weight>
 		<skillPrereq>
@@ -211,11 +211,11 @@
 	        <skill>Gunnery/Aircraft::Regular</skill>
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>range_master</lookupName>	
+		<lookupName>range_master</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 	    <skillPrereq>
@@ -226,10 +226,10 @@
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>sniper</lookupName>	
+		<lookupName>sniper</lookupName>
 		<xpCost>15</xpCost>
 		<weight>1</weight>
 		<skillPrereq>
@@ -239,11 +239,11 @@
 	        <skill>Gunnery/Vehicle::Veteran</skill>
 	        <skill>Gunnery/Spacecraft::Veteran</skill>
 	        <skill>Gunnery/Battlesuit::Veteran</skill>
-	        <skill>Gunnery/Protomech::Veteran</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Veteran</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>sandblaster</lookupName>	
+		<lookupName>sandblaster</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 		<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
@@ -255,10 +255,10 @@
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>specialist</lookupName>	
+		<lookupName>specialist</lookupName>
 		<xpCost>6</xpCost>
 		<weight>4</weight>
 		<invalidAbilities>weapon_specialist</invalidAbilities>
@@ -269,11 +269,11 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>weapon_specialist</lookupName>	
+		<lookupName>weapon_specialist</lookupName>
 		<xpCost>15</xpCost>
 		<weight>2</weight>
 		<invalidAbilities>specialist</invalidAbilities>
@@ -284,11 +284,11 @@
 	        <skill>Gunnery/Vehicle::Veteran</skill>
 	        <skill>Gunnery/Spacecraft::Veteran</skill>
 	        <skill>Gunnery/Battlesuit::Veteran</skill>
-	        <skill>Gunnery/Protomech::Veteran</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Veteran</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>aptitude_gunnery</lookupName>	
+		<lookupName>aptitude_gunnery</lookupName>
 		<xpCost>40</xpCost>
 		<weight>0</weight>
 	    <skillPrereq>
@@ -298,17 +298,17 @@
 	        <skill>Gunnery/Vehicle</skill>
 	        <skill>Gunnery/Spacecraft</skill>
 	        <skill>Gunnery/Battlesuit</skill>
-	        <skill>Gunnery/Protomech</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>some_like_it_hot</lookupName>	
+		<lookupName>some_like_it_hot</lookupName>
 		<xpCost>5</xpCost>
 		<weight>2</weight>
 	    <skillPrereq>
 	    	<skill>Gunnery/Mech::Regular</skill>
 	        <skill>Gunnery/Aerospace::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 
 	<!-- Misc SPA -->
@@ -364,7 +364,7 @@
     	</skillPrereq>
 	</ability>
     <ability>
-		<lookupName>tactical_genius</lookupName>	
+		<lookupName>tactical_genius</lookupName>
 		<xpCost>15</xpCost>
 		<weight>1</weight>
 		<skillPrereq>
@@ -383,7 +383,7 @@
 	    	<skill>Piloting/Aerospace::Regular</skill>
 	        <skill>Piloting/Aircraft::Regular</skill>
 	        <skill>Piloting/Naval::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>sensor_geek</lookupName>
@@ -398,7 +398,7 @@
 	        <skill>Piloting/Aircraft::Green</skill>
 	        <skill>Piloting/Naval::Green</skill>
 	        <skill>Gunnery/Battlesuit::Green</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>weathered</lookupName>
@@ -412,7 +412,7 @@
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>blind_fighter</lookupName>
@@ -425,12 +425,12 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 
 	<!-- Infantry SPA -->
 	<ability>
-		<lookupName>foot_cav</lookupName>	
+		<lookupName>foot_cav</lookupName>
 		<xpCost>5</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
@@ -438,7 +438,7 @@
     	</skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>urban_guerrilla</lookupName>	
+		<lookupName>urban_guerrilla</lookupName>
 		<xpCost>5</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
@@ -449,8 +449,8 @@
 
     <!-- Tech SPA -->
     <ability>
-        <lookupName>clan_tech_knowledge</lookupName> 
-        <displayName>Clan Tech Knowledge (Unofficial)</displayName>   
+        <lookupName>clan_tech_knowledge</lookupName>
+        <displayName>Clan Tech Knowledge (Unofficial)</displayName>
         <xpCost>4</xpCost>
         <weight>2</weight>
         <skillPrereq>
@@ -463,9 +463,9 @@
         <miscPrereq>clanner:false</miscPrereq>
     </ability>
     <ability>
-        <lookupName>tech_weapon_specialist</lookupName> 
-        <displayName>Tech Specialist, Weapon (Unofficial)</displayName>  
-        <desc>-1 to repair and maintenance checks when working with weapons</desc>  
+        <lookupName>tech_weapon_specialist</lookupName>
+        <displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+        <desc>-1 to repair and maintenance checks when working with weapons</desc>
         <xpCost>4</xpCost>
         <weight>2</weight>
         <skillPrereq>
@@ -477,9 +477,9 @@
         </skillPrereq>
     </ability>
     <ability>
-        <lookupName>tech_armor_specialist</lookupName> 
-        <displayName>Tech Specialist, Armor (Unofficial)</displayName>  
-        <desc>-1 to repair and maintenance checks when working with armor</desc> 
+        <lookupName>tech_armor_specialist</lookupName>
+        <displayName>Tech Specialist, Armor (Unofficial)</displayName>
+        <desc>-1 to repair and maintenance checks when working with armor</desc>
         <xpCost>4</xpCost>
         <weight>2</weight>
         <skillPrereq>
@@ -491,9 +491,9 @@
         </skillPrereq>
     </ability>
     <ability>
-        <lookupName>tech_internal_specialist</lookupName> 
-        <displayName>Tech Specialist, Internal (Unofficial)</displayName>   
-        <desc>-1 to repair and maintenance checks when working with internal systems</desc> 
+        <lookupName>tech_internal_specialist</lookupName>
+        <displayName>Tech Specialist, Internal (Unofficial)</displayName>
+        <desc>-1 to repair and maintenance checks when working with internal systems</desc>
         <xpCost>6</xpCost>
         <weight>2</weight>
         <skillPrereq>
@@ -504,32 +504,60 @@
             <skill>Tech/Vessel::Regular</skill>
         </skillPrereq>
     </ability>
-	
+    <ability>
+        <lookupName>tech_engineer</lookupName>
+        <displayName>Engineer (unofficial)</displayName>
+        <desc>-2 on refit rolls</desc>
+        <xpCost>8</xpCost>
+        <weight>2</weight>
+        <skillPrereq>
+            <skill>Tech/Mech::Veteran</skill>
+            <skill>Tech/Mechanic::Veteran</skill>
+            <skill>Tech/Aero::Veteran</skill>
+            <skill>Tech/BA::Veteran</skill>
+            <skill>Tech/Vessel::Veteran</skill>
+        </skillPrereq>
+    </ability>
+    <ability>
+        <lookupName>tech_fixer</lookupName>
+        <displayName>Mr/Ms Fix-it (unofficial)</displayName>
+        <desc>Ignore first point of penalty for repair and maintenance on low quality equipment</desc>
+        <xpCost>4</xpCost>
+        <weight>2</weight>
+        <skillPrereq>
+            <skill>Tech/Mech::Regular</skill>
+            <skill>Tech/Mechanic::Regular</skill>
+            <skill>Tech/Aero::Regular</skill>
+            <skill>Tech/BA::Regular</skill>
+            <skill>Tech/Vessel::Regular</skill>
+        </skillPrereq>
+    </ability>
+
 	<!-- OTHER SPA -->
 	<ability>
-		<lookupName>pain_resistance</lookupName>	
+		<lookupName>pain_resistance</lookupName>
 		<xpCost>4</xpCost>
 		<weight>2</weight>
 	</ability>
-	
+
 	<edgeTrigger>
 		<lookupName>edge_when_heal_crit_fail</lookupName>
 		<displayName>Use Edge for doctor critical failure.</displayName>
 		<desc>Healing check critical failure will be rerolled with Edge.</desc>
 	</edgeTrigger>
-	
+
 	<edgeTrigger>
 		<lookupName>edge_when_repair_break_part</lookupName>
 		<displayName>Use Edge for tech breaking part.</displayName>
 		<desc>Failed repair check that breaks the part will be rerolled with Edge.</desc>
 	</edgeTrigger>
-	
+
 	<edgeTrigger>
 		<lookupName>edge_when_fail_refit_check</lookupName>
 		<displayName>Use Edge for refit failure.</displayName>
 		<desc>Failed refit check will be rerolled with Edge.</desc>
 	</edgeTrigger>
-	
+
 	<edgeTrigger>
 		<lookupName>edge_when_admin_acquire_fail</lookupName>
 		<displayName>Use Edge for acquisition failure.</displayName>
@@ -538,7 +566,7 @@
 
 <!-- Example entries corresponding to the examples in customspa.xml
      See docs/custom_spa.txt
-	
+
 	<ability>
 		<lookupName>tetris_master</lookupName>
 		<displayName>Tetris Master</displayName>
@@ -550,13 +578,13 @@
         <desc>Increase the capacity of a cargo or transport bay.</desc>
         <choiceValues>None::Cargo::Mech::Vehicle::Fighter::Infantry</choiceValues>
 	</ability>
-	
+
 	<edgeTrigger>
 	    <lookupName>edge_paper_cut</lookupName>
 	    <displayName>Use Edge to avoid paper cut.</displayName>
 	    <desc>A paper cut injury check will be rerolled with edge.</desc>
 	</edgeTrigger>
-	
+
 	<implant>
 	    <lookupName>md_prosthetic_blowtorch</lookupName>
 	    <displayName>Prosthetic Blowtorch</displayName>
@@ -570,10 +598,10 @@
         </skillPrereq>
 	</implant>
 -->
-	
+
 </abilities>
 
-<!--  
+<!--
 
 public static final String S_PILOT_MECH  = "Piloting/Mech";
 	public static final String S_PILOT_AERO  = "Piloting/Aerospace";
@@ -638,7 +666,7 @@ public static final String S_PILOT_MECH  = "Piloting/Mech";
         addOption(adv, "allweather", false); //$NON-NLS-1$
         addOption(adv, "blind_fighter", false); //$NON-NLS-1$
         addOption(adv, "sensor_geek", false); //$NON-NLS-1$
-        
+
         /*
 		abilityCosts = new HashMap<String, Integer>();
 		abilityCosts.put("hot_dog", 4);

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -949,27 +949,8 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 			 	|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.GENERAL_LOCATION)) {
 			mods.addModifier(-1, "Internal specialist");
 		}
-		String qualityName = getQualityName(quality, campaign.getCampaignOptions().reverseQualityNames());
-		switch(quality) {
-		case QUALITY_A:
-            mods.addModifier(3, qualityName);
-            break;
-        case QUALITY_B:
-            mods.addModifier(2, qualityName);
-            break;
-        case QUALITY_C:
-            mods.addModifier(1, qualityName);
-            break;
-        case QUALITY_D:
-            mods.addModifier(0, qualityName);
-            break;
-        case QUALITY_E:
-            mods.addModifier(-1, qualityName);
-            break;
-        case QUALITY_F:
-            mods.addModifier(-2, qualityName);
-            break;
-        }
+
+		mods = getQualityMods(mods, tech);
 
         return mods;
     }
@@ -1000,29 +981,47 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         }
 
         if(campaign.getCampaignOptions().useQualityMaintenance()) {
-            switch(quality) {
+            mods = getQualityMods(mods, getUnit().getTech());
+        }
+        return mods;
+    }
+
+    /**
+     * adds the quality modifiers for repair and maintenance of this part to a TargetRoll
+     * @param mods - the {@link TargetRoll} that quality modifiers should be added to
+     * @param tech - the {@link Person} that will make the repair or maintenance check, may be null
+     * @return the modified {@link TargetRoll}
+     */
+    private TargetRoll getQualityMods(TargetRoll mods, Person tech) {
+        int qualityMod = 0;
+        switch(quality) {
             case QUALITY_A:
-                mods.addModifier(3, "Quality A");
+                qualityMod = 3;
                 break;
             case QUALITY_B:
-                mods.addModifier(2, "Quality B");
+                qualityMod = 2;
                 break;
             case QUALITY_C:
-                mods.addModifier(1, "Quality C");
+                qualityMod = 1;
                 break;
             case QUALITY_D:
-                mods.addModifier(0, "Quality D");
+                qualityMod = 0;
                 break;
             case QUALITY_E:
-                mods.addModifier(-1, "Quality E");
+                qualityMod = -1;
                 break;
             case QUALITY_F:
-                mods.addModifier(-2, "Quality F");
+                qualityMod = -2;
                 break;
-            }
         }
-
-        return mods;
+        mods.addModifier(qualityMod, getQualityName(quality, campaign.getCampaignOptions().reverseQualityNames()));
+        if(qualityMod > 0 &&
+                null != tech &&
+                tech.getOptions().booleanOption(PersonnelOptions.TECH_FIXER)) {
+            //fixers can ignore the first point of penalty for poor quality
+            mods.addModifier(-1, "Mr/Ms Fix-it");
+        }
+	    return mods;
     }
 
     public String getCurrentModeName() {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -994,7 +994,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
      */
     private TargetRoll getQualityMods(TargetRoll mods, Person tech) {
         int qualityMod = 0;
-        switch(quality) {
+        switch (quality) {
             case QUALITY_A:
                 qualityMod = 3;
                 break;
@@ -1015,8 +1015,8 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                 break;
         }
         mods.addModifier(qualityMod, getQualityName(quality, campaign.getCampaignOptions().reverseQualityNames()));
-        if(qualityMod > 0 &&
-                null != tech &&
+        if ((qualityMod > 0) &&
+                (null != tech) &&
                 tech.getOptions().booleanOption(PersonnelOptions.TECH_FIXER)) {
             //fixers can ignore the first point of penalty for poor quality
             mods.addModifier(-1, "Mr/Ms Fix-it");

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1600,6 +1600,9 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         if(customJob) {
             mods.addModifier(2, "custom job");
         }
+        if(null != tech && tech.getOptions().booleanOption("tech_engineer")) {
+            mods.addModifier(-2, "engineer");
+        }
         return mods;
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1600,7 +1600,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         if(customJob) {
             mods.addModifier(2, "custom job");
         }
-        if(null != tech && tech.getOptions().booleanOption("tech_engineer")) {
+        if ((null != tech) && tech.getOptions().booleanOption("tech_engineer")) {
             mods.addModifier(-2, "engineer");
         }
         return mods;

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -52,6 +52,9 @@ public class PersonnelOptions extends PilotOptions {
     public static final String TECH_WEAPON_SPECIALIST = "tech_weapon_specialist";
     public static final String TECH_ARMOR_SPECIALIST = "tech_armor_specialist";
     public static final String TECH_INTERNAL_SPECIALIST = "tech_internal_specialist";
+    public static final String TECH_ENGINEER = "tech_engineer";
+    public static final String TECH_FIXER = "tech_fixer";
+
 
     @Override
     public void initialize() {
@@ -97,6 +100,9 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, TECH_WEAPON_SPECIALIST, false);
         addOption(l3a, TECH_ARMOR_SPECIALIST, false);
         addOption(l3a, TECH_INTERNAL_SPECIALIST, false);
+        addOption(l3a, TECH_ENGINEER, false);
+        addOption(l3a, TECH_FIXER, false);
+
 
 
         addOption(edge, EDGE_MEDICAL, false);


### PR DESCRIPTION
This PR adds two new unofficial special abilities for techs:

* Engineer: subtract 2 from all refit rolls
* Mr/Ms Fix-It: ignore the first point of penalty for repairing or maintaining poor quality parts

In addition to the two new abilities, I also refactored a new method `getQualityMods` in Parts, because both `getAllMods` and `getAllModsforMaintenance` need to add those quality modifiers and it was being done slightly differently in each case.

I have not added the new abilities to any of our predefined game option sets because I am planning to be update all of those with our existing abilities in a separate PR. 