### PR TITLE
Updates to special abilities in all presets

### DIFF
--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -79,6 +79,7 @@
 		<xpCost>15</xpCost>
 		<weight>6</weight>
         <prereqAbilities>melee_specialist</prereqAbilities>
+        <invalidAbilities>zweihander</invalidAbilities>
         <skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
@@ -89,6 +90,7 @@
         <xpCost>10</xpCost>
         <weight>6</weight>
         <prereqAbilities>melee_specialist</prereqAbilities>
+        <invalidAbilities>melee_master</invalidAbilities>
         <skillPrereq>
             <skill>Piloting/Mech::Regular</skill>
         </skillPrereq>
@@ -222,7 +224,8 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>
+            <skill>Artillery::Regular</skill>
+        </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>range_master</lookupName>

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -78,7 +78,8 @@
 		<lookupName>melee_master</lookupName>
 		<xpCost>15</xpCost>
 		<weight>6</weight>
-		<skillPrereq>
+        <prereqAbilities>melee_specialist</prereqAbilities>
+        <skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
 	    </skillPrereq>
@@ -87,9 +88,9 @@
         <lookupName>zweihander</lookupName>
         <xpCost>10</xpCost>
         <weight>6</weight>
+        <prereqAbilities>melee_specialist</prereqAbilities>
         <skillPrereq>
             <skill>Piloting/Mech::Regular</skill>
-            <skill>Gunnery/Protomech::Regular</skill>
         </skillPrereq>
     </ability>
 	<ability>

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -4,7 +4,7 @@
 
 	<!-- PILOTING SPA -->
 	<ability>
-		<lookupName>animal_mimic</lookupName>	
+		<lookupName>animal_mimic</lookupName>
 		<xpCost>5</xpCost>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
@@ -12,7 +12,7 @@
 	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>dodge_maneuver</lookupName>	
+		<lookupName>dodge_maneuver</lookupName>
 		<xpCost>10</xpCost>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
@@ -20,7 +20,7 @@
 	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>hot_dog</lookupName>	
+		<lookupName>hot_dog</lookupName>
 		<xpCost>5</xpCost>
 		<weight>2</weight>
 		<skillPrereq>
@@ -35,21 +35,21 @@
 		<invalidAbilities>jumping_jack</invalidAbilities>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>jumping_jack</lookupName>	
+		<lookupName>jumping_jack</lookupName>
 		<xpCost>10</xpCost>
-		<!-- the extra weight on this one helps increase its likelihood if hopping 
+		<!-- the extra weight on this one helps increase its likelihood if hopping
 		     jack was already selected -->
 		<weight>6</weight>
 		<prereqAbilities>hopping_jack</prereqAbilities>
 	    <removeAbilities>hopping_jack</removeAbilities>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>maneuvering_ace</lookupName>
@@ -63,35 +63,44 @@
 	    	<skill>Piloting/Aerospace::Regular</skill>
 	        <skill>Piloting/Aircraft::Regular</skill>
 	        <skill>Piloting/Naval::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>melee_specialist</lookupName>	
+		<lookupName>melee_specialist</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>melee_master</lookupName>	
+		<lookupName>melee_master</lookupName>
 		<xpCost>15</xpCost>
 		<weight>6</weight>
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
+    <ability>
+        <lookupName>zweihander</lookupName>
+        <xpCost>10</xpCost>
+        <weight>6</weight>
+        <skillPrereq>
+            <skill>Piloting/Mech::Regular</skill>
+            <skill>Gunnery/Protomech::Regular</skill>
+        </skillPrereq>
+    </ability>
 	<ability>
-		<lookupName>shaky_stick</lookupName>	
+		<lookupName>shaky_stick</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
 	    	<skill>Piloting/VTOL::Regular</skill>
 	    	<skill>Piloting/Aerospace::Regular</skill>
 	        <skill>Piloting/Aircraft::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>tm_forest_ranger</lookupName>
@@ -101,7 +110,7 @@
 	    	<skill>Piloting/Mech::Veteran</skill>
 	        <skill>Gunnery/Protomech::Veteran</skill>
 			<skill>Piloting/Ground Vehicle::Veteran</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>tm_frogman</lookupName>
@@ -110,7 +119,7 @@
 		<skillPrereq>
 	    	<skill>Piloting/Mech::Veteran</skill>
 	        <skill>Gunnery/Protomech::Veteran</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>tm_mountaineer</lookupName>
@@ -135,7 +144,7 @@
 
 	<!-- GUNNERY SPA -->
 	<ability>
-		<lookupName>cluster_hitter</lookupName>	
+		<lookupName>cluster_hitter</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
@@ -145,12 +154,12 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 		<invalidAbilities>cluster_master</invalidAbilities>
 	</ability>
 	<ability>
-		<lookupName>cluster_master</lookupName>	
+		<lookupName>cluster_master</lookupName>
 		<weight>6</weight>
 		<xpCost>5</xpCost>
 		<prereqAbilities>cluster_hitter</prereqAbilities>
@@ -163,19 +172,19 @@
 	        <skill>Gunnery/Spacecraft::Veteran</skill>
 	        <skill>Gunnery/Battlesuit::Veteran</skill>
 	        <skill>Gunnery/Protomech::Veteran</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>golden_goose</lookupName>	
+		<lookupName>golden_goose</lookupName>
 		<weight>3</weight>
 		<xpCost>10</xpCost>
 	    <skillPrereq>
 	        <skill>Gunnery/Aerospace::Regular</skill>
 	        <skill>Gunnery/Aircraft::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>multi_tasker</lookupName>	
+		<lookupName>multi_tasker</lookupName>
 		<xpCost>5</xpCost>
 		<weight>2</weight>
 		<skillPrereq>
@@ -185,11 +194,11 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>oblique_attacker</lookupName>	
+		<lookupName>oblique_attacker</lookupName>
 		<xpCost>5</xpCost>
 		<weight>2</weight>
 		<skillPrereq>
@@ -198,11 +207,11 @@
 	        <skill>Gunnery/Aircraft::Regular</skill>
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>oblique_artillery</lookupName>	
+		<lookupName>oblique_artillery</lookupName>
 		<xpCost>10</xpCost>
 		<weight>2</weight>
 		<skillPrereq>
@@ -211,11 +220,11 @@
 	        <skill>Gunnery/Aircraft::Regular</skill>
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>range_master</lookupName>	
+		<lookupName>range_master</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 	    <skillPrereq>
@@ -226,10 +235,10 @@
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>sniper</lookupName>	
+		<lookupName>sniper</lookupName>
 		<xpCost>15</xpCost>
 		<weight>1</weight>
 		<skillPrereq>
@@ -239,11 +248,11 @@
 	        <skill>Gunnery/Vehicle::Veteran</skill>
 	        <skill>Gunnery/Spacecraft::Veteran</skill>
 	        <skill>Gunnery/Battlesuit::Veteran</skill>
-	        <skill>Gunnery/Protomech::Veteran</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Veteran</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>sandblaster</lookupName>	
+		<lookupName>sandblaster</lookupName>
 		<xpCost>10</xpCost>
 		<weight>3</weight>
 		<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
@@ -255,10 +264,10 @@
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>specialist</lookupName>	
+		<lookupName>specialist</lookupName>
 		<xpCost>6</xpCost>
 		<weight>4</weight>
 		<invalidAbilities>weapon_specialist</invalidAbilities>
@@ -269,11 +278,11 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
-	        <skill>Gunnery/Protomech::Regular</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Regular</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>weapon_specialist</lookupName>	
+		<lookupName>weapon_specialist</lookupName>
 		<xpCost>15</xpCost>
 		<weight>2</weight>
 		<invalidAbilities>specialist</invalidAbilities>
@@ -284,11 +293,11 @@
 	        <skill>Gunnery/Vehicle::Veteran</skill>
 	        <skill>Gunnery/Spacecraft::Veteran</skill>
 	        <skill>Gunnery/Battlesuit::Veteran</skill>
-	        <skill>Gunnery/Protomech::Veteran</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech::Veteran</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>aptitude_gunnery</lookupName>	
+		<lookupName>aptitude_gunnery</lookupName>
 		<xpCost>40</xpCost>
 		<weight>0</weight>
 	    <skillPrereq>
@@ -298,17 +307,17 @@
 	        <skill>Gunnery/Vehicle</skill>
 	        <skill>Gunnery/Spacecraft</skill>
 	        <skill>Gunnery/Battlesuit</skill>
-	        <skill>Gunnery/Protomech</skill>	    		    	    	
-	    </skillPrereq>	
+	        <skill>Gunnery/Protomech</skill>
+	    </skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>some_like_it_hot</lookupName>	
+		<lookupName>some_like_it_hot</lookupName>
 		<xpCost>5</xpCost>
 		<weight>2</weight>
 	    <skillPrereq>
 	    	<skill>Gunnery/Mech::Regular</skill>
 	        <skill>Gunnery/Aerospace::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 
 	<!-- Misc SPA -->
@@ -364,7 +373,7 @@
     	</skillPrereq>
 	</ability>
     <ability>
-		<lookupName>tactical_genius</lookupName>	
+		<lookupName>tactical_genius</lookupName>
 		<xpCost>15</xpCost>
 		<weight>1</weight>
 		<skillPrereq>
@@ -383,7 +392,7 @@
 	    	<skill>Piloting/Aerospace::Regular</skill>
 	        <skill>Piloting/Aircraft::Regular</skill>
 	        <skill>Piloting/Naval::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>sensor_geek</lookupName>
@@ -398,7 +407,7 @@
 	        <skill>Piloting/Aircraft::Green</skill>
 	        <skill>Piloting/Naval::Green</skill>
 	        <skill>Gunnery/Battlesuit::Green</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>weathered</lookupName>
@@ -412,7 +421,7 @@
 	        <skill>Gunnery/Spacecraft::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 	<ability>
 		<lookupName>blind_fighter</lookupName>
@@ -425,12 +434,12 @@
 	        <skill>Gunnery/Vehicle::Regular</skill>
 	        <skill>Gunnery/Battlesuit::Regular</skill>
 	        <skill>Gunnery/Protomech::Regular</skill>
-	    </skillPrereq>	
+	    </skillPrereq>
 	</ability>
 
 	<!-- Infantry SPA -->
 	<ability>
-		<lookupName>foot_cav</lookupName>	
+		<lookupName>foot_cav</lookupName>
 		<xpCost>5</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
@@ -438,7 +447,7 @@
     	</skillPrereq>
 	</ability>
 	<ability>
-		<lookupName>urban_guerrilla</lookupName>	
+		<lookupName>urban_guerrilla</lookupName>
 		<xpCost>5</xpCost>
 		<weight>3</weight>
 		<skillPrereq>
@@ -449,8 +458,8 @@
 
     <!-- Tech SPA -->
     <ability>
-        <lookupName>clan_tech_knowledge</lookupName> 
-        <displayName>Clan Tech Knowledge (Unofficial)</displayName>   
+        <lookupName>clan_tech_knowledge</lookupName>
+        <displayName>Clan Tech Knowledge (Unofficial)</displayName>
         <xpCost>4</xpCost>
         <weight>2</weight>
         <skillPrereq>
@@ -463,9 +472,9 @@
         <miscPrereq>clanner:false</miscPrereq>
     </ability>
     <ability>
-        <lookupName>tech_weapon_specialist</lookupName> 
-        <displayName>Tech Specialist, Weapon (Unofficial)</displayName>  
-        <desc>-1 to repair and maintenance checks when working with weapons</desc>  
+        <lookupName>tech_weapon_specialist</lookupName>
+        <displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+        <desc>-1 to repair and maintenance checks when working with weapons</desc>
         <xpCost>4</xpCost>
         <weight>2</weight>
         <skillPrereq>
@@ -477,9 +486,9 @@
         </skillPrereq>
     </ability>
     <ability>
-        <lookupName>tech_armor_specialist</lookupName> 
-        <displayName>Tech Specialist, Armor (Unofficial)</displayName>  
-        <desc>-1 to repair and maintenance checks when working with armor</desc> 
+        <lookupName>tech_armor_specialist</lookupName>
+        <displayName>Tech Specialist, Armor (Unofficial)</displayName>
+        <desc>-1 to repair and maintenance checks when working with armor</desc>
         <xpCost>4</xpCost>
         <weight>2</weight>
         <skillPrereq>
@@ -491,9 +500,9 @@
         </skillPrereq>
     </ability>
     <ability>
-        <lookupName>tech_internal_specialist</lookupName> 
-        <displayName>Tech Specialist, Internal (Unofficial)</displayName>   
-        <desc>-1 to repair and maintenance checks when working with internal systems</desc> 
+        <lookupName>tech_internal_specialist</lookupName>
+        <displayName>Tech Specialist, Internal (Unofficial)</displayName>
+        <desc>-1 to repair and maintenance checks when working with internal systems</desc>
         <xpCost>6</xpCost>
         <weight>2</weight>
         <skillPrereq>
@@ -504,32 +513,32 @@
             <skill>Tech/Vessel::Regular</skill>
         </skillPrereq>
     </ability>
-	
+
 	<!-- OTHER SPA -->
 	<ability>
-		<lookupName>pain_resistance</lookupName>	
+		<lookupName>pain_resistance</lookupName>
 		<xpCost>4</xpCost>
 		<weight>2</weight>
 	</ability>
-	
+
 	<edgeTrigger>
 		<lookupName>edge_when_heal_crit_fail</lookupName>
 		<displayName>Use Edge for doctor critical failure.</displayName>
 		<desc>Healing check critical failure will be rerolled with Edge.</desc>
 	</edgeTrigger>
-	
+
 	<edgeTrigger>
 		<lookupName>edge_when_repair_break_part</lookupName>
 		<displayName>Use Edge for tech breaking part.</displayName>
 		<desc>Failed repair check that breaks the part will be rerolled with Edge.</desc>
 	</edgeTrigger>
-	
+
 	<edgeTrigger>
 		<lookupName>edge_when_fail_refit_check</lookupName>
 		<displayName>Use Edge for refit failure.</displayName>
 		<desc>Failed refit check will be rerolled with Edge.</desc>
 	</edgeTrigger>
-	
+
 	<edgeTrigger>
 		<lookupName>edge_when_admin_acquire_fail</lookupName>
 		<displayName>Use Edge for acquisition failure.</displayName>
@@ -538,7 +547,7 @@
 
 <!-- Example entries corresponding to the examples in customspa.xml
      See docs/custom_spa.txt
-	
+
 	<ability>
 		<lookupName>tetris_master</lookupName>
 		<displayName>Tetris Master</displayName>
@@ -550,13 +559,13 @@
         <desc>Increase the capacity of a cargo or transport bay.</desc>
         <choiceValues>None::Cargo::Mech::Vehicle::Fighter::Infantry</choiceValues>
 	</ability>
-	
+
 	<edgeTrigger>
 	    <lookupName>edge_paper_cut</lookupName>
 	    <displayName>Use Edge to avoid paper cut.</displayName>
 	    <desc>A paper cut injury check will be rerolled with edge.</desc>
 	</edgeTrigger>
-	
+
 	<implant>
 	    <lookupName>md_prosthetic_blowtorch</lookupName>
 	    <displayName>Prosthetic Blowtorch</displayName>
@@ -570,10 +579,10 @@
         </skillPrereq>
 	</implant>
 -->
-	
+
 </abilities>
 
-<!--  
+<!--
 
 public static final String S_PILOT_MECH  = "Piloting/Mech";
 	public static final String S_PILOT_AERO  = "Piloting/Aerospace";
@@ -638,7 +647,7 @@ public static final String S_PILOT_MECH  = "Piloting/Mech";
         addOption(adv, "allweather", false); //$NON-NLS-1$
         addOption(adv, "blind_fighter", false); //$NON-NLS-1$
         addOption(adv, "sensor_geek", false); //$NON-NLS-1$
-        
+
         /*
 		abilityCosts = new HashMap<String, Integer>();
 		abilityCosts.put("hot_dog", 4);

--- a/MekHQ/mmconf/mhqPresets/CamOps.xml
+++ b/MekHQ/mmconf/mhqPresets/CamOps.xml
@@ -3,7 +3,8 @@
 	<title>Campaign Operations</title>
 	<description>Options to run a unit using the Campaign Operations rules. This preset uses the basic rules and rating system. Optional rules are off by default as well as SPAs, Implants, and Quirks. For games using the older Field Manual Mercenaries system use the Total Warfare (TW) preset instead.</description>
 	<campaignOptions>
-		<clanPriceModifier>1.0</clanPriceModifier>
+		<displayDateFormat>yyyy-MM-dd</displayDateFormat>
+		<logMaintenance>false</logMaintenance>
 		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
@@ -23,25 +24,11 @@
 		<useAdvancedMedical>false</useAdvancedMedical>
 		<useDylansRandomXp>false</useDylansRandomXp>
 		<useQuirks>false</useQuirks>
-		<payForParts>true</payForParts>
-		<payForUnits>true</payForUnits>
-		<payForSalaries>true</payForSalaries>
-		<payForOverhead>false</payForOverhead>
-		<payForMaintain>true</payForMaintain>
-		<payForTransport>false</payForTransport>
-		<usePeacetimeCost>true</usePeacetimeCost>
-		<useExtendedPartsModifier>false</useExtendedPartsModifier>
-		<showPeacetimeCost>false</showPeacetimeCost>
-		<usedPartsValueA>0.1</usedPartsValueA>
-		<usedPartsValueB>0.2</usedPartsValueB>
-		<usedPartsValueC>0.3</usedPartsValueC>
-		<usedPartsValueD>0.5</usedPartsValueD>
-		<usedPartsValueE>0.7</usedPartsValueE>
-		<usedPartsValueF>0.9</usedPartsValueF>
-		<damagedPartsValue>0.33</damagedPartsValue>
-		<canceledOrderReimbursement>0.5</canceledOrderReimbursement>
-		<sellUnits>true</sellUnits>
-		<sellParts>true</sellParts>
+		<showOriginFaction>true</showOriginFaction>
+		<randomizeOrigin>false</randomizeOrigin>
+		<randomizeDependentOrigin>false</randomizeDependentOrigin>
+		<originSearchRadius>45</originSearchRadius>
+		<isOriginExtraRandom>false</isOriginExtraRandom>
 		<scenarioXP>1</scenarioXP>
 		<killsForXP>0</killsForXP>
 		<killXPAward>0</killXPAward>
@@ -65,7 +52,6 @@
 		<variableTechLevel>false</variableTechLevel>
 		<factionIntroDate>false</factionIntroDate>
 		<useAmmoByType>false</useAmmoByType>
-		<usePercentageMaint>false</usePercentageMaint>
 		<waitingPeriod>7</waitingPeriod>
 		<acquisitionSkill>Tech</acquisitionSkill>
 		<acquisitionSupportStaffOnly>true</acquisitionSupportStaffOnly>
@@ -77,6 +63,13 @@
 		<acquireMosUnit>2</acquireMosUnit>
 		<acquireMinimumTime>1</acquireMinimumTime>
 		<acquireMinimumTimeUnit>2</acquireMinimumTimeUnit>
+		<usePlanetaryAcquisition>false</usePlanetaryAcquisition>
+		<planetAcquisitionFactionLimit>1</planetAcquisitionFactionLimit>
+		<planetAcquisitionNoClanCrossover>true</planetAcquisitionNoClanCrossover>
+		<noClanPartsFromIS>true</noClanPartsFromIS>
+		<penaltyClanPartsFromIS>4</penaltyClanPartsFromIS>
+		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
+		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
 		<dropshipContractPercent>0.0</dropshipContractPercent>
 		<jumpshipContractPercent>0.0</jumpshipContractPercent>
@@ -86,13 +79,12 @@
 		<blcSaleValue>false</blcSaleValue>
 		<clanAcquisitionPenalty>0</clanAcquisitionPenalty>
 		<isAcquisitionPenalty>0</isAcquisitionPenalty>
-		<useLoanLimits>false</useLoanLimits>
-		<payForRecruitment>false</payForRecruitment>
 		<healWaitingPeriod>1</healWaitingPeriod>
 		<naturalHealingWaitingPeriod>15</naturalHealingWaitingPeriod>
 		<destroyByMargin>false</destroyByMargin>
 		<destroyMargin>4</destroyMargin>
 		<destroyPartTarget>10</destroyPartTarget>
+		<useAeroSystemHits>false</useAeroSystemHits>
 		<maintenanceCycleDays>7</maintenanceCycleDays>
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
@@ -102,15 +94,63 @@
 		<useRandomHitsForVees>false</useRandomHitsForVees>
 		<minimumHitsForVees>1</minimumHitsForVees>
 		<maxAcquisitions>0</maxAcquisitions>
+		<minimumMarriageAge>16</minimumMarriageAge>
+		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
+		<logMarriageNameChange>false</logMarriageNameChange>
+		<useRandomMarriages>false</useRandomMarriages>
+		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
+		<marriageAgeRange>10</marriageAgeRange>
+		<randomMarriageSurnameWeights>100,55,55,10,5,30,20,10,5,30,20,500,160</randomMarriageSurnameWeights>
+		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
+		<chanceRandomSameSexMarriages>2.0E-5</chanceRandomSameSexMarriages>
 		<useUnofficialProcreation>false</useUnofficialProcreation>
+		<chanceProcreation>5.0E-4</chanceProcreation>
 		<useUnofficialProcreationNoRelationship>false</useUnofficialProcreationNoRelationship>
-		<useParentage>false</useParentage>
+		<chanceProcreationNoRelationship>5.0E-5</chanceProcreationNoRelationship>
+		<displayTrueDueDate>false</displayTrueDueDate>
 		<logConception>false</logConception>
+		<babySurnameStyle>MOTHERS</babySurnameStyle>
+		<determineFatherAtBirth>false</determineFatherAtBirth>
+		<useParentage>false</useParentage>
+		<displayFamilyLevel>0</displayFamilyLevel>
+		<useRandomDeaths>true</useRandomDeaths>
+		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
+		<payForParts>true</payForParts>
+		<payForRepairs>false</payForRepairs>
+		<payForUnits>true</payForUnits>
+		<payForSalaries>true</payForSalaries>
+		<payForOverhead>false</payForOverhead>
+		<payForMaintain>true</payForMaintain>
+		<payForTransport>false</payForTransport>
+		<sellUnits>true</sellUnits>
+		<sellParts>true</sellParts>
+		<payForRecruitment>false</payForRecruitment>
+		<useLoanLimits>false</useLoanLimits>
+		<usePercentageMaint>false</usePercentageMaint>
+		<infantryDontCount>false</infantryDontCount>
+		<usePeacetimeCost>true</usePeacetimeCost>
+		<useExtendedPartsModifier>false</useExtendedPartsModifier>
+		<showPeacetimeCost>false</showPeacetimeCost>
+		<financialYearDuration>ANNUAL</financialYearDuration>
+		<newFinancialYearFinancesToCSVExport>false</newFinancialYearFinancesToCSVExport>
+		<clanPriceModifier>1.0</clanPriceModifier>
+		<usedPartsValueA>0.1</usedPartsValueA>
+		<usedPartsValueB>0.2</usedPartsValueB>
+		<usedPartsValueC>0.3</usedPartsValueC>
+		<usedPartsValueD>0.5</usedPartsValueD>
+		<usedPartsValueE>0.7</usedPartsValueE>
+		<usedPartsValueF>0.9</usedPartsValueF>
+		<damagedPartsValue>0.33</damagedPartsValue>
+		<canceledOrderReimbursement>0.5</canceledOrderReimbursement>
 		<useTransfers>true</useTransfers>
 		<useTimeInService>false</useTimeInService>
+		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
+		<useTimeInRank>false</useTimeInRank>
+		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<trackTotalEarnings>false</trackTotalEarnings>
 		<capturePrisoners>true</capturePrisoners>
-		<defaultPrisonerStatus>0</defaultPrisonerStatus>
-		<personnelMarketType>3</personnelMarketType>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<personnelMarketName>Strat Ops</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
 		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
@@ -145,12 +185,15 @@
 		<retirementRolls>true</retirementRolls>
 		<customRetirementMods>false</customRetirementMods>
 		<foundersNeverRetire>false</foundersNeverRetire>
+		<atbAddDependents>true</atbAddDependents>
+		<dependentsNeverLeave>false</dependentsNeverLeave>
 		<trackUnitFatigue>false</trackUnitFatigue>
 		<mercSizeLimited>false</mercSizeLimited>
 		<trackOriginalUnit>false</trackOriginalUnit>
 		<regionalMechVariations>false</regionalMechVariations>
 		<searchRadius>800</searchRadius>
 		<intensity>1.0</intensity>
+		<generateChases>true</generateChases>
 		<variableContractLength>false</variableContractLength>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<useWeatherConditions>true</useWeatherConditions>
@@ -173,6 +216,7 @@
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>
 		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<historicalDailyLog>false</historicalDailyLog>
 		<massRepairUseExtraTime>true</massRepairUseExtraTime>
 		<massRepairUseRushJob>true</massRepairUseRushJob>
 		<massRepairAllowCarryover>true</massRepairAllowCarryover>
@@ -246,7 +290,7 @@
 				<btnMax>4</btnMax>
 			</massRepairOption7>
 			<massRepairOption8>
-				<type>12</type>
+				<type>8</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
@@ -254,7 +298,7 @@
 				<btnMax>4</btnMax>
 			</massRepairOption8>
 			<massRepairOption9>
-				<type>8</type>
+				<type>12</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
@@ -262,9 +306,12 @@
 				<btnMax>4</btnMax>
 			</massRepairOption9>
 		</massRepairOptions>
-		<salaryTypeBase>0,1500,1500,900,900,900,900,960,750,960,900,1000,1000,1000,1000,800,800,800,800,400,1500,400,500,500,500,500,0</salaryTypeBase>
+		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
+		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
+		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
+		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
-		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>
@@ -624,8 +671,8 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -639,12 +686,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -660,12 +707,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -681,8 +728,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/Aero</skill>
 				<skill>Tech/BA</skill>
+				<skill>Tech/Aero</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -705,6 +752,24 @@ Note: Only one Tactical Genius may be utilized per team.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
 			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
 			<lookupName>tm_forest_ranger</lookupName>
 			<desc>Movement in woods or jungle costs 1 less MP.
@@ -718,8 +783,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -736,8 +801,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -766,12 +831,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -788,8 +853,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -803,12 +868,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -862,12 +927,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -896,12 +961,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -917,8 +982,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -934,6 +999,24 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<skillPrereq>
 				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
+			<lookupName>tech_internal_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -954,8 +1037,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -986,11 +1069,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1013,8 +1096,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1028,12 +1111,26 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>10</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1047,8 +1144,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1062,12 +1159,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -1085,8 +1182,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1101,8 +1198,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1159,8 +1256,8 @@ Note: This ability is only used for BattleMechs.</desc>
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1191,8 +1288,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1206,7 +1303,26 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
+				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1221,38 +1337,37 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>10</xpCost>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>4</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
 	<randomSkillPreferences>
 		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
 		<specialAbilBonus>-10,-10,-2,0,1</specialAbilBonus>
 		<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
 		<randomizeSkill>true</randomizeSkill>

--- a/MekHQ/mmconf/mhqPresets/DefaultTotalWarfare.xml
+++ b/MekHQ/mmconf/mhqPresets/DefaultTotalWarfare.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gamePreset>
 	<title>TW Standard Default</title>
-	<description>This is the default settings used by MHQ. It is intended to follow the Total Warfare line of rulebooks whenever possible, and for rules outside of this scope it uses Field Manual: Mercenaries, revised rules. </description>
+	<description>This is the default settings used by MHQ. It is intended to follow the Total Warfare line of rulebooks whenever possible, and for rules outside of this scope it uses Field Manual: Mercenaries, revised rules.</description>
 	<campaignOptions>
-		<clanPriceModifier>1.0</clanPriceModifier>
+		<displayDateFormat>yyyy-MM-dd</displayDateFormat>
+		<logMaintenance>false</logMaintenance>
 		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
@@ -17,27 +18,17 @@
 		<useArtillery>false</useArtillery>
 		<useAbilities>false</useAbilities>
 		<useEdge>false</useEdge>
+		<useSupportEdge>false</useSupportEdge>
 		<useImplants>false</useImplants>
 		<altQualityAveraging>false</altQualityAveraging>
 		<useAdvancedMedical>false</useAdvancedMedical>
 		<useDylansRandomXp>false</useDylansRandomXp>
 		<useQuirks>false</useQuirks>
-		<payForParts>false</payForParts>
-		<payForUnits>false</payForUnits>
-		<payForSalaries>false</payForSalaries>
-		<payForOverhead>false</payForOverhead>
-		<payForMaintain>false</payForMaintain>
-		<payForTransport>false</payForTransport>
-		<usedPartsValueA>0.1</usedPartsValueA>
-		<usedPartsValueB>0.2</usedPartsValueB>
-		<usedPartsValueC>0.3</usedPartsValueC>
-		<usedPartsValueD>0.5</usedPartsValueD>
-		<usedPartsValueE>0.7</usedPartsValueE>
-		<usedPartsValueF>0.9</usedPartsValueF>
-		<damagedPartsValue>0.33</damagedPartsValue>
-		<canceledOrderReimbursement>0.5</canceledOrderReimbursement>
-		<sellUnits>false</sellUnits>
-		<sellParts>false</sellParts>
+		<showOriginFaction>true</showOriginFaction>
+		<randomizeOrigin>false</randomizeOrigin>
+		<randomizeDependentOrigin>false</randomizeDependentOrigin>
+		<originSearchRadius>45</originSearchRadius>
+		<isOriginExtraRandom>false</isOriginExtraRandom>
 		<scenarioXP>1</scenarioXP>
 		<killsForXP>0</killsForXP>
 		<killXPAward>0</killXPAward>
@@ -50,13 +41,17 @@
 		<monthsIdleXP>2</monthsIdleXP>
 		<contractNegotiationXP>0</contractNegotiationXP>
 		<adminWeeklyXP>0</adminWeeklyXP>
+		<adminXPPeriod>1</adminXPPeriod>
+		<edgeCost>10</edgeCost>
 		<limitByYear>true</limitByYear>
 		<disallowExtinctStuff>false</disallowExtinctStuff>
 		<allowClanPurchases>true</allowClanPurchases>
 		<allowISPurchases>true</allowISPurchases>
 		<allowCanonOnly>false</allowCanonOnly>
+		<allowCanonRefitOnly>false</allowCanonRefitOnly>
+		<variableTechLevel>false</variableTechLevel>
+		<factionIntroDate>false</factionIntroDate>
 		<useAmmoByType>false</useAmmoByType>
-		<usePercentageMaint>false</usePercentageMaint>
 		<waitingPeriod>7</waitingPeriod>
 		<acquisitionSkill>Tech</acquisitionSkill>
 		<acquisitionSupportStaffOnly>true</acquisitionSupportStaffOnly>
@@ -68,30 +63,94 @@
 		<acquireMosUnit>2</acquireMosUnit>
 		<acquireMinimumTime>1</acquireMinimumTime>
 		<acquireMinimumTimeUnit>2</acquireMinimumTimeUnit>
+		<usePlanetaryAcquisition>false</usePlanetaryAcquisition>
+		<planetAcquisitionFactionLimit>1</planetAcquisitionFactionLimit>
+		<planetAcquisitionNoClanCrossover>true</planetAcquisitionNoClanCrossover>
+		<noClanPartsFromIS>true</noClanPartsFromIS>
+		<penaltyClanPartsFromIS>4</penaltyClanPartsFromIS>
+		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
+		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
+		<dropshipContractPercent>1.0</dropshipContractPercent>
+		<jumpshipContractPercent>0.0</jumpshipContractPercent>
+		<warshipContractPercent>0.0</warshipContractPercent>
 		<equipmentContractBase>false</equipmentContractBase>
 		<equipmentContractSaleValue>false</equipmentContractSaleValue>
 		<blcSaleValue>false</blcSaleValue>
 		<clanAcquisitionPenalty>0</clanAcquisitionPenalty>
 		<isAcquisitionPenalty>0</isAcquisitionPenalty>
-		<useLoanLimits>false</useLoanLimits>
-		<payForRecruitment>false</payForRecruitment>
 		<healWaitingPeriod>1</healWaitingPeriod>
 		<naturalHealingWaitingPeriod>15</naturalHealingWaitingPeriod>
 		<destroyByMargin>false</destroyByMargin>
 		<destroyMargin>4</destroyMargin>
+		<destroyPartTarget>10</destroyPartTarget>
+		<useAeroSystemHits>false</useAeroSystemHits>
 		<maintenanceCycleDays>7</maintenanceCycleDays>
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
+		<reverseQualityNames>false</reverseQualityNames>
 		<useUnofficalMaintenance>false</useUnofficalMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<useRandomHitsForVees>false</useRandomHitsForVees>
 		<minimumHitsForVees>1</minimumHitsForVees>
 		<maxAcquisitions>0</maxAcquisitions>
+		<minimumMarriageAge>16</minimumMarriageAge>
+		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
+		<logMarriageNameChange>false</logMarriageNameChange>
+		<useRandomMarriages>false</useRandomMarriages>
+		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
+		<marriageAgeRange>10</marriageAgeRange>
+		<randomMarriageSurnameWeights>100,55,55,10,5,30,20,10,5,30,20,500,160</randomMarriageSurnameWeights>
+		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
+		<chanceRandomSameSexMarriages>2.0E-5</chanceRandomSameSexMarriages>
 		<useUnofficialProcreation>false</useUnofficialProcreation>
+		<chanceProcreation>5.0E-4</chanceProcreation>
 		<useUnofficialProcreationNoRelationship>false</useUnofficialProcreationNoRelationship>
+		<chanceProcreationNoRelationship>5.0E-5</chanceProcreationNoRelationship>
+		<displayTrueDueDate>false</displayTrueDueDate>
+		<logConception>false</logConception>
+		<babySurnameStyle>MOTHERS</babySurnameStyle>
+		<determineFatherAtBirth>false</determineFatherAtBirth>
+		<useParentage>false</useParentage>
+		<displayFamilyLevel>0</displayFamilyLevel>
+		<useRandomDeaths>true</useRandomDeaths>
+		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
+		<payForParts>false</payForParts>
+		<payForRepairs>false</payForRepairs>
+		<payForUnits>false</payForUnits>
+		<payForSalaries>false</payForSalaries>
+		<payForOverhead>false</payForOverhead>
+		<payForMaintain>false</payForMaintain>
+		<payForTransport>false</payForTransport>
+		<sellUnits>false</sellUnits>
+		<sellParts>false</sellParts>
+		<payForRecruitment>false</payForRecruitment>
+		<useLoanLimits>false</useLoanLimits>
+		<usePercentageMaint>false</usePercentageMaint>
+		<infantryDontCount>false</infantryDontCount>
+		<usePeacetimeCost>false</usePeacetimeCost>
+		<useExtendedPartsModifier>false</useExtendedPartsModifier>
+		<showPeacetimeCost>false</showPeacetimeCost>
+		<financialYearDuration>ANNUAL</financialYearDuration>
+		<newFinancialYearFinancesToCSVExport>false</newFinancialYearFinancesToCSVExport>
+		<clanPriceModifier>1.0</clanPriceModifier>
+		<usedPartsValueA>0.1</usedPartsValueA>
+		<usedPartsValueB>0.2</usedPartsValueB>
+		<usedPartsValueC>0.3</usedPartsValueC>
+		<usedPartsValueD>0.5</usedPartsValueD>
+		<usedPartsValueE>0.7</usedPartsValueE>
+		<usedPartsValueF>0.9</usedPartsValueF>
+		<damagedPartsValue>0.33</damagedPartsValue>
+		<canceledOrderReimbursement>0.5</canceledOrderReimbursement>
 		<useTransfers>true</useTransfers>
-		<personnelMarketType>2</personnelMarketType>
+		<useTimeInService>false</useTimeInService>
+		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
+		<useTimeInRank>false</useTimeInRank>
+		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<trackTotalEarnings>false</trackTotalEarnings>
+		<capturePrisoners>true</capturePrisoners>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<personnelMarketName>FM: Mercenaries Revised</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
 		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
@@ -125,18 +184,21 @@
 		<sharesForAll>false</sharesForAll>
 		<retirementRolls>true</retirementRolls>
 		<customRetirementMods>false</customRetirementMods>
+		<foundersNeverRetire>false</foundersNeverRetire>
+		<atbAddDependents>true</atbAddDependents>
+		<dependentsNeverLeave>false</dependentsNeverLeave>
 		<trackUnitFatigue>false</trackUnitFatigue>
 		<mercSizeLimited>false</mercSizeLimited>
 		<trackOriginalUnit>false</trackOriginalUnit>
 		<regionalMechVariations>false</regionalMechVariations>
 		<searchRadius>800</searchRadius>
 		<intensity>1.0</intensity>
+		<generateChases>true</generateChases>
 		<variableContractLength>false</variableContractLength>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>false</usePlanetaryConditions>
-		<useAltMapgen>false</useAltMapgen>
 		<useLeadership>true</useLeadership>
 		<useStrategy>true</useStrategy>
 		<baseStrategyDeployment>3</baseStrategyDeployment>
@@ -149,11 +211,108 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<startGameDelay>500</startGameDelay>
-		<salaryTypeBase>0,1500,1500,900,900,900,900,960,750,960,900,1000,1000,1000,1000,800,800,800,800,400,1500,400,500,500,500,500</salaryTypeBase>
+		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowOpforAeros>false</allowOpforAeros>
+		<allowOpforLocalUnits>false</allowOpforLocalUnits>
+		<opforAeroChance>5</opforAeroChance>
+		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<historicalDailyLog>false</historicalDailyLog>
+		<massRepairUseExtraTime>true</massRepairUseExtraTime>
+		<massRepairUseRushJob>true</massRepairUseRushJob>
+		<massRepairAllowCarryover>true</massRepairAllowCarryover>
+		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
+		<massRepairScrapImpossible>false</massRepairScrapImpossible>
+		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
+		<massRepairReplacePod>true</massRepairReplacePod>
+		<massRepairOptions>
+			<massRepairOption0>
+				<type>0</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption0>
+			<massRepairOption1>
+				<type>1</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption1>
+			<massRepairOption2>
+				<type>2</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption2>
+			<massRepairOption3>
+				<type>3</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption3>
+			<massRepairOption4>
+				<type>4</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption4>
+			<massRepairOption5>
+				<type>5</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption5>
+			<massRepairOption6>
+				<type>6</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption6>
+			<massRepairOption7>
+				<type>7</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption7>
+			<massRepairOption8>
+				<type>12</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption8>
+			<massRepairOption9>
+				<type>8</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption9>
+		</massRepairOptions>
+		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
+		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
+		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
+		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
-		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
 		<rats>Xotl,Total Warfare</rats>
-		<ratsNoEra>Xotl,Total Warfare</ratsNoEra>
 	</campaignOptions>
 	<skillTypes>
 		<skillType>
@@ -512,8 +671,8 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -527,12 +686,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -548,12 +707,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -569,8 +728,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
 				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -606,8 +765,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -624,8 +783,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -654,12 +813,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -676,8 +835,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -691,12 +850,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -711,12 +870,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit</skill>
 				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Battlesuit</skill>
 				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Vehicle</skill>
+				<skill>Gunnery/Spacecraft</skill>
 				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Vehicle</skill>
 				<skill>Gunnery/Protomech</skill>
 			</skillPrereq>
 		</ability>
@@ -770,12 +929,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -804,12 +963,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -825,8 +984,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -863,8 +1022,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -895,11 +1054,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -922,8 +1081,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -937,12 +1096,26 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>10</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -956,8 +1129,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -971,12 +1144,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -994,8 +1167,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1010,8 +1183,8 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1026,12 +1199,12 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1089,8 +1262,8 @@ Note: This ability is only used for BattleMechs.</desc>
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1121,8 +1294,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1136,8 +1309,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1151,12 +1324,12 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1171,18 +1344,18 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
 	<randomSkillPreferences>
 		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
 		<specialAbilBonus>-10,-10,-2,0,1</specialAbilBonus>
 		<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
 		<randomizeSkill>true</randomizeSkill>

--- a/MekHQ/mmconf/mhqPresets/DefaultTotalWarfare.xml
+++ b/MekHQ/mmconf/mhqPresets/DefaultTotalWarfare.xml
@@ -290,7 +290,7 @@
 				<btnMax>4</btnMax>
 			</massRepairOption7>
 			<massRepairOption8>
-				<type>12</type>
+				<type>8</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
@@ -298,7 +298,7 @@
 				<btnMax>4</btnMax>
 			</massRepairOption8>
 			<massRepairOption9>
-				<type>8</type>
+				<type>12</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
@@ -671,8 +671,8 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -686,12 +686,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -707,12 +707,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -728,8 +728,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/Aero</skill>
 				<skill>Tech/BA</skill>
+				<skill>Tech/Aero</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -752,6 +752,24 @@ Note: Only one Tactical Genius may be utilized per team.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
 			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
 			<lookupName>tm_forest_ranger</lookupName>
 			<desc>Movement in woods or jungle costs 1 less MP.
@@ -765,8 +783,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -783,8 +801,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -813,12 +831,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -835,8 +853,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -850,12 +868,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -870,12 +888,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft</skill>
 				<skill>Gunnery/Battlesuit</skill>
-				<skill>Gunnery/Aerospace</skill>
+				<skill>Gunnery/Aircraft</skill>
 				<skill>Gunnery/Spacecraft</skill>
-				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Aerospace</skill>
 				<skill>Gunnery/Vehicle</skill>
+				<skill>Gunnery/Mech</skill>
 				<skill>Gunnery/Protomech</skill>
 			</skillPrereq>
 		</ability>
@@ -929,12 +947,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -963,12 +981,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -984,8 +1002,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1002,6 +1020,24 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
+			<lookupName>tech_internal_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1022,8 +1058,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1054,11 +1090,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1081,8 +1117,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1096,12 +1132,27 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Master (CamOps)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>15</xpCost>
+			<weight>6</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1119,21 +1170,6 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Melee Master (CamOps)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-			<xpCost>15</xpCost>
-			<weight>6</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Cluster Master (Unofficial)</displayName>
 			<lookupName>cluster_master</lookupName>
 			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
@@ -1144,12 +1180,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -1167,8 +1203,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1183,8 +1219,8 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1199,12 +1235,12 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1262,8 +1298,8 @@ Note: This ability is only used for BattleMechs.</desc>
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1294,8 +1330,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1309,8 +1345,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1324,12 +1360,12 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1344,12 +1380,30 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>

--- a/MekHQ/mmconf/mhqPresets/SimpleOptions.xml
+++ b/MekHQ/mmconf/mhqPresets/SimpleOptions.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gamePreset>
 	<title>Simple Presets</title>
-	<description>This set of presets attempts to provide the simplest rules settings possible for those who just want to get into the action. Acquisitions are automatic and maintenance is turned off. </description>
+	<description>This set of presets attempts to provide the simplest rules settings possible for those who just want to get into the action. Acquisitions are automatic and maintenance is turned off.</description>
 	<campaignOptions>
-		<clanPriceModifier>1.0</clanPriceModifier>
+		<displayDateFormat>yyyy-MM-dd</displayDateFormat>
+		<logMaintenance>false</logMaintenance>
 		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
-		<unitRatingMethod>Interstellar Ops</unitRatingMethod>
+		<unitRatingMethod>Campaign Ops</unitRatingMethod>
 		<useEraMods>false</useEraMods>
 		<assignedTechFirst>false</assignedTechFirst>
 		<resetToFirstTech>false</resetToFirstTech>
@@ -17,27 +18,17 @@
 		<useArtillery>false</useArtillery>
 		<useAbilities>false</useAbilities>
 		<useEdge>false</useEdge>
+		<useSupportEdge>false</useSupportEdge>
 		<useImplants>false</useImplants>
 		<altQualityAveraging>false</altQualityAveraging>
 		<useAdvancedMedical>false</useAdvancedMedical>
 		<useDylansRandomXp>false</useDylansRandomXp>
 		<useQuirks>false</useQuirks>
-		<payForParts>false</payForParts>
-		<payForUnits>false</payForUnits>
-		<payForSalaries>false</payForSalaries>
-		<payForOverhead>false</payForOverhead>
-		<payForMaintain>false</payForMaintain>
-		<payForTransport>false</payForTransport>
-		<usedPartsValueA>0.1</usedPartsValueA>
-		<usedPartsValueB>0.2</usedPartsValueB>
-		<usedPartsValueC>0.3</usedPartsValueC>
-		<usedPartsValueD>0.5</usedPartsValueD>
-		<usedPartsValueE>0.7</usedPartsValueE>
-		<usedPartsValueF>0.9</usedPartsValueF>
-		<damagedPartsValue>0.33</damagedPartsValue>
-		<canceledOrderReimbursement>0.5</canceledOrderReimbursement>
-		<sellUnits>false</sellUnits>
-		<sellParts>false</sellParts>
+		<showOriginFaction>true</showOriginFaction>
+		<randomizeOrigin>false</randomizeOrigin>
+		<randomizeDependentOrigin>false</randomizeDependentOrigin>
+		<originSearchRadius>45</originSearchRadius>
+		<isOriginExtraRandom>false</isOriginExtraRandom>
 		<scenarioXP>1</scenarioXP>
 		<killsForXP>0</killsForXP>
 		<killXPAward>0</killXPAward>
@@ -50,13 +41,17 @@
 		<monthsIdleXP>2</monthsIdleXP>
 		<contractNegotiationXP>0</contractNegotiationXP>
 		<adminWeeklyXP>0</adminWeeklyXP>
+		<adminXPPeriod>1</adminXPPeriod>
+		<edgeCost>10</edgeCost>
 		<limitByYear>true</limitByYear>
 		<disallowExtinctStuff>true</disallowExtinctStuff>
 		<allowClanPurchases>true</allowClanPurchases>
 		<allowISPurchases>true</allowISPurchases>
 		<allowCanonOnly>false</allowCanonOnly>
+		<allowCanonRefitOnly>false</allowCanonRefitOnly>
+		<variableTechLevel>false</variableTechLevel>
+		<factionIntroDate>false</factionIntroDate>
 		<useAmmoByType>false</useAmmoByType>
-		<usePercentageMaint>false</usePercentageMaint>
 		<waitingPeriod>7</waitingPeriod>
 		<acquisitionSkill>Automatic Success</acquisitionSkill>
 		<acquisitionSupportStaffOnly>false</acquisitionSupportStaffOnly>
@@ -68,30 +63,94 @@
 		<acquireMosUnit>2</acquireMosUnit>
 		<acquireMinimumTime>1</acquireMinimumTime>
 		<acquireMinimumTimeUnit>2</acquireMinimumTimeUnit>
+		<usePlanetaryAcquisition>false</usePlanetaryAcquisition>
+		<planetAcquisitionFactionLimit>1</planetAcquisitionFactionLimit>
+		<planetAcquisitionNoClanCrossover>true</planetAcquisitionNoClanCrossover>
+		<noClanPartsFromIS>true</noClanPartsFromIS>
+		<penaltyClanPartsFromIS>4</penaltyClanPartsFromIS>
+		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
+		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
+		<dropshipContractPercent>1.0</dropshipContractPercent>
+		<jumpshipContractPercent>0.0</jumpshipContractPercent>
+		<warshipContractPercent>0.0</warshipContractPercent>
 		<equipmentContractBase>false</equipmentContractBase>
 		<equipmentContractSaleValue>false</equipmentContractSaleValue>
 		<blcSaleValue>false</blcSaleValue>
 		<clanAcquisitionPenalty>0</clanAcquisitionPenalty>
 		<isAcquisitionPenalty>0</isAcquisitionPenalty>
-		<useLoanLimits>false</useLoanLimits>
-		<payForRecruitment>false</payForRecruitment>
 		<healWaitingPeriod>1</healWaitingPeriod>
 		<naturalHealingWaitingPeriod>15</naturalHealingWaitingPeriod>
 		<destroyByMargin>false</destroyByMargin>
 		<destroyMargin>4</destroyMargin>
+		<destroyPartTarget>10</destroyPartTarget>
+		<useAeroSystemHits>false</useAeroSystemHits>
 		<maintenanceCycleDays>7</maintenanceCycleDays>
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
+		<reverseQualityNames>false</reverseQualityNames>
 		<useUnofficalMaintenance>false</useUnofficalMaintenance>
 		<checkMaintenance>false</checkMaintenance>
 		<useRandomHitsForVees>false</useRandomHitsForVees>
 		<minimumHitsForVees>1</minimumHitsForVees>
 		<maxAcquisitions>0</maxAcquisitions>
+		<minimumMarriageAge>16</minimumMarriageAge>
+		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
+		<logMarriageNameChange>false</logMarriageNameChange>
+		<useRandomMarriages>false</useRandomMarriages>
+		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
+		<marriageAgeRange>10</marriageAgeRange>
+		<randomMarriageSurnameWeights>100,55,55,10,5,30,20,10,5,30,20,500,160</randomMarriageSurnameWeights>
+		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
+		<chanceRandomSameSexMarriages>2.0E-5</chanceRandomSameSexMarriages>
 		<useUnofficialProcreation>false</useUnofficialProcreation>
+		<chanceProcreation>5.0E-4</chanceProcreation>
 		<useUnofficialProcreationNoRelationship>false</useUnofficialProcreationNoRelationship>
+		<chanceProcreationNoRelationship>5.0E-5</chanceProcreationNoRelationship>
+		<displayTrueDueDate>false</displayTrueDueDate>
+		<logConception>false</logConception>
+		<babySurnameStyle>MOTHERS</babySurnameStyle>
+		<determineFatherAtBirth>false</determineFatherAtBirth>
+		<useParentage>false</useParentage>
+		<displayFamilyLevel>0</displayFamilyLevel>
+		<useRandomDeaths>true</useRandomDeaths>
+		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
+		<payForParts>false</payForParts>
+		<payForRepairs>false</payForRepairs>
+		<payForUnits>false</payForUnits>
+		<payForSalaries>false</payForSalaries>
+		<payForOverhead>false</payForOverhead>
+		<payForMaintain>false</payForMaintain>
+		<payForTransport>false</payForTransport>
+		<sellUnits>false</sellUnits>
+		<sellParts>false</sellParts>
+		<payForRecruitment>false</payForRecruitment>
+		<useLoanLimits>false</useLoanLimits>
+		<usePercentageMaint>false</usePercentageMaint>
+		<infantryDontCount>false</infantryDontCount>
+		<usePeacetimeCost>false</usePeacetimeCost>
+		<useExtendedPartsModifier>false</useExtendedPartsModifier>
+		<showPeacetimeCost>false</showPeacetimeCost>
+		<financialYearDuration>ANNUAL</financialYearDuration>
+		<newFinancialYearFinancesToCSVExport>false</newFinancialYearFinancesToCSVExport>
+		<clanPriceModifier>1.0</clanPriceModifier>
+		<usedPartsValueA>0.1</usedPartsValueA>
+		<usedPartsValueB>0.2</usedPartsValueB>
+		<usedPartsValueC>0.3</usedPartsValueC>
+		<usedPartsValueD>0.5</usedPartsValueD>
+		<usedPartsValueE>0.7</usedPartsValueE>
+		<usedPartsValueF>0.9</usedPartsValueF>
+		<damagedPartsValue>0.33</damagedPartsValue>
+		<canceledOrderReimbursement>0.5</canceledOrderReimbursement>
 		<useTransfers>true</useTransfers>
-		<personnelMarketType>3</personnelMarketType>
+		<useTimeInService>false</useTimeInService>
+		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
+		<useTimeInRank>false</useTimeInRank>
+		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<trackTotalEarnings>false</trackTotalEarnings>
+		<capturePrisoners>true</capturePrisoners>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<personnelMarketName>Strat Ops</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
 		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
@@ -125,18 +184,21 @@
 		<sharesForAll>false</sharesForAll>
 		<retirementRolls>true</retirementRolls>
 		<customRetirementMods>false</customRetirementMods>
+		<foundersNeverRetire>false</foundersNeverRetire>
+		<atbAddDependents>true</atbAddDependents>
+		<dependentsNeverLeave>false</dependentsNeverLeave>
 		<trackUnitFatigue>false</trackUnitFatigue>
 		<mercSizeLimited>false</mercSizeLimited>
 		<trackOriginalUnit>false</trackOriginalUnit>
 		<regionalMechVariations>false</regionalMechVariations>
 		<searchRadius>800</searchRadius>
 		<intensity>1.0</intensity>
+		<generateChases>true</generateChases>
 		<variableContractLength>false</variableContractLength>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>false</usePlanetaryConditions>
-		<useAltMapgen>false</useAltMapgen>
 		<useLeadership>true</useLeadership>
 		<useStrategy>true</useStrategy>
 		<baseStrategyDeployment>3</baseStrategyDeployment>
@@ -149,11 +211,108 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<startGameDelay>500</startGameDelay>
-		<salaryTypeBase>0,1500,1500,900,900,900,900,960,750,960,900,1000,1000,1000,1000,800,800,800,800,400,1500,400,500,500,500,500</salaryTypeBase>
+		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowOpforAeros>false</allowOpforAeros>
+		<allowOpforLocalUnits>false</allowOpforLocalUnits>
+		<opforAeroChance>5</opforAeroChance>
+		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<historicalDailyLog>false</historicalDailyLog>
+		<massRepairUseExtraTime>true</massRepairUseExtraTime>
+		<massRepairUseRushJob>true</massRepairUseRushJob>
+		<massRepairAllowCarryover>true</massRepairAllowCarryover>
+		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
+		<massRepairScrapImpossible>false</massRepairScrapImpossible>
+		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
+		<massRepairReplacePod>true</massRepairReplacePod>
+		<massRepairOptions>
+			<massRepairOption0>
+				<type>0</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption0>
+			<massRepairOption1>
+				<type>1</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption1>
+			<massRepairOption2>
+				<type>2</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption2>
+			<massRepairOption3>
+				<type>3</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption3>
+			<massRepairOption4>
+				<type>4</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption4>
+			<massRepairOption5>
+				<type>5</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption5>
+			<massRepairOption6>
+				<type>6</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption6>
+			<massRepairOption7>
+				<type>7</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption7>
+			<massRepairOption8>
+				<type>12</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption8>
+			<massRepairOption9>
+				<type>8</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption9>
+		</massRepairOptions>
+		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
+		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
+		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
+		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
-		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
 		<rats>Xotl,Total Warfare</rats>
-		<ratsNoEra>Xotl,Total Warfare</ratsNoEra>
 	</campaignOptions>
 	<skillTypes>
 		<skillType>
@@ -512,8 +671,8 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -527,12 +686,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -548,12 +707,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -569,8 +728,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
 				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -593,6 +752,24 @@ Note: Only one Tactical Genius may be utilized per team.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
 			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
 			<lookupName>tm_forest_ranger</lookupName>
 			<desc>Movement in woods or jungle costs 1 less MP.
@@ -606,8 +783,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -624,8 +801,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -654,12 +831,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -676,8 +853,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -691,12 +868,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -711,12 +888,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit</skill>
 				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Battlesuit</skill>
 				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Vehicle</skill>
+				<skill>Gunnery/Spacecraft</skill>
 				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Vehicle</skill>
 				<skill>Gunnery/Protomech</skill>
 			</skillPrereq>
 		</ability>
@@ -770,12 +947,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -804,12 +981,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -825,8 +1002,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -843,6 +1020,24 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
+			<lookupName>tech_internal_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -863,8 +1058,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -895,11 +1090,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -922,8 +1117,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -937,12 +1132,26 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>10</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -956,8 +1165,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -971,12 +1180,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -994,8 +1203,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1010,8 +1219,8 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1026,12 +1235,12 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1089,8 +1298,8 @@ Note: This ability is only used for BattleMechs.</desc>
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1121,8 +1330,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1136,8 +1345,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1151,12 +1360,12 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1171,18 +1380,36 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
 	<randomSkillPreferences>
 		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
 		<specialAbilBonus>-10,-10,-10,-10,-10</specialAbilBonus>
 		<tacticsMod>-10,-10,-10,-10,-10</tacticsMod>
 		<randomizeSkill>false</randomizeSkill>

--- a/MekHQ/mmconf/mhqPresets/TaharqaMW2ish.xml
+++ b/MekHQ/mmconf/mhqPresets/TaharqaMW2ish.xml
@@ -83,12 +83,12 @@
 		<naturalHealingWaitingPeriod>28</naturalHealingWaitingPeriod>
 		<destroyByMargin>true</destroyByMargin>
 		<destroyMargin>4</destroyMargin>
-		<destroyPartTarget>10</destroyPartTarget>
+		<destroyPartTarget>9</destroyPartTarget>
 		<useAeroSystemHits>false</useAeroSystemHits>
 		<maintenanceCycleDays>28</maintenanceCycleDays>
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>false</useQualityMaintenance>
-		<reverseQualityNames>false</reverseQualityNames>
+		<reverseQualityNames>true</reverseQualityNames>
 		<useUnofficalMaintenance>false</useUnofficalMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<useRandomHitsForVees>true</useRandomHitsForVees>
@@ -290,7 +290,7 @@
 				<btnMax>4</btnMax>
 			</massRepairOption7>
 			<massRepairOption8>
-				<type>12</type>
+				<type>8</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
@@ -298,7 +298,7 @@
 				<btnMax>4</btnMax>
 			</massRepairOption8>
 			<massRepairOption9>
-				<type>8</type>
+				<type>12</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
@@ -685,12 +685,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -706,12 +706,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -727,8 +727,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
 				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -764,8 +764,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -797,8 +797,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
 			</skillPrereq>
@@ -832,12 +832,12 @@ Plasma and Flamer).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -855,12 +855,12 @@ RL and ATM).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -875,12 +875,12 @@ RL and ATM).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -897,8 +897,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -908,16 +908,16 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<xpCost>12</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
+			<invalidAbilities>gunnery_laser::gunnery_missile::gunnery_ballistic</invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -971,12 +971,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1005,12 +1005,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1026,8 +1026,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1058,8 +1058,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
 			</skillPrereq>
@@ -1113,11 +1113,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1154,11 +1154,11 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Artillery::Green</skill>
 			</skillPrereq>
@@ -1202,12 +1202,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1225,8 +1225,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1315,8 +1315,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1344,12 +1344,12 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1364,11 +1364,11 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1384,8 +1384,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
 			</skillPrereq>
@@ -1403,12 +1403,12 @@ Gaussrifles).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>

--- a/MekHQ/mmconf/mhqPresets/TaharqaMW2ish.xml
+++ b/MekHQ/mmconf/mhqPresets/TaharqaMW2ish.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gamePreset>
 	<title>Taharqa&apos;s MW2ish Presets</title>
-	<description>This preset largely affects skill levels and XP costs. Namely, all skills range from level 0 to level 6 and XP costs rise with the level of the skill such that, for example, it costs more XP to advance from Regular to Veteran than from Green to Regular. Special abilities have also been tweaked with these costs in mind.</description>
+	<description>This preset largely affects skill levels and XP costs. Namely, all skills range from level 0 to level 6 and XP costs rise with the level of the skill such that, for example, it costs more XP to advance from Regular to Veteran than from Green to Regular. Special abilities have also been tweaked with these costs in mind, so that players have more incentive to pay for special abilities at higher skill levels rather than increasing skills further.</description>
 	<campaignOptions>
-		<clanPriceModifier>4.0</clanPriceModifier>
-		<useFactionForNames>false</useFactionForNames>
+		<displayDateFormat>yyyy-MM-dd</displayDateFormat>
+		<logMaintenance>false</logMaintenance>
+		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
-		<unitRatingMethod>Interstellar Ops</unitRatingMethod>
+		<unitRatingMethod>Campaign Ops</unitRatingMethod>
 		<useEraMods>false</useEraMods>
 		<assignedTechFirst>true</assignedTechFirst>
 		<resetToFirstTech>true</resetToFirstTech>
@@ -17,27 +18,17 @@
 		<useArtillery>true</useArtillery>
 		<useAbilities>true</useAbilities>
 		<useEdge>true</useEdge>
+		<useSupportEdge>true</useSupportEdge>
 		<useImplants>true</useImplants>
-		<altQualityAveraging>false</altQualityAveraging>
+		<altQualityAveraging>true</altQualityAveraging>
 		<useAdvancedMedical>false</useAdvancedMedical>
 		<useDylansRandomXp>false</useDylansRandomXp>
 		<useQuirks>true</useQuirks>
-		<payForParts>true</payForParts>
-		<payForUnits>true</payForUnits>
-		<payForSalaries>true</payForSalaries>
-		<payForOverhead>true</payForOverhead>
-		<payForMaintain>true</payForMaintain>
-		<payForTransport>true</payForTransport>
-		<usedPartsValueA>0.1</usedPartsValueA>
-		<usedPartsValueB>0.2</usedPartsValueB>
-		<usedPartsValueC>0.3</usedPartsValueC>
-		<usedPartsValueD>0.5</usedPartsValueD>
-		<usedPartsValueE>0.7</usedPartsValueE>
-		<usedPartsValueF>0.9</usedPartsValueF>
-		<damagedPartsValue>0.4</damagedPartsValue>
-		<canceledOrderReimbursement>0.5</canceledOrderReimbursement>
-		<sellUnits>true</sellUnits>
-		<sellParts>true</sellParts>
+		<showOriginFaction>false</showOriginFaction>
+		<randomizeOrigin>false</randomizeOrigin>
+		<randomizeDependentOrigin>false</randomizeDependentOrigin>
+		<originSearchRadius>45</originSearchRadius>
+		<isOriginExtraRandom>false</isOriginExtraRandom>
 		<scenarioXP>1</scenarioXP>
 		<killsForXP>2</killsForXP>
 		<killXPAward>1</killXPAward>
@@ -50,13 +41,17 @@
 		<monthsIdleXP>2</monthsIdleXP>
 		<contractNegotiationXP>0</contractNegotiationXP>
 		<adminWeeklyXP>0</adminWeeklyXP>
+		<adminXPPeriod>1</adminXPPeriod>
+		<edgeCost>10</edgeCost>
 		<limitByYear>true</limitByYear>
 		<disallowExtinctStuff>false</disallowExtinctStuff>
 		<allowClanPurchases>true</allowClanPurchases>
 		<allowISPurchases>true</allowISPurchases>
 		<allowCanonOnly>false</allowCanonOnly>
+		<allowCanonRefitOnly>false</allowCanonRefitOnly>
+		<variableTechLevel>false</variableTechLevel>
+		<factionIntroDate>false</factionIntroDate>
 		<useAmmoByType>false</useAmmoByType>
-		<usePercentageMaint>true</usePercentageMaint>
 		<waitingPeriod>14</waitingPeriod>
 		<acquisitionSkill>Administration</acquisitionSkill>
 		<acquisitionSupportStaffOnly>true</acquisitionSupportStaffOnly>
@@ -68,30 +63,94 @@
 		<acquireMosUnit>1</acquireMosUnit>
 		<acquireMinimumTime>0</acquireMinimumTime>
 		<acquireMinimumTimeUnit>1</acquireMinimumTimeUnit>
+		<usePlanetaryAcquisition>false</usePlanetaryAcquisition>
+		<planetAcquisitionFactionLimit>1</planetAcquisitionFactionLimit>
+		<planetAcquisitionNoClanCrossover>true</planetAcquisitionNoClanCrossover>
+		<noClanPartsFromIS>true</noClanPartsFromIS>
+		<penaltyClanPartsFromIS>4</penaltyClanPartsFromIS>
+		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
+		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>2.5</equipmentContractPercent>
+		<dropshipContractPercent>1.0</dropshipContractPercent>
+		<jumpshipContractPercent>0.0</jumpshipContractPercent>
+		<warshipContractPercent>0.0</warshipContractPercent>
 		<equipmentContractBase>true</equipmentContractBase>
 		<equipmentContractSaleValue>true</equipmentContractSaleValue>
 		<blcSaleValue>true</blcSaleValue>
 		<clanAcquisitionPenalty>6</clanAcquisitionPenalty>
 		<isAcquisitionPenalty>0</isAcquisitionPenalty>
-		<useLoanLimits>true</useLoanLimits>
-		<payForRecruitment>true</payForRecruitment>
 		<healWaitingPeriod>7</healWaitingPeriod>
 		<naturalHealingWaitingPeriod>28</naturalHealingWaitingPeriod>
 		<destroyByMargin>true</destroyByMargin>
 		<destroyMargin>4</destroyMargin>
+		<destroyPartTarget>10</destroyPartTarget>
+		<useAeroSystemHits>false</useAeroSystemHits>
 		<maintenanceCycleDays>28</maintenanceCycleDays>
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>false</useQualityMaintenance>
+		<reverseQualityNames>false</reverseQualityNames>
 		<useUnofficalMaintenance>false</useUnofficalMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<useRandomHitsForVees>true</useRandomHitsForVees>
 		<minimumHitsForVees>1</minimumHitsForVees>
 		<maxAcquisitions>0</maxAcquisitions>
+		<minimumMarriageAge>16</minimumMarriageAge>
+		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
+		<logMarriageNameChange>false</logMarriageNameChange>
+		<useRandomMarriages>false</useRandomMarriages>
+		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
+		<marriageAgeRange>10</marriageAgeRange>
+		<randomMarriageSurnameWeights>100,55,55,10,5,30,20,10,5,30,20,500,160</randomMarriageSurnameWeights>
+		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
+		<chanceRandomSameSexMarriages>2.0E-5</chanceRandomSameSexMarriages>
 		<useUnofficialProcreation>false</useUnofficialProcreation>
+		<chanceProcreation>5.0E-4</chanceProcreation>
 		<useUnofficialProcreationNoRelationship>false</useUnofficialProcreationNoRelationship>
+		<chanceProcreationNoRelationship>5.0E-5</chanceProcreationNoRelationship>
+		<displayTrueDueDate>false</displayTrueDueDate>
+		<logConception>false</logConception>
+		<babySurnameStyle>MOTHERS</babySurnameStyle>
+		<determineFatherAtBirth>false</determineFatherAtBirth>
+		<useParentage>false</useParentage>
+		<displayFamilyLevel>0</displayFamilyLevel>
+		<useRandomDeaths>false</useRandomDeaths>
+		<keepMarriedNameUponSpouseDeath>false</keepMarriedNameUponSpouseDeath>
+		<payForParts>true</payForParts>
+		<payForRepairs>false</payForRepairs>
+		<payForUnits>true</payForUnits>
+		<payForSalaries>true</payForSalaries>
+		<payForOverhead>true</payForOverhead>
+		<payForMaintain>true</payForMaintain>
+		<payForTransport>true</payForTransport>
+		<sellUnits>true</sellUnits>
+		<sellParts>true</sellParts>
+		<payForRecruitment>true</payForRecruitment>
+		<useLoanLimits>true</useLoanLimits>
+		<usePercentageMaint>true</usePercentageMaint>
+		<infantryDontCount>false</infantryDontCount>
+		<usePeacetimeCost>false</usePeacetimeCost>
+		<useExtendedPartsModifier>false</useExtendedPartsModifier>
+		<showPeacetimeCost>false</showPeacetimeCost>
+		<financialYearDuration>ANNUAL</financialYearDuration>
+		<newFinancialYearFinancesToCSVExport>false</newFinancialYearFinancesToCSVExport>
+		<clanPriceModifier>4.0</clanPriceModifier>
+		<usedPartsValueA>0.1</usedPartsValueA>
+		<usedPartsValueB>0.2</usedPartsValueB>
+		<usedPartsValueC>0.3</usedPartsValueC>
+		<usedPartsValueD>0.5</usedPartsValueD>
+		<usedPartsValueE>0.7</usedPartsValueE>
+		<usedPartsValueF>0.9</usedPartsValueF>
+		<damagedPartsValue>0.4</damagedPartsValue>
+		<canceledOrderReimbursement>0.5</canceledOrderReimbursement>
 		<useTransfers>true</useTransfers>
-		<personnelMarketType>2</personnelMarketType>
+		<useTimeInService>false</useTimeInService>
+		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
+		<useTimeInRank>false</useTimeInRank>
+		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<trackTotalEarnings>false</trackTotalEarnings>
+		<capturePrisoners>false</capturePrisoners>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<personnelMarketName>FM: Mercenaries Revised</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
 		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
@@ -125,18 +184,21 @@
 		<sharesForAll>false</sharesForAll>
 		<retirementRolls>true</retirementRolls>
 		<customRetirementMods>false</customRetirementMods>
+		<foundersNeverRetire>false</foundersNeverRetire>
+		<atbAddDependents>true</atbAddDependents>
+		<dependentsNeverLeave>false</dependentsNeverLeave>
 		<trackUnitFatigue>false</trackUnitFatigue>
 		<mercSizeLimited>false</mercSizeLimited>
 		<trackOriginalUnit>false</trackOriginalUnit>
 		<regionalMechVariations>false</regionalMechVariations>
 		<searchRadius>800</searchRadius>
 		<intensity>1.0</intensity>
+		<generateChases>true</generateChases>
 		<variableContractLength>false</variableContractLength>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>false</usePlanetaryConditions>
-		<useAltMapgen>false</useAltMapgen>
 		<useLeadership>true</useLeadership>
 		<useStrategy>true</useStrategy>
 		<baseStrategyDeployment>3</baseStrategyDeployment>
@@ -149,11 +211,108 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<startGameDelay>500</startGameDelay>
-		<salaryTypeBase>0,1500,1500,900,900,900,900,960,750,960,900,1000,1000,1000,1000,800,800,800,800,400,1500,400,500,500,500,500</salaryTypeBase>
+		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowOpforAeros>false</allowOpforAeros>
+		<allowOpforLocalUnits>false</allowOpforLocalUnits>
+		<opforAeroChance>5</opforAeroChance>
+		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<historicalDailyLog>false</historicalDailyLog>
+		<massRepairUseExtraTime>true</massRepairUseExtraTime>
+		<massRepairUseRushJob>true</massRepairUseRushJob>
+		<massRepairAllowCarryover>true</massRepairAllowCarryover>
+		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
+		<massRepairScrapImpossible>false</massRepairScrapImpossible>
+		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
+		<massRepairReplacePod>true</massRepairReplacePod>
+		<massRepairOptions>
+			<massRepairOption0>
+				<type>0</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption0>
+			<massRepairOption1>
+				<type>1</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption1>
+			<massRepairOption2>
+				<type>2</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption2>
+			<massRepairOption3>
+				<type>3</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption3>
+			<massRepairOption4>
+				<type>4</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption4>
+			<massRepairOption5>
+				<type>5</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption5>
+			<massRepairOption6>
+				<type>6</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption6>
+			<massRepairOption7>
+				<type>7</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption7>
+			<massRepairOption8>
+				<type>12</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption8>
+			<massRepairOption9>
+				<type>8</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption9>
+		</massRepairOptions>
+		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
+		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
+		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
+		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
-		<usePortraitForType>false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+		<usePortraitForType>false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
 		<rats>Xotl,Total Warfare</rats>
-		<ratsNoEra>Xotl,Total Warfare</ratsNoEra>
 	</campaignOptions>
 	<skillTypes>
 		<skillType>
@@ -479,38 +638,60 @@
 	</skillTypes>
 	<specialAbilities>
 		<ability>
-			<displayName>Gunnery Specialization (aToW)</displayName>
-			<lookupName>specialist</lookupName>
-			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
- +1 to-hit modifier when using other types of weapons.</desc>
-			<xpCost>6</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hot Dog (aToW)</displayName>
-			<lookupName>hot_dog</lookupName>
-			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-			<xpCost>2</xpCost>
+			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
+			<lookupName>eagle_eyes</lookupName>
+			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
+			<xpCost>4</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Spacecraft::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Naval::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Small Arms::Green</skill>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Jumping Jack (aToW)</displayName>
+			<lookupName>jumping_jack</lookupName>
+			<desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
+			<xpCost>6</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>hopping_jack</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities>hopping_jack</removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Multi-Tasker (aToW)</displayName>
+			<lookupName>multi_tasker</lookupName>
+			<desc>Secondary target modifiers are reduced by one.</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -523,6 +704,133 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Clan Tech Knowledge (Unofficial)</displayName>
+			<lookupName>clan_tech_knowledge</lookupName>
+			<desc>clan_tech_knowledge</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel</skill>
+				<skill>Tech/BA</skill>
+				<skill>Tech/Aero</skill>
+				<skill>Tech/Mechanic</skill>
+				<skill>Tech/Mech</skill>
+			</skillPrereq>
+			<miscPrereq>clanner:false</miscPrereq>
+		</ability>
+		<ability>
+			<displayName>Tactical Genius (CamOps)</displayName>
+			<lookupName>tactical_genius</lookupName>
+			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
+ The second roll must be accepted.
+Note: Only one Tactical Genius may be utilized per team.</desc>
+			<xpCost>8</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tactics::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
+			<lookupName>tm_forest_ranger</lookupName>
+			<desc>Movement in woods or jungle costs 1 less MP.
+Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
+Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Dodge (MaxTech)</displayName>
+			<lookupName>dodge_maneuver</lookupName>
+			<desc>Enables the unit to make a dodge maneuver instead of a physical attack.
+This maneuver adds +2 to the BTH to physical attacks against the unit.
+NOTE: The dodge maneuver is declared during the weapons phase.
+Note: This ability is only used for BattleMechs.</desc>
+			<xpCost>2</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Green</skill>
+				<skill>Tech/BA::Green</skill>
+				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/Mechanic::Green</skill>
+				<skill>Tech/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Golden Goose (CamOps)</displayName>
+			<lookupName>golden_goose</lookupName>
+			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Gunnery/Energy (Unofficial)</displayName>
+			<lookupName>gunnery_laser</lookupName>
+			<desc>NOTE: This is a unofficial rule.
+Pilot gets a -1 to-hit bonus on all energy-based weapons (Laser,
+PPC,
+Plasma and Flamer).</desc>
+			<xpCost>6</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
@@ -534,32 +842,156 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Some Like It Hot (Unofficial)</displayName>
-			<lookupName>some_like_it_hot</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
+			<displayName>Gunnery/Missile (Unofficial)</displayName>
+			<lookupName>gunnery_missile</lookupName>
+			<desc>Pilot gets a -1 to-hit bonus on all missile weapons (LRM,
+SRM,
+MRM,
+RL and ATM).</desc>
+			<xpCost>6</xpCost>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Melee Specialist (aToW)</displayName>
-			<lookupName>melee_specialist</lookupName>
-			<desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>6</xpCost>
+			<displayName>Sniper (aToW)</displayName>
+			<lookupName>sniper</lookupName>
+			<desc>Range penalties are halved.</desc>
+			<xpCost>12</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Mountaineer] (CamOps)</displayName>
+			<lookupName>tm_mountaineer</lookupName>
+			<desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
+The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
+			<xpCost>4</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Weapon Specialist (aToW)</displayName>
+			<lookupName>weapon_specialist</lookupName>
+			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
+			<xpCost>12</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Forward Observer (CamOps)</displayName>
+			<lookupName>forward_observer</lookupName>
+			<desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Spacecraft::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Naval::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Small Arms::Green</skill>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Shaky Stick (CamOps)</displayName>
+			<lookupName>shaky_stick</lookupName>
+			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Hitter (AToW)</displayName>
+			<lookupName>cluster_hitter</lookupName>
+			<desc>A pilot with this ability gets a +1 to the cluster hit table </desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Foot Cavalry (CamOps)</displayName>
+			<lookupName>foot_cav</lookupName>
+			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Small Arms::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -571,51 +1003,121 @@ Note: This ability is only used for BattleMechs.</desc>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Cluster Master (AToW)</displayName>
-			<lookupName>cluster_master</lookupName>
-			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
-			<xpCost>6</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>cluster_hitter</prereqAbilities>
+			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
+			<lookupName>tm_frogman</lookupName>
+			<desc>Movement in depth 2 or greater water costs 1 MP less.
+Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
-			<removeAbilities>cluster_hitter</removeAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Multi-Tasker (aToW)</displayName>
-			<lookupName>multi_tasker</lookupName>
-			<desc>Secondary target modifiers are reduced by one.</desc>
+			<displayName>Some Like It Hot (Unofficial)</displayName>
+			<lookupName>some_like_it_hot</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
 			<xpCost>4</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
+			<lookupName>tech_internal_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Green</skill>
+				<skill>Tech/BA::Green</skill>
+				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/Mechanic::Green</skill>
+				<skill>Tech/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Sensor Geek (Unofficial)</displayName>
+			<lookupName>sensor_geek</lookupName>
+			<desc>A pilot with this ability gets a -2 bonus on sensor checks.
+ Note that this is really only a bonus, if inclusive sensor ranges are in use.</desc>
+			<xpCost>3</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/Naval::Green</skill>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Urban Guerrilla (CamOps)</displayName>
+			<lookupName>urban_guerrilla</lookupName>
+			<desc>Urban Guerrilla gives infantry a better chance of survival in urban or suburban environments (+1 to be hit)
+It also keeps them from taking double damage in the open when in pavement or road terrain types.
+Finally, urban guerrillas can call on local support once per scenario.</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Small Arms::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Oblique Attacker (aToW)</displayName>
+			<lookupName>oblique_attacker</lookupName>
+			<desc>The penalty for indirect fire is reduced by one.</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -631,6 +1133,7 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Aerospace::Green</skill>
 				<skill>Piloting/Naval::Green</skill>
@@ -641,14 +1144,15 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Oblique Attacker (aToW)</displayName>
-			<lookupName>oblique_attacker</lookupName>
-			<desc>The penalty for indirect fire is reduced by one.</desc>
+			<displayName>Oblique Artilleryman (CamOps)</displayName>
+			<lookupName>oblique_artillery</lookupName>
+			<desc>Reduces scatter distance by two hexes.</desc>
 			<xpCost>4</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
@@ -656,19 +1160,111 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Artillery::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Hopping Jack (Unofficial)</displayName>
-			<lookupName>hopping_jack</lookupName>
-			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
+			<displayName>Melee Master (aToW)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>6</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>zweihander</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>6</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Master (AToW)</displayName>
+			<lookupName>cluster_master</lookupName>
+			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
+			<xpCost>6</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>cluster_hitter</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities>cluster_hitter</removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Animal Mimicry (CamOps)</displayName>
+			<lookupName>animal_mimic</lookupName>
+			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
+-1 MP per hex of Woods and Jungle terrain.
+ In addition quads gain a -1 to any quad related PSR check.
+NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
+			<xpCost>6</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Specialist (aToW)</displayName>
+			<lookupName>melee_specialist</lookupName>
+			<desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
+Note: This ability is only used for BattleMechs.</desc>
 			<xpCost>6</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>jumping_jack</invalidAbilities>
+			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Human TRO (CamOps)</displayName>
+			<lookupName>human_tro</lookupName>
+			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Spacecraft::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Naval::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Small Arms::Green</skill>
+				<skill>Piloting/Ground Vehicle::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -680,6 +1276,7 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Aerospace::Green</skill>
 				<skill>Piloting/Naval::Green</skill>
@@ -690,27 +1287,62 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Jumping Jack (aToW)</displayName>
-			<lookupName>jumping_jack</lookupName>
-			<desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>6</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>hopping_jack</prereqAbilities>
+			<displayName>Hot Dog (aToW)</displayName>
+			<lookupName>hot_dog</lookupName>
+			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
+			<xpCost>2</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
-			<removeAbilities>hopping_jack</removeAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
+			<lookupName>tm_swamp_beast</lookupName>
+			<desc>Movement in mud or swamp costs 1 less MP.
+Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hopping Jack (Unofficial)</displayName>
+			<lookupName>hopping_jack</lookupName>
+			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>jumping_jack</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Sniper (aToW)</displayName>
-			<lookupName>sniper</lookupName>
-			<desc>Range penalties are halved.</desc>
-			<xpCost>12</xpCost>
-			<weight>1</weight>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
@@ -719,22 +1351,6 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Dodge (MaxTech)</displayName>
-			<lookupName>dodge_maneuver</lookupName>
-			<desc>Enables the unit to make a dodge maneuver instead of a physical attack.
-This maneuver adds +2 to the BTH to physical attacks against the unit.
-NOTE: The dodge maneuver is declared during the weapons phase.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>2</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -746,90 +1362,60 @@ Note: This ability is only used for BattleMechs.</desc>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Cluster Hitter (AToW)</displayName>
-			<lookupName>cluster_hitter</lookupName>
-			<desc>A pilot with this ability gets a +1 to the cluster hit table </desc>
-			<xpCost>4</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Weapon Specialist (aToW)</displayName>
-			<lookupName>weapon_specialist</lookupName>
-			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
-			<xpCost>12</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Melee Master (aToW)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
 			<xpCost>6</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Sensor Geek (Unofficial)</displayName>
-			<lookupName>sensor_geek</lookupName>
-			<desc>A pilot with this ability gets a -2 bonus on sensor checks.
- Note that this is really only a bonus, if inclusive sensor ranges are in use.</desc>
-			<xpCost>3</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/Naval::Green</skill>
-				<skill>Piloting/Ground Vehicle::Green</skill>
+				<skill>Tech/Vessel::Green</skill>
+				<skill>Tech/BA::Green</skill>
+				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/Mechanic::Green</skill>
+				<skill>Tech/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Gunnery/Ballistic (Unofficial)</displayName>
+			<lookupName>gunnery_ballistic</lookupName>
+			<desc>Pilot gets a -1 to-hit bonus on all ballistic weapons (MGs,
+all ACs,
+Gaussrifles).</desc>
+			<xpCost>6</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Piloting/VTOL::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
 	<randomSkillPreferences>
 		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
 		<specialAbilBonus>-10,-10,-2,0,0</specialAbilBonus>
 		<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
 		<randomizeSkill>true</randomizeSkill>


### PR DESCRIPTION
This PR updates all of the presets that ship with MHQ to include some SPAs that have not been included. This varied from preset to preset, but in all cases it included Zweihander and all of the options for tech special abilities except clan tech knowledge. I have also set default values for all of these special abilities in the defaultspa.xml file. I have tried to be consistent with the existing point ranges and weights for all presets. 