### PR TITLE
Marking usedForRefitPlanning as transient

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -185,7 +185,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     protected UUID refitId;
     protected UUID reserveId;
     //temporarily mark the part used by current refit planning
-    protected boolean usedForRefitPlanning;
+    protected transient boolean usedForRefitPlanning;
 
     //for delivery
     protected int daysToArrival;


### PR DESCRIPTION
This is to make it obvious the value is transient and not saved to file.