### PR TITLE
order refit techs by role, then ascending skill

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.time.DayOfWeek;
 import java.util.*;
+import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
 import javax.swing.*;
@@ -1585,9 +1586,13 @@ public class CampaignGUI extends JPanel {
         } else if (getCampaign().getTechs().size() > 0) {
             String name;
             Map<String, Person> techHash = new HashMap<>();
+            List<String> techList = new ArrayList<>();
             String skillLvl;
             int TimePerDay;
-            for (Person tech : getCampaign().getTechs()) {
+            
+            List<Person> techs = getCampaign().getTechs();
+            techs.sort(Comparator.comparingInt(Person::getPrimaryRole));
+            for (Person tech : techs) {
                 if (getCampaign().isWorkingOnRefit(tech) || tech.isEngineer()) {
                     continue;
                 }
@@ -1609,19 +1614,17 @@ public class CampaignGUI extends JPanel {
                         + tech.getMinutesLeft() + "/" + TimePerDay
                         + " minutes";
                 techHash.put(name, tech);
+                techList.add(name);
             }
-            String[] techNames = new String[techHash.keySet().size()];
-            int i = 0;
-            for (String n : techHash.keySet()) {
-                techNames[i] = n;
-                i++;
-            }
+            
             String s = (String) JOptionPane.showInputDialog(frame,
                     "Which tech should work on the refit?", "Select Tech",
-                    JOptionPane.PLAIN_MESSAGE, null, techNames, techNames[0]);
+                    JOptionPane.PLAIN_MESSAGE, null, techList.toArray(), techList.get(0));
+            
             if (null == s) {
                 return;
             }
+            
             r.setTeamId(techHash.get(s).getId());
         } else {
             JOptionPane.showMessageDialog(frame,


### PR DESCRIPTION
When picking techs to carry out refits, it's very annoying to have to search through a large list looking for the right type of tech. Now, it's ordered by tech type (mech/aero/ba/etc), then skill in descending order.