### PR TITLE
fix NPE when generating contracts for suddenly extinct faction

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -256,6 +256,8 @@ public class RandomFactionGenerator {
      */
     public String getEnemy(Faction employer, boolean useRebels) {
         final String METHOD_NAME = "getEnemy(Faction,boolean)"; //$NON-NLS-1$
+        
+        String employerName = employer != null ? employer.getShortName() : "no employer supplied or faction does not exist";
 
         /* Rebels occur on a 1-4 (d20) on nearly every enemy chart */
         if (useRebels && (Compute.randomInt(5) == 0)) {
@@ -267,15 +269,18 @@ public class RandomFactionGenerator {
             employer = factionHints.getContainedFactionHost(employer, currentDate());
         }
         if (null != employer) {
+            employerName = employer.getShortName();
             WeightedMap<Faction> enemyMap = buildEnemyMap(employer);
             enemy = enemyMap.randomItem();
         }
         if (null != enemy) {
             return enemy.getShortName();
         }
-        // Fallback; there are always pirates.
+        
         MekHQ.getLogger().error(getClass(), METHOD_NAME,
-                "Could not find enemy for " + employer.getShortName()); //$NON-NLS-1$
+                "Could not find enemy for " + employerName); //$NON-NLS-1$
+        
+        // Fallback; there are always pirates.
         return "PIR";
     }
 


### PR DESCRIPTION
The code attempting to log the error gracefully was throwing an NPE by attempting to access the short name property of a non-existent object.

The player still won't get any contracts generated, but that's a wider issue beyond the scope of a simple bug fix.

Addresses #1828 