### PR TITLE
DateTime to LocalDate Switchover

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -72,9 +72,6 @@ import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.equipment.*;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDateTime;
 
 import megamek.client.Client;
 import megamek.common.ASFBay;
@@ -1395,16 +1392,6 @@ public class Utilities {
             return 1;
         }
         return diff;
-    }
-
-    /** @return the current date as a DateTime time stamp for midnight in UTC time zone */
-    public static DateTime getDateTimeDay(Calendar cal) {
-        return new LocalDateTime(cal).toDateTime(DateTimeZone.UTC);
-    }
-
-    /** @return the current date as a DateTime time stamp for midnight in UTC time zone */
-    public static DateTime getDateTimeDay(Date date) {
-        return new LocalDateTime(date).toDateTime(DateTimeZone.UTC);
     }
 
     /**

--- a/MekHQ/src/mekhq/adapter/DateAdapter.java
+++ b/MekHQ/src/mekhq/adapter/DateAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 MegaMek team
+ * Copyright (C) 2016 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -7,35 +7,31 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.adapter;
 
+import mekhq.MekHqXmlUtil;
+
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-import org.joda.time.DateTime;
-import org.joda.time.chrono.GJChronology;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import java.time.LocalDate;
 
-public class DateAdapter extends XmlAdapter<String, DateTime> {
-    private final static DateTimeFormatter FORMATTER =
-        DateTimeFormat.forPattern("yyyy-MM-dd").withChronology(GJChronology.getInstanceUTC());
-    
+public class DateAdapter extends XmlAdapter<String, LocalDate> {
     @Override
-    public DateTime unmarshal(final String xml) throws Exception {
-        return FORMATTER.parseDateTime(xml);
+    public LocalDate unmarshal(final String xml) throws Exception {
+        return MekHqXmlUtil.parseDate(xml);
     }
 
     @Override
-    public String marshal(final DateTime object) throws Exception {
-        return object.toString(FORMATTER);
+    public String marshal(final LocalDate object) throws Exception {
+        return MekHqXmlUtil.saveFormattedDate(object);
     }
 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -12,11 +12,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign;
 
@@ -50,7 +50,6 @@ import mekhq.campaign.personnel.generator.AbstractPersonnelGenerator;
 import mekhq.campaign.personnel.generator.DefaultPersonnelGenerator;
 import mekhq.service.AutosaveService;
 import mekhq.service.IAutosaveService;
-import org.joda.time.DateTime;
 
 import megamek.common.*;
 import megamek.common.enums.Gender;
@@ -215,7 +214,6 @@ public class Campaign implements Serializable, ITechManager {
 
     // calendar stuff
     private GregorianCalendar calendar;
-    private DateTime currentDateTime;
     private String dateFormat;
     private String shortDateFormat;
 
@@ -288,7 +286,6 @@ public class Campaign implements Serializable, ITechManager {
         player = new Player(0, "self");
         game.addPlayer(0, player);
         calendar = new GregorianCalendar(3067, Calendar.JANUARY, 1);
-        currentDateTime = new DateTime(calendar);
         CurrencyManager.getInstance().setCampaign(this);
         location = new CurrentLocation(Systems.getInstance().getSystems().get("Outreach"), 0);
         campaignOptions = new CampaignOptions();
@@ -422,7 +419,6 @@ public class Campaign implements Serializable, ITechManager {
     @Deprecated
     public void setCalendar(GregorianCalendar c) {
         calendar = c;
-        currentDateTime = new DateTime(c);
     }
 
     @Deprecated
@@ -441,7 +437,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public String getCurrentSystemName() {
-        return location.getCurrentSystem().getPrintableName(getDateTime());
+        return location.getCurrentSystem().getPrintableName(getLocalDate());
     }
 
     public PlanetarySystem getCurrentSystem() {
@@ -1715,16 +1711,11 @@ public class Campaign implements Serializable, ITechManager {
         return calendar.getTime();
     }
 
-    @Deprecated
-    public DateTime getDateTime() {
-        return currentDateTime;
-    }
-
     /**
      * For now, this is just going to parse through the current date time
      */
     public LocalDate getLocalDate() {
-        return LocalDate.of(currentDateTime.getYear(), currentDateTime.getMonthOfYear(), currentDateTime.getDayOfMonth());
+        return LocalDate.of(getCalendar().get(Calendar.YEAR), getCalendar().get(Calendar.MONTH), getCalendar().get(Calendar.DAY_OF_MONTH));
     }
 
     public List<Person> getPatients() {
@@ -2584,7 +2575,7 @@ public class Campaign implements Serializable, ITechManager {
 
         // we are shopping by planets, so more involved
         List<IAcquisitionWork> currentList = sList.getAllShoppingItems();
-        DateTime currentDate = Utilities.getDateTimeDay(getCalendar());
+        LocalDate currentDate = getLocalDate();
 
         // a list of items than can be taken out of the search and put back on the
         // shopping list
@@ -2592,8 +2583,7 @@ public class Campaign implements Serializable, ITechManager {
 
         //find planets within a certain radius - the function will weed out dead planets
         List<PlanetarySystem> systems = Systems.getInstance().getShoppingSystems(getCurrentSystem(),
-                getCampaignOptions().getMaxJumpsPlanetaryAcquisition(),
-                currentDate);
+                getCampaignOptions().getMaxJumpsPlanetaryAcquisition(), currentDate);
 
         for (Person person : logisticsPersonnel) {
             if (currentList.isEmpty()) {
@@ -2714,27 +2704,28 @@ public class Campaign implements Serializable, ITechManager {
      * @return true if your target roll succeeded.
      */
     public boolean findContactForAcquisition(IAcquisitionWork acquisition, Person person, PlanetarySystem system) {
-
-        DateTime currentDate = Utilities.getDateTimeDay(getCalendar());
         TargetRoll target = getTargetForAcquisition(acquisition, person, false);
-        target = system.getPrimaryPlanet().getAcquisitionMods(target, getDate(), getCampaignOptions(), getFaction(),
+        target = system.getPrimaryPlanet().getAcquisitionMods(target, getLocalDate(), getCampaignOptions(), getFaction(),
                 acquisition.getTechBase() == Part.T_CLAN);
 
         if (target.getValue() == TargetRoll.IMPOSSIBLE) {
-            if(getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
-                addReport("<font color='red'><b>Can't search for " + acquisition.getAcquisitionName() + " on " + system.getPrintableName(currentDate) + " because:</b></font> " + target.getDesc());
+            if (getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
+                addReport("<font color='red'><b>Can't search for " + acquisition.getAcquisitionName()
+                        + " on " + system.getPrintableName(getLocalDate()) + " because:</b></font> " + target.getDesc());
             }
             return false;
         }
-        if(Compute.d6(2) < target.getValue()) {
+        if (Compute.d6(2) < target.getValue()) {
             //no contacts on this planet, move along
-            if(getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
-                addReport("<font color='red'><b>No contacts available for " + acquisition.getAcquisitionName() + " on " + system.getPrintableName(currentDate) + "</b></font>");
+            if (getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
+                addReport("<font color='red'><b>No contacts available for " + acquisition.getAcquisitionName()
+                        + " on " + system.getPrintableName(getLocalDate()) + "</b></font>");
             }
             return false;
         } else {
-            if(getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
-                addReport("<font color='green'>Possible contact for " + acquisition.getAcquisitionName() + " on " + system.getPrintableName(currentDate) + "</font>");
+            if (getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
+                addReport("<font color='green'>Possible contact for " + acquisition.getAcquisitionName()
+                        + " on " + system.getPrintableName(getLocalDate()) + "</font>");
             }
             return true;
         }
@@ -2770,13 +2761,13 @@ public class Campaign implements Serializable, ITechManager {
         TargetRoll target = getTargetForAcquisition(acquisition, person, false);
 
         //check on funds
-        if(!canPayFor(acquisition)) {
+        if (!canPayFor(acquisition)) {
             target.addModifier(TargetRoll.IMPOSSIBLE, "Cannot afford this purchase");
         }
 
-        if(null != system) {
-            target = system.getPrimaryPlanet().getAcquisitionMods(target, getDate(), getCampaignOptions(), getFaction(),
-                    acquisition.getTechBase() == Part.T_CLAN);
+        if (null != system) {
+            target = system.getPrimaryPlanet().getAcquisitionMods(target, getLocalDate(),
+                    getCampaignOptions(), getFaction(), acquisition.getTechBase() == Part.T_CLAN);
         }
 
         report += "attempts to find " + acquisition.getAcquisitionName();
@@ -2784,7 +2775,7 @@ public class Campaign implements Serializable, ITechManager {
         //if impossible then return
         if (target.getValue() == TargetRoll.IMPOSSIBLE) {
             report += ":<font color='red'><b> " + target.getDesc() + "</b></font>";
-            if(!getCampaignOptions().usesPlanetaryAcquisition() || getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
+            if (!getCampaignOptions().usesPlanetaryAcquisition() || getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
                 addReport(report);
             }
             return false;
@@ -2850,7 +2841,7 @@ public class Campaign implements Serializable, ITechManager {
             acquisition.decrementQuantity();
             MekHQ.triggerEvent(new AcquisitionEvent(acquisition));
         }
-        if(!getCampaignOptions().usesPlanetaryAcquisition() || getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
+        if (!getCampaignOptions().usesPlanetaryAcquisition() || getCampaignOptions().usePlanetAcquisitionVerboseReporting()) {
             addReport(report);
         }
         return found;
@@ -2986,12 +2977,12 @@ public class Campaign implements Serializable, ITechManager {
             addReport("No tech is assigned to refit " + r.getOriginalEntity().getShortName() + ". Refit cancelled.");
             r.cancel();
             return;
-                }
+        }
         TargetRoll target = getTargetFor(r, tech);
         // check that all parts have arrived
         if (!r.acquireParts()) {
             return;
-                }
+        }
         String report = tech.getHyperlinkedFullTitle() + " works on " + r.getPartName();
         int minutes = r.getTimeLeft();
         // FIXME: Overtime?
@@ -3289,11 +3280,10 @@ public class Campaign implements Serializable, ITechManager {
      */
     public void readNews() {
         //read the news
-        DateTime now = getDateTime();
-        for(NewsItem article : news.fetchNewsFor(now)) {
+        for(NewsItem article : news.fetchNewsFor(getLocalDate())) {
             addReport(article.getHeadlineForReport());
         }
-        for(NewsItem article : Systems.getInstance().getPlanetaryNews(now)) {
+        for(NewsItem article : Systems.getInstance().getPlanetaryNews(getLocalDate())) {
             addReport(article.getHeadlineForReport());
         }
     }
@@ -3724,7 +3714,6 @@ public class Campaign implements Serializable, ITechManager {
 
         // Advance the day by one - TODO : LocalDate : Swap me to LocalDate tracking instead
         calendar.add(Calendar.DAY_OF_MONTH, 1);
-        currentDateTime = new DateTime(calendar);
 
         // Determine if we have an active contract or not, as this can get used elsewhere before
         // we actually hit the AtB new day (e.g. personnel market)
@@ -5008,13 +4997,13 @@ public class Campaign implements Serializable, ITechManager {
     public Vector<String> getSystemNames() {
         Vector<String> systemNames = new Vector<>();
         for (PlanetarySystem key : Systems.getInstance().getSystems().values()) {
-            systemNames.add(key.getPrintableName(getDateTime()));
+            systemNames.add(key.getPrintableName(getLocalDate()));
         }
         return systemNames;
     }
 
     public PlanetarySystem getSystemByName(String name) {
-        return Systems.getInstance().getSystemByName(name, getDateTime());
+        return Systems.getInstance().getSystemByName(name, getLocalDate());
     }
 
     public void setRanks(Ranks r) {
@@ -5113,7 +5102,6 @@ public class Campaign implements Serializable, ITechManager {
         String startKey = start.getId();
         String endKey = end.getId();
 
-        final DateTime now = getDateTime();
         String current = startKey;
         Set<String> closed = new HashSet<>();
         Set<String> open = new HashSet<>();
@@ -5140,7 +5128,7 @@ public class Campaign implements Serializable, ITechManager {
 
         while (!found && jumps < 10000) {
             jumps++;
-            double currentG = scoreG.get(current) + Systems.getInstance().getSystemById(current).getRechargeTime(now);
+            double currentG = scoreG.get(current) + Systems.getInstance().getSystemById(current).getRechargeTime(getLocalDate());
 
             final String localCurrent = current;
             Systems.getInstance().visitNearbySystems(Systems.getInstance().getSystemById(current), 30, p -> {
@@ -5174,7 +5162,7 @@ public class Campaign implements Serializable, ITechManager {
             }
 
             current = bestMatch;
-            if(null == current) {
+            if (null == current) {
                 // We're done - probably failed to find anything
                 break;
             }
@@ -8525,7 +8513,7 @@ public class Campaign implements Serializable, ITechManager {
 
     @Override
     public int getGameYear() {
-        return currentDateTime.getYear();
+        return getCalendar().get(Calendar.YEAR);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -214,6 +214,7 @@ public class Campaign implements Serializable, ITechManager {
 
     // calendar stuff
     private GregorianCalendar calendar;
+    private LocalDate currentDay;
     private String dateFormat;
     private String shortDateFormat;
 
@@ -286,6 +287,7 @@ public class Campaign implements Serializable, ITechManager {
         player = new Player(0, "self");
         game.addPlayer(0, player);
         calendar = new GregorianCalendar(3067, Calendar.JANUARY, 1);
+        currentDay = LocalDate.ofYearDay(3067, 1);
         CurrencyManager.getInstance().setCampaign(this);
         location = new CurrentLocation(Systems.getInstance().getSystems().get("Outreach"), 0);
         campaignOptions = new CampaignOptions();
@@ -417,13 +419,21 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     @Deprecated
+    public GregorianCalendar getCalendar() {
+        return calendar;
+    }
+
+    @Deprecated
     public void setCalendar(GregorianCalendar c) {
         calendar = c;
     }
 
-    @Deprecated
-    public GregorianCalendar getCalendar() {
-        return calendar;
+    public LocalDate getLocalDate() {
+        return currentDay;
+    }
+
+    public void setLocalDate(LocalDate currentDay) {
+        this.currentDay = currentDay;
     }
 
     @Deprecated
@@ -434,6 +444,21 @@ public class Campaign implements Serializable, ITechManager {
     @Deprecated
     public DateFormat getShortDateFormatter() {
         return new SimpleDateFormat(shortDateFormat);
+    }
+
+    @Deprecated
+    public Date getDate() {
+        return calendar.getTime();
+    }
+
+    @Deprecated
+    public String getDateAsString() {
+        return getDateFormatter().format(calendar.getTime());
+    }
+
+    @Deprecated
+    public String getShortDateAsString() {
+        return getShortDateFormatter().format(calendar.getTime());
     }
 
     public String getCurrentSystemName() {
@@ -1705,18 +1730,6 @@ public class Campaign implements Serializable, ITechManager {
     }
     //endregion Personnel Selectors and Generators
     //endregion Personnel
-
-    @Deprecated
-    public Date getDate() {
-        return calendar.getTime();
-    }
-
-    /**
-     * For now, this is just going to parse through the current date time
-     */
-    public LocalDate getLocalDate() {
-        return LocalDate.of(getCalendar().get(Calendar.YEAR), getCalendar().get(Calendar.MONTH), getCalendar().get(Calendar.DAY_OF_MONTH));
-    }
 
     public List<Person> getPatients() {
         List<Person> patients = new ArrayList<>();
@@ -3280,10 +3293,10 @@ public class Campaign implements Serializable, ITechManager {
      */
     public void readNews() {
         //read the news
-        for(NewsItem article : news.fetchNewsFor(getLocalDate())) {
+        for (NewsItem article : news.fetchNewsFor(getLocalDate())) {
             addReport(article.getHeadlineForReport());
         }
-        for(NewsItem article : Systems.getInstance().getPlanetaryNews(getLocalDate())) {
+        for (NewsItem article : Systems.getInstance().getPlanetaryNews(getLocalDate())) {
             addReport(article.getHeadlineForReport());
         }
     }
@@ -3575,7 +3588,7 @@ public class Campaign implements Serializable, ITechManager {
                 p.resetCurrentEdge();
             }
 
-            if ((getCampaignOptions().getIdleXP() > 0) && (calendar.get(Calendar.DAY_OF_MONTH) == 1)
+            if ((getCampaignOptions().getIdleXP() > 0) && (getLocalDate().getDayOfMonth() == 1)
                     && p.isActive() && !p.getPrisonerStatus().isPrisoner()) { // Prisoners can't gain XP, while Bondsmen can gain xp
                 p.setIdleMonths(p.getIdleMonths() + 1);
                 if (p.getIdleMonths() >= getCampaignOptions().getMonthsIdleXP()) {
@@ -3712,8 +3725,9 @@ public class Campaign implements Serializable, ITechManager {
         // Autosave based on the previous day's information
         this.autosaveService.requestDayAdvanceAutosave(this);
 
-        // Advance the day by one - TODO : LocalDate : Swap me to LocalDate tracking instead
+        // Advance the day by one - TODO : LocalDate : Remove the Calendar addition
         calendar.add(Calendar.DAY_OF_MONTH, 1);
+        currentDay = currentDay.plus(1, ChronoUnit.DAYS);
 
         // Determine if we have an active contract or not, as this can get used elsewhere before
         // we actually hit the AtB new day (e.g. personnel market)
@@ -4181,14 +4195,6 @@ public class Campaign implements Serializable, ITechManager {
         }
 
         return null;
-    }
-
-    public String getDateAsString() {
-        return getDateFormatter().format(calendar.getTime());
-    }
-
-    public String getShortDateAsString() {
-        return getShortDateFormatter().format(calendar.getTime());
     }
 
     public void restore() {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8519,7 +8519,7 @@ public class Campaign implements Serializable, ITechManager {
 
     @Override
     public int getGameYear() {
-        return getCalendar().get(Calendar.YEAR);
+        return getLocalDate().getYear();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/ExtraData.java
+++ b/MekHQ/src/mekhq/campaign/ExtraData.java
@@ -20,7 +20,6 @@ package mekhq.campaign;
 
 import java.io.OutputStream;
 import java.io.Writer;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/MekHQ/src/mekhq/campaign/ExtraData.java
+++ b/MekHQ/src/mekhq/campaign/ExtraData.java
@@ -20,6 +20,7 @@ package mekhq.campaign;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +40,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 
 import mekhq.MekHQ;
@@ -112,10 +112,6 @@ public class ExtraData {
         ADAPTERS.put(Boolean.class, new StringAdapter<Boolean>() {
             @Override
             public Boolean adapt(String str) { return Boolean.valueOf(str); }
-        });
-        ADAPTERS.put(DateTime.class, new StringAdapter<DateTime>() {
-            @Override
-            public DateTime adapt(String str) { return new DateTime(str); }
         });
     }
 
@@ -417,13 +413,6 @@ public class ExtraData {
     public static class BooleanKey extends Key<Boolean> {
         public BooleanKey(String name) {
             super(name, Boolean.class);
-        }
-    }
-
-    /** A key referencing a joda-time DateTime value */
-    public static class DateKey extends Key<DateTime> {
-        public DateKey(String name) {
-            super(name, DateTime.class);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/JumpPath.java
+++ b/MekHQ/src/mekhq/campaign/JumpPath.java
@@ -12,21 +12,20 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -45,12 +44,8 @@ import mekhq.campaign.universe.PlanetarySystem;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class JumpPath implements Serializable {
-
-	/**
-	 *
-	 */
 	private static final long serialVersionUID = 708430867050359759L;
-	private ArrayList<PlanetarySystem> path;
+	private List<PlanetarySystem> path;
 
 	public JumpPath() {
 		path = new ArrayList<>();
@@ -60,7 +55,7 @@ public class JumpPath implements Serializable {
 		path = p;
 	}
 
-	public ArrayList<PlanetarySystem> getSystems() {
+	public List<PlanetarySystem> getSystems() {
 		return path;
 	}
 
@@ -69,7 +64,7 @@ public class JumpPath implements Serializable {
 	}
 
 	public PlanetarySystem getFirstSystem() {
-		if(path.isEmpty()) {
+		if (path.isEmpty()) {
 			return null;
 		} else {
 			return path.get(0);
@@ -77,7 +72,7 @@ public class JumpPath implements Serializable {
 	}
 
 	public PlanetarySystem getLastSystem() {
-		if(path.isEmpty()) {
+		if (path.isEmpty()) {
 			return null;
 		} else {
 			return path.get(path.size() - 1);
@@ -86,7 +81,7 @@ public class JumpPath implements Serializable {
 
 	public double getStartTime(double currentTransit) {
 		double startTime = 0.0;
-		if(null != getFirstSystem()) {
+		if (null != getFirstSystem()) {
 			startTime = getFirstSystem().getTimeToJumpPoint(1.0);
 		}
 		return startTime - currentTransit;
@@ -94,19 +89,19 @@ public class JumpPath implements Serializable {
 
 	public double getEndTime() {
 		double endTime = 0.0;
-		if(null != getLastSystem()) {
+		if (null != getLastSystem()) {
 			endTime = getLastSystem().getTimeToJumpPoint(1.0);
 		}
 		return endTime;
 	}
 
-	public double getTotalRechargeTime(DateTime when) {
+	public double getTotalRechargeTime(LocalDate when) {
 		int rechargeTime = 0;
-		for(PlanetarySystem system : path) {
-			if(system.equals(getFirstSystem())) {
+		for (PlanetarySystem system : path) {
+			if (system.equals(getFirstSystem())) {
 				continue;
 			}
-			if(system.equals(getLastSystem())) {
+			if (system.equals(getLastSystem())) {
 				continue;
 			}
 			rechargeTime += (int) Math.ceil(system.getRechargeTime(when));
@@ -115,10 +110,10 @@ public class JumpPath implements Serializable {
 	}
 
 	public int getJumps() {
-		return size()-1;
+		return size() - 1;
 	}
 
-	public double getTotalTime(DateTime when, double currentTransit) {
+	public double getTotalTime(LocalDate when, double currentTransit) {
 		return getTotalRechargeTime(when) + getStartTime(currentTransit) + getEndTime();
 	}
 
@@ -131,7 +126,7 @@ public class JumpPath implements Serializable {
 	}
 
 	public void removeFirstSystem() {
-		if(!path.isEmpty()) {
+		if (!path.isEmpty()) {
 			path.remove(0);
 		}
 	}
@@ -141,7 +136,7 @@ public class JumpPath implements Serializable {
 	}
 
 	public PlanetarySystem get(int i) {
-		if(i >= size()) {
+		if (i >= size()) {
 			return null;
 		} else {
 			return path.get(i);
@@ -154,11 +149,11 @@ public class JumpPath implements Serializable {
 
 	public void writeToXml(PrintWriter pw1, int indent) {
 		pw1.println(MekHqXmlUtil.indentStr(indent) + "<jumpPath>");
-		for(PlanetarySystem p : path) {
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<planetName>"
-				+MekHqXmlUtil.escape(p.getId())
-				+"</planetName>");
+		for (PlanetarySystem p : path) {
+            pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                    +"<planetName>"
+                    +MekHqXmlUtil.escape(p.getId())
+                    +"</planetName>");
 		}
 		pw1.println(MekHqXmlUtil.indentStr(indent) + "</jumpPath>");
 
@@ -173,11 +168,11 @@ public class JumpPath implements Serializable {
 			retVal = new JumpPath();
 			NodeList nl = wn.getChildNodes();
 
-			for (int x=0; x<nl.getLength(); x++) {
+			for (int x = 0; x < nl.getLength(); x++) {
 				Node wn2 = nl.item(x);
 				if (wn2.getNodeName().equalsIgnoreCase("planetName")) {
 					PlanetarySystem p = c.getSystemByName(wn2.getTextContent());
-					if(null != p) {
+					if (null != p) {
 						retVal.addSystem(p);
 					} else {
 					    MekHQ.getLogger().log(JumpPath.class, METHOD_NAME, LogLevel.ERROR,

--- a/MekHQ/src/mekhq/campaign/finances/CurrencyManager.java
+++ b/MekHQ/src/mekhq/campaign/finances/CurrencyManager.java
@@ -12,13 +12,12 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.finances;
 
 import megamek.common.logging.LogLevel;
@@ -33,7 +32,6 @@ import mekhq.campaign.universe.PlanetarySystem;
 import org.joda.money.CurrencyUnitDataProvider;
 import org.joda.money.format.MoneyFormatter;
 import org.joda.money.format.MoneyFormatterBuilder;
-import org.joda.time.DateTime;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -41,6 +39,7 @@ import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilder;
 import java.io.FileInputStream;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,9 +60,9 @@ public class CurrencyManager extends CurrencyUnitDataProvider {
     private static final CurrencyManager instance = new CurrencyManager();
 
     /** The last time the default currency was checked. */
-    private DateTime lastChecked;
+    private LocalDate lastChecked;
 
-    /** 
+    /**
      * The last planetary system the campaign was on
      * when the default currency was checked.
      */
@@ -144,11 +143,11 @@ public class CurrencyManager extends CurrencyUnitDataProvider {
         // Check if we need to update the default currency
         // by comparing the campaign's current date and
         // planetary system against our cached date and systems
-        DateTime date = this.campaign.getDateTime();
+        LocalDate date = campaign.getLocalDate();
         PlanetarySystem currentSystem = this.campaign.getCurrentSystem();
-        if (this.lastChecked == null 
-            || this.lastChecked.isBefore(date)
-            || !Objects.equals(this.lastSystem, currentSystem)) {
+        if ((lastChecked == null)
+                || this.lastChecked.isBefore(date)
+                || !Objects.equals(this.lastSystem, currentSystem)) {
             this.lastChecked = date;
             this.lastSystem = currentSystem;
             this.defaultCurrency = this.backupCurrency;
@@ -158,8 +157,7 @@ public class CurrencyManager extends CurrencyUnitDataProvider {
             // Use the default currency in this time period, if it exists
             int year = date.getYear();
             for (Currency currency : this.currencies) {
-                if ((year >= currency.getStartYear()) &&
-                        (year <= currency.getEndYear())) {
+                if ((year >= currency.getStartYear()) && (year <= currency.getEndYear())) {
 
                     if (currency.getIsDefault()) {
                         return defaultCurrency = currency;

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - The MegaMek Team
+ * Copyright (c) 2018 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.io;
 
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.UUID;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -889,6 +888,7 @@ public class CampaignXmlParser {
                             .getInstance();
                     c.setTime(parseDate(df, wn.getTextContent().trim()));
                     retVal.setCalendar(c);
+                    retVal.setLocalDate(MekHqXmlUtil.parseDate(wn.getTextContent().trim()));
                 } else if (xn.equalsIgnoreCase("camoCategory")) {
                     String val = wn.getTextContent().trim();
 

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -12,13 +12,12 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.market;
 
 import java.io.PrintWriter;
@@ -28,7 +27,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Set;
 
-import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -37,7 +35,6 @@ import megamek.common.Compute;
 import megamek.common.logging.LogLevel;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
-import mekhq.Utilities;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
@@ -58,13 +55,8 @@ import mekhq.campaign.universe.Systems;
  * Based on PersonnelMarket
  *
  * @author Neoancient
- *
  */
 public class ContractMarket implements Serializable {
-
-	/**
-	 *
-	 */
 	private static final long serialVersionUID = 1303462872220110093L;
 
 	public static int TYPE_ATBMONTHLY = 0;
@@ -93,10 +85,10 @@ public class ContractMarket implements Serializable {
 	private HashMap<Integer, Integer> followupContracts;
 
 	public ContractMarket() {
-		contracts = new ArrayList<Contract>();
-		contractIds = new HashMap<Integer, Contract>();
-		clauseMods = new HashMap<Integer, ClauseMods>();
-		followupContracts = new HashMap<Integer, Integer>();
+		contracts = new ArrayList<>();
+		contractIds = new HashMap<>();
+		clauseMods = new HashMap<>();
+		followupContracts = new HashMap<>();
 	}
 
 	public ArrayList<Contract> getContracts() {
@@ -169,9 +161,7 @@ public class ContractMarket implements Serializable {
 
 			int numContracts = Compute.d6() - 4 + unitRatingMod;
 
-			DateTime currentDate = Utilities.getDateTimeDay(campaign.getCalendar());
-			Set<Faction> currentFactions =
-					campaign.getCurrentSystem().getFactionSet(currentDate);
+			Set<Faction> currentFactions = campaign.getCurrentSystem().getFactionSet(campaign.getLocalDate());
 			boolean inMinorFaction = true;
 			for (Faction f : currentFactions) {
 				if (RandomFactionGenerator.getInstance().getFactionHints().isISMajorPower(f) ||
@@ -198,8 +188,8 @@ public class ContractMarket implements Serializable {
                 Faction onlyFaction = currentFactions.iterator().next();
                 if( !onlyFaction.isPeriphery() ) {
                     for (PlanetarySystem key : Systems.getInstance().getNearbySystems(campaign.getCurrentSystem(), 30)) {
-                        for (Faction f : key.getFactionSet(currentDate)) {
-                            if( !onlyFaction.equals(f) ) {
+                        for (Faction f : key.getFactionSet(campaign.getLocalDate())) {
+                            if (!onlyFaction.equals(f)) {
                                 inBackwater = false;
                                 break;
                             }
@@ -235,7 +225,7 @@ public class ContractMarket implements Serializable {
 			/* If located on a faction's capital (interpreted as the starting planet for that faction),
 			 * generate one contract offer for that faction.
 			 */
-			for (Faction f : campaign.getCurrentSystem().getFactionSet(currentDate)) {
+			for (Faction f : campaign.getCurrentSystem().getFactionSet(campaign.getLocalDate())) {
 				try {
 					if (f.getStartingPlanet(campaign.getGameYear()).equals(campaign.getCurrentSystem().getId())
 							&& RandomFactionGenerator.getInstance().getEmployerSet().contains(f.getShortName())) {
@@ -266,8 +256,7 @@ public class ContractMarket implements Serializable {
 		}
 	}
 
-	private void checkForSubcontracts(Campaign campaign,
-			AtBContract contract, int unitRatingMod) {
+	private void checkForSubcontracts(Campaign campaign, AtBContract contract, int unitRatingMod) {
 		if (contract.getMissionType() == AtBContract.MT_GARRISONDUTY) {
 			int numSubcontracts = 0;
 			for (Mission m : campaign.getMissions()) {
@@ -360,7 +349,7 @@ public class ContractMarket implements Serializable {
 		 */
 		if (RandomFactionGenerator.getInstance().getFactionHints().isNeutral(Faction.getFaction(employer)) &&
 				!RandomFactionGenerator.getInstance().getFactionHints().isAtWarWith(Faction.getFaction(employer),
-						Faction.getFaction(contract.getEnemyCode()), campaign.getDate())) {
+						Faction.getFaction(contract.getEnemyCode()), campaign.getLocalDate())) {
 			if (contract.getMissionType() == AtBContract.MT_PLANETARYASSAULT) {
 				contract.setMissionType(AtBContract.MT_GARRISONDUTY);
 			} else if (contract.getMissionType() == AtBContract.MT_RELIEFDUTY) {
@@ -468,7 +457,7 @@ public class ContractMarket implements Serializable {
         	boolean factionValid = false;
         	for (PlanetarySystem p : Systems.getInstance().getNearbySystems(campaign.getCurrentSystem(), 30)) {
         		if (factionValid) break;
-        		for (Faction f : p.getFactionSet(Utilities.getDateTimeDay(campaign.getCalendar()))) {
+        		for (Faction f : p.getFactionSet(campaign.getLocalDate())) {
         			if (f.getShortName().equals(contract.getEnemyCode())) {
         				factionValid = true;
         				break;

--- a/MekHQ/src/mekhq/campaign/market/UnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/UnitMarket.java
@@ -12,11 +12,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.market;
 
@@ -52,13 +52,8 @@ import mekhq.campaign.universe.UnitGeneratorParameters;
  * Generates units available for sale.
  *
  * @author Neoancient
- *
  */
 public class UnitMarket implements Serializable {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -2085002038852079114L;
 
     public static class MarketOffer {
@@ -167,7 +162,7 @@ public class UnitMarket implements Serializable {
             }
 
             if (campaign.getUnitRatingMod() >= IUnitRating.DRAGOON_B) {
-                Set<Faction> factions = campaign.getCurrentSystem().getFactionSet(Utilities.getDateTimeDay(campaign.getCalendar()));
+                Set<Faction> factions = campaign.getCurrentSystem().getFactionSet(campaign.getLocalDate());
                 String faction = Utilities.getRandomItem(factions).getShortName();
                 if (campaign.getFaction().isClan() ||
                         !Faction.getFaction(faction).isClan()) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -12,11 +12,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.mission;
 
@@ -32,7 +32,6 @@ import java.util.GregorianCalendar;
 import java.util.UUID;
 
 import mekhq.campaign.finances.Money;
-import mekhq.campaign.personnel.enums.PrisonerStatus;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -63,13 +62,8 @@ import mekhq.gui.view.LanceAssignmentView;
  * Contract class for use with Against the Bot rules
  *
  * @author Neoancient
- *
  */
 public class AtBContract extends Contract implements Serializable {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 1491090021356604379L;
 
     public static final int MT_GARRISONDUTY = 0;
@@ -1045,7 +1039,7 @@ public class AtBContract extends Contract implements Serializable {
                 getMissionType() != MT_RIOTDUTY) {
             String warName = RandomFactionGenerator.getInstance()
                     .getFactionHints().getCurrentWar(Faction.getFaction(getEmployerCode()),
-                    Faction.getFaction(getEnemyCode()), campaign.getDate());
+                    Faction.getFaction(getEnemyCode()), campaign.getLocalDate());
             if (null != warName) {
                 int extension = 0;
                 int roll = Compute.d6();

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -18,6 +18,7 @@
  */
 package mekhq.campaign.mission;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,7 +31,6 @@ import java.util.stream.Collectors;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.common.enums.Gender;
 import megamek.common.util.StringUtil;
-import org.joda.time.DateTime;
 
 import megamek.client.Client;
 import megamek.client.generator.RandomNameGenerator;
@@ -277,7 +277,7 @@ public class AtBDynamicScenarioFactory {
         int skill = 0;
         int quality = 0;
         int generatedLanceCount = 0;
-        DateTime currentDate = Utilities.getDateTimeDay(campaign.getCalendar());
+        LocalDate currentDate = campaign.getLocalDate();
         ForceAlignment forceAlignment = ForceAlignment.getForceAlignment(forceTemplate.getForceAlignment());
 
         // planet owner logic requires some special handling
@@ -754,7 +754,7 @@ public class AtBDynamicScenarioFactory {
             PlanetarySystem pSystem = Systems.getInstance().getSystemById(mission.getSystemId());
             Planet p = pSystem.getPrimaryPlanet();
             if (null != p) {
-                int atmosphere = Utilities.nonNull(p.getPressure(Utilities.getDateTimeDay(campaign.getCalendar())), scenario.getAtmosphere());
+                int atmosphere = Utilities.nonNull(p.getPressure(campaign.getLocalDate()), scenario.getAtmosphere());
                 float gravity = Utilities.nonNull(p.getGravity(), scenario.getGravity()).floatValue();
 
                 scenario.setAtmosphere(atmosphere);
@@ -2329,7 +2329,7 @@ public class AtBDynamicScenarioFactory {
      * @param currentDate Current date.
      * @return Faction code.
      */
-    private static String getPlanetOwnerFaction(AtBContract contract, DateTime currentDate) {
+    private static String getPlanetOwnerFaction(AtBContract contract, LocalDate currentDate) {
         String factionCode = "MERC";
 
         // planet owner is the first of the factions that owns the current planet.
@@ -2354,7 +2354,7 @@ public class AtBDynamicScenarioFactory {
      * @param currentDate Current date.
      * @return ForceAlignment.
      */
-    private static ForceAlignment getPlanetOwnerAlignment(AtBContract contract, String factionCode, DateTime currentDate) {
+    private static ForceAlignment getPlanetOwnerAlignment(AtBContract contract, String factionCode, LocalDate currentDate) {
         // if the faction is one of the planet owners, see if it's either the employer or opfor. If it's not, third-party.
         if (contract.getSystem().getFactions(currentDate).contains(factionCode)) {
             if (factionCode.equals(contract.getEmployerCode())) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -402,7 +402,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             //assume primary planet for now
             Planet p = psystem.getPrimaryPlanet();
             if (null != p) {
-                atmosphere = Utilities.nonNull(p.getPressure(Utilities.getDateTimeDay(campaign.getCalendar())), atmosphere);
+                atmosphere = Utilities.nonNull(p.getPressure(campaign.getLocalDate()), atmosphere);
                 gravity = Utilities.nonNull(p.getGravity(), gravity).floatValue();
             }
         }
@@ -1296,8 +1296,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
         AtBContract contract = getContract(campaign);
 
-        boolean opForOwnsPlanet = contract.getSystem().getFactions(Utilities.getDateTimeDay(campaign.getCalendar()))
-                                    .contains(contract.getEnemyCode());
+        boolean opForOwnsPlanet = contract.getSystem().getFactions(campaign.getLocalDate())
+                .contains(contract.getEnemyCode());
 
         boolean spawnConventional = opForOwnsPlanet && Compute.d6() >=
                 CampaignOptions.MAXIMUM_D6_VALUE - campaign.getCampaignOptions().getOpforAeroChance();
@@ -1365,7 +1365,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
         AtBContract contract = getContract(campaign);
 
-        boolean opForOwnsPlanet = contract.getSystem().getFactions(Utilities.getDateTimeDay(campaign.getCalendar()))
+        boolean opForOwnsPlanet = contract.getSystem().getFactions(campaign.getLocalDate())
                                     .contains(contract.getEnemyCode());
         boolean spawnTurrets = opForOwnsPlanet &&
                 Compute.d6() >= CampaignOptions.MAXIMUM_D6_VALUE - campaign.getCampaignOptions().getOpforLocalUnitChance();

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -12,11 +12,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.mission;
 
@@ -31,7 +31,6 @@ import java.util.GregorianCalendar;
 import mekhq.campaign.finances.Money;
 import org.apache.commons.text.CharacterPredicate;
 import org.apache.commons.text.RandomStringGenerator;
-import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -94,7 +93,7 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
     // runs through initial calculations, as the same jump path is referenced multiple times
     // and calculating it each time is expensive. No need to preserve it in save date.
     private JumpPath cachedJumpPath;
-    
+
     // need to keep track of total value salvaged for salvage rights
     private Money salvagedByUnit = Money.zero();
     private Money salvagedByEmployer = Money.zero();
@@ -397,28 +396,28 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
         super.setSystemId(n);
         cachedJumpPath = null;
     }
-    
+
     /**
      * Gets the currently calculated jump path for this contract,
      * only recalculating if it's not valid any longer or hasn't been calculated yet.
      */
     public JumpPath getJumpPath(Campaign c) {
-        // if we don't have a cached jump path, or if the jump path's starting/ending point 
+        // if we don't have a cached jump path, or if the jump path's starting/ending point
         // no longer match the campaign's current location or contract's destination
-        if((cachedJumpPath == null) ||
+        if ((cachedJumpPath == null) ||
                 (cachedJumpPath.size() == 0) ||
                 !cachedJumpPath.getFirstSystem().getId().equals(c.getCurrentSystem().getId()) ||
                 !cachedJumpPath.getLastSystem().getId().equals(getSystem().getId())) {
             cachedJumpPath = c.calculateJumpPath(c.getCurrentSystem(), getSystem());
         }
-        
+
         return cachedJumpPath;
     }
-    
+
     public void setJumpPath(JumpPath path) {
         cachedJumpPath = path;
     }
-    
+
     public Money getMonthlyPayOut() {
         if (getLength() <= 0) {
             return Money.zero();
@@ -458,9 +457,8 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
 
     private int getTravelDays(Campaign c) {
         if (null != this.getSystem()) {
-            DateTime currentDate = Utilities.getDateTimeDay(c.getCalendar());
             JumpPath jumpPath = getJumpPath(c);
-            double days = Math.round(jumpPath.getTotalTime(currentDate, c.getLocation().getTransitTime()) * 100.0) / 100.0;
+            double days = Math.round(jumpPath.getTotalTime(c.getLocalDate(), c.getLocation().getTransitTime()) * 100.0) / 100.0;
             return (int) Math.round(days);
         }
         return 0;
@@ -670,8 +668,8 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
         GregorianCalendar cal = new GregorianCalendar();
         cal.setTime(startDate);
         if (adjustStartDate && null != c.getSystemByName(systemId)) {
-            int days = (int) Math.ceil(getJumpPath(c)
-                    .getTotalTime(Utilities.getDateTimeDay(cal), c.getLocation().getTransitTime()));
+            int days = (int) Math.ceil(getJumpPath(c).getTotalTime(c.getLocalDate(),
+                    c.getLocation().getTransitTime()));
             while (days > 0) {
                 cal.add(Calendar.DAY_OF_YEAR, 1);
                 days--;

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -1,31 +1,31 @@
 /*
  * Mission.java
- * 
+ *
  * Copyright (c) 2011 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.mission;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.text.ParseException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 
-import org.joda.time.DateTime;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -41,16 +41,12 @@ import mekhq.campaign.universe.Systems;
 
 /**
  * Missions are primarily holder objects for a set of scenarios.
- * 
+ *
  * The really cool stuff will happen when we subclass this into Contract
- * 
+ *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class Mission implements Serializable, MekHqXmlSerializable {
-
-    /**
-     * 
-     */
     private static final long serialVersionUID = -5692134027829715149L;
 
     public static final int S_ACTIVE = 0;
@@ -82,18 +78,17 @@ public class Mission implements Serializable, MekHqXmlSerializable {
     }
 
     public static String getStatusName(int s) {
-
         switch (s) {
-        case S_ACTIVE:
-            return "Active";
-        case S_SUCCESS:
-            return "Success";
-        case S_FAILED:
-            return "Failed";
-        case S_BREACH:
-            return "Contract Breach";
-        default:
-            return "?";
+            case S_ACTIVE:
+                return "Active";
+            case S_SUCCESS:
+                return "Success";
+            case S_FAILED:
+                return "Failed";
+            case S_BREACH:
+                return "Contract Breach";
+            default:
+                return "?";
         }
     }
 
@@ -124,21 +119,21 @@ public class Mission implements Serializable, MekHqXmlSerializable {
     public PlanetarySystem getSystem() {
         return Systems.getInstance().getSystemById(systemId);
     }
-    
+
     /**
-     * Convenience property to return the name of the current planet. 
+     * Convenience property to return the name of the current planet.
      * Sometimes, the "current planet" doesn't match up with an existing planet in our planet database,
      * in which case we return whatever was stored.
      * @return
      */
-    public String getSystemName(DateTime when) {
-        if(getSystem() == null) {
+    public String getSystemName(LocalDate when) {
+        if (getSystem() == null) {
             return legacyPlanetName;
         }
-        
+
         return getSystem().getName(when);
     }
-    
+
     public void setLegacyPlanetName(String name) {
         legacyPlanetName = name;
     }
@@ -170,7 +165,7 @@ public class Mission implements Serializable, MekHqXmlSerializable {
     /**
      * Don't use this method directly as it will not add an id to the added
      * scenario. Use Campaign#AddScenario instead
-     * 
+     *
      * @param s
      */
     public void addScenario(Scenario s) {
@@ -228,8 +223,8 @@ public class Mission implements Serializable, MekHqXmlSerializable {
         pw1.println(MekHqXmlUtil.indentStr(indent) + "<mission id=\"" + id + "\" type=\"" + this.getClass().getName() + "\">");
         pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<name>" + MekHqXmlUtil.escape(name) + "</name>");
         pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<type>" + MekHqXmlUtil.escape(type) + "</type>");
-        
-        if(systemId != null) {         
+
+        if (systemId != null) {
             pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<systemId>" + MekHqXmlUtil.escape(systemId) + "</systemId>");
         } else {
             pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<planetName>" + MekHqXmlUtil.escape(legacyPlanetName) + "</planetName>");
@@ -278,7 +273,7 @@ public class Mission implements Serializable, MekHqXmlSerializable {
                     retVal.systemId = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("planetName")) {
                     PlanetarySystem system = c.getSystemByName(wn2.getTextContent());
-                    
+
                     if(system != null) {
                         retVal.systemId = c.getSystemByName(wn2.getTextContent()).getId();
                     } else {
@@ -325,5 +320,4 @@ public class Mission implements Serializable, MekHqXmlSerializable {
 
         return retVal;
     }
-
 }

--- a/MekHQ/src/mekhq/campaign/personnel/Injury.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Injury.java
@@ -111,7 +111,7 @@ public class Injury {
      * This should never be used, but is required for the Unmarshaller
      */
     public Injury() {
-        this(0, "", BodyLocation.GENERIC, InjuryType.BAD_HEALTH, 1, LocalDate.now(ZoneId.of("UTC")), false, false, false);
+        this(0, "", BodyLocation.GENERIC, InjuryType.BAD_HEALTH, 1, LocalDate.now(), false, false, false);
     }
 
     public Injury(LocalDate start) {

--- a/MekHQ/src/mekhq/campaign/personnel/Injury.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Injury.java
@@ -21,6 +21,8 @@
 package mekhq.campaign.personnel;
 
 import java.io.PrintWriter;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.UUID;
@@ -39,7 +41,6 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.enums.InjuryHiding;
 import mekhq.campaign.personnel.enums.InjuryLevel;
-import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 
 import mekhq.MekHQ;
@@ -89,7 +90,7 @@ public class Injury {
     private int days;
     private int originalDays;
     @XmlJavaTypeAdapter(DateAdapter.class)
-    private DateTime start;
+    private LocalDate start;
     /** 0 = past injury, for scars, 1 = default, max depends on type */
     private int hits;
     private BodyLocation location;
@@ -110,25 +111,25 @@ public class Injury {
      * This should never be used, but is required for the Unmarshaller
      */
     public Injury() {
-        this(0, "", BodyLocation.GENERIC, InjuryType.BAD_HEALTH, 1, new DateTime(), false, false, false);
+        this(0, "", BodyLocation.GENERIC, InjuryType.BAD_HEALTH, 1, LocalDate.now(ZoneId.of("UTC")), false, false, false);
     }
 
-    public Injury(DateTime start) {
+    public Injury(LocalDate start) {
         this(0, "", BodyLocation.GENERIC, InjuryType.BAD_HEALTH, 1, start, false, false, false);
     }
 
     // Normal constructor for a new injury that has not been treated by a doctor & does not have extended time
-    public Injury(int time, String text, BodyLocation loc, InjuryType type, int num, DateTime start, boolean perm) {
+    public Injury(int time, String text, BodyLocation loc, InjuryType type, int num, LocalDate start, boolean perm) {
         this(time, text, loc, type, num, start, perm, false, false);
     }
 
     // Constructor if this injury has been treated by a doctor, but without extended time
-    public Injury(int time, String text, BodyLocation loc, InjuryType type, int num, DateTime start, boolean perm, boolean workedOn) {
+    public Injury(int time, String text, BodyLocation loc, InjuryType type, int num, LocalDate start, boolean perm, boolean workedOn) {
         this(time, text, loc, type, num, start, perm, workedOn, false);
     }
 
     // Constructor for when this injury has extended time, full options including worked on by a doctor
-    public Injury(int time, String text, BodyLocation loc, InjuryType type, int num, DateTime start,
+    public Injury(int time, String text, BodyLocation loc, InjuryType type, int num, LocalDate start,
                   boolean perm, boolean workedOn, boolean extended) {
         setTime(time);
         setOriginalTime(time);
@@ -154,11 +155,11 @@ public class Injury {
     // End UUID Control Methods
 
     // Time Control Methods
-    public DateTime getStart() {
+    public LocalDate getStart() {
         return start;
     }
 
-    public void setStart(DateTime start) {
+    public void setStart(LocalDate start) {
         this.start = Objects.requireNonNull(start);
     }
 
@@ -203,9 +204,9 @@ public class Injury {
     public void setHits(int num) {
         final int minSeverity = isPermanent() ? 1 : 0;
         final int maxSeverity = type.getMaxSeverity();
-        if(num < minSeverity) {
+        if (num < minSeverity) {
             num = minSeverity;
-        } else if(num > maxSeverity) {
+        } else if (num > maxSeverity) {
             num = maxSeverity;
         }
         hits = num;
@@ -300,10 +301,10 @@ public class Injury {
     @SuppressWarnings({ "unused" })
     private void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
         // Fix old-style "hits" into "severity".
-        if(version < 1) {
-            if(type == InjuryTypes.CONCUSSION) {
+        if (version < 1) {
+            if (type == InjuryTypes.CONCUSSION) {
                 hits -= 1;
-            } else if(type == InjuryTypes.INTERNAL_BLEEDING) {
+            } else if (type == InjuryTypes.INTERNAL_BLEEDING) {
                 hits -= 2;
             } else {
                 hits = 1;
@@ -311,15 +312,15 @@ public class Injury {
         }
 
         // Fix hand/foot locations
-        if(fluff.endsWith(" hand")) {
-            switch(location) {
+        if (fluff.endsWith(" hand")) {
+            switch (location) {
                 case LEFT_ARM: location = BodyLocation.LEFT_HAND; break;
                 case RIGHT_ARM: location = BodyLocation.RIGHT_HAND; break;
                 default: // do nothing
             }
         }
-        if(fluff.endsWith(" foot")) {
-            switch(location) {
+        if (fluff.endsWith(" foot")) {
+            switch (location) {
                 case LEFT_LEG: location = BodyLocation.LEFT_FOOT; break;
                 case RIGHT_LEG: location = BodyLocation.RIGHT_FOOT; break;
                 default: // do nothing
@@ -330,7 +331,7 @@ public class Injury {
             id = UUID.randomUUID();
         }
 
-        if(null == extraData) {
+        if (null == extraData) {
             extraData = new ExtraData();
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/InjuryType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/InjuryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 MegaMek team
+ * Copyright (C) 2016 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.personnel;
 
@@ -26,7 +26,6 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import megamek.common.enums.Gender;
 import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.campaign.personnel.enums.InjuryLevel;
-import org.joda.time.DateTime;
 
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -123,6 +122,7 @@ public class InjuryType {
     protected Set<BodyLocation> allowedLocations = null;
 
     protected InjuryType() {
+
     }
 
     public final int getId() {
@@ -134,7 +134,7 @@ public class InjuryType {
     }
 
     public boolean isValidInLocation(BodyLocation loc) {
-        if(null == allowedLocations) {
+        if (null == allowedLocations) {
             allowedLocations = EnumSet.allOf(BodyLocation.class);
         }
         return allowedLocations.contains(loc);
@@ -200,7 +200,7 @@ public class InjuryType {
         }
         final int recoveryTime = getRecoveryTime(severity);
         final String fluff = getFluffText(loc, severity, p.getGender());
-        Injury result = new Injury(recoveryTime, fluff, loc, this, severity, new DateTime(c.getCalendar()), false);
+        Injury result = new Injury(recoveryTime, fluff, loc, this, severity, c.getLocalDate(), false);
         result.setVersion(Injury.VERSION);
         return result;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -40,7 +40,6 @@ import mekhq.campaign.*;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.*;
 import mekhq.campaign.personnel.enums.*;
-import org.joda.time.DateTime;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -144,7 +143,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     private static final IntSupplier PREGNANCY_SIZE = () -> {
         int children = 1;
         // Hellin's law says it's 1:89 chance, to not make it appear too seldom, we use 1:50
-        while(Compute.randomInt(50) == 0) {
+        while (Compute.randomInt(50) == 0) {
             ++ children;
         }
         return Math.min(children, 10); // Limit to decuplets, for the sake of sanity
@@ -2109,7 +2108,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                         }
                         retVal.injuries.add(Injury.generateInstanceFromXML(wn3));
                     }
-                    DateTime now = new DateTime(c.getCalendar());
+                    LocalDate now = c.getLocalDate();
                     retVal.injuries.stream().filter(inj -> (null == inj.getStart()))
                         .forEach(inj -> inj.setStart(now.minusDays(inj.getOriginalTime() - inj.getTime())));
                 } else if (wn2.getNodeName().equalsIgnoreCase("founder")) {
@@ -3254,11 +3253,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
 
     public void setMinutesLeft(int m) {
         this.minutesLeft = m;
-        if(engineer && null != getUnitId()) {
+        if (engineer && null != getUnitId()) {
             //set minutes for all crewmembers
             Unit u = campaign.getUnit(getUnitId());
-            if(null != u) {
-                for(Person p : u.getActiveCrew()) {
+            if (null != u) {
+                for (Person p : u.getActiveCrew()) {
                     p.setMinutesLeft(m);
                 }
             }
@@ -3271,11 +3270,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
 
     public void setOvertimeLeft(int m) {
         this.overtimeLeft = m;
-        if(engineer && null != getUnitId()) {
+        if (engineer && null != getUnitId()) {
             //set minutes for all crewmembers
             Unit u = campaign.getUnit(getUnitId());
-            if(null != u) {
-                for(Person p : u.getActiveCrew()) {
+            if (null != u) {
+                for (Person p : u.getActiveCrew()) {
                     p.setMinutesLeft(m);
                 }
             }

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -1,7 +1,7 @@
 /*
  * Faction.java
  *
- * Copyright (C) 2009-2016 MegaMek team
+ * Copyright (C) 2009-2016 - The MegaMek Team. All Rights Reserved.
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  *
  * This file is part of MekHQ.
@@ -13,18 +13,18 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.universe;
 
 import java.awt.Color;
 import java.io.FileInputStream;
 import java.text.ParseException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,9 +40,6 @@ import java.util.TreeMap;
 
 import javax.xml.parsers.DocumentBuilder;
 
-import mekhq.campaign.finances.Currency;
-import mekhq.campaign.finances.CurrencyManager;
-import org.joda.time.DateTime;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -229,7 +226,7 @@ public class Faction {
         return (year >= start) && (year <= end);
     }
 
-    public boolean validIn(DateTime time) {
+    public boolean validIn(LocalDate time) {
         return validIn(time.getYear());
     }
 

--- a/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - The MegaMek Team
+ * Copyright (c) 2018 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,14 +10,15 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.universe;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,12 +31,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.joda.time.DateTime;
-
 import megamek.common.annotations.Nullable;
 import megamek.common.event.Subscribe;
 import mekhq.MekHQ;
-import mekhq.Utilities;
 import mekhq.campaign.event.LocationChangedEvent;
 import mekhq.campaign.event.NewDayEvent;
 
@@ -54,13 +52,11 @@ import mekhq.campaign.event.NewDayEvent;
  * is registered with the event bus.
  *
  * @author Neoancient
- *
  */
 public class FactionBorderTracker {
-
     private final RegionHex regionHex;
-    private DateTime lastUpdate;
-    private DateTime now;
+    private LocalDate lastUpdate;
+    private LocalDate now;
 
     private Map<Faction, FactionBorders> borders;
     private Map<Faction, Map<Faction, List<PlanetarySystem>>> borderSystems;
@@ -93,7 +89,7 @@ public class FactionBorderTracker {
      */
     public FactionBorderTracker(double x, double y, double radius) {
         regionHex = new RegionHex(x, y, radius);
-        now = new DateTime();
+        now = LocalDate.now();
         lastUpdate = now;
 
         borders = new ConcurrentHashMap<>();
@@ -162,7 +158,7 @@ public class FactionBorderTracker {
      *
      * @param when The campaign date
      */
-    public synchronized void setDate(DateTime when) {
+    public synchronized void setDate(LocalDate when) {
         invalid |= now.plusDays(dayThreshold).isAfter(when)
                 || now.minusDays(dayThreshold).isBefore(when);
         now = when;
@@ -172,7 +168,7 @@ public class FactionBorderTracker {
     /**
      * @return The campaign date of the last completed border calculation
      */
-    public synchronized DateTime getLastUpdated() {
+    public synchronized LocalDate getLastUpdated() {
         return lastUpdate;
     }
 
@@ -487,7 +483,7 @@ public class FactionBorderTracker {
      */
     @Subscribe
     public synchronized void handleNewDayEvent(NewDayEvent event) {
-        now = Utilities.getDateTimeDay(event.getCampaign().getCalendar());
+        now = event.getCampaign().getLocalDate();
         invalid |= now.minusDays(dayThreshold).isAfter(lastUpdate)
                 || now.plusDays(dayThreshold).isBefore(lastUpdate);
 

--- a/MekHQ/src/mekhq/campaign/universe/FactionBorders.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionBorders.java
@@ -1,64 +1,62 @@
 /*
- * Copyright (c) 2018 - The MegaMek Team
- * 
+ * Copyright (c) 2018 - The MegaMek Team. All Rights Reserved.
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.universe;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.joda.time.DateTime;
-
 /**
  * Finds all planets controlled by a given faction at a particular date and can find all planets
  * controlled by another faction within a set distance.
- * 
- * @author Neoancient
  *
+ * @author Neoancient
  */
 public class FactionBorders {
-    
     private final Faction faction;
     private Set<PlanetarySystem> systems;
     private RegionPerimeter border;
-    
+
     /**
      * Creates a FactionBorders object for a faction using all the known planets.
-     * 
+     *
      * @param faction The faction to calculate the border for
      * @param when    The date to use to determine planet control.
      */
-    public FactionBorders(Faction faction, DateTime when) {
+    public FactionBorders(Faction faction, LocalDate when) {
         this.faction = faction;
         calculateRegion(when);
     }
-    
+
     /**
      * Creates a FactionBorders object for a faction using a particular set of planets
-     * 
+     *
      * @param faction The faction to calculate the border for
      * @param when    The date to use to determine planet control.
      * @param region  A collection of planets within a region of space.
      */
-    public FactionBorders(Faction faction, DateTime when, Collection<PlanetarySystem> region) {
+    public FactionBorders(Faction faction, LocalDate when, Collection<PlanetarySystem> region) {
         this.faction = faction;
         calculateRegion(when, region);
     }
@@ -66,52 +64,52 @@ public class FactionBorders {
     /**
      * Finds all planets currently owned (completely or partially) by the faction and finds
      * its border.
-     * 
+     *
      * @param when The date for testing faction ownership.
      */
-    public void calculateRegion(DateTime when) {
+    public void calculateRegion(LocalDate when) {
         calculateRegion(when, Systems.getInstance().getSystems().values());
     }
-    
+
     /**
      * Finds all planets within the supplied collection currently owned (completely or partially)
      * by the faction and finds its border. This can be used to narrow the area to one section of
      * the galaxy.
-     * 
+     *
      * @param when    The date for testing faction ownership.
      * @param systems The set of <code>planetarySystem</code>'s to include in the region.
      */
-    public void calculateRegion(DateTime when, Collection<PlanetarySystem> systems) {
+    public void calculateRegion(LocalDate when, Collection<PlanetarySystem> systems) {
         this.systems = systems.stream()
                 .filter(p -> p.getFactionSet(when).contains(faction))
                 .collect(Collectors.toSet());
         border = new RegionPerimeter(systems);
     }
-    
+
     /**
      * @return The faction used to calculate the borders
      */
     public Faction getFaction() {
         return faction;
     }
-    
+
     /**
      * @return The planets controlled by the indicated faction at the indicated time.
      */
     public Set<PlanetarySystem> getSystems() {
         return Collections.unmodifiableSet(systems);
     }
-    
+
     /**
      * @return A polygon that surrounds the region controlled by this faction.
      */
     public RegionPerimeter getBorder() {
         return border;
     }
-    
+
     /**
      * Finds planets of another faction that are on a border with this faction.
-     * 
+     *
      * @param other       The other faction's region.
      * @param borderSize  The size of the border.
      * @return            All planets from the other faction that are within borderSize light years
@@ -124,13 +122,13 @@ public class FactionBorders {
         }
         List<PlanetarySystem> theirSystems = other.getSystems().stream()
                 .filter(p -> RegionPerimeter.isInsideRegion(p.getX(), p.getY(), intersection))
-                .sorted((p1, p2) -> Double.compare(p1.getX(), p2.getX()))
+                .sorted(Comparator.comparingDouble(PlanetarySystem::getX))
                 .collect(Collectors.toList());
         List<PlanetarySystem> ourSystems = getSystems().stream()
                 .filter(p -> RegionPerimeter.isInsideRegion(p.getX(), p.getY(), intersection))
-                .sorted((p1, p2) -> Double.compare(p1.getX(), p2.getX()))
+                .sorted(Comparator.comparingDouble(PlanetarySystem::getX))
                 .collect(Collectors.toList());
-        
+
         List<PlanetarySystem> retVal = new ArrayList<>();
         int start = 0;
         for (PlanetarySystem p : theirSystems) {
@@ -156,8 +154,7 @@ public class FactionBorders {
                 }
             }
         }
-        
+
         return retVal;
     }
-
 }

--- a/MekHQ/src/mekhq/campaign/universe/FactionHints.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - The MegaMek Team
+ * Copyright (c) 2018 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,20 +10,19 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.universe;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -44,7 +43,6 @@ import mekhq.MekHqXmlUtil;
 
 /**
  * @author Neoancient
- *
  */
 public class FactionHints {
 
@@ -127,7 +125,7 @@ public class FactionHints {
      * @param f2 Faction Two
      * @return   Whether the factions are allies
      */
-    public boolean isAlliedWith(Faction f1, Faction f2, Date date) {
+    public boolean isAlliedWith(Faction f1, Faction f2, LocalDate date) {
         return hintApplies(alliances, f1, f2, date);
     }
 
@@ -136,7 +134,7 @@ public class FactionHints {
      * @param f2 Faction Two
      * @return   Whether the factions are rivals
      */
-    public boolean isRivalOf(Faction f1, Faction f2, Date date) {
+    public boolean isRivalOf(Faction f1, Faction f2, LocalDate date) {
         return hintApplies(rivals, f1, f2, date);
     }
 
@@ -145,7 +143,7 @@ public class FactionHints {
      * @param f2 Faction Two
      * @return   Whether the factions are at war on the given date
      */
-    public boolean isAtWarWith(Faction f1, Faction f2, Date date) {
+    public boolean isAtWarWith(Faction f1, Faction f2, LocalDate date) {
         return hintApplies(wars, f1, f2, date);
     }
 
@@ -157,7 +155,7 @@ public class FactionHints {
      * @return      The name of the current war the two factions are involved in, or {@code null} if they
      *              are not currently at war.
      */
-    @Nullable public String getCurrentWar(Faction f1, Faction f2, Date date) {
+    @Nullable public String getCurrentWar(Faction f1, Faction f2, LocalDate date) {
         if (wars.get(f1) != null && wars.get(f1).get(f2) != null) {
             for (FactionHint fh : wars.get(f1).get(f2)) {
                 if (fh.isInDateRange(date)) {
@@ -196,14 +194,14 @@ public class FactionHints {
      * @param date     The campaign date
      * @return         true if the potential opponent should not be considered as an enemy
      */
-    public boolean isNeutral(Faction faction, Faction opponent, Date date) {
+    public boolean isNeutral(Faction faction, Faction opponent, LocalDate date) {
         return neutralFactions.contains(faction)
                 && !hintApplies(neutralExceptions, faction, opponent, date)
                 && !isAtWarWith(faction, opponent, date);
     }
 
     private boolean hintApplies(Map<Faction, Map<Faction, List<FactionHint>>> hints,
-                Faction f1, Faction f2, Date date) {
+                                Faction f1, Faction f2, LocalDate date) {
         if (hints.get(f1) != null && hints.get(f1).get(f2) != null) {
             for (FactionHint fh : hints.get(f1).get(f2)) {
                 if (fh.isInDateRange(date)) {
@@ -231,7 +229,7 @@ public class FactionHints {
      * @param date  The campaign date
      * @return      A Set of all factions (if any) contained within the borders of the host faction.
      */
-    public Set<Faction> getContainedFactions(Faction f, Date date) {
+    public Set<Faction> getContainedFactions(Faction f, LocalDate date) {
         HashSet<Faction> retval = new HashSet<>();
         if (containedFactions.get(f) != null) {
             for (Faction f2 : containedFactions.get(f).keySet()) {
@@ -252,7 +250,7 @@ public class FactionHints {
      * @return           The faction that controls the planets where the contained faction is positioned,
      *                   or {@code null} if the faction is not contained within another at the time.
      */
-    @Nullable public Faction getContainedFactionHost(Faction contained, Date date) {
+    @Nullable public Faction getContainedFactionHost(Faction contained, LocalDate date) {
         for (Faction f : containedFactions.keySet()) {
             List<AltLocation> locs = containedFactions.get(f).get(contained);
             if (null != locs) {
@@ -274,7 +272,7 @@ public class FactionHints {
      * @param date      The campaign date
      * @return          The ratio of space taken up by the contained faction to that of the host.
      */
-    public double getAltLocationFraction(Faction host, Faction contained, Date date) {
+    public double getAltLocationFraction(Faction host, Faction contained, LocalDate date) {
         if (containedFactions.get(host) != null && containedFactions.get(host).get(contained) != null) {
             for (AltLocation l : containedFactions.get(host).get(contained)) {
                 if (l.isInDateRange(date)) {
@@ -300,14 +298,12 @@ public class FactionHints {
      * @param date      The campaign date
      * @return          Whether {@code opponent} can be treated as an enemy of {@code inner}.
      */
-    public boolean isContainedFactionOpponent(Faction outer, Faction inner,
-            Faction opponent, Date date) {
+    public boolean isContainedFactionOpponent(Faction outer, Faction inner, Faction opponent, LocalDate date) {
         if (containedFactions.get(outer) != null && containedFactions.get(outer).get(inner) != null) {
             for (AltLocation l : containedFactions.get(outer).get(inner)) {
                 if (l.isInDateRange(date)) {
                     if (l.opponents == null) {
-                        return !inner.equals(opponent) ||
-                                hintApplies(wars, inner, inner, date);
+                        return !inner.equals(opponent) || hintApplies(wars, inner, inner, date);
                     }
                     for (Faction f : l.opponents) {
                         if (f.equals(opponent)) {
@@ -328,7 +324,7 @@ public class FactionHints {
      * @param end          The alliance end date
      * @param parties      All the factions involved in the alliance
      */
-    protected void addAlliance(String allianceName, @Nullable Date start, @Nullable Date end, Faction... parties) {
+    protected void addAlliance(String allianceName, @Nullable LocalDate start, @Nullable LocalDate end, Faction... parties) {
         addFactionHint(alliances, allianceName, start, end, parties);
     }
 
@@ -341,7 +337,7 @@ public class FactionHints {
      * @param end          The war end date
      * @param parties      All the factions involved in the war.
      */
-    protected void addWar(String warName, @Nullable Date start, @Nullable Date end, Faction... parties) {
+    protected void addWar(String warName, @Nullable LocalDate start, @Nullable LocalDate end, Faction... parties) {
         addFactionHint(wars, warName, start, end, parties);
     }
 
@@ -353,7 +349,7 @@ public class FactionHints {
      * @param end          The rivalry end date
      * @param parties      All the factions involved in the rivalry
      */
-    protected void addRivalry(String rivalryName, @Nullable Date start, @Nullable Date end, Faction... parties) {
+    protected void addRivalry(String rivalryName, @Nullable LocalDate start, @Nullable LocalDate end, Faction... parties) {
         addFactionHint(rivals, rivalryName, start, end, parties);
     }
 
@@ -365,8 +361,8 @@ public class FactionHints {
      * @param faction    The generally neutral faction
      * @param exceptions The factions that should be considered exceptions to neutrality
      */
-    protected void addNeutralExceptions(String exceptionName, @Nullable Date start, @Nullable Date end,
-            Faction faction, Faction... exceptions) {
+    protected void addNeutralExceptions(String exceptionName, @Nullable LocalDate start,
+                                        @Nullable LocalDate end, Faction faction, Faction... exceptions) {
         neutralExceptions.putIfAbsent(faction, new HashMap<>());
         for (Faction exception : exceptions) {
             neutralExceptions.get(faction).putIfAbsent(exception, new ArrayList<>());
@@ -413,7 +409,8 @@ public class FactionHints {
      * @param end        The end date
      * @param ratio      The ratio of the size of the contained faction to that of the host
      */
-    protected void addContainedFaction(Faction host, Faction contained, Date start, Date end, double ratio) {
+    protected void addContainedFaction(Faction host, Faction contained, LocalDate start,
+                                       LocalDate end, double ratio) {
         addContainedFaction(host, contained, start, end, ratio, null);
     }
 
@@ -429,15 +426,15 @@ public class FactionHints {
      * @param opponents  If non-null, all possible opponents based on the position within the other
      *                   faction should be restricted to this list.
      */
-    protected void addContainedFaction(Faction host, Faction contained, Date start, Date end,
-            double ratio, @Nullable List<Faction> opponents) {
+    protected void addContainedFaction(Faction host, Faction contained, LocalDate start, LocalDate end,
+                                       double ratio, @Nullable List<Faction> opponents) {
         containedFactions.putIfAbsent(host, new HashMap<>());
         containedFactions.get(host).putIfAbsent(contained, new ArrayList<>());
         containedFactions.get(host).get(contained).add(new AltLocation(start, end, ratio, opponents));
     }
 
-    private void addFactionHint(Map<Faction, Map<Faction, List<FactionHint>>> hintMap,
-            String name, Date start, Date end, Faction[] parties) {
+    private void addFactionHint(Map<Faction, Map<Faction, List<FactionHint>>> hintMap, String name,
+                                LocalDate start, LocalDate end, Faction[] parties) {
         FactionHint hint = new FactionHint(name, start, end);
         for (int i = 0; i < parties.length - 1; i++) {
             for (int j = i + 1; j < parties.length; j++) {
@@ -470,7 +467,6 @@ public class FactionHints {
         NodeList nl = rootElement.getChildNodes();
         rootElement.normalize();
 
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
         for (int i = 0; i < nl.getLength(); i++) {
             Node wn = nl.item(i);
 
@@ -517,17 +513,17 @@ public class FactionHints {
                 } else if (nodeName.equals("alliance")) {
                     setFactionHint(alliances, wn);
                 } else if (nodeName.equals("location")) {
-                    Date start = null;
-                    Date end = null;
+                    LocalDate start = null;
+                    LocalDate end = null;
                     double fraction = 0.0;
                     Faction outer = null;
                     Faction inner = null;
                     List<Faction> opponents = null;
                     if (wn.getAttributes().getNamedItem("start") != null) {
-                        start = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+                        start = MekHqXmlUtil.parseDate(wn.getAttributes().getNamedItem("start").getTextContent().trim());
                     }
                     if (wn.getAttributes().getNamedItem("end") != null) {
-                        end = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+                        end = MekHqXmlUtil.parseDate(wn.getAttributes().getNamedItem("end").getTextContent().trim());
                     }
                     for (int j = 0; j < wn.getChildNodes().getLength(); j++) {
                         Node wn2 = wn.getChildNodes().item(j);
@@ -558,34 +554,31 @@ public class FactionHints {
         }
     }
 
-    private void setFactionHint(Map<Faction, Map<Faction, List<FactionHint>>> hint,
-            Node node) throws DOMException, ParseException {
+    private void setFactionHint(Map<Faction, Map<Faction, List<FactionHint>>> hint, Node node) throws DOMException {
         final String METHOD_NAME = "setFactionHint(Map<Faction,Map<Faction,List<FactionHint>>>,Node"; //$NON-NLS-1$
 
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-
         String name = "";
-        Date start = null;
-        Date end = null;
+        LocalDate start = null;
+        LocalDate end = null;
         if (node.getAttributes().getNamedItem("name") != null) {
             name = node.getAttributes().getNamedItem("name").getTextContent().trim();
         }
         if (node.getAttributes().getNamedItem("start") != null) {
-            start = df.parse(node.getAttributes().getNamedItem("start").getTextContent().trim());
+            start = MekHqXmlUtil.parseDate(node.getAttributes().getNamedItem("start").getTextContent().trim());
         }
         if (node.getAttributes().getNamedItem("end") != null) {
-            end = df.parse(node.getAttributes().getNamedItem("end").getTextContent().trim());
+            end = MekHqXmlUtil.parseDate(node.getAttributes().getNamedItem("end").getTextContent().trim());
         }
         for (int n = 0; n < node.getChildNodes().getLength(); n++) {
             Node wn = node.getChildNodes().item(n);
             if (wn.getNodeName().equals("parties")) {
-                Date localStart = start;
-                Date localEnd = end;
+                LocalDate localStart = start;
+                LocalDate localEnd = end;
                 if (wn.getAttributes().getNamedItem("start") != null) {
-                    localStart = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+                    localStart = MekHqXmlUtil.parseDate(wn.getAttributes().getNamedItem("start").getTextContent().trim());
                 }
                 if (wn.getAttributes().getNamedItem("end") != null) {
-                    localEnd = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+                    localEnd = MekHqXmlUtil.parseDate(wn.getAttributes().getNamedItem("end").getTextContent().trim());
                 }
 
                 String[] factionKeys = wn.getTextContent().trim().split(",");
@@ -602,25 +595,23 @@ public class FactionHints {
         }
     }
 
-    private void addNeutralExceptions(Faction faction, Node node) throws DOMException, ParseException {
+    private void addNeutralExceptions(Faction faction, Node node) throws DOMException {
         final String METHOD_NAME = "addNeutralExceptions(Faction,Node)"; //$NON-NLS-1$
 
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-
-        Date end = null;
+        LocalDate end = null;
         if (node.getAttributes().getNamedItem("end") != null) {
-            end = df.parse(node.getAttributes().getNamedItem("end").getTextContent().trim());
+            end = MekHqXmlUtil.parseDate(node.getAttributes().getNamedItem("end").getTextContent().trim());
         }
         for (int n = 0; n < node.getChildNodes().getLength(); n++) {
             Node wn = node.getChildNodes().item(n);
             if (wn.getNodeName().equals("exceptions")) {
-                Date localStart = null;
-                Date localEnd = end;
+                LocalDate localStart = null;
+                LocalDate localEnd = end;
                 if (wn.getAttributes().getNamedItem("start") != null) {
-                    localStart = df.parse(wn.getAttributes().getNamedItem("start").getTextContent().trim());
+                    localStart = MekHqXmlUtil.parseDate(wn.getAttributes().getNamedItem("start").getTextContent().trim());
                 }
                 if (wn.getAttributes().getNamedItem("end") != null) {
-                    localEnd = df.parse(wn.getAttributes().getNamedItem("end").getTextContent().trim());
+                    localEnd = MekHqXmlUtil.parseDate(wn.getAttributes().getNamedItem("end").getTextContent().trim());
                 }
 
                 String[] parties = wn.getTextContent().trim().split(",");
@@ -644,17 +635,17 @@ public class FactionHints {
          * of this class for each of the other factions involved.
          */
         public String name;
-        public Date start;
-        public Date end;
+        public LocalDate start;
+        public LocalDate end;
 
-        public FactionHint (String n, Date s, Date e) {
+        public FactionHint (String n, LocalDate s, LocalDate e) {
             name = n;
-            start = (s == null)? null : (Date) s.clone();
-            end = (e == null)? null : (Date) e.clone();
+            start = s;
+            end = e;
         }
 
-        public boolean isInDateRange(Date date) {
-            return ((start == null) || date.after(start)) && ((end == null) || date.before(end));
+        public boolean isInDateRange(LocalDate date) {
+            return ((start == null) || date.isAfter(start)) && ((end == null) || date.isBefore(end));
         }
     }
 
@@ -662,7 +653,7 @@ public class FactionHints {
         public double fraction;
         public List<Faction> opponents;
 
-        public AltLocation (Date s, Date e, double f, List<Faction> opponents) {
+        public AltLocation (LocalDate s, LocalDate e, double f, List<Faction> opponents) {
             super(null, s, e);
             fraction = f;
             if (null != opponents) {

--- a/MekHQ/src/mekhq/campaign/universe/NewsItem.java
+++ b/MekHQ/src/mekhq/campaign/universe/NewsItem.java
@@ -1,26 +1,28 @@
 /*
  * NewsItem.java
- * 
+ *
  * Copyright (c) 2011 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.universe;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
 import javax.xml.bind.Unmarshaller;
@@ -30,29 +32,22 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
-import org.joda.time.DateTime;
-import org.joda.time.Days;
-import org.joda.time.chrono.GJChronology;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-
 import megamek.common.Compute;
 
+import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
+import mekhq.campaign.Campaign;
 
 /**
  * NewsItem
- * 
+ *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 @XmlRootElement(name="newsItem")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class NewsItem {
-    private final static DateTimeFormatter FORMATTER =
-        DateTimeFormat.forPattern("yyyy-MM-dd").withChronology(GJChronology.getInstanceUTC());
-    
     @XmlTransient
-    private DateTime date;
+    private LocalDate date;
     @XmlTransient
     private Precision datePrecision;
     private String headline;
@@ -60,13 +55,13 @@ public class NewsItem {
     private String description;
     private String service;
     private String location;
-    
+
     @XmlElement(name="date")
     private String dateString;
-    
+
     //ids will only be assigned when news is read in for the year
     transient private int id;
-    
+
     public NewsItem() {
         this.headline = "None";
         this.location = null;
@@ -74,15 +69,15 @@ public class NewsItem {
         this.description = null;
         this.service = null;
     }
-    
+
     public String getHeadline() {
         return headline;
     }
-    
+
     public void setHeadline(String headline) {
         this.headline = Utilities.nonNull(headline, this.headline);
     }
-    
+
     public void setLocation(String location) {
         this.location = location;
     }
@@ -90,11 +85,11 @@ public class NewsItem {
     public String getDescription() {
         return description;
     }
-    
+
     public void setDescription(String description) {
         this.description = description;
     }
-    
+
     public String getService() {
         return service;
     }
@@ -103,44 +98,44 @@ public class NewsItem {
         this.service = service;
     }
 
-    public DateTime getDate() {
+    public LocalDate getDate() {
         return date;
     }
-    
-    public void setDate(DateTime date) {
+
+    public void setDate(LocalDate date) {
         this.date = date;
     }
-    
+
     public int getId() {
         return id;
     }
-    
+
     public void setId(int i) {
         id = i;
     }
-    
+
     public int getYear() {
         return date.getYear();
     }
-    
+
     /**
      * Finalize this news item's date according to its precision.
      */
     public void finalizeDate() {
-        if((null == date) || (null == datePrecision) || (datePrecision == Precision.DAY)) {
+        if ((null == date) || (null == datePrecision) || (datePrecision == Precision.DAY)) {
             return;
         }
-        
+
         int maxRandomDays;
-        switch(datePrecision) {
+        switch (datePrecision) {
             case MONTH:
-                maxRandomDays = Days.daysBetween(date, date.plusMonths(1)).getDays();
+                maxRandomDays = date.lengthOfMonth() - date.getDayOfMonth();
                 break;
             case YEAR:
-                maxRandomDays = Days.daysBetween(date, date.plusYears(1)).getDays();
+                maxRandomDays = date.lengthOfYear() - date.getDayOfYear();
                 break;
             case DECADE:
-                maxRandomDays = Days.daysBetween(date, date.plusYears(10)).getDays();
+                maxRandomDays = Math.toIntExact(ChronoUnit.DAYS.between(date, date.plus(1, ChronoUnit.DECADES)));
                 break;
             default:
                 return;
@@ -148,71 +143,72 @@ public class NewsItem {
         date = date.plusDays(Compute.randomInt(maxRandomDays));
         datePrecision = Precision.DAY;
     }
-    
+
     // Precision-aware year checker
     public boolean isInYear(int year) {
-        if(null == date) {
+        if (null == date) {
             return false;
         }
-        if(datePrecision == Precision.DECADE) {
+        if (datePrecision == Precision.DECADE) {
             return ((year / 10) * 10 == date.getYear());
         }
         return year == date.getYear();
     }
-    
+
     public String getPrefix() {
         String prefix = "";
-        if(null != location) {
+        if (null != location) {
             prefix = location;
         }
-        if(null != service) {
-            if(!prefix.isEmpty()) {
+        if (null != service) {
+            if (!prefix.isEmpty()) {
                 prefix += " ";
             }
             prefix += "[" + service + "]";
         }
-        if(!prefix.isEmpty()) {
+        if (!prefix.isEmpty()) {
             prefix += " - ";
         }
         return prefix;
     }
-    
+
     public String getHeadlineForReport() {
         String s = getPrefix() + "<b>" + getHeadline() + "</b>";
-        if(null != description) {
+        if (null != description) {
             s += " [<a href='NEWS|" + getId() + "'>read more</a>]";
         }
         return s;
     }
-    
-    public String getFullDescription() {
-        String s = "<html><h1>" + getHeadline() + "</h1>(" + date.toString(FORMATTER) + ")<br><p>" + getPrefix() + description + "</p></html>";
-        return s;
+
+    public String getFullDescription(Campaign campaign) {
+        return "<html><h1>" + getHeadline() + "</h1>("
+                + date.format(DateTimeFormatter.ofPattern(campaign.getCampaignOptions().getDisplayDateFormat()))
+                + ")<br><p>" + getPrefix() + description + "</p></html>";
     }
-    
+
     // JAXB marshalling support
 
     @SuppressWarnings({ "unused" })
     private void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
-        if(null != dateString) {
+        if (null != dateString) {
             dateString = dateString.trim().toUpperCase(Locale.ROOT);
             // Try to parse and set proper precision
-            if(dateString.matches("^\\d\\d\\dX$")) {
-                date = FORMATTER.parseDateTime(dateString.substring(0, 3) + "0-01-01");
+            if (dateString.matches("^\\d\\d\\dX$")) {
+                date = MekHqXmlUtil.parseDate(dateString.substring(0, 3) + "0-01-01");
                 datePrecision = Precision.DECADE;
-            } else if(dateString.matches("^\\d\\d\\d\\d$")) {
-                date = FORMATTER.parseDateTime(dateString + "-01-01");
+            } else if (dateString.matches("^\\d\\d\\d\\d$")) {
+                date = MekHqXmlUtil.parseDate(dateString + "-01-01");
                 datePrecision = Precision.YEAR;
-            } else if(dateString.matches("^\\d\\d\\d\\d-\\d\\d$")) {
-                date = FORMATTER.parseDateTime(dateString + "-01");
+            } else if (dateString.matches("^\\d\\d\\d\\d-\\d\\d$")) {
+                date = MekHqXmlUtil.parseDate(dateString + "-01");
                 datePrecision = Precision.MONTH;
             } else {
-                date = FORMATTER.parseDateTime(dateString);
+                date = MekHqXmlUtil.parseDate(dateString);
                 datePrecision = Precision.DAY;
             }
         }
     }
-    
+
     /** News precision enum */
-    public static enum Precision { DAY, MONTH, YEAR, DECADE }
+    public enum Precision { DAY, MONTH, YEAR, DECADE }
 }

--- a/MekHQ/src/mekhq/campaign/universe/NewsItem.java
+++ b/MekHQ/src/mekhq/campaign/universe/NewsItem.java
@@ -129,10 +129,10 @@ public class NewsItem {
         int maxRandomDays;
         switch (datePrecision) {
             case MONTH:
-                maxRandomDays = date.lengthOfMonth() - date.getDayOfMonth();
+                maxRandomDays = Math.toIntExact(ChronoUnit.DAYS.between(date, date.plus(1, ChronoUnit.MONTHS)));
                 break;
             case YEAR:
-                maxRandomDays = date.lengthOfYear() - date.getDayOfYear();
+                maxRandomDays = Math.toIntExact(ChronoUnit.DAYS.between(date, date.plus(1, ChronoUnit.YEARS)));
                 break;
             case DECADE:
                 maxRandomDays = Math.toIntExact(ChronoUnit.DAYS.between(date, date.plus(1, ChronoUnit.DECADES)));

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -1,7 +1,5 @@
 /*
- * Planet.java
- *
- * Copyright (C) 2011-2016 MegaMek team
+ * Copyright (C) 2011-2020 - The MegaMek Team. All Rights Reserved.
  * Copyright (c) 2011 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  *
  * This file is part of MekHQ.
@@ -13,20 +11,19 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.universe;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -46,9 +43,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeComparator;
-
 import megamek.common.EquipmentType;
 import megamek.common.ITechnology;
 import megamek.common.PlanetaryConditions;
@@ -67,11 +61,9 @@ import mekhq.adapter.StringListAdapter;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.universe.Faction.Tag;
 
-
 /**
  * This is the start of a planet object that will keep lots of information about
  * planets that can be displayed on the interstellar map.
- *
  *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
@@ -172,7 +164,7 @@ public class Planet implements Serializable {
      * Package-private so that Planets can access it
      */
     @XmlTransient
-    TreeMap<DateTime, PlanetaryEvent> events;
+    TreeMap<LocalDate, PlanetaryEvent> events;
 
     /**
      * This is a cache of the current event data based
@@ -184,7 +176,7 @@ public class Planet implements Serializable {
     CurrentEvents currentEvents;
 
     //a hash to keep track of dynamic garrison changes
-    //TreeMap<DateTime, List<String>> garrisonHistory;
+    //TreeMap<LocalDate, List<String>> garrisonHistory;
 
     /** @deprecated Use "event", which can have any number of changes to the planetary data */
     @Deprecated
@@ -212,7 +204,7 @@ public class Planet implements Serializable {
      * @param years The list of years acquired from the tsv file
      * @throws Exception
      */
-    public Planet(String tsvData, List<DateTime> years) throws Exception {
+    public Planet(String tsvData, List<LocalDate> years) throws Exception {
         eventList = new ArrayList<>();
         events = new TreeMap<>();
 
@@ -238,14 +230,14 @@ public class Planet implements Serializable {
             int nameChangeYear = 2000;
 
             // this indicates that there's an (Alternate Name YEAR+) here
-            if(plusIndex > 0) {
+            if (plusIndex > 0) {
                 String yearString = nameString.substring(plusIndex - 4, plusIndex);
                 nameChangeYear = Integer.parseInt(yearString);
             }
 
             // this is a dirty hack: in order to avoid colliding with faction changes, we
             // set name changes to be a second into the new year
-            DateTime nameChangeYearDate = new DateTime(nameChangeYear, 1, 1, 0, 0, 1, 0);
+            LocalDate nameChangeYearDate = new DateTime(nameChangeYear, 1, 1, 0, 0, 1, 0);
 
             String altName;
             String primaryName = nameString;
@@ -253,9 +245,9 @@ public class Planet implements Serializable {
             int parenIndex = nameString.indexOf('(');
             int closingParenIndex = nameString.indexOf(')');
             // this indicates that there's an (Alternate Name) sequence of some kind
-            if(parenIndex > 0) {
+            if (parenIndex > 0) {
                 // we chop off the year if there is one
-                if(plusIndex > 0) {
+                if (plusIndex > 0) {
                     altName = nameString.substring(parenIndex + 1, plusIndex - 5);
                 }
                 // otherwise, we just chop off the closing paren
@@ -266,7 +258,7 @@ public class Planet implements Serializable {
                 // there are a few situations where all this stuff with parens is for naught, which is
                 // PlanetName (FactionCode) or if the PlanetName (AltName) is already in our planets "database"
 
-                if(null == Faction.getFaction(altName) && null == Systems.getInstance().getSystemById(primaryName)) {
+                if ((null == Faction.getFaction(altName)) && (null == Systems.getInstance().getSystemById(primaryName))) {
                     primaryName = nameString.substring(0, parenIndex - 1);
 
                     nameChangeEvent = new PlanetaryEvent();
@@ -278,7 +270,7 @@ public class Planet implements Serializable {
             // now we have a primary name and possibly a name change planetary event
             this.name = primaryName;
 
-            if(null != nameChangeEvent) {
+            if (null != nameChangeEvent) {
                 this.events.put(nameChangeYearDate, nameChangeEvent);
                 this.eventList.add(nameChangeEvent);
             }
@@ -287,16 +279,16 @@ public class Planet implements Serializable {
             this.x = Double.parseDouble(infoElements[1]);
             this.y = Double.parseDouble(infoElements[2]);
 
-            for(int x = 3; x < infoElements.length; x++) {
+            for (int x = 3; x < infoElements.length; x++) {
                 String infoElement = infoElements[x].replace("\"", "");
                 String newFaction;
 
-                if(infoElement.trim().length() == 0) {
+                if (infoElement.trim().length() == 0) {
                     newFaction = "";
                 }
 
                 int commaIndex = infoElement.indexOf(',');
-                if(commaIndex < 0) { // sometimes there are no commas
+                if (commaIndex < 0) { // sometimes there are no commas
                     newFaction = infoElement;
                 } else {
                     // anything after the first comma is fluff
@@ -305,7 +297,7 @@ public class Planet implements Serializable {
                 }
 
                 //dirty hack, replace faction name with one we can use
-                if(factionReplacements.containsKey(newFaction)) {
+                if (factionReplacements.containsKey(newFaction)) {
                     newFaction = factionReplacements.get(newFaction);
                 }
 
@@ -314,10 +306,10 @@ public class Planet implements Serializable {
 
                 // dirty hack here assumes that there's only one faction per event, which is true in the case
                 // of this spreadsheet
-                if(x == 3 || !eventList.get(eventList.size() - 1).faction.get(0).equals(newFaction)) {
+                if ((x == 3) || !eventList.get(eventList.size() - 1).faction.get(0).equals(newFaction)) {
                     PlanetaryEvent pe = new PlanetaryEvent();
-                    DateTime eventDate = years.get(x - 3);
-                    pe.faction = new ArrayList<String>();
+                    LocalDate eventDate = years.get(x - 3);
+                    pe.faction = new ArrayList<>();
                     pe.faction.add(newFaction);
                     pe.date = eventDate;
 
@@ -325,7 +317,7 @@ public class Planet implements Serializable {
                     this.events.put(eventDate, pe);
                 }
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             Exception ne = new Exception("Error running Planet constructor with following line:\n" + tsvData);
             ne.addSuppressed(e);
             throw(ne);
@@ -368,7 +360,7 @@ public class Planet implements Serializable {
 
 
     public ArrayList<Satellite> getSatellites() {
-        return null != satellites ? new ArrayList<Satellite>(satellites) : null;
+        return null != satellites ? new ArrayList<>(satellites) : null;
     }
 
     public int getSmallMoons() {
@@ -377,22 +369,22 @@ public class Planet implements Serializable {
 
     public String getSatelliteDescription() {
     	String desc = "";
-    	if(null != satellites) {
-    		List<String> satNames = new ArrayList<String>();
-    		for(Satellite satellite : satellites) {
+    	if (null != satellites) {
+    		List<String> satNames = new ArrayList<>();
+    		for (Satellite satellite : satellites) {
     			satNames.add(satellite.getDescription());
     		}
     		desc = Utilities.combineString(satNames, ", "); //$NON-NLS-1$ //$NON-NLS-2$
     	}
-    	if(smallMoons > 0) {
+    	if (smallMoons > 0) {
     		String smallDesc = smallMoons + " small moons"; //$NON-NLS-1$ //$NON-NLS-2$
-    		if(desc.length()==0) {
+    		if (desc.length()==0) {
                 desc = smallDesc;
             } else {
                 desc = desc + ", " + smallDesc;
             }
     	}
-    	if(hasRing()) {
+    	if (hasRing()) {
     		desc = desc + ", and a dust ring"; //$NON-NLS-1$ //$NON-NLS-2$
     	}
     	return desc;
@@ -404,7 +396,7 @@ public class Planet implements Serializable {
 
 
     public List<String> getLandMasses() {
-        return null != landMasses ? new ArrayList<String>(landMasses) : null;
+        return null != landMasses ? new ArrayList<>(landMasses) : null;
     }
 
     public String getLandMassDescription() {
@@ -419,11 +411,9 @@ public class Planet implements Serializable {
         return tectonicActivity;
     }
 
-    public Double getDayLength(DateTime when) {
+    public Double getDayLength(LocalDate when) {
     	//yes day length can change because Venus
-        return getEventData(when, dayLength, new EventGetter<Double>() {
-            @Override public Double get(PlanetaryEvent e) { return e.dayLength; }
-        });
+        return getEventData(when, dayLength, e -> e.dayLength);
     }
 
     public Double getYearLength() {
@@ -446,12 +436,12 @@ public class Planet implements Serializable {
     public String getDiplayableSystemPosition() {
     	//We won't give the actual system position here, because we don't want asteroid belts to count
     	//for system position
-    	if(null == getParentSystem() || null == sysPos) {
+    	if ((null == getParentSystem()) || (null == sysPos)) {
     		return "?";
     	}
     	int pos = 0;
-    	for(int i = 1; i <= sysPos; i++) {
-    		if(getParentSystem().getPlanet(i).getPlanetType().equals("Asteroid Belt")) {
+    	for (int i = 1; i <= sysPos; i++) {
+    		if (getParentSystem().getPlanet(i).getPlanetType().equals("Asteroid Belt")) {
     			continue;
     		}
     		pos++;
@@ -483,15 +473,15 @@ public class Planet implements Serializable {
 
     // Date-dependant data
 
-    public synchronized PlanetaryEvent getOrCreateEvent(DateTime when) {
-        if(null == when) {
+    public synchronized PlanetaryEvent getOrCreateEvent(LocalDate when) {
+        if (null == when) {
             return null;
         }
-        if(null == events) {
-            events = new TreeMap<DateTime, PlanetaryEvent>(DateTimeComparator.getDateOnlyInstance());
+        if (null == events) {
+            events = new TreeMap<>();
         }
         PlanetaryEvent event = events.get(when);
-        if(null == event) {
+        if (null == event) {
             event = new PlanetaryEvent();
             event.date = when;
             events.put(when, event);
@@ -500,18 +490,18 @@ public class Planet implements Serializable {
         return event;
     }
 
-    public PlanetaryEvent getEvent(DateTime when) {
-        if((null == when) || (null == events)) {
+    public PlanetaryEvent getEvent(LocalDate when) {
+        if ((null == when) || (null == events)) {
             return null;
         }
         return events.get(when);
     }
 
     public List<PlanetaryEvent> getEvents() {
-        if( null == events ) {
+        if (null == events) {
             return null;
         }
-        return new ArrayList<PlanetaryEvent>(events.values());
+        return new ArrayList<>(events.values());
     }
 
     public List<PlanetaryEvent> getCustomEvents() {
@@ -526,8 +516,8 @@ public class Planet implements Serializable {
         return Collections.unmodifiableList(customEvents);
     }
 
-    protected <T> T getEventData(DateTime when, T defaultValue, EventGetter<T> getter) {
-        if( null == when || null == events || null == getter ) {
+    protected <T> T getEventData(LocalDate when, T defaultValue, EventGetter<T> getter) {
+        if ((null == when) || (null == events) || (null == getter)) {
             return defaultValue;
         }
 
@@ -538,7 +528,7 @@ public class Planet implements Serializable {
         return Utilities.nonNull(result, defaultValue);
     }
 
-    private synchronized PlanetaryEvent getCurrentEvent(DateTime now) {
+    private synchronized PlanetaryEvent getCurrentEvent(LocalDate now) {
         if (currentEvents == null) {
             currentEvents = new CurrentEvents();
         }
@@ -560,12 +550,12 @@ public class Planet implements Serializable {
      * This class tracks the current {@link PlanetaryEvent}.
      */
     class CurrentEvents {
-        private DateTime lastUpdated;
+        private LocalDate lastUpdated;
         private PlanetaryEvent planetaryEvent = new PlanetaryEvent();
-        private Map.Entry<DateTime, PlanetaryEvent> nextEvent;
-        private Iterator<Map.Entry<DateTime, PlanetaryEvent>> eventStream;
+        private Map.Entry<LocalDate, PlanetaryEvent> nextEvent;
+        private Iterator<Map.Entry<LocalDate, PlanetaryEvent>> eventStream;
 
-        private void initialize(DateTime now) {
+        private void initialize(LocalDate now) {
             lastUpdated = now;
             if (events != null) {
                 eventStream = events.entrySet().iterator();
@@ -580,8 +570,8 @@ public class Planet implements Serializable {
          * @param now The current time.
          * @return The up-to-date {@link PlanetaryEvent} as of {@code now}.
          */
-        public PlanetaryEvent getCurrentEvent(DateTime now) {
-            if (lastUpdated == null || lastUpdated.isAfter(now)) {
+        public PlanetaryEvent getCurrentEvent(LocalDate now) {
+            if ((lastUpdated == null) || lastUpdated.isAfter(now)) {
                 // initialize ourselves if we're fresh or if we
                 // went back in time (which breaks how the event stream works)
                 initialize(now);
@@ -590,7 +580,7 @@ public class Planet implements Serializable {
             // if we have no more events for this planet,
             // or if our current date is before the next date
             // return our cached event
-            if (nextEvent == null || now.isBefore(nextEvent.getKey())) {
+            if ((nextEvent == null) || now.isBefore(nextEvent.getKey())) {
                 return planetaryEvent;
             }
 
@@ -603,7 +593,7 @@ public class Planet implements Serializable {
                     nextEvent = null;
                 }
 
-            } while(nextEvent != null && !now.isBefore(nextEvent.getKey()));
+            } while ((nextEvent != null) && !now.isBefore(nextEvent.getKey()));
 
             return planetaryEvent;
         }
@@ -611,37 +601,33 @@ public class Planet implements Serializable {
 
     /** @return events for this year. Never returns <i>null</i>. */
     public List<PlanetaryEvent> getEvents(int year) {
-        if( null == events ) {
-            return Collections.<PlanetaryEvent>emptyList();
+        if (null == events) {
+            return Collections.emptyList();
         }
-        List<PlanetaryEvent> result = new ArrayList<PlanetaryEvent>();
-        for( DateTime date : events.navigableKeySet() ) {
-            if( date.getYear() > year ) {
+        List<PlanetaryEvent> result = new ArrayList<>();
+        for (LocalDate date : events.navigableKeySet()) {
+            if (date.getYear() > year) {
                 break;
             }
-            if( date.getYear() == year ) {
+            if (date.getYear() == year) {
                 result.add(events.get(date));
             }
         }
         return result;
     }
 
-    public String getName(DateTime when) {
-        return getEventData(when, name, new EventGetter<String>() {
-            @Override public String get(PlanetaryEvent e) { return e.name; }
-        });
+    public String getName(LocalDate when) {
+        return getEventData(when, name, e -> e.name);
     }
 
-    public String getShortName(DateTime when) {
-        return getEventData(when, shortName, new EventGetter<String>() {
-            @Override public String get(PlanetaryEvent e) { return e.shortName; }
-        });
+    public String getShortName(LocalDate when) {
+        return getEventData(when, shortName, e -> e.shortName);
     }
 
     public List<String> getNames() {
         List<String> names = new ArrayList<>();
 
-        for(PlanetaryEvent p : events.values()) {
+        for (PlanetaryEvent p : events.values()) {
             names.add(p.name);
         }
 
@@ -649,92 +635,74 @@ public class Planet implements Serializable {
     }
 
     /** @return short name if set, else full name, else "unnamed" */
-    public String getPrintableName(DateTime when) {
+    public String getPrintableName(LocalDate when) {
         String result = getShortName(when);
-        if( null == result ) {
+        if (null == result) {
             result = getName(when);
         }
         return null != result ? result : "unnamed"; //$NON-NLS-1$
     }
 
-    public SocioIndustrialData getSocioIndustrial(DateTime when) {
-        return getEventData(when, socioIndustrial, new EventGetter<SocioIndustrialData>() {
-            @Override public SocioIndustrialData get(PlanetaryEvent e) { return e.socioIndustrial; }
-        });
+    public SocioIndustrialData getSocioIndustrial(LocalDate when) {
+        return getEventData(when, socioIndustrial, e -> e.socioIndustrial);
     }
 
-    public String getSocioIndustrialText(DateTime when) {
+    public String getSocioIndustrialText(LocalDate when) {
         SocioIndustrialData sid = getSocioIndustrial(when);
         return null != sid ? sid.toString() : ""; //$NON-NLS-1$
     }
 
-    public Integer getHPG(DateTime when) {
-        return getEventData(when, hpg, new EventGetter<Integer>() {
-            @Override public Integer get(PlanetaryEvent e) { return e.hpg; }
-        });
+    public Integer getHPG(LocalDate when) {
+        return getEventData(when, hpg, e -> e.hpg);
     }
 
-    public String getHPGClass(DateTime when) {
+    public String getHPGClass(LocalDate when) {
         return StarUtil.getHPGClass(getHPG(when));
     }
 
-    public Long getPopulation(DateTime when) {
-        return getEventData(when, population, new EventGetter<Long>() {
-            @Override public Long get(PlanetaryEvent e) { return e.population; }
-        });
+    public Long getPopulation(LocalDate when) {
+        return getEventData(when, population, e -> e.population);
     }
 
 
-    public LifeForm getLifeForm(DateTime when) {
-        return getEventData(when, null != life ? life : LifeForm.NONE, new EventGetter<LifeForm>() {
-            @Override public LifeForm get(PlanetaryEvent e) { return e.lifeForm; }
-        });
+    public LifeForm getLifeForm(LocalDate when) {
+        return getEventData(when, null != life ? life : LifeForm.NONE, e -> e.lifeForm);
     }
 
-    public String getLifeFormName(DateTime when) {
+    public String getLifeFormName(LocalDate when) {
         return getLifeForm(when).name;
     }
 
-    public Integer getPercentWater(DateTime when) {
-        return getEventData(when, percentWater, new EventGetter<Integer>() {
-            @Override public Integer get(PlanetaryEvent e) { return e.percentWater; }
-        });
+    public Integer getPercentWater(LocalDate when) {
+        return getEventData(when, percentWater, e -> e.percentWater);
     }
 
-    public Integer getTemperature(DateTime when) {
-        return getEventData(when, temperature, new EventGetter<Integer>() {
-            @Override public Integer get(PlanetaryEvent e) { return e.temperature; }
-        });
+    public Integer getTemperature(LocalDate when) {
+        return getEventData(when, temperature, e -> e.temperature);
     }
 
-    public Integer getPressure(DateTime when) {
-        return getEventData(when, pressure, new EventGetter<Integer>() {
-            @Override public Integer get(PlanetaryEvent e) { return e.pressure; }
-        });
+    public Integer getPressure(LocalDate when) {
+        return getEventData(when, pressure, e -> e.pressure);
     }
 
-    public String getPressureName(DateTime when) {
+    public String getPressureName(LocalDate when) {
         Integer currentPressure = getPressure(when);
         return null != currentPressure ? PlanetaryConditions.getAtmosphereDisplayableName(currentPressure) : "unknown";
     }
 
-    public Atmosphere getAtmosphere(DateTime when) {
-        return getEventData(when, null != atmosphere ? atmosphere : Atmosphere.NONE, new EventGetter<Atmosphere>() {
-            @Override public Atmosphere get(PlanetaryEvent e) { return e.atmosphere; }
-        });
+    public Atmosphere getAtmosphere(LocalDate when) {
+        return getEventData(when, null != atmosphere ? atmosphere : Atmosphere.NONE, e -> e.atmosphere);
     }
 
-    public String getAtmosphereName(DateTime when) {
+    public String getAtmosphereName(LocalDate when) {
         return getAtmosphere(when).name;
     }
 
-    public String getComposition(DateTime when) {
-        return getEventData(when, composition, new EventGetter<String>() {
-            @Override public String get(PlanetaryEvent e) { return e.composition; }
-        });
+    public String getComposition(LocalDate when) {
+        return getEventData(when, composition, e -> e.composition);
     }
 
-    public List<String> getFactions(DateTime when) {
+    public List<String> getFactions(LocalDate when) {
         List<String> retVal = getEventData(when, factions, e -> e.faction);
         if (retVal != null) {
             return retVal;
@@ -746,26 +714,26 @@ public class Planet implements Serializable {
         if (null == codes) {
             return Collections.emptySet();
         }
-        Set<Faction> factions = new HashSet<Faction>(codes.size());
-        for(String code : codes) {
+        Set<Faction> factions = new HashSet<>(codes.size());
+        for (String code : codes) {
             factions.add(Faction.getFaction(code));
         }
         return factions;
     }
 
     /** @return set of factions at a given date */
-    public Set<Faction> getFactionSet(DateTime when) {
+    public Set<Faction> getFactionSet(LocalDate when) {
         List<String> currentFactions = getFactions(when);
         return getFactionsFrom(currentFactions);
     }
 
-    public String getShortDesc(DateTime when) {
+    public String getShortDesc(LocalDate when) {
         return getShortName(when) + " (" + getFactionDesc(when) + ")"; //$NON-NLS-1$ //$NON-NLS-2$
     }
 
-    public String getFactionDesc(DateTime when) {
+    public String getFactionDesc(LocalDate when) {
     	String toReturn = Faction.getFactionNames(getFactionSet(when), when.getYear());
-    	if(toReturn.isEmpty()) {
+    	if (toReturn.isEmpty()) {
     		toReturn = "Uncolonized"; //$NON-NLS-1$ $NON-NLS-2$
     	}
         return toReturn;
@@ -791,7 +759,7 @@ public class Planet implements Serializable {
 
     /** @return the average distance to the system's jump point in km */
     public double getDistanceToJumpPoint() {
-        if(null == parentSystem) {
+        if (null == parentSystem) {
         	MekHQ.getLogger().error(Planet.class, "getDistanceToJumpPoint",
         			"reference to planet with no parent system");
             return 0;
@@ -800,7 +768,7 @@ public class Planet implements Serializable {
     }
 
     public double getOrbitRadiusKm() {
-        if(null == orbitRadius) {
+        if (null == orbitRadius) {
             //TODO: figure out a better way to handle missing orbit radius (really this should not be missing)
             return 0.5 * StarUtil.AU;
         }
@@ -811,17 +779,17 @@ public class Planet implements Serializable {
     /**
      * Returns whether the planet has not been discovered or is a dead planet. This code was adapted from
      * InterstellarPlanetMapPanel.isPlanetEmpty
-     * @param when - the <code>DateTime</code> object indicating what time we are asking about.
+     * @param when - the <code>LocalDate</code> object indicating what time we are asking about.
      * @return true if the planet is empty; false if the planet is not empty
      */
-    public boolean isEmpty(DateTime when) {
+    public boolean isEmpty(LocalDate when) {
         Set<Faction> factions = getFactionSet(when);
-        if((null == factions) || factions.isEmpty()) {
+        if ((null == factions) || factions.isEmpty()) {
             return true;
         }
 
-        for(Faction faction : factions) {
-            if(!faction.is(Tag.ABANDONED)) {
+        for (Faction faction : factions) {
+            if (!faction.is(Tag.ABANDONED)) {
                 return false;
             }
         }
@@ -835,63 +803,63 @@ public class Planet implements Serializable {
      * about these mods as well as faction information.
      *
      * @param target - current TargetRoll for acquisitions
-     * @param when - a DateTime object for the campaign to retrieve information from the planet
+     * @param when - a LocalDate object for the campaign to retrieve information from the planet
      * @param options - the campaign options from which important values need to be determined
      * @return an updated TargetRoll with planet specific mods
      */
-    public TargetRoll getAcquisitionMods(TargetRoll target, Date when, CampaignOptions options, Faction faction, boolean clanPart) {
-
+    public TargetRoll getAcquisitionMods(TargetRoll target, LocalDate when, CampaignOptions options, Faction faction, boolean clanPart) {
         //check faction limitations
-        Set<Faction> planetFactions = getFactionSet(Utilities.getDateTimeDay(when));
-        if(null != planetFactions) {
+        Set<Faction> planetFactions = getFactionSet(when);
+        if (null != planetFactions) {
             boolean enemies = false;
             boolean neutrals = false;
             boolean allies = false;
             boolean ownFaction = false;
             boolean clanCrossover = true;
             boolean noClansPresent = true;
-            for(Faction planetFaction : planetFactions) {
-                if(faction.equals(planetFaction)) {
+            for (Faction planetFaction : planetFactions) {
+                if (faction.equals(planetFaction)) {
                     ownFaction = true;
                 }
-                if(RandomFactionGenerator.getInstance().getFactionHints().isAtWarWith(faction, planetFaction, when)) {
+                if (RandomFactionGenerator.getInstance().getFactionHints().isAtWarWith(faction, planetFaction, when)) {
                     enemies = true;
-                } else if(RandomFactionGenerator.getInstance().getFactionHints().isAlliedWith(faction, planetFaction, when)) {
+                } else if (RandomFactionGenerator.getInstance().getFactionHints().isAlliedWith(faction, planetFaction, when)) {
                     allies = true;
                 } else {
                     neutrals = true;
-                      }
-                if(faction.isClan()) {
+                }
+
+                if (faction.isClan()) {
                     noClansPresent = false;
                 }
-                if(faction.isClan() == planetFaction.isClan()) {
+                if (faction.isClan() == planetFaction.isClan()) {
                     clanCrossover = false;
                 }
             }
-            if(!ownFaction) {
-                if(enemies && !neutrals && !allies
-                        && options.getPlanetAcquisitionFactionLimit() > CampaignOptions.PLANET_ACQUISITION_ALL) {
+            if (!ownFaction) {
+                if (enemies && !neutrals && !allies
+                        && (options.getPlanetAcquisitionFactionLimit() > CampaignOptions.PLANET_ACQUISITION_ALL)) {
                     return new TargetRoll(TargetRoll.IMPOSSIBLE, "No supplies from enemy planets");
-                } else if(neutrals && !allies
-                        && options.getPlanetAcquisitionFactionLimit() > CampaignOptions.PLANET_ACQUISITION_NEUTRAL) {
+                } else if (neutrals && !allies
+                        && (options.getPlanetAcquisitionFactionLimit() > CampaignOptions.PLANET_ACQUISITION_NEUTRAL)) {
                     return new TargetRoll(TargetRoll.IMPOSSIBLE, "No supplies from neutral planets");
-                } else if(allies && options.getPlanetAcquisitionFactionLimit() > CampaignOptions.PLANET_ACQUISITION_ALLY) {
+                } else if (allies && (options.getPlanetAcquisitionFactionLimit() > CampaignOptions.PLANET_ACQUISITION_ALLY)) {
                     return new TargetRoll(TargetRoll.IMPOSSIBLE, "No supplies from allied planets");
-                }
-                if(options.disallowPlanetAcquisitionClanCrossover() && clanCrossover) {
+                } else if (options.disallowPlanetAcquisitionClanCrossover() && clanCrossover) {
                     return new TargetRoll(TargetRoll.IMPOSSIBLE, "The clans and inner sphere do not trade supplies");
                 }
             }
-            if(noClansPresent && clanPart) {
-                if(options.disallowClanPartsFromIS()) {
+
+            if (noClansPresent && clanPart) {
+                if (options.disallowClanPartsFromIS()) {
                     return new TargetRoll(TargetRoll.IMPOSSIBLE, "No clan parts from non-clan factions");
                 }
                 target.addModifier(options.getPenaltyClanPartsFroIS(), "clan parts from non-clan faction");
             }
         }
 
-        SocioIndustrialData socioIndustrial = getSocioIndustrial(Utilities.getDateTimeDay(when));
-        if(null == socioIndustrial) {
+        SocioIndustrialData socioIndustrial = getSocioIndustrial(when);
+        if (null == socioIndustrial) {
             //nothing has been coded for this planet, so we will assume C across the board
             socioIndustrial = new SocioIndustrialData();
             socioIndustrial.tech = EquipmentType.RATING_C;
@@ -902,7 +870,7 @@ public class Planet implements Serializable {
         }
 
         //don't allow acquisitions from caveman planets
-        if(socioIndustrial.tech==EquipmentType.RATING_X ||
+        if (socioIndustrial.tech==EquipmentType.RATING_X ||
                 socioIndustrial.industry==EquipmentType.RATING_X ||
                 socioIndustrial.output==EquipmentType.RATING_X) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE,"Regressed: Pre-industrial world");
@@ -923,15 +891,15 @@ public class Planet implements Serializable {
 
     @SuppressWarnings({ "unused", "unchecked" })
     private void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
-        if( null == id ) {
+        if (null == id) {
             id = name;
         }
 
         // Fill up events
-        events = new TreeMap<DateTime, PlanetaryEvent>(DateTimeComparator.getDateOnlyInstance());
-        if( null != eventList ) {
-            for( PlanetaryEvent event : eventList ) {
-                if( null != event && null != event.date ) {
+        events = new TreeMap<>();
+        if (null != eventList) {
+            for (PlanetaryEvent event : eventList) {
+                if ((null != event) && (null != event.date)) {
                     events.put(event.date, event);
                 }
             }
@@ -939,9 +907,9 @@ public class Planet implements Serializable {
         }
         eventList = null;
         // Merge faction change events into the event data
-        if( null != factionChanges ) {
-            for( FactionChange change : factionChanges ) {
-                if( null != change && null != change.date ) {
+        if (null != factionChanges) {
+            for (FactionChange change : factionChanges) {
+                if ((null != change) && (null != change.date)) {
                     PlanetaryEvent event = getOrCreateEvent(change.date);
                     event.faction = change.faction;
                 }
@@ -954,7 +922,7 @@ public class Planet implements Serializable {
     @SuppressWarnings("unused")
     private boolean beforeMarshal(Marshaller marshaller) {
         // Fill up our event list from the internal data type
-        eventList = new ArrayList<PlanetaryEvent>(events.values());
+        eventList = new ArrayList<>(events.values());
         return true;
     }
 
@@ -968,10 +936,11 @@ public class Planet implements Serializable {
     public String updateFromTSVPlanet(final Planet tsvPlanet, boolean dryRun) {
         StringBuilder sb = new StringBuilder();
 
-        if(!tsvPlanet.x.equals(this.x) || !tsvPlanet.y.equals(this.y)) {
-            sb.append("Coordinate update from " + x + ", " + y + " to " + tsvPlanet.x + ", " + tsvPlanet.y + "\r\n");
+        if (!tsvPlanet.x.equals(this.x) || !tsvPlanet.y.equals(this.y)) {
+            sb.append("Coordinate update from ").append(x).append(", ").append(y).append(" to ")
+                    .append(tsvPlanet.x).append(", ").append(tsvPlanet.y).append("\r\n");
 
-            if(!dryRun) {
+            if (!dryRun) {
                 this.x = tsvPlanet.x;
                 this.y = tsvPlanet.y;
             }
@@ -981,7 +950,7 @@ public class Planet implements Serializable {
         // look ahead by one event (if possible) and check that getFaction(next event year) isn't already
         // the same as the faction from the current event : sometimes, our data is more exact than the incoming data
         List<PlanetaryEvent> tsvEvents = tsvPlanet.getEvents();
-        for(int eventIndex = 0; eventIndex < tsvEvents.size(); eventIndex++) {
+        for (int eventIndex = 0; eventIndex < tsvEvents.size(); eventIndex++) {
             PlanetaryEvent event = tsvEvents.get(eventIndex);
             // check other planet events (currently only updating faction change events)
             // if the other planet has an 'ownership change' event with a non-"U" faction
@@ -989,29 +958,29 @@ public class Planet implements Serializable {
             // and does not acquire such a faction between this and the next event
             // Then we will add an the ownership change event
 
-            if(event.faction != null && event.faction.size() > 0) {
+            if ((event.faction != null) && (event.faction.size() > 0)) {
                 // the purpose of this code is to evaluate whether the current "other planet" event is
                 // a faction change to an active, valid faction.
                 Faction eventFaction = Faction.getFaction(event.faction.get(0));
-                boolean eventHasActualFaction = eventFaction != null ? !eventFaction.is(Tag.INACTIVE) && !eventFaction.is(Tag.ABANDONED) : false;
+                boolean eventHasActualFaction = eventFaction != null && (!eventFaction.is(Tag.INACTIVE) && !eventFaction.is(Tag.ABANDONED));
 
-                if(eventHasActualFaction) {
+                if (eventHasActualFaction) {
                     List<String> currentFactions = this.getFactions(event.date);
 
                     // if this planet has an "inactive and abandoned" current faction...
                     // we also want to catch the situation where the next faction change isn't to the same exact faction
-                    if(currentFactions.size() == 1 &&
-                            Faction.getFaction(currentFactions.get(0)).is(Tag.INACTIVE) &&
-                            Faction.getFaction(currentFactions.get(0)).is(Tag.ABANDONED)) {
+                    if ((currentFactions.size() == 1)
+                            && Faction.getFaction(currentFactions.get(0)).is(Tag.INACTIVE)
+                            && Faction.getFaction(currentFactions.get(0)).is(Tag.ABANDONED)) {
 
                         // now we travel into the future, to the next "other" event, and if this planet has acquired a faction
                         // before the next "other" event, then we
                         int nextEventIndex = eventIndex + 1;
                         PlanetaryEvent nextEvent = nextEventIndex < tsvEvents.size() ? tsvEvents.get(nextEventIndex) : null;
-                        DateTime nextEventDate;
+                        LocalDate nextEventDate;
 
                         // if we're at the last event, then just check that the planet doesn't have a faction in the year 3600
-                        if(nextEvent == null) {
+                        if (nextEvent == null) {
                             nextEventDate = new DateTime(3600, 1, 1, 0, 0, 1, 0);
                         } else {
                             nextEventDate = nextEvent.date;
@@ -1022,10 +991,12 @@ public class Planet implements Serializable {
                                 Faction.getFaction(nextFactions.get(0)).is(Tag.INACTIVE) &&
                                 Faction.getFaction(nextFactions.get(0)).is(Tag.ABANDONED));
 
-                        if(!factionBeforeNextEvent) {
-                            sb.append("Adding faction change in " + event.date.getYear() + " from " + currentFactions.get(0) + " to " + event.faction + "\r\n");
+                        if (!factionBeforeNextEvent) {
+                            sb.append("Adding faction change in ").append(event.date.getYear())
+                                    .append(" from ").append(currentFactions.get(0)).append(" to ")
+                                    .append(event.faction).append("\r\n");
 
-                            if(!dryRun) {
+                            if (!dryRun) {
                                 this.events.put(event.date, event);
                             }
                         }
@@ -1034,7 +1005,7 @@ public class Planet implements Serializable {
             }
         }
 
-        if(sb.length() > 0) {
+        if (sb.length() > 0) {
             sb.insert(0, "Updating planet " + this.getId() + "\r\n");
         }
 
@@ -1047,7 +1018,7 @@ public class Planet implements Serializable {
      * To effectively delete an event, simply create a new one with <i>just</i> the date.
      */
     public void copyDataFrom(Planet other) {
-        if( null != other ) {
+        if (null != other) {
             // We don't change the ID
             name = Utilities.nonNull(other.name, name);
             shortName = Utilities.nonNull(other.shortName, shortName);
@@ -1073,9 +1044,9 @@ public class Planet implements Serializable {
             socioIndustrial = Utilities.nonNull(other.socioIndustrial, socioIndustrial);
             icon = Utilities.nonNull(other.icon, icon);
             // Merge (not replace!) events
-            if( null != other.events ) {
-                for( PlanetaryEvent event : other.getEvents() ) {
-                    if( null != event && null != event.date ) {
+            if (null != other.events) {
+                for (PlanetaryEvent event : other.getEvents()) {
+                    if ((null != event) && (null != event.date)) {
                         PlanetaryEvent myEvent = getOrCreateEvent(event.date);
                         myEvent.copyDataFrom(event);
                     }
@@ -1092,10 +1063,10 @@ public class Planet implements Serializable {
 
     @Override
     public boolean equals(Object object) {
-        if(this == object) {
+        if (this == object) {
             return true;
         }
-        if((null == object) || (getClass() != object.getClass())) {
+        if ((null == object) || (getClass() != object.getClass())) {
             return false;
         }
         final Planet other = (Planet) object;
@@ -1103,34 +1074,28 @@ public class Planet implements Serializable {
     }
 
     public static int convertRatingToCode(String rating) {
-        if(rating.equalsIgnoreCase("A")) { //$NON-NLS-1$
+        if (rating.equalsIgnoreCase("A")) { //$NON-NLS-1$
             return EquipmentType.RATING_A;
-        }
-        else if(rating.equalsIgnoreCase("B")) { //$NON-NLS-1$
+        } else if (rating.equalsIgnoreCase("B")) { //$NON-NLS-1$
             return EquipmentType.RATING_B;
-        }
-        else if(rating.equalsIgnoreCase("C")) { //$NON-NLS-1$
+        } else if (rating.equalsIgnoreCase("C")) { //$NON-NLS-1$
+            return EquipmentType.RATING_C;
+        } else if (rating.equalsIgnoreCase("D")) { //$NON-NLS-1$
+            return EquipmentType.RATING_D;
+        } else if (rating.equalsIgnoreCase("E")) { //$NON-NLS-1$
+            return EquipmentType.RATING_E;
+        } else if (rating.equalsIgnoreCase("F")) { //$NON-NLS-1$
+            return EquipmentType.RATING_F;
+        } else {
             return EquipmentType.RATING_C;
         }
-        else if(rating.equalsIgnoreCase("D")) { //$NON-NLS-1$
-            return EquipmentType.RATING_D;
-        }
-        else if(rating.equalsIgnoreCase("E")) { //$NON-NLS-1$
-            return EquipmentType.RATING_E;
-        }
-        else if(rating.equalsIgnoreCase("F")) { //$NON-NLS-1$
-            return EquipmentType.RATING_F;
-        }
-        return EquipmentType.RATING_C;
     }
-
-
 
     /** A class representing some event, possibly changing planetary information */
     @XmlRootElement(name="event")
     public static final class PlanetaryEvent {
         @XmlJavaTypeAdapter(DateAdapter.class)
-        public DateTime date;
+        public LocalDate date;
         public String message;
         public String name;
         public String shortName;
@@ -1220,27 +1185,23 @@ public class Planet implements Serializable {
 
     public static final class FactionChange {
         @XmlJavaTypeAdapter(DateAdapter.class)
-        public DateTime date;
+        public LocalDate date;
         @XmlJavaTypeAdapter(StringListAdapter.class)
         public List<String> faction;
 
         @Override
         public String toString() {
-            StringBuilder sb = new StringBuilder();
-            sb.append("{"); //$NON-NLS-1$
-               sb.append("date=").append(date).append(","); //$NON-NLS-1$ //$NON-NLS-2$
-               sb.append("faction=").append(faction).append("}"); //$NON-NLS-1$ //$NON-NLS-2$
-               return sb.toString();
+            return "{" + "date=" + date + "," + "faction=" + faction + "}";
         }
     }
 
     // @FunctionalInterface in Java 8, or just use Function<PlanetaryEvent, T>
-    private static interface EventGetter<T> {
+    private interface EventGetter<T> {
         T get(PlanetaryEvent e);
     }
 
     /** BT planet types */
-    public static enum PlanetaryType {
-        SMALL_ASTEROID, MEDIUM_ASTEROID, DWARF_TERRESTRIAL, TERRESTRIAL, GIANT_TERRESTRIAL, GAS_GIANT, ICE_GIANT;
+    public enum PlanetaryType {
+        SMALL_ASTEROID, MEDIUM_ASTEROID, DWARF_TERRESTRIAL, TERRESTRIAL, GIANT_TERRESTRIAL, GAS_GIANT, ICE_GIANT
     }
 }

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -161,10 +161,9 @@ public class Planet implements Serializable {
      * <p>
      * sorted map of [date of change: change information]
      * <p>
-     * Package-private so that Planets can access it
      */
     @XmlTransient
-    TreeMap<LocalDate, PlanetaryEvent> events;
+    private transient TreeMap<LocalDate, PlanetaryEvent> events;
 
     /**
      * This is a cache of the current event data based
@@ -258,11 +257,9 @@ public class Planet implements Serializable {
                 if ((null == Faction.getFaction(altName)) && (null == Systems.getInstance().getSystemById(primaryName))) {
                     primaryName = nameString.substring(0, parenIndex - 1);
 
-                    PlanetaryEvent nameChangeEvent = new PlanetaryEvent();
-                    nameChangeEvent.date = nameChangeYearDate;
+                    PlanetaryEvent nameChangeEvent = getOrCreateEvent(nameChangeYearDate);
                     nameChangeEvent.name = altName;
 
-                    events.put(nameChangeYearDate, nameChangeEvent);
                     eventList.add(nameChangeEvent);
                 }
             }
@@ -304,10 +301,7 @@ public class Planet implements Serializable {
                     pe.faction = new ArrayList<>();
                     pe.faction.add(newFaction);
 
-                    if (!events.containsKey(eventDate)) {
-                        pe.date = eventDate;
-
-                        events.put(eventDate, pe);
+                    if (!eventList.contains(pe)) {
                         eventList.add(pe);
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -433,7 +433,7 @@ public class Planet implements Serializable {
      * this result may be different than that actual sysPos variable.
      * @return String of system position after removing asteroid belts
      */
-    public String getDiplayableSystemPosition() {
+    public String getDisplayableSystemPosition() {
     	//We won't give the actual system position here, because we don't want asteroid belts to count
     	//for system position
     	if ((null == getParentSystem()) || (null == sysPos)) {

--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -19,10 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.universe;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,17 +41,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeComparator;
-
 import megamek.common.EquipmentType;
 import mekhq.Utilities;
 import mekhq.adapter.BooleanValueAdapter;
 import mekhq.adapter.DateAdapter;
 import mekhq.adapter.SpectralClassAdapter;
 import mekhq.campaign.universe.Planet.PlanetaryEvent;
-import mekhq.campaign.universe.SocioIndustrialData;
-
 
 /**
  * This is a PlanetarySystem object which will contain information
@@ -60,7 +55,6 @@ import mekhq.campaign.universe.SocioIndustrialData;
  *
  * @author Taharqa
  */
-
 @XmlRootElement(name="system")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class PlanetarySystem implements Serializable {
@@ -151,7 +145,7 @@ public class PlanetarySystem implements Serializable {
      * Package-private so that Planets can access it
      */
     @XmlTransient
-    TreeMap<DateTime, PlanetarySystemEvent> events;
+    TreeMap<LocalDate, PlanetarySystemEvent> events;
 
     // For export and import only (lists are easier than maps) */
     @XmlElement(name = "event")
@@ -176,50 +170,50 @@ public class PlanetarySystem implements Serializable {
         return y;
     }
 
-    public String getName(DateTime when) {
-    	if(primarySlot<1) {
+    public String getName(LocalDate when) {
+    	if (primarySlot < 1) {
     		//if no primary slot, then just return the id
-    		if(null != id) {
+    		if (null != id) {
     			return id;
     		}
     	}
-        if(null != getPrimaryPlanet()) {
+        if (null != getPrimaryPlanet()) {
             return getPrimaryPlanet().getName(when);
         }
         return "Unknown";
     }
 
-    public List<String> getFactions(DateTime when) {
+    public List<String> getFactions(LocalDate when) {
         List<String> factions = new ArrayList<>();
-        for(Planet planet : planets.values()) {
+        for (Planet planet : planets.values()) {
             List<String> f = planet.getFactions(when);
-            if(null != f) {
+            if (null != f) {
                 factions.addAll(f);
             }
         }
         return factions;
     }
 
-    public Set<Faction> getFactionSet(DateTime when) {
+    public Set<Faction> getFactionSet(LocalDate when) {
         Set<Faction> factions = new HashSet<>();
-        for(Planet planet : planets.values()) {
+        for (Planet planet : planets.values()) {
             Set<Faction> f = planet.getFactionSet(when);
-            if(null != f) {
+            if (null != f) {
                 factions.addAll(f);
             }
         }
         //ignore cases where abandoned (ABN) is given in addition
         //to real factions
-        if(factions.size()>1) {
+        if (factions.size() > 1) {
         	factions.remove(Faction.getFaction("ABN"));
         }
         return factions;
     }
 
-    public long getPopulation(DateTime when) {
+    public long getPopulation(LocalDate when) {
     	long pop = 0L;
-    	for(Planet planet : planets.values()) {
-    		if(null != planet.getPopulation(when)) {
+    	for (Planet planet : planets.values()) {
+    		if (null != planet.getPopulation(when)) {
     			pop += planet.getPopulation(when);
     		}
     	}
@@ -227,29 +221,29 @@ public class PlanetarySystem implements Serializable {
     }
 
     /** highest socio-industrial ratings among all planets in system for the map **/
-    public SocioIndustrialData getSocioIndustrial(DateTime when) {
+    public SocioIndustrialData getSocioIndustrial(LocalDate when) {
         int tech = EquipmentType.RATING_X;
         int industry = EquipmentType.RATING_X;
         int rawMaterials = EquipmentType.RATING_X;
         int output = EquipmentType.RATING_X;
         int agriculture = EquipmentType.RATING_X;
 
-        for(Planet planet : planets.values()) {
+        for (Planet planet : planets.values()) {
             SocioIndustrialData sic = planet.getSocioIndustrial(when);
-            if(null != sic) {
-                if(sic.tech < tech) {
+            if (null != sic) {
+                if (sic.tech < tech) {
                     tech = sic.tech;
                 }
-                if(sic.industry < industry) {
+                if (sic.industry < industry) {
                     industry = sic.industry;
                 }
-                if(sic.rawMaterials < rawMaterials) {
+                if (sic.rawMaterials < rawMaterials) {
                     rawMaterials = sic.rawMaterials;
                 }
-                if(sic.output < output) {
+                if (sic.output < output) {
                     output = sic.output;
                 }
-                if(sic.agriculture < agriculture) {
+                if (sic.agriculture < agriculture) {
                     agriculture = sic.agriculture;
                 }
             }
@@ -258,10 +252,10 @@ public class PlanetarySystem implements Serializable {
     }
 
     /** @return the highest HPG rating among planets **/
-    public Integer getHPG(DateTime when) {
+    public Integer getHPG(LocalDate when) {
         int rating = EquipmentType.RATING_X;
-        for(Planet planet : planets.values()) {
-            if(null != planet.getHPG(when) && planet.getHPG(when) < rating) {
+        for (Planet planet : planets.values()) {
+            if ((null != planet.getHPG(when)) && (planet.getHPG(when) < rating)) {
                 rating = planet.getHPG(when);
             }
         }
@@ -269,9 +263,9 @@ public class PlanetarySystem implements Serializable {
     }
 
     /** @return short name if set, else full name, else "unnamed" */
-    public String getPrintableName(DateTime when) {
+    public String getPrintableName(LocalDate when) {
         String result = getName(when);
-        if(null == result) {
+        if (null == result) {
             return "Unknown System"; //$NON-NLS-1$ $NON-NLS-2$
         }
         return result; //$NON-NLS-1$
@@ -287,26 +281,26 @@ public class PlanetarySystem implements Serializable {
         return Math.sqrt(Math.pow(x - anotherSystem.x, 2) + Math.pow(y - anotherSystem.y, 2));
     }
 
-    public Boolean isNadirCharge(DateTime when) {
+    public Boolean isNadirCharge(LocalDate when) {
         return getEventData(when, nadirCharge, e -> e.nadirCharge);
     }
 
-    public boolean isZenithCharge(DateTime when) {
+    public boolean isZenithCharge(LocalDate when) {
         return getEventData(when, zenithCharge, e -> e.zenithCharge);
     }
 
-    public int getNumberRechargeStations(DateTime when) {
+    public int getNumberRechargeStations(LocalDate when) {
     	return (isNadirCharge(when) ? 1 : 0) + (isZenithCharge(when) ? 1 : 0);
     }
 
-    public String getRechargeStationsText(DateTime when) {
+    public String getRechargeStationsText(LocalDate when) {
         boolean nadir = isNadirCharge(when);
         boolean zenith = isZenithCharge(when);
-        if(nadir && zenith) {
+        if (nadir && zenith) {
             return "Zenith, Nadir";
         } else if (zenith) {
             return "Zenith";
-        } else if(nadir) {
+        } else if (nadir) {
             return "Nadir";
         } else {
             return "None";
@@ -314,8 +308,8 @@ public class PlanetarySystem implements Serializable {
     }
 
     /** Recharge time in hours (assuming the usage of the fastest charing method available) */
-    public double getRechargeTime(DateTime when) {
-        if(isZenithCharge(when) || isNadirCharge(when)) {
+    public double getRechargeTime(LocalDate when) {
+        if (isZenithCharge(when) || isNadirCharge(when)) {
         	//The 176 value comes from pg. 87-88 and 138 of StratOps
             return Math.min(176.0, getSolarRechargeTime());
         } else {
@@ -325,16 +319,16 @@ public class PlanetarySystem implements Serializable {
 
     /** Recharge time in hours using solar radiation alone (at jump point and 100% efficiency) */
     public double getSolarRechargeTime() {
-        if( null == spectralClass || null == subtype ) {
+        if ((null == spectralClass) || (null == subtype)) {
         	//176 is the average recharge time across all spectral classes and subtypes
             return 176;
         }
         return StarUtil.getSolarRechargeTime(spectralClass, subtype);
     }
 
-    public String getRechargeTimeText(DateTime when) {
+    public String getRechargeTimeText(LocalDate when) {
         double time = getRechargeTime(when);
-        if(Double.isInfinite(time)) {
+        if (Double.isInfinite(time)) {
             return "recharging impossible"; //$NON-NLS-1$
         } else {
             return String.format("%.0f hours", time); //$NON-NLS-1$
@@ -342,7 +336,7 @@ public class PlanetarySystem implements Serializable {
     }
 
     public double getStarDistanceToJumpPoint() {
-        if( null == spectralClass || null == subtype ) {
+        if ((null == spectralClass) || (null == subtype)) {
         	//40 is close to the midpoint value across all star types
             return StarUtil.getDistanceToJumpPoint(40);
         }
@@ -369,15 +363,19 @@ public class PlanetarySystem implements Serializable {
     }
 
     public String getSpectralTypeText() {
-        if(null == spectralType || spectralType.isEmpty()) {
+        if ((null == spectralType) || spectralType.isEmpty()) {
             return "unknown";
         }
-        if(spectralType.startsWith("Q")) {
-            switch(spectralType) {
-                case "QB": return "black hole"; //$NON-NLS-1$
-                case "QN": return "neutron star"; //$NON-NLS-1$
-                case "QP": return "pulsar"; //$NON-NLS-1$
-                default: return "unknown";
+        if (spectralType.startsWith("Q")) {
+            switch (spectralType) {
+                case "QB":
+                    return "black hole"; //$NON-NLS-1$
+                case "QN":
+                    return "neutron star"; //$NON-NLS-1$
+                case "QP":
+                    return "pulsar"; //$NON-NLS-1$
+                default:
+                    return "unknown";
             }
         }
         return spectralType;
@@ -437,31 +435,31 @@ public class PlanetarySystem implements Serializable {
 
 
     public String getIcon() {
-        switch(getSpectralClass()) {
-        case(SPECTRAL_B):
-            return "B_" + luminosity;
-        case(SPECTRAL_A):
-            return  "A_" + luminosity;
-        case(SPECTRAL_F):
-            return "F_" + luminosity;
-        case(SPECTRAL_G):
-            return "G_" + luminosity;
-        case(SPECTRAL_K):
-            return "K_" + luminosity;
-        case(SPECTRAL_M):
-            return "M_" + luminosity;
-        default:
-            return "default";
+        switch (getSpectralClass()) {
+            case SPECTRAL_B:
+                return "B_" + luminosity;
+            case SPECTRAL_A:
+                return  "A_" + luminosity;
+            case SPECTRAL_F:
+                return "F_" + luminosity;
+            case SPECTRAL_G:
+                return "G_" + luminosity;
+            case SPECTRAL_K:
+                return "K_" + luminosity;
+            case SPECTRAL_M:
+                return "M_" + luminosity;
+            default:
+                return "default";
         }
 
     }
 
     @Override
     public boolean equals(Object object) {
-        if(this == object) {
+        if (this == object) {
             return true;
         }
-        if((null == object) || (getClass() != object.getClass())) {
+        if ((null == object) || (getClass() != object.getClass())) {
             return false;
         }
         final PlanetarySystem other = (PlanetarySystem) object;
@@ -473,15 +471,15 @@ public class PlanetarySystem implements Serializable {
        return Objects.hash(id);
     }
 
-    public PlanetarySystemEvent getOrCreateEvent(DateTime when) {
-        if(null == when) {
+    public PlanetarySystemEvent getOrCreateEvent(LocalDate when) {
+        if (null == when) {
             return null;
         }
-        if(null == events) {
-            events = new TreeMap<>(DateTimeComparator.getDateOnlyInstance());
+        if (null == events) {
+            events = new TreeMap<>();
         }
         PlanetarySystemEvent event = events.get(when);
-        if(null == event) {
+        if (null == event) {
             event = new PlanetarySystemEvent();
             event.date = when;
             events.put(when, event);
@@ -489,28 +487,28 @@ public class PlanetarySystem implements Serializable {
         return event;
     }
 
-    public PlanetaryEvent getOrCreateEvent(DateTime when, int position) {
+    public PlanetaryEvent getOrCreateEvent(LocalDate when, int position) {
         Planet p = getPlanet(position);
-        if(null == p) {
+        if (null == p) {
         	return null;
         }
-        return(p.getOrCreateEvent(when));
+        return p.getOrCreateEvent(when);
     }
 
-    public PlanetarySystemEvent getEvent(DateTime when) {
-        if((null == when) || (null == events)) {
+    public PlanetarySystemEvent getEvent(LocalDate when) {
+        if ((null == when) || (null == events)) {
             return null;
         }
         return events.get(when);
     }
 
-    protected <T> T getEventData(DateTime when, T defaultValue, EventGetter<T> getter) {
-        if( null == when || null == events || null == getter ) {
+    protected <T> T getEventData(LocalDate when, T defaultValue, EventGetter<T> getter) {
+        if ((null == when) || (null == events) || (null == getter)) {
             return defaultValue;
         }
         T result = defaultValue;
-        for( DateTime date : events.navigableKeySet() ) {
-            if( date.isAfter(when) ) {
+        for (LocalDate date : events.navigableKeySet()) {
+            if (date.isAfter(when)) {
                 break;
             }
             result = Utilities.nonNull(getter.get(events.get(date)), result);
@@ -519,7 +517,7 @@ public class PlanetarySystem implements Serializable {
     }
 
     public List<PlanetarySystemEvent> getEvents() {
-        if( null == events ) {
+        if (null == events) {
             return null;
         }
         return new ArrayList<>(events.values());
@@ -529,7 +527,7 @@ public class PlanetarySystem implements Serializable {
     protected void setSpectralType(String type) {
         SpectralDefinition scDef = StarUtil.parseSpectralType(type);
 
-        if( null == scDef ) {
+        if (null == scDef) {
             return;
         }
 
@@ -542,12 +540,12 @@ public class PlanetarySystem implements Serializable {
     // JAXB marshalling support
     @SuppressWarnings({ "unused" })
     private void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
-        if( null == id ) {
+        if (null == id) {
             id = name;
         }
 
         // Spectral classification: use spectralType if available, else the separate values
-        if( null != spectralType ) {
+        if (null != spectralType) {
             setSpectralType(spectralType);
         }
         nadirCharge = Utilities.nonNull(nadirCharge, Boolean.FALSE);
@@ -555,10 +553,10 @@ public class PlanetarySystem implements Serializable {
 
         //fill up planets
         planets = new TreeMap<>();
-        if(null != planetList) {
-            for(Planet p : planetList) {
+        if (null != planetList) {
+            for (Planet p : planetList) {
                 p.setParentSystem(this);
-                if(!planets.containsKey(p.getSystemPosition())) {
+                if (!planets.containsKey(p.getSystemPosition())) {
                     planets.put(p.getSystemPosition(), p);
                 }
             }
@@ -566,10 +564,10 @@ public class PlanetarySystem implements Serializable {
         }
         planetList = null;
         // Fill up events
-        events = new TreeMap<>(DateTimeComparator.getDateOnlyInstance());
-        if( null != eventList ) {
-            for( PlanetarySystemEvent event : eventList ) {
-                if( null != event && null != event.date ) {
+        events = new TreeMap<>();
+        if (null != eventList) {
+            for (PlanetarySystemEvent event : eventList) {
+                if ((null != event) && (null != event.date)) {
                     events.put(event.date, event);
                 }
             }
@@ -588,7 +586,7 @@ public class PlanetarySystem implements Serializable {
     }
 
     public void copyDataFrom(PlanetarySystem other) {
-        if( null != other ) {
+        if (null != other) {
             // We don't change the ID
             name = Utilities.nonNull(other.name, name);
             x = Utilities.nonNull(other.x, x);
@@ -597,19 +595,19 @@ public class PlanetarySystem implements Serializable {
             zenithCharge = Utilities.nonNull(other.zenithCharge, zenithCharge);
             //TODO: some other changes should be possible
             // Merge (not replace!) events
-            if(null != other.events) {
-                for(PlanetarySystemEvent event : other.getEvents()) {
-                    if( null != event && null != event.date ) {
+            if (null != other.events) {
+                for (PlanetarySystemEvent event : other.getEvents()) {
+                    if ((null != event) && (null != event.date)) {
                     	PlanetarySystemEvent myEvent = getOrCreateEvent(event.date);
                         myEvent.copyDataFrom(event);
                     }
                 }
             }
             //check for planet level changes
-            if(null != other.planets) {
-                for(Planet p : other.planets.values()) {
+            if (null != other.planets) {
+                for (Planet p : other.planets.values()) {
                     int pos = p.getSystemPosition();
-                    if(planets.containsKey(pos)) {
+                    if (planets.containsKey(pos)) {
                         planets.get(pos).copyDataFrom(p);
                     } else {
                         planets.put(pos, p);
@@ -643,7 +641,7 @@ public class PlanetarySystem implements Serializable {
     @XmlRootElement(name="event")
     public static final class PlanetarySystemEvent {
     	@XmlJavaTypeAdapter(DateAdapter.class)
-        public DateTime date;
+        public LocalDate date;
         public Boolean nadirCharge;
         public Boolean zenithCharge;
         // Events marked as "custom" are saved to scenario files and loaded from there

--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -307,7 +307,7 @@ public class PlanetarySystem implements Serializable {
         }
     }
 
-    /** Recharge time in hours (assuming the usage of the fastest charing method available) */
+    /** Recharge time in hours (assuming the usage of the fastest charging method available) */
     public double getRechargeTime(LocalDate when) {
         if (isZenithCharge(when) || isNadirCharge(when)) {
         	//The 176 value comes from pg. 87-88 and 138 of StratOps

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -12,20 +12,20 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.universe;
 
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import megamek.common.util.WeightedMap;
-import org.joda.time.DateTime;
 
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
@@ -41,14 +41,10 @@ import mekhq.campaign.event.OptionsChangedEvent;
  * Uses Factions and Planets to weighted lists of potential employers
  * and enemies for contract generation. Also finds a suitable planet
  * for the action.
- *
- */
-
-/* TODO : Account for the de facto alliance of the invading Clans and the
+ * TODO : Account for the de facto alliance of the invading Clans and the
  * TODO : Fortress Republic in a way that doesn't involve hard-coding them here.
  */
 public class RandomFactionGenerator {
-
     /* When checking for potential enemies, count the planets controlled
      * by potentially hostile factions within a certain number of jumps of
      * friendly worlds; the number is based on the region of space.
@@ -58,8 +54,7 @@ public class RandomFactionGenerator {
     private static final int BORDER_RANGE_NEAR_PERIPHERY = 90;
     private static final int BORDER_RANGE_DEEP_PERIPHERY = 210; //a bit more than this distance between HL and NC
 
-    private static final Date FORTRESS_REPUBLIC = new Date (new GregorianCalendar(3135,
-            Calendar.NOVEMBER,1).getTimeInMillis());
+    private static final LocalDate FORTRESS_REPUBLIC = LocalDate.of(3135, Month.NOVEMBER, 1);
 
     private static RandomFactionGenerator rfg = null;
 
@@ -96,7 +91,7 @@ public class RandomFactionGenerator {
     }
 
     public void startup(Campaign c) {
-        borderTracker.setDate(Utilities.getDateTimeDay(c.getCalendar()));
+        borderTracker.setDate(c.getLocalDate());
         final PlanetarySystem location = c.getLocation().getCurrentSystem();
         borderTracker.setRegionCenter(location.getX(), location.getY());
         borderTracker.setRegionRadius(c.getCampaignOptions().getSearchRadius());
@@ -109,12 +104,8 @@ public class RandomFactionGenerator {
         }
     }
 
-    public void setDate(GregorianCalendar calendar) {
-        borderTracker.setDate(Utilities.getDateTimeDay(calendar));
-    }
-
-    public void setDate(DateTime when) {
-        borderTracker.setDate(when);
+    public void setDate(LocalDate date) {
+        borderTracker.setDate(date);
     }
 
     public void setSearchCenter(double x, double y) {
@@ -143,8 +134,8 @@ public class RandomFactionGenerator {
         MekHQ.unregisterHandler(this);
     }
 
-    private Date currentDate() {
-        return borderTracker.getLastUpdated().toDate();
+    private LocalDate getCurrentDate() {
+        return borderTracker.getLastUpdated();
     }
 
     /**
@@ -158,14 +149,14 @@ public class RandomFactionGenerator {
                     || f.getShortName().equals("CLAN")) {
                 continue;
             }
-            if (f.getShortName().equals("ROS") && currentDate().after(FORTRESS_REPUBLIC)) {
+            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
                 continue;
             }
 
             retVal.add(f.getShortName());
             /* Add factions which do not control any planets to the employer list */
-            factionHints.getContainedFactions(f, currentDate())
-            .forEach(cf -> retVal.add(cf.getShortName()));
+            factionHints.getContainedFactions(f, getCurrentDate())
+                    .forEach(cf -> retVal.add(cf.getShortName()));
         }
         //Add rebels and pirates
         retVal.add("REB");
@@ -185,7 +176,7 @@ public class RandomFactionGenerator {
             if (f.isClan() || FactionHints.isEmptyFaction(f)) {
                 continue;
             }
-            if (f.getShortName().equals("ROS") && currentDate().after(FORTRESS_REPUBLIC)) {
+            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
                 continue;
             }
 
@@ -193,11 +184,11 @@ public class RandomFactionGenerator {
             retVal.add(weight, f);
 
             /* Add factions which do not control any planets to the employer list */
-            for (Faction cfaction : factionHints.getContainedFactions(f, currentDate())) {
+            for (Faction cfaction : factionHints.getContainedFactions(f, getCurrentDate())) {
                 if (null != cfaction) {
                     if (!cfaction.isClan()) {
                         weight = (int) Math.floor((borderTracker.getBorders(f).getSystems().size()
-                                * factionHints.getAltLocationFraction(f, cfaction, currentDate())) + 0.5);
+                                * factionHints.getAltLocationFraction(f, cfaction, getCurrentDate())) + 0.5);
                         retVal.add(weight, f);
                     }
                 }
@@ -264,7 +255,7 @@ public class RandomFactionGenerator {
 
         Faction enemy = null;
         if (!borderTracker.getFactionsInRegion().contains(employer)) {
-            employer = factionHints.getContainedFactionHost(employer, currentDate());
+            employer = factionHints.getContainedFactionHost(employer, getCurrentDate());
         }
         if (null != employer) {
             WeightedMap<Faction> enemyMap = buildEnemyMap(employer);
@@ -295,25 +286,25 @@ public class RandomFactionGenerator {
             int totalCount = borderTracker.getBorderSystems(employer, enemy).size();
             double count = totalCount;
             // Split the border between main controlling faction and any contained factions.
-            for (Faction cFaction : factionHints.getContainedFactions(employer, currentDate())) {
+            for (Faction cFaction : factionHints.getContainedFactions(employer, getCurrentDate())) {
                 if ((null == cFaction)
                         || !factionHints.isContainedFactionOpponent(enemy, cFaction,
-                                employer, currentDate())) {
+                                employer, getCurrentDate())) {
                     continue;
                 }
-                if (factionHints.isNeutral(cFaction, enemy, currentDate())
-                        || factionHints.isNeutral(enemy, cFaction, currentDate())) {
+                if (factionHints.isNeutral(cFaction, enemy, getCurrentDate())
+                        || factionHints.isNeutral(enemy, cFaction, getCurrentDate())) {
                     continue;
                 }
                 double cfCount = totalCount;
-                if (factionHints.getAltLocationFraction(employer, cFaction, currentDate()) > 0.0) {
-                    cfCount = totalCount * factionHints.getAltLocationFraction(employer, cFaction, currentDate());
+                if (factionHints.getAltLocationFraction(employer, cFaction, getCurrentDate()) > 0.0) {
+                    cfCount = totalCount * factionHints.getAltLocationFraction(employer, cFaction, getCurrentDate());
                     count -= cfCount;
                 }
-                cfCount = adjustBorderWeight(cfCount, employer, enemy, currentDate());
+                cfCount = adjustBorderWeight(cfCount, employer, enemy, getCurrentDate());
                 enemyMap.add((int) Math.floor(cfCount + 0.5), cFaction);
             }
-            count = adjustBorderWeight(count, employer, enemy, currentDate());
+            count = adjustBorderWeight(count, employer, enemy, getCurrentDate());
             enemyMap.add((int) Math.floor(count + 0.5), enemy);
         }
         return enemyMap;
@@ -328,11 +319,11 @@ public class RandomFactionGenerator {
             if (!f.isClan() && !FactionHints.isEmptyFaction(f)) {
                 set.add(f.getShortName());
             }
-            if (f.getShortName().equals("ROS") && currentDate().after(FORTRESS_REPUBLIC)) {
+            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
                 continue;
             }
             /* Add factions which do not control any planets to the employer list */
-            for (Faction cfaction : factionHints.getContainedFactions(f, currentDate())) {
+            for (Faction cfaction : factionHints.getContainedFactions(f, getCurrentDate())) {
                 if (!cfaction.isClan()) {
                     set.add(cfaction.getShortName());
                 }
@@ -363,26 +354,25 @@ public class RandomFactionGenerator {
      */
     public List<String> getEnemyList(Faction employer) {
         Set<Faction> list = new HashSet<>();
-        Faction outer = factionHints.getContainedFactionHost(employer, currentDate());
+        Faction outer = factionHints.getContainedFactionHost(employer, getCurrentDate());
         for (Faction enemy : borderTracker.getFactionsInRegion()) {
             if (FactionHints.isEmptyFaction(enemy)) {
                 continue;
             }
-            if (enemy.equals(employer) && !factionHints.isAtWarWith(enemy,
-                    enemy, currentDate())) {
+            if (enemy.equals(employer) && !factionHints.isAtWarWith(enemy, enemy, getCurrentDate())) {
                 continue;
             }
-            if (factionHints.isAlliedWith(employer, enemy, currentDate())
+            if (factionHints.isAlliedWith(employer, enemy, getCurrentDate())
                     && !employer.isClan() && !enemy.isClan()) {
                 continue;
             }
-            if (factionHints.isNeutral(employer, enemy, currentDate())
-                    || factionHints.isNeutral(enemy, employer, currentDate())) {
+            if (factionHints.isNeutral(employer, enemy, getCurrentDate())
+                    || factionHints.isNeutral(enemy, employer, getCurrentDate())) {
                 continue;
             }
             Faction useBorder = employer;
             if (null != outer) {
-                if (!factionHints.isContainedFactionOpponent(outer, employer, enemy, currentDate())) {
+                if (!factionHints.isContainedFactionOpponent(outer, employer, enemy, getCurrentDate())) {
                     continue;
                 }
                 useBorder = outer;
@@ -390,9 +380,9 @@ public class RandomFactionGenerator {
 
             if (!borderTracker.getBorderSystems(useBorder, enemy).isEmpty()) {
                 list.add(enemy);
-                for (Faction cf : factionHints.getContainedFactions(enemy, currentDate())) {
+                for (Faction cf : factionHints.getContainedFactions(enemy, getCurrentDate())) {
                     if ((null != cf)
-                            && factionHints.isContainedFactionOpponent(enemy, cf, employer, currentDate())) {
+                            && factionHints.isContainedFactionOpponent(enemy, cf, employer, getCurrentDate())) {
                         list.add(cf);
                     }
                 }
@@ -411,12 +401,11 @@ public class RandomFactionGenerator {
      * @param date   The current campaign date
      * @return       An adjusted weight
      */
-    protected double adjustBorderWeight(double count, Faction f,
-            Faction enemy, Date date) {
-        final Date TUKKAYID = new Date(new GregorianCalendar(3052, Calendar.JUNE,20).getTimeInMillis());
+    protected double adjustBorderWeight(double count, Faction f, Faction enemy, LocalDate date) {
+        final LocalDate TUKKAYID = LocalDate.of(3052, Month.JUNE, 20);
 
-        if (factionHints.isNeutral(f, enemy, currentDate())
-                || factionHints.isNeutral(enemy, f, currentDate())) {
+        if (factionHints.isNeutral(f, enemy, getCurrentDate())
+                || factionHints.isNeutral(enemy, f, getCurrentDate())) {
             return 0;
         }
         if (!f.isClan() && factionHints.isAlliedWith(f, enemy, date)) {
@@ -424,11 +413,11 @@ public class RandomFactionGenerator {
         }
         if (f.isClan() && enemy.isClan() &&
                 (factionHints.isAlliedWith(f, enemy, date) ||
-                        (date.before(TUKKAYID) && (borderTracker.getCenterY() < 600)))) {
+                        (date.isBefore(TUKKAYID) && (borderTracker.getCenterY() < 600)))) {
             /* Treat invading Clans as allies in the Inner Sphere */
             count /= 4.0;
         }
-        if (factionHints.isAtWarWith(f, enemy, date) && (f != enemy)) {
+        if (factionHints.isAtWarWith(f, enemy, date) && !f.equals(enemy)) {
             count *= 2.0;
         }
         if (factionHints.isRivalOf(f, enemy, date)) {
@@ -513,12 +502,12 @@ public class RandomFactionGenerator {
         // (e.g. Nova Cat in the Draconis Combine, or Wolf-in-Exile in Lyran space
         if (!borderTracker.getFactionsInRegion().contains(attacker)
                 && !attacker.is(Faction.Tag.PIRATE)) {
-            attacker = factionHints.getContainedFactionHost(attacker, currentDate());
+            attacker = factionHints.getContainedFactionHost(attacker, getCurrentDate());
         }
         if (!borderTracker.getFactionsInRegion().contains(defender)
                 && !defender.is(Faction.Tag.PIRATE)
                 && !defender.is(Faction.Tag.REBEL)) {
-            defender = factionHints.getContainedFactionHost(defender, currentDate());
+            defender = factionHints.getContainedFactionHost(defender, getCurrentDate());
         }
         if ((null == attacker) || (null == defender)) {
             return Collections.emptyList();
@@ -544,15 +533,13 @@ public class RandomFactionGenerator {
          */
         if (planetSet.isEmpty()) {
             for (Faction f : borderTracker.getFactionsInRegion()) {
-                for (Faction cf : factionHints.getContainedFactions(f, currentDate())) {
+                for (Faction cf : factionHints.getContainedFactions(f, getCurrentDate())) {
                     if (cf.equals(attacker)
-                            && factionHints.isContainedFactionOpponent(f,
-                                    cf, defender, currentDate())) {
+                            && factionHints.isContainedFactionOpponent(f, cf, defender, getCurrentDate())) {
                         planetSet.addAll(borderTracker.getBorderSystems(f, defender));
                     }
                     if (cf.equals(defender)
-                            && factionHints.isContainedFactionOpponent(f,
-                                    cf, attacker, currentDate())) {
+                            && factionHints.isContainedFactionOpponent(f, cf, attacker, getCurrentDate())) {
                         planetSet.addAll(borderTracker.getBorderSystems(attacker, f));
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/universe/RangedPlanetSelector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RangedPlanetSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 MegaMek team
+ * Copyright (C) 2019 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,23 +10,21 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.universe;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.joda.time.DateTime;
-
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.Faction.Tag;
 
@@ -35,7 +33,6 @@ import mekhq.campaign.universe.Faction.Tag;
  * a planet from a range of planets and a {@link Faction}.
  */
 public class RangedPlanetSelector extends AbstractPlanetSelector {
-
     /**
      * The range around {@link Campaign#getCurrentSystem()} to search
      * for planets.
@@ -46,7 +43,7 @@ public class RangedPlanetSelector extends AbstractPlanetSelector {
      * The current date of the {@link Campaign} when the values were
      * cached.
      */
-    private DateTime cachedDate;
+    private LocalDate cachedDate;
 
     /**
      * The current {@link PlanetarySystem} of the {@link Campaign} when
@@ -56,7 +53,7 @@ public class RangedPlanetSelector extends AbstractPlanetSelector {
 
     /**
      * This map stores cached weights for a planet keyed by faction.
-     * Each weight should be cummulative. That is, if two planets have
+     * Each weight should be cumulative. That is, if two planets have
      * equal weights, you could express this with weights of 1.0 and 2.0
      * or 5.0 and 10.0. This way, when selecting a planet at random using
      * the weights you can create a random double between 0.0 and the largest
@@ -152,10 +149,10 @@ public class RangedPlanetSelector extends AbstractPlanetSelector {
 
     @Override
     public Planet selectPlanet(Campaign campaign, Faction faction) {
-        if (cachedPlanets == null
-            || !cachedPlanets.containsKey(faction)
-            || !cachedSystem.equals(campaign.getCurrentSystem())
-            || Utilities.getDateTimeDay(campaign.getDate()).isAfter(cachedDate)) {
+        if ((cachedPlanets == null)
+                || !cachedPlanets.containsKey(faction)
+                || !cachedSystem.equals(campaign.getCurrentSystem())
+                || campaign.getLocalDate().isAfter(cachedDate)) {
             createLookupMap(campaign, faction);
         }
 
@@ -176,7 +173,7 @@ public class RangedPlanetSelector extends AbstractPlanetSelector {
     }
 
     private void createLookupMap(Campaign campaign, Faction faction) {
-        DateTime now = Utilities.getDateTimeDay(campaign.getDate());
+        LocalDate now = campaign.getLocalDate();
 
         PlanetarySystem currentSystem = campaign.getCurrentSystem();
 
@@ -190,15 +187,15 @@ public class RangedPlanetSelector extends AbstractPlanetSelector {
                 if (!isExtraRandom) {
                     Planet planet = system.getPrimaryPlanet();
                     Long pop = planet.getPopulation(now);
-                    if (pop != null && (long)pop > 0) {
-                        total += 100.0 * Math.log10((long)pop) / (1 + distance * distanceScale);
+                    if (pop != null && pop > 0) {
+                        total += 100.0 * Math.log10(pop) / (1 + distance * distanceScale);
                         planets.put(total, planet);
                     }
                 } else {
                     for (Planet planet : system.getPlanets()) {
                         Long pop = planet.getPopulation(now);
-                        if (pop != null && (long)pop > 0) {
-                            total += 100.0 * Math.log10((long)pop) / (1 + distance * distanceScale);
+                        if (pop != null && pop > 0) {
+                            total += 100.0 * Math.log10(pop) / (1 + distance * distanceScale);
                             planets.put(total, planet);
                         }
                     }

--- a/MekHQ/src/mekhq/campaign/universe/Systems.java
+++ b/MekHQ/src/mekhq/campaign/universe/Systems.java
@@ -89,16 +89,16 @@ public class Systems {
     private static Marshaller planetMarshaller;
     private static Unmarshaller planetUnmarshaller;
     static {
-    	try {
-    		//creating the JAXB context
-    		JAXBContext jContext = JAXBContext.newInstance(Planet.class);
-    		planetMarshaller = jContext.createMarshaller();
-    		planetMarshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
-    		planetMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-	        planetUnmarshaller = jContext.createUnmarshaller();
-	    } catch (Exception e) {
-    	    MekHQ.getLogger().error(Systems.class, "Systems", e);
-    	}
+        try {
+            //creating the JAXB context
+            JAXBContext jContext = JAXBContext.newInstance(Planet.class);
+            planetMarshaller = jContext.createMarshaller();
+            planetMarshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+            planetMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            planetUnmarshaller = jContext.createUnmarshaller();
+        } catch (Exception e) {
+            MekHQ.getLogger().error(Systems.class, "Systems", e);
+        }
     }
 
     public static Systems getInstance() {
@@ -154,7 +154,7 @@ public class Systems {
     }
 
     public List<PlanetarySystem> getNearbySystems(final double centerX, final double centerY, int distance) {
-    	 List<PlanetarySystem> neighbors = new ArrayList<>();
+         List<PlanetarySystem> neighbors = new ArrayList<>();
 
          visitNearbySystems(centerX, centerY, distance, neighbors::add);
 
@@ -187,10 +187,10 @@ public class Systems {
         //remove dead planets
         Iterator<PlanetarySystem> iter = shoppingSystems.iterator();
         while (iter.hasNext()) {
-        	PlanetarySystem s = iter.next();
-        	if (null == s.getPrimaryPlanet() || s.getPrimaryPlanet().isEmpty(when)) {
-        		iter.remove();
-        	}
+            PlanetarySystem s = iter.next();
+            if (null == s.getPrimaryPlanet() || s.getPrimaryPlanet().isEmpty(when)) {
+                iter.remove();
+            }
         }
 
         shoppingSystems.sort((p1, p2) -> {
@@ -368,7 +368,7 @@ public class Systems {
                 }
                 //make sure the primary slot is not larger than the number of planets
                 if (system.getPrimaryPlanetPosition() > system.getPlanets().size()) {
-                	MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
+                    MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                             String.format("System \"%s\" has a primary slot greater than the number of planets", system.getId())); //$NON-NLS-1$
                     toRemove.add(system);
                     continue;
@@ -570,14 +570,14 @@ public class Systems {
      * @return
      */
     public boolean updatePlanetaryEvents(String id, Collection<Planet.PlanetaryEvent> events, boolean replace) {
-    	//assume the primary planet
-    	PlanetarySystem system = getSystemById(id);
+        //assume the primary planet
+        PlanetarySystem system = getSystemById(id);
         if (null == system) {
             return false;
         }
         int pos = system.getPrimaryPlanetPosition();
         if (pos == 0) {
-        	return false;
+            return false;
         }
         return(updatePlanetaryEvents(id, events, replace, pos));
     }
@@ -593,7 +593,7 @@ public class Systems {
                 if (null != event.date) {
                     Planet.PlanetaryEvent planetaryEvent = system.getOrCreateEvent(event.date, position);
                     if (null == planetaryEvent) {
-                    	continue;
+                        continue;
                     }
                     if (replace) {
                         planetaryEvent.replaceDataFrom(event);
@@ -623,12 +623,12 @@ public class Systems {
                 if (null != event.date) {
                     PlanetarySystem.PlanetarySystemEvent systemEvent = system.getOrCreateEvent(event.date);
                     if (null == systemEvent) {
-                    	continue;
+                        continue;
                     }
                     if (replace) {
-                    	systemEvent.replaceDataFrom(event);
+                        systemEvent.replaceDataFrom(event);
                     } else {
-                    	systemEvent.copyDataFrom(event);
+                        systemEvent.copyDataFrom(event);
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/universe/Systems.java
+++ b/MekHQ/src/mekhq/campaign/universe/Systems.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 MegaMek team
+ * Copyright (C) 2011-2016 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.universe;
 
@@ -22,12 +22,11 @@ import java.io.FileInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.Writer;
 import java.text.ParseException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,7 +48,6 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
-import org.joda.time.DateTime;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 
@@ -83,7 +81,7 @@ public class Systems {
             unmarshaller = context.createUnmarshaller();
             // For debugging only!
             // unmarshaller.setEventHandler(new javax.xml.bind.helpers.DefaultValidationEventHandler());
-        } catch(JAXBException e) {
+        } catch (JAXBException e) {
             MekHQ.getLogger().error(Systems.class, "<init>", e); //$NON-NLS-1$
         }
     }
@@ -91,30 +89,25 @@ public class Systems {
     private static Marshaller planetMarshaller;
     private static Unmarshaller planetUnmarshaller;
     static {
-    	try{
+    	try {
     		//creating the JAXB context
     		JAXBContext jContext = JAXBContext.newInstance(Planet.class);
     		planetMarshaller = jContext.createMarshaller();
     		planetMarshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
     		planetMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
 	        planetUnmarshaller = jContext.createUnmarshaller();
-	    } catch(Exception e) {
+	    } catch (Exception e) {
     	    MekHQ.getLogger().error(Systems.class, "Systems", e);
     	}
     }
 
     public static Systems getInstance() {
-        if(systems == null) {
+        if (systems == null) {
             systems = new Systems();
         }
-        if(!systems.initialized && !systems.initializing) {
+        if (!systems.initialized && !systems.initializing) {
             systems.initializing = true;
-            systems.loader = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    systems.initialize();
-                }
-            }, "Planet Loader");
+            systems.loader = new Thread(() -> systems.initialize(), "Planet Loader");
             systems.loader.setPriority(Thread.NORM_PRIORITY - 1);
             systems.loader.start();
         }
@@ -128,7 +121,7 @@ public class Systems {
 
     // HPG Network cache (to not recalculate all the damn time)
     private Collection<Systems.HPGLink> hpgNetworkCache = null;
-    private DateTime hpgNetworkCacheDate = null;
+    private LocalDate hpgNetworkCacheDate = null;
 
     private Thread loader;
     private boolean initialized = false;
@@ -137,22 +130,22 @@ public class Systems {
     private Systems() {}
 
     private Set<PlanetarySystem> getSystemGrid(int x, int y) {
-        if( !systemGrid.containsKey(x) ) {
+        if (!systemGrid.containsKey(x)) {
             return null;
         }
         return systemGrid.get(x).get(y);
     }
 
     /** Return the planet by given name at a given time point */
-    public PlanetarySystem getSystemByName(String name, DateTime when) {
-        if(null == name) {
+    public PlanetarySystem getSystemByName(String name, LocalDate when) {
+        if (null == name) {
             return null;
         }
         name = name.toLowerCase(Locale.ROOT);
-        for(PlanetarySystem system : systemList.values()) {
-            if(null != system) {
+        for (PlanetarySystem system : systemList.values()) {
+            if (null != system) {
                 String systemName = system.getName(when);
-                if((null != systemName) && systemName.toLowerCase(Locale.ROOT).equals(name)) {
+                if ((null != systemName) && systemName.toLowerCase(Locale.ROOT).equals(name)) {
                     return system;
                 }
             }
@@ -165,12 +158,7 @@ public class Systems {
 
          visitNearbySystems(centerX, centerY, distance, neighbors::add);
 
-         Collections.sort(neighbors, new Comparator<PlanetarySystem>() {
-             @Override
-             public int compare(PlanetarySystem o1, PlanetarySystem o2) {
-                 return Double.compare(o1.getDistanceTo(centerX, centerY), o2.getDistanceTo(centerX, centerY));
-             }
-         });
+         neighbors.sort(Comparator.comparingDouble(o -> o.getDistanceTo(centerX, centerY)));
          return neighbors;
     }
 
@@ -193,8 +181,7 @@ public class Systems {
      * @param jumps - number of jumps out to look as an integer
      * @return a list of planets where you can go shopping
      */
-    public List<PlanetarySystem> getShoppingSystems(final PlanetarySystem system, int jumps, DateTime when) {
-
+    public List<PlanetarySystem> getShoppingSystems(final PlanetarySystem system, int jumps, LocalDate when) {
         List<PlanetarySystem> shoppingSystems = getNearbySystems(system, jumps*30);
 
         //remove dead planets
@@ -206,36 +193,31 @@ public class Systems {
         	}
         }
 
-        Collections.sort(shoppingSystems, new Comparator<PlanetarySystem>() {
-            @Override
-            public int compare(final PlanetarySystem p1, final PlanetarySystem p2) {
+        shoppingSystems.sort((p1, p2) -> {
+            //sort first on number of jumps required
+            int jump1 = (int) Math.ceil(p1.getDistanceTo(system) / 30.0);
+            int jump2 = (int) Math.ceil(p2.getDistanceTo(system) / 30.0);
+            int sComp = Integer.compare(jump1, jump2);
 
-                //sort first on number of jumps required
-                int jump1 = (int)Math.ceil(p1.getDistanceTo(system)/30.0);
-                int jump2 = (int)Math.ceil(p2.getDistanceTo(system)/30.0);
-                int sComp = Integer.compare(jump1, jump2);
-
-                if (sComp != 0) {
-                   return sComp;
-                }
-
-                //if number of jumps the same then sort on in system transit time
-                return Double.compare(p1.getTimeToJumpPoint(1.0), p2.getTimeToJumpPoint(1.0));
-
+            if (sComp != 0) {
+                return sComp;
             }
+
+            //if number of jumps the same then sort on in system transit time
+            return Double.compare(p1.getTimeToJumpPoint(1.0), p2.getTimeToJumpPoint(1.0));
         });
 
         return shoppingSystems;
     }
 
-    public List<NewsItem> getPlanetaryNews(DateTime when) {
+    public List<NewsItem> getPlanetaryNews(LocalDate when) {
         List<NewsItem> news = new ArrayList<>();
-        for(PlanetarySystem system : systemList.values()) {
-            if(null != system) {
+        for (PlanetarySystem system : systemList.values()) {
+            if (null != system) {
                 Planet.PlanetaryEvent event;
-                for(Planet p : system.getPlanets()) {
+                for (Planet p : system.getPlanets()) {
                     event = p.getEvent(when);
-                    if((null != event) && (null != event.message)) {
+                    if ((null != event) && (null != event.message)) {
                         NewsItem item = new NewsItem();
                         item.setHeadline(event.message);
                         item.setDate(event.date);
@@ -253,23 +235,21 @@ public class Systems {
         hpgNetworkCacheDate = null;
     }
 
-    public Collection<Systems.HPGLink> getHPGNetwork(DateTime when) {
-        if((null != when) && when.equals(hpgNetworkCacheDate)) {
+    public Collection<Systems.HPGLink> getHPGNetwork(LocalDate when) {
+        if ((null != when) && when.equals(hpgNetworkCacheDate)) {
             return hpgNetworkCache;
         }
 
         Set<HPGLink> result = new HashSet<>();
-        for(PlanetarySystem system : systemList.values()) {
+        for (PlanetarySystem system : systemList.values()) {
             Integer hpg = system.getHPG(when);
-            if((null != hpg) && (hpg.intValue() == EquipmentType.RATING_A)) {
+            if ((null != hpg) && (hpg == EquipmentType.RATING_A)) {
                 Collection<PlanetarySystem> neighbors = getNearbySystems(system, 50);
-                for(PlanetarySystem neighbor : neighbors) {
+                for (PlanetarySystem neighbor : neighbors) {
                     hpg = neighbor.getHPG(when);
-                    if(null != hpg) {
-                        HPGLink link = new HPGLink(system, neighbor, hpg.intValue());
-                        if(!result.contains(link)) {
-                            result.add(link);
-                        }
+                    if (null != hpg) {
+                        HPGLink link = new HPGLink(system, neighbor, hpg);
+                        result.add(link);
                     }
                 }
             }
@@ -301,7 +281,7 @@ public class Systems {
     private void updateSystems(FileInputStream source) {
         final String METHOD_NAME = "updateSystems(FileInputStream)"; //$NON-NLS-1$
         // JAXB unmarshaller closes the stream it doesn't own. Bad JAXB. BAD.
-        try(InputStream is = new FilterInputStream(source) {
+        try (InputStream is = new FilterInputStream(source) {
                 @Override
                 public void close() {  }
             }) {
@@ -312,9 +292,9 @@ public class Systems {
                     MekHqXmlUtil.createSafeXmlSource(is), LocalSystemList.class).getValue();
 
             // Run through the list again, this time creating and updating systems as we go
-            for( PlanetarySystem system : systems.list ) {
+            for (PlanetarySystem system : systems.list) {
                 PlanetarySystem oldSystem = systemList.get(system.getId());
-                if( null == oldSystem ) {
+                if (null == oldSystem) {
                     systemList.put(system.getId(), system);
                 } else {
                     // Update with new data
@@ -324,14 +304,14 @@ public class Systems {
             }
 
             // Process system deletions
-            for( String systemId : systems.toDelete ) {
-                if( null != systemId ) {
+            for (String systemId : systems.toDelete) {
+                if (null != systemId) {
                     systemList.remove(systemId);
                 }
             }
         } catch (JAXBException e) {
             MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
-        } catch(IOException e) {
+        } catch (IOException e) {
             MekHQ.getLogger().error(getClass(), METHOD_NAME, e);
         }
     }
@@ -348,28 +328,28 @@ public class Systems {
         long currentTime = System.currentTimeMillis();
         synchronized (LOADING_LOCK) {
             // Step 1: Initialize variables.
-            if( null == systemList ) {
+            if (null == systemList) {
                 systemList = new ConcurrentHashMap<>();
             }
             systemList.clear();
-            if( null == systemGrid ) {
+            if (null == systemGrid) {
                 systemGrid = new HashMap<>();
             }
             // Be nice to the garbage collector
-            for( Map.Entry<Integer, Map<Integer, Set<PlanetarySystem>>> systemGridColumn : systemGrid.entrySet() ) {
-                for( Map.Entry<Integer, Set<PlanetarySystem>> systemGridElement : systemGridColumn.getValue().entrySet() ) {
-                    if( null != systemGridElement.getValue() ) {
+            for (Map.Entry<Integer, Map<Integer, Set<PlanetarySystem>>> systemGridColumn : systemGrid.entrySet()) {
+                for (Map.Entry<Integer, Set<PlanetarySystem>> systemGridElement : systemGridColumn.getValue().entrySet()) {
+                    if (null != systemGridElement.getValue()) {
                         systemGridElement.getValue().clear();
                     }
                 }
-                if( null != systemGridColumn.getValue() ) {
+                if (null != systemGridColumn.getValue()) {
                     systemGridColumn.getValue().clear();
                 }
             }
             systemGrid.clear();
 
             // Step 2: Read the default file
-            try(FileInputStream fis = new FileInputStream(defaultFilePath)) { //$NON-NLS-1$
+            try (FileInputStream fis = new FileInputStream(defaultFilePath)) { //$NON-NLS-1$
                 updateSystems(fis);
             } catch (Exception ex) {
                 MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
@@ -380,32 +360,26 @@ public class Systems {
 
             List<PlanetarySystem> toRemove = new ArrayList<>();
             for (PlanetarySystem system : systemList.values()) {
-                if((null == system.getX()) || (null == system.getY())) {
+                if ((null == system.getX()) || (null == system.getY())) {
                     MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                             String.format("System \"%s\" is missing coordinates", system.getId())); //$NON-NLS-1$
                     toRemove.add(system);
                     continue;
                 }
                 //make sure the primary slot is not larger than the number of planets
-                if(system.getPrimaryPlanetPosition() > system.getPlanets().size()) {
+                if (system.getPrimaryPlanetPosition() > system.getPlanets().size()) {
                 	MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
                             String.format("System \"%s\" has a primary slot greater than the number of planets", system.getId())); //$NON-NLS-1$
                     toRemove.add(system);
                     continue;
                 }
-                int x = (int)(system.getX()/30.0);
-                int y = (int)(system.getY()/30.0);
-                if (systemGrid.get(x) == null) {
-                    systemGrid.put(x, new HashMap<Integer, Set<PlanetarySystem>>());
-                }
-                if (systemGrid.get(x).get(y) == null) {
-                    systemGrid.get(x).put(y, new HashSet<PlanetarySystem>());
-                }
-                if( !systemGrid.get(x).get(y).contains(system) ) {
-                    systemGrid.get(x).get(y).add(system);
-                }
+                int x = (int) (system.getX() / 30.0);
+                int y = (int) (system.getY() / 30.0);
+                systemGrid.computeIfAbsent(x, k -> new HashMap<>());
+                systemGrid.get(x).computeIfAbsent(y, k -> new HashSet<>());
+                systemGrid.get(x).get(y).add(system);
             }
-            for(PlanetarySystem system : toRemove) {
+            for (PlanetarySystem system : toRemove) {
                 systemList.remove(system.getId());
             }
             done();
@@ -415,14 +389,14 @@ public class Systems {
                         "Loaded a total of %d systems in %.3fs.", //$NON-NLS-1$
                         systemList.size(), (System.currentTimeMillis() - currentTime) / 1000.0));
         // Planetary sanity check time!
-        for(PlanetarySystem system : systemList.values()) {
+        for (PlanetarySystem system : systemList.values()) {
             List<PlanetarySystem> veryCloseSystems = getNearbySystems(system, 1);
-            if(veryCloseSystems.size() > 1) {
-                for(PlanetarySystem closeSystem : veryCloseSystems) {
-                    if(!system.getId().equals(closeSystem.getId())) {
+            if (veryCloseSystems.size() > 1) {
+                for (PlanetarySystem closeSystem : veryCloseSystems) {
+                    if (!system.getId().equals(closeSystem.getId())) {
                         MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.WARNING,
                                 String.format(Locale.ROOT,
-                                        "Extremly close systems detected. Data error? %s <-> %s: %.3f ly", //$NON-NLS-1$
+                                        "Extremely close systems detected. Data error? %s <-> %s: %.3f ly", //$NON-NLS-1$
                                         system.getId(), closeSystem.getId(), system.getDistanceTo(closeSystem)));
                     }
                 }
@@ -440,14 +414,14 @@ public class Systems {
 
         @SuppressWarnings("unused")
         private void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
-            toDelete = new ArrayList<String>();
-            if( null == list ) {
-                list = new ArrayList<PlanetarySystem>();
+            toDelete = new ArrayList<>();
+            if (null == list) {
+                list = new ArrayList<>();
             } else {
                 // Fill in the "toDelete" list
-                List<PlanetarySystem> filteredList = new ArrayList<PlanetarySystem>(list.size());
-                for( PlanetarySystem system : list ) {
-                    if( null != system.delete && system.delete && null != system.getId() ) {
+                List<PlanetarySystem> filteredList = new ArrayList<>(list.size());
+                for (PlanetarySystem system : list) {
+                    if ((null != system.delete) && system.delete && (null != system.getId())) {
                         toDelete.add(system.getId());
                     } else {
                         filteredList.add(system);
@@ -478,10 +452,10 @@ public class Systems {
 
         @Override
         public boolean equals(Object obj) {
-            if(this == obj) {
+            if (this == obj) {
                 return true;
             }
-            if((null == obj) || (getClass() != obj.getClass())) {
+            if ((null == obj) || (getClass() != obj.getClass())) {
                 return false;
             }
             final HPGLink other = (HPGLink) obj;
@@ -491,9 +465,9 @@ public class Systems {
     }
 
     public void visitNearbySystems(final double centerX, final double centerY, final int distance, Consumer<PlanetarySystem> visitor) {
-        int gridRadius = (int)Math.ceil(distance / 30.0);
-        int gridX = (int)(centerX / 30.0);
-        int gridY = (int)(centerY / 30.0);
+        int gridRadius = (int) Math.ceil(distance / 30.0);
+        int gridX = (int) (centerX / 30.0);
+        int gridY = (int) (centerY / 30.0);
         for (int x = gridX - gridRadius; x <= gridX + gridRadius; x++) {
             for (int y = gridY - gridRadius; y <= gridY + gridRadius; y++) {
                 Set<PlanetarySystem> grid = getSystemGrid(x, y);
@@ -571,12 +545,12 @@ public class Systems {
     public static void reload(boolean waitForFinish) {
         systems = null;
         getInstance();
-        if(waitForFinish) {
+        if (waitForFinish) {
             try {
-                while(!systems.isInitialized()) {
+                while (!systems.isInitialized()) {
                     Thread.sleep(10);
                 }
-            } catch(InterruptedException iex) {
+            } catch (InterruptedException iex) {
                 MekHQ.getLogger().error(Systems.class, "reload(boolean)", iex); //$NON-NLS-1$
             }
         }
@@ -598,11 +572,11 @@ public class Systems {
     public boolean updatePlanetaryEvents(String id, Collection<Planet.PlanetaryEvent> events, boolean replace) {
     	//assume the primary planet
     	PlanetarySystem system = getSystemById(id);
-        if(null == system) {
+        if (null == system) {
             return false;
         }
         int pos = system.getPrimaryPlanetPosition();
-        if(pos == 0) {
+        if (pos == 0) {
         	return false;
         }
         return(updatePlanetaryEvents(id, events, replace, pos));
@@ -611,17 +585,17 @@ public class Systems {
     /** @return <code>true</code> if the planet was known and got updated, <code>false</code> otherwise */
     public boolean updatePlanetaryEvents(String id, Collection<Planet.PlanetaryEvent> events, boolean replace, int position) {
         PlanetarySystem system = getSystemById(id);
-        if(null == system || position<1) {
+        if ((null == system) || (position < 1)) {
             return false;
         }
-        if(null != events) {
-            for(Planet.PlanetaryEvent event : events) {
-                if(null != event.date) {
+        if (null != events) {
+            for (Planet.PlanetaryEvent event : events) {
+                if (null != event.date) {
                     Planet.PlanetaryEvent planetaryEvent = system.getOrCreateEvent(event.date, position);
-                    if(null == planetaryEvent) {
+                    if (null == planetaryEvent) {
                     	continue;
                     }
-                    if(replace) {
+                    if (replace) {
                         planetaryEvent.replaceDataFrom(event);
                     } else {
                         planetaryEvent.copyDataFrom(event);
@@ -641,17 +615,17 @@ public class Systems {
      */
     public boolean updatePlanetarySystemEvents(String id, Collection<PlanetarySystem.PlanetarySystemEvent> events, boolean replace) {
         PlanetarySystem system = getSystemById(id);
-        if(null == system) {
+        if (null == system) {
             return false;
         }
-        if(null != events) {
-            for(PlanetarySystem.PlanetarySystemEvent event : events) {
-                if(null != event.date) {
+        if (null != events) {
+            for (PlanetarySystem.PlanetarySystemEvent event : events) {
+                if (null != event.date) {
                     PlanetarySystem.PlanetarySystemEvent systemEvent = system.getOrCreateEvent(event.date);
-                    if(null == systemEvent) {
+                    if (null == systemEvent) {
                     	continue;
                     }
-                    if(replace) {
+                    if (replace) {
                     	systemEvent.replaceDataFrom(event);
                     } else {
                     	systemEvent.copyDataFrom(event);
@@ -661,5 +635,4 @@ public class Systems {
         }
         return true;
     }
-
 }

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -12,11 +12,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui;
 
@@ -1015,7 +1015,7 @@ public class CampaignGUI extends JPanel {
     private void initTopButtons() {
         GridBagConstraints gridBagConstraints;
 
-        lblLocation = new JLabel(getCampaign().getLocation().getReport(getCampaign().getCalendar().getTime())); // NOI18N
+        lblLocation = new JLabel(getCampaign().getLocation().getReport(getCampaign().getLocalDate())); // NOI18N
 
         btnPanel = new JPanel(new GridBagLayout());
 
@@ -1171,7 +1171,7 @@ public class CampaignGUI extends JPanel {
     public void showNews(int id) {
         NewsItem news = getCampaign().getNews().getNewsItem(id);
         if (null != news) {
-            NewsReportDialog nrd = new NewsReportDialog(frame, news);
+            NewsReportDialog nrd = new NewsReportDialog(frame, news, getCampaign());
             nrd.setVisible(true);
         }
     }
@@ -2636,8 +2636,7 @@ public class CampaignGUI extends JPanel {
     }
 
     public void refreshLocation() {
-        lblLocation.setText(getCampaign().getLocation().getReport(
-                getCampaign().getCalendar().getTime()));
+        lblLocation.setText(getCampaign().getLocation().getReport(getCampaign().getLocalDate()));
     }
 
     protected MekHQ getApplication() {

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 MegaMek team
+ * Copyright (C) 2011-2016 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui;
 
@@ -47,6 +47,7 @@ import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -78,8 +79,6 @@ import javax.swing.Timer;
 import javax.vecmath.Vector2d;
 
 import mekhq.MekHQ;
-import org.joda.time.DateTime;
-
 import megamek.common.EquipmentType;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -145,7 +144,7 @@ public class InterstellarMapPanel extends JPanel {
     private transient double minY;
     private transient double maxX;
     private transient double maxY;
-    private transient DateTime now;
+    private transient LocalDate now;
 
     public InterstellarMapPanel(Campaign c, CampaignGUI view) {
         campaign = c;
@@ -164,10 +163,10 @@ public class InterstellarMapPanel extends JPanel {
                 int maxHeight = optionPanel.getHeight();
                 int minWidth = 30;
                 int minHeight = 30;
-                if(optionPanelHidden && ((width !=  minWidth) || (height != minHeight))) {
+                if (optionPanelHidden && ((width !=  minWidth) || (height != minHeight))) {
                     width = Math.max(width - maxWidth / 5, minWidth);
                     height = Math.max(height - maxHeight / 5, minHeight);
-                } else if(!optionPanelHidden && ((width != maxWidth) || (height != maxHeight))) {
+                } else if (!optionPanelHidden && ((width != maxWidth) || (height != maxHeight))) {
                     width = Math.min(width + maxWidth / 5, maxWidth);
                     height = Math.min(height + maxHeight / 5, maxHeight);
                 } else {
@@ -190,23 +189,23 @@ public class InterstellarMapPanel extends JPanel {
             public void keyPressed(KeyEvent e) {
                 int keyCode = e.getKeyCode();
                 boolean moved = false;
-                if(keyCode == KeyEvent.VK_LEFT) {
+                if (keyCode == KeyEvent.VK_LEFT) {
                     conf.centerY -= 1.0;
                     moved = true;
                 }
-                if(keyCode == KeyEvent.VK_RIGHT) {
+                if (keyCode == KeyEvent.VK_RIGHT) {
                     conf.centerY += 1.0;
                     moved = true;
                 }
-                if(keyCode == KeyEvent.VK_DOWN) {
+                if (keyCode == KeyEvent.VK_DOWN) {
                     conf.centerX += 1.0;
                     moved = true;
                 }
-                if(keyCode == KeyEvent.VK_UP) {
+                if (keyCode == KeyEvent.VK_UP) {
                     conf.centerX -= 1.0;
                     moved = true;
                 }
-                if(moved) {
+                if (moved) {
                     repaint();
                 }
             }
@@ -241,64 +240,40 @@ public class InterstellarMapPanel extends JPanel {
                     JPopupMenu popup = new JPopupMenu();
                     JMenuItem item;
                     item = new JMenuItem("Zoom In");
-                    item.addActionListener(new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent ae) {
-                            zoom(1.5, lastMousePos);
-                        }
-                    });
+                    item.addActionListener(ae -> zoom(1.5, lastMousePos));
                     popup.add(item);
                     item = new JMenuItem("Zoom Out");
-                    item.addActionListener(new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent ae) {
-                            zoom(0.5, lastMousePos);
-                        }
-                    });
+                    item.addActionListener(ae -> zoom(0.5, lastMousePos));
                     popup.add(item);
                     JMenu centerM = new JMenu("Center Map");
                     item = new JMenuItem("On Selected Planet");
                     item.setEnabled(selectedSystem != null);
                     if (selectedSystem != null) {// only add if there is a planet to center on
-                        item.addActionListener(new ActionListener() {
-                            @Override
-                            public void actionPerformed(ActionEvent ae) {
-                                center(selectedSystem);
-                            }
-                        });
+                        item.addActionListener(ae -> center(selectedSystem));
                     }
                     centerM.add(item);
                     item = new JMenuItem("On Current Location");
                     item.setEnabled(campaign.getCurrentSystem() != null);
                     if (campaign.getCurrentSystem() != null) {// only add if there is a planet to center on
-                        item.addActionListener(new ActionListener() {
-                            @Override
-                            public void actionPerformed(ActionEvent ae) {
-                                selectedSystem = campaign.getCurrentSystem();
-                                center(campaign.getCurrentSystem());
-                            }
+                        item.addActionListener(ae -> {
+                            selectedSystem = campaign.getCurrentSystem();
+                            center(campaign.getCurrentSystem());
                         });
                     }
                     centerM.add(item);
                     item = new JMenuItem("On Terra");
-                    item.addActionListener(new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent ae) {
-                            conf.centerX = 0.0;
-                            conf.centerY = 0.0;
-                            repaint();
-                        }
+                    item.addActionListener(ae -> {
+                        conf.centerX = 0.0;
+                        conf.centerY = 0.0;
+                        repaint();
                     });
                     centerM.add(item);
                     popup.add(centerM);
                     item = new JMenuItem("Cancel Current Trip");
                     item.setEnabled(null != campaign.getLocation().getJumpPath());
-                    item.addActionListener(new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent ae) {
-                            campaign.getLocation().setJumpPath(null);
-                            repaint();
-                        }
+                    item.addActionListener(ae -> {
+                        campaign.getLocation().setJumpPath(null);
+                        repaint();
                     });
                     popup.add(item);
                     item = new JMenuItem("Save Map (64 Mpx at current zoom level) ...");
@@ -336,13 +311,10 @@ public class InterstellarMapPanel extends JPanel {
                     item = new JMenuItem("Move to selected planet");
                     item.setEnabled(selectedSystem != null  && campaign.isGM());
                     if (selectedSystem != null) {// only add if there is a planet to center on
-                        item.addActionListener(new ActionListener() {
-                            @Override
-                            public void actionPerformed(ActionEvent ae) {
-                                campaign.moveToPlanetarySystem(selectedSystem);
-                                jumpPath = new JumpPath();
-                                center(selectedSystem);
-                            }
+                        item.addActionListener(ae -> {
+                            campaign.moveToPlanetarySystem(selectedSystem);
+                            jumpPath = new JumpPath();
+                            center(selectedSystem);
                         });
                     }
                     menuGM.add(item);
@@ -364,13 +336,10 @@ public class InterstellarMapPanel extends JPanel {
 
                     item = new JMenuItem("Recharge Jumpdrive");
                     item.setEnabled(campaign.getLocation().isRecharging(campaign) && campaign.isGM());
-                    item.addActionListener(new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent ae) {
-                            campaign.getLocation().setRecharged(campaign);
-                            campaign.addReport("GM: Jumpship drives fully charged");
-                            hqview.refreshLocation();
-                        }
+                    item.addActionListener(ae -> {
+                        campaign.getLocation().setRecharged(campaign);
+                        campaign.addReport("GM: Jumpship drives fully charged");
+                        hqview.refreshLocation();
                     });
                     menuGM.add(item);
 
@@ -383,9 +352,9 @@ public class InterstellarMapPanel extends JPanel {
             public void mouseClicked(MouseEvent e) {
                 if (e.getButton() == MouseEvent.BUTTON1) {
                     if (e.getClickCount() >= 2) {
-                      //center and zoom
+                        //center and zoom
                         changeSelectedSystem(nearestNeighbour(scr2mapX(e.getX()), scr2mapY(e.getY())));
-                        if(conf.scale < 4.0) {
+                        if (conf.scale < 4.0) {
                             conf.scale = 4.0;
                         }
                         center(selectedSystem);
@@ -393,33 +362,31 @@ public class InterstellarMapPanel extends JPanel {
                         hqview.getMapTab().switchPlanetaryMap(selectedSystem);
                     } else {
                         PlanetarySystem target = nearestNeighbour(scr2mapX(e.getX()), scr2mapY(e.getY()));
-                        if(null == target) {
+                        if (null == target) {
                             return;
                         }
-                        if(e.isAltDown()) {
+                        if (e.isAltDown()) {
                             //calculate a new jump path from the current location
                             jumpPath = campaign.calculateJumpPath(campaign.getCurrentSystem(), target);
                             selectedSystem = target;
                             repaint();
                             notifyListeners();
                             return;
-
-                        }
-                        else if(e.isShiftDown()) {
+                        } else if (e.isShiftDown()) {
                             //add to the existing jump path
                             PlanetarySystem lastSystem = jumpPath.getLastSystem();
-                            if(null == lastSystem) {
+                            if (null == lastSystem) {
                                 lastSystem = campaign.getCurrentSystem();
                             }
                             JumpPath addPath = campaign.calculateJumpPath(lastSystem, target);
-                              if(!jumpPath.isEmpty()) {
-                                  addPath.removeFirstSystem();
-                              }
+                            if (!jumpPath.isEmpty()) {
+                                addPath.removeFirstSystem();
+                            }
                             jumpPath.addSystems(addPath.getSystems());
                             selectedSystem = target;
-                              repaint();
-                              notifyListeners();
-                              return;
+                            repaint();
+                            notifyListeners();
+                            return;
                         }
                         changeSelectedSystem(target);
                         repaint();
@@ -455,7 +422,7 @@ public class InterstellarMapPanel extends JPanel {
         });
 
         addMouseWheelListener(new MouseAdapter() {
-             @Override
+            @Override
             public void mouseWheelMoved(MouseWheelEvent e) {
                  zoom(Math.pow(1.5,-1 * e.getWheelRotation()), e.getPoint());
              }
@@ -484,11 +451,11 @@ public class InterstellarMapPanel extends JPanel {
                 minY = scr2mapY(getHeight() + size * 2.0);
                 maxX = scr2mapX(getWidth() + size * 2.0);
                 maxY = scr2mapY(- size * 2.0);
-                now = Utilities.getDateTimeDay(campaign.getCalendar());
+                now = campaign.getLocalDate();
 
                 Arc2D.Double arc = new Arc2D.Double();
                 //first get the jump diameter for selected planet
-                if(null != selectedSystem && conf.scale > conf.showPlanetNamesThreshold) {
+                if (null != selectedSystem && conf.scale > conf.showPlanetNamesThreshold) {
                     double x = map2scrX(selectedSystem.getX());
                     double y = map2scrY(selectedSystem.getY());
                     double z = map2scrX(selectedSystem.getX() + 30);
@@ -496,7 +463,7 @@ public class InterstellarMapPanel extends JPanel {
                     g2.setPaint(Color.DARK_GRAY);
                     arc.setArcByCenter(x, y, jumpRadius, 0, 360, Arc2D.OPEN);
                     g2.fill(arc);
-                    if(optHPGNetwork.isSelected()) {
+                    if (optHPGNetwork.isSelected()) {
                         z = map2scrX(selectedSystem.getX() + 50);
                         jumpRadius = (z - x);
                         g2.setPaint(darkCyan);
@@ -506,7 +473,7 @@ public class InterstellarMapPanel extends JPanel {
                     }
                 }
 
-                if((conf.scale > 1.0) && optISWAreas.isSelected()) {
+                if ((conf.scale > 1.0) && optISWAreas.isSelected()) {
                     // IDEA: Allow for different hex sizes later on.
                     final double HEX_SIZE = 30.0;
                     final double SPACING_X = HEX_SIZE * Math.sqrt(3) / 2.0;
@@ -516,8 +483,8 @@ public class InterstellarMapPanel extends JPanel {
                     int minY = (int) Math.floor(scr2mapY(getHeight()) / HEX_SIZE);
                     int maxY = (int) Math.ceil(scr2mapY(0.0) / HEX_SIZE);
                     GeneralPath path = new GeneralPath();
-                    for(int x = minX; x <= maxX; ++ x) {
-                        for(int y = minY; y <= maxY; ++ y) {
+                    for (int x = minX; x <= maxX; ++ x) {
+                        for (int y = minY; y <= maxY; ++ y) {
                             double coordX = x * SPACING_X;
                             double coordY = y * HEX_SIZE + (x % 2) * HEX_SIZE / 2.0;
                             setupHexPath(path, coordX, coordY, HEX_SIZE / 2.0);
@@ -525,15 +492,15 @@ public class InterstellarMapPanel extends JPanel {
                             Paint factionPaint = new Color(0.0f, 0.0f, 0.0f, 0.25f);
                             Paint linePaint = new Color(1.0f, 1.0f, 1.0f, 0.25f);
                             Set<Faction> hexFactions = new HashSet<>();
-                            for(PlanetarySystem system : Systems.getInstance().getNearbySystems(coordX, coordY, (int) Math.round(HEX_SIZE * 1.3))) {
-                                if(!isSystemEmpty(system) && path.contains(system.getX(), system.getY())) {
+                            for (PlanetarySystem system : Systems.getInstance().getNearbySystems(coordX, coordY, (int) Math.round(HEX_SIZE * 1.3))) {
+                                if (!isSystemEmpty(system) && path.contains(system.getX(), system.getY())) {
                                     hexFactions.addAll(system.getFactionSet(now));
                                 }
                             }
 
                             path.transform(transform);
 
-                            if(hexFactions.size() == 1) {
+                            if (hexFactions.size() == 1) {
                                 // Single-faction hex
                                 Color factionColor = hexFactions.iterator().next().getColor();
                                 float[] colorComponents = new float[4];
@@ -542,14 +509,14 @@ public class InterstellarMapPanel extends JPanel {
                                 Color lineColor = factionColor.brighter();
                                 lineColor.getComponents(colorComponents);
                                 linePaint = new Color(colorComponents[0], colorComponents[1], colorComponents[2], 0.25f);
-                            } else if(hexFactions.size() > 1) {
+                            } else if (hexFactions.size() > 1) {
                                 // Create the painted stripes data
                                 int factionSize = hexFactions.size();
                                 Iterator<Faction> factionIterator = hexFactions.iterator();
                                 float[] colorComponents = new float[4];
                                 float[] paintFractions = new float[factionSize * 2];
                                 Color[] paintColors = new Color[factionSize * 2];
-                                for(int i = 0; i < factionSize; ++ i) {
+                                for (int i = 0; i < factionSize; ++ i) {
                                     paintFractions[i * 2] = i * (1.0f / factionSize) + 0.001f;
                                     paintFractions[i * 2 + 1] = (i + 1) * (1.0f / factionSize);
                                     Color factionColor = factionIterator.next().getColor();
@@ -584,7 +551,7 @@ public class InterstellarMapPanel extends JPanel {
 
                 //draw a jump path
                 g2.setStroke(new BasicStroke(1.0f));
-                for(int i = 0; i < jumpPath.size(); i++) {
+                for (int i = 0; i < jumpPath.size(); i++) {
                     PlanetarySystem systemB = jumpPath.get(i);
                     double x = map2scrX(systemB.getX());
                     double y = map2scrY(systemB.getY());
@@ -601,7 +568,7 @@ public class InterstellarMapPanel extends JPanel {
                     g2.setPaint(Color.BLACK);
                     arc.setArcByCenter(x, y, size * 1.2, 0, 360, Arc2D.OPEN);
                     g2.fill(arc);
-                    if(i > 0) {
+                    if (i > 0) {
                         PlanetarySystem systemA = jumpPath.get(i-1);
                         g2.setPaint(Color.WHITE);
                         g2.draw(new Line2D.Double(map2scrX(systemA.getX()), map2scrY(systemA.getY()), map2scrX(systemB.getX()), map2scrY(systemB.getY())));
@@ -609,16 +576,16 @@ public class InterstellarMapPanel extends JPanel {
                 }
 
                 // Brute-force HPG network drawing. Will be optimised
-                if(optHPGNetwork.isSelected()) {
+                if (optHPGNetwork.isSelected()) {
                     // Grab the network from the planet manager
                     Collection<Systems.HPGLink> hpgNetwork = Systems.getInstance().getHPGNetwork(now);
 
-                    for(PlanetarySystem system : systems) {
-                        if(isSystemVisible(system, true)) {
+                    for (PlanetarySystem system : systems) {
+                        if (isSystemVisible(system, true)) {
                             double x = map2scrX(system.getX());
                             double y = map2scrY(system.getY());
                             int hpgRating = Utilities.nonNull(system.getHPG(now), EquipmentType.RATING_X);
-                            if(hpgRating == EquipmentType.RATING_A) {
+                            if (hpgRating == EquipmentType.RATING_A) {
                                 g2.setPaint(Color.CYAN);
                                 arc.setArcByCenter(x, y, size * 1.6, 0, 360, Arc2D.OPEN);
                                 g2.setStroke(thick);
@@ -628,19 +595,19 @@ public class InterstellarMapPanel extends JPanel {
                                 //arc.setArcByCenter(x, y, size * 1.6, 0, 360, Arc2D.OPEN);
                                 //g2.fill(arc);
                             }
-                            if(hpgRating == EquipmentType.RATING_A || hpgRating == EquipmentType.RATING_B) {
+                            if (hpgRating == EquipmentType.RATING_A || hpgRating == EquipmentType.RATING_B) {
                                 g2.setPaint(Color.CYAN);
                                 arc.setArcByCenter(x, y, size * 1.3, 0, 360, Arc2D.OPEN);
                                 g2.setStroke(thin);
                                 g2.draw(arc);
                             }
-                            if(hpgRating == EquipmentType.RATING_C) {
+                            if (hpgRating == EquipmentType.RATING_C) {
                                 g2.setPaint(Color.CYAN);
                                 arc.setArcByCenter(x, y, size * 1.3, 0, 360, Arc2D.OPEN);
                                 g2.setStroke(dashed);
                                 g2.draw(arc);
                             }
-                            if(hpgRating == EquipmentType.RATING_D) {
+                            if (hpgRating == EquipmentType.RATING_D) {
                                 g2.setPaint(darkCyan);
                                 arc.setArcByCenter(x, y, size * 1.3, 0, 360, Arc2D.OPEN);
                                 g2.setStroke(dotted);
@@ -648,16 +615,16 @@ public class InterstellarMapPanel extends JPanel {
                             }
                         }
                     }
-                    for(Systems.HPGLink link : hpgNetwork) {
+                    for (Systems.HPGLink link : hpgNetwork) {
                         PlanetarySystem p1 = link.primary;
                         PlanetarySystem p2 = link.secondary;
-                        if(isSystemVisible(p1, false) || isSystemVisible(p2, false)) {
-                            if(link.rating == EquipmentType.RATING_A) {
+                        if (isSystemVisible(p1, false) || isSystemVisible(p2, false)) {
+                            if (link.rating == EquipmentType.RATING_A) {
                                 g2.setPaint(Color.CYAN);
                                 g2.setStroke(thick);
                                 g2.draw(new Line2D.Double(map2scrX(p1.getX()), map2scrY(p1.getY()), map2scrX(p2.getX()), map2scrY(p2.getY())));
                             }
-                            if(link.rating == EquipmentType.RATING_B) {
+                            if (link.rating == EquipmentType.RATING_B) {
                                 g2.setPaint(Color.CYAN);
                                 g2.setStroke(dashed);
                                 g2.draw(new Line2D.Double(map2scrX(p1.getX()), map2scrY(p1.getY()), map2scrX(p2.getX()), map2scrY(p2.getY())));
@@ -669,8 +636,8 @@ public class InterstellarMapPanel extends JPanel {
 
                 //check to see if the unit is traveling on a jump path currently and if so
                 //draw this one too, in a different color
-                if(null != campaign.getLocation().getJumpPath()) {
-                    for(int i = 0; i < campaign.getLocation().getJumpPath().size(); i++) {
+                if (null != campaign.getLocation().getJumpPath()) {
+                    for (int i = 0; i < campaign.getLocation().getJumpPath().size(); i++) {
                         PlanetarySystem systemB = campaign.getLocation().getJumpPath().get(i);
                         double x = map2scrX(systemB.getX());
                         double y = map2scrY(systemB.getY());
@@ -687,7 +654,7 @@ public class InterstellarMapPanel extends JPanel {
                         g2.setPaint(Color.BLACK);
                         arc.setArcByCenter(x, y, size * 1.2, 0, 360, Arc2D.OPEN);
                         g2.fill(arc);
-                        if(i > 0) {
+                        if (i > 0) {
                             PlanetarySystem systemA = campaign.getLocation().getJumpPath().get(i-1);
                             g2.setPaint(Color.YELLOW);
                             g2.draw(new Line2D.Double(map2scrX(systemA.getX()), map2scrY(systemA.getY()),
@@ -698,14 +665,14 @@ public class InterstellarMapPanel extends JPanel {
 
                 Map<Faction, String> capitals = new HashMap<>();
                 for (Faction faction : Faction.getFactions()) {
-                	capitals.put(faction,faction.getStartingPlanet(campaign.getGameYear()));
+                    capitals.put(faction,faction.getStartingPlanet(campaign.getGameYear()));
                 }
 
-                for(PlanetarySystem system : systems) {
-                    if(isSystemVisible(system, false)) {
+                for (PlanetarySystem system : systems) {
+                    if (isSystemVisible(system, false)) {
                         double x = map2scrX(system.getX());
                         double y = map2scrY(system.getY());
-                        if(system.equals(campaign.getCurrentSystem())) {
+                        if (system.equals(campaign.getCurrentSystem())) {
                             //lest try rings
                             g2.setPaint(Color.ORANGE);
                             arc.setArcByCenter(x, y, size * 1.8, 0, 360, Arc2D.OPEN);
@@ -720,7 +687,7 @@ public class InterstellarMapPanel extends JPanel {
                             arc.setArcByCenter(x, y, size * 1.2, 0, 360, Arc2D.OPEN);
                             g2.fill(arc);
                         }
-                        if(null != selectedSystem && selectedSystem.equals(system)) {
+                        if (null != selectedSystem && selectedSystem.equals(system)) {
                             //lest try rings
                             g2.setPaint(Color.WHITE);
                             arc.setArcByCenter(x, y, size * 1.8, 0, 360, Arc2D.OPEN);
@@ -738,49 +705,49 @@ public class InterstellarMapPanel extends JPanel {
 
                         //if factions are selected then we need to do it differently, because
                         //of multiple factions per planet
-                        if(isFactionsSelected()) {
-	                        Set<Faction> factions = system.getFactionSet(now);
-	                        if(null != factions && !isSystemEmpty(system)) {
-	                            int i = 0;
-	                            for(Faction faction : factions) {
-	                            	if (capitals.get(faction).equals(system.getId())) {
-	                            		g2.setPaint(new Color(212,175,55));
-		                                arc.setArcByCenter(x, y, size+3, 0, 360.0 * (1-((double)i)/factions.size()), Arc2D.PIE);
-		                                g2.fill(arc);
-	                            	}
-	                            	if (campaign.getCampaignOptions().getUseAtB()  && campaign.getAtBConfig().isHiringHall(system.getId(), campaign.getDate())) {
-	                            		g2.setPaint(new Color(192,192,192));
-		                                arc.setArcByCenter(x, y, size+2, 0, 360.0 * (1-((double)i)/factions.size()), Arc2D.PIE);
-		                                g2.fill(arc);
-		                            }
-	                                g2.setPaint(faction.getColor());
-	                                arc.setArcByCenter(x, y, size, 0, 360.0 * (1-((double)i)/factions.size()), Arc2D.PIE);
-	                                g2.fill(arc);
-	                                ++ i;
-	                            }
-	                        } else {
-	                            // Just a black circle then
-	                            g2.setPaint(new Color(0.0f, 0.0f, 0.0f, 0.5f));
-	                            arc.setArcByCenter(x, y, size, 0, 360.0, Arc2D.PIE);
-	                            g2.fill(arc);
-	                        }
+                        if (isFactionsSelected()) {
+                            Set<Faction> factions = system.getFactionSet(now);
+                            if (null != factions && !isSystemEmpty(system)) {
+                                int i = 0;
+                                for (Faction faction : factions) {
+                                    if (capitals.get(faction).equals(system.getId())) {
+                                        g2.setPaint(new Color(212,175,55));
+                                        arc.setArcByCenter(x, y, size+3, 0, 360.0 * (1-((double)i)/factions.size()), Arc2D.PIE);
+                                        g2.fill(arc);
+                                    }
+                                    if (campaign.getCampaignOptions().getUseAtB()  && campaign.getAtBConfig().isHiringHall(system.getId(), campaign.getDate())) {
+                                        g2.setPaint(new Color(192,192,192));
+                                        arc.setArcByCenter(x, y, size+2, 0, 360.0 * (1-((double)i)/factions.size()), Arc2D.PIE);
+                                        g2.fill(arc);
+                                    }
+                                    g2.setPaint(faction.getColor());
+                                    arc.setArcByCenter(x, y, size, 0, 360.0 * (1-((double)i)/factions.size()), Arc2D.PIE);
+                                    g2.fill(arc);
+                                    ++ i;
+                                }
+                            } else {
+                                // Just a black circle then
+                                g2.setPaint(new Color(0.0f, 0.0f, 0.0f, 0.5f));
+                                arc.setArcByCenter(x, y, size, 0, 360.0, Arc2D.PIE);
+                                g2.fill(arc);
+                            }
                         } else {
-	                        g2.setPaint(getSystemColor(system));
-	                        arc.setArcByCenter(x, y, size, 0, 360.0, Arc2D.PIE);
-	                        g2.fill(arc);
+                            g2.setPaint(getSystemColor(system));
+                            arc.setArcByCenter(x, y, size, 0, 360.0, Arc2D.PIE);
+                            g2.fill(arc);
                         }
                     }
                 }
 
                 //cycle through planets again and assign names - to make sure names go on outside
-                for(PlanetarySystem system : systems) {
-                    if(isSystemVisible(system, !optEmptySystems.isSelected())) {
+                for (PlanetarySystem system : systems) {
+                    if (isSystemVisible(system, !optEmptySystems.isSelected())) {
                         double x = map2scrX(system.getX());
                         double y = map2scrY(system.getY());
                         if (conf.showPlanetNamesThreshold == 0 || conf.scale > conf.showPlanetNamesThreshold
                                 || jumpPath.contains(system)
                                 || (null != campaign.getLocation().getJumpPath() && campaign.getLocation().getJumpPath().contains(system))) {
-                            final String planetName = system.getPrintableName(Utilities.getDateTimeDay(campaign.getCalendar()));
+                            final String planetName = system.getPrintableName(campaign.getLocalDate());
                             final float xPos = (float) (x + size * 1.8);
                             final float yPos = (float) y;
                             g2.setPaint(Color.BLACK);
@@ -856,12 +823,9 @@ public class InterstellarMapPanel extends JPanel {
         optionButton.setBackground(new Color(0, 100, 230, 150));
         optionButton.setFocusable(false);
         optionButton.setIcon(new ImageIcon("data/images/misc/option_button.png"));
-        optionButton.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                optionPanelHidden = !optionPanelHidden;
-                optionPanelTimer.start();
-            }
+        optionButton.addActionListener(e -> {
+            optionPanelHidden = !optionPanelHidden;
+            optionPanelTimer.start();
         });
         optionPanel.add(optionButton);
 
@@ -898,11 +862,11 @@ public class InterstellarMapPanel extends JPanel {
     }
 
     private JLabel createLabel(String text) {
-    	JLabel label = new JLabel(text);
-    	label.setOpaque(false);
-    	label.setForeground(new Color(150, 220, 255));
-    	label.setFont(label.getFont().deriveFont(Font.BOLD));
-    	return(label);
+        JLabel label = new JLabel(text);
+        label.setOpaque(false);
+        label.setForeground(new Color(150, 220, 255));
+        label.setFont(label.getFont().deriveFont(Font.BOLD));
+        return(label);
     }
 
     private JCheckBox createOptionCheckBox(String text, Icon checkboxIcon, Icon checkboxSelectedIcon) {
@@ -915,12 +879,7 @@ public class InterstellarMapPanel extends JPanel {
         checkBox.setIcon(checkboxIcon);
         checkBox.setSelectedIcon(checkboxSelectedIcon);
         checkBox.setSelected(false);
-        checkBox.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                repaint();
-            }
-        });
+        checkBox.addActionListener(e -> repaint());
         return checkBox;
     }
 
@@ -934,23 +893,18 @@ public class InterstellarMapPanel extends JPanel {
         radioButton.setIcon(checkboxIcon);
         radioButton.setSelectedIcon(checkboxSelectedIcon);
         radioButton.setSelected(false);
-        radioButton.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                repaint();
-            }
-        });
+        radioButton.addActionListener(e -> repaint());
         return radioButton;
     }
 
     private void setupHexPath(GeneralPath path, double centerX, double centerY, double radius) {
-        if(null == path) {
+        if (null == path) {
             return;
         }
         radius *= Math.sqrt(4.0/3.0);
         path.reset();
         path.moveTo(centerX + radius * BASE_HEXCOORDS[0].x, centerY + radius * BASE_HEXCOORDS[0].y);
-        for(int i = 1; i < 6; ++ i) {
+        for (int i = 1; i < 6; ++ i) {
             path.lineTo(centerX + radius * BASE_HEXCOORDS[i].x, centerY + radius * BASE_HEXCOORDS[i].y);
         }
         path.closePath();
@@ -984,7 +938,7 @@ public class InterstellarMapPanel extends JPanel {
     }
     public void setSelectedSystem(PlanetarySystem p) {
         selectedSystem = p;
-        if(conf.scale < 4.0) {
+        if (conf.scale < 4.0) {
             conf.scale = 4.0;
         }
         center(selectedSystem);
@@ -996,9 +950,9 @@ public class InterstellarMapPanel extends JPanel {
      */
     private PlanetarySystem nearestNeighbour(double x, double y) {
         double minDiff = Double.MAX_VALUE;
-        double diff = 0.0;
+        double diff;
         PlanetarySystem minPlanet = null;
-        for(PlanetarySystem p : systems) {
+        for (PlanetarySystem p : systems) {
             diff = Math.sqrt(Math.pow(x - p.getX(), 2) + Math.pow(y - p.getY(), 2));
             if (diff < minDiff) {
                 minDiff = diff;
@@ -1010,12 +964,12 @@ public class InterstellarMapPanel extends JPanel {
 
     private boolean isSystemEmpty(PlanetarySystem system) {
         Set<Faction> factions = system.getFactionSet(now);
-        if((null == factions) || factions.isEmpty()) {
+        if ((null == factions) || factions.isEmpty()) {
             return true;
         }
 
-        for(Faction faction : factions) {
-            if(!faction.is(Tag.ABANDONED)) {
+        for (Faction faction : factions) {
+            if (!faction.is(Tag.ABANDONED)) {
                 return false;
             }
         }
@@ -1024,20 +978,20 @@ public class InterstellarMapPanel extends JPanel {
     }
 
     private boolean isSystemVisible(PlanetarySystem system, boolean hideEmpty) {
-        if(null == system) {
+        if (null == system) {
             return false;
         }
         // The current planet and the selected one are always visible
-        if(system.equals(campaign.getCurrentSystem()) || system.equals(selectedSystem)) {
+        if (system.equals(campaign.getCurrentSystem()) || system.equals(selectedSystem)) {
             return true;
         }
         // viewport check
-        double x = system.getX().doubleValue();
-        double y = system.getY().doubleValue();
-        if((x < minX) || (x > maxX) || (y < minY) || (y > maxY)) {
+        double x = system.getX();
+        double y = system.getY();
+        if ((x < minX) || (x > maxX) || (y < minY) || (y > maxY)) {
             return false;
         }
-        if(hideEmpty) {
+        if (hideEmpty) {
             // Filter out "empty" systems
             return !isSystemEmpty(system);
         }
@@ -1058,7 +1012,7 @@ public class InterstellarMapPanel extends JPanel {
     }
 
     private void zoom(double percent, Point pos) {
-        if(null != pos) {
+        if (null != pos) {
             // TODO: Calculate offset to zoom at mouse position
         }
         conf.scale *= percent;
@@ -1086,167 +1040,166 @@ public class InterstellarMapPanel extends JPanel {
      */
     public Color getSystemColor(PlanetarySystem p) {
 
-    	//color shading is from the Viridis color palettes
+        //color shading is from the Viridis color palettes
 
-		long pop = p.getPopulation(Utilities.getDateTimeDay(campaign.getCalendar()));
+        long pop = p.getPopulation(campaign.getLocalDate());
 
-		//if no population, then just return black no matter what we asked for
-		if(pop==0l) {
-			return Color.BLACK;
-		}
+        //if no population, then just return black no matter what we asked for
+        if (pop == 0L) {
+            return Color.BLACK;
+        }
 
-    	SocioIndustrialData socio = p.getSocioIndustrial(Utilities.getDateTimeDay(campaign.getCalendar()));
+        SocioIndustrialData socio = p.getSocioIndustrial(campaign.getLocalDate());
 
-    	if(null != socio && optTech.isSelected()) {
-	    	switch(socio.tech) {
-	    		case EquipmentType.RATING_F:
-	    		case EquipmentType.RATING_E:
-	    			return new Color(68,1,84);
-	    		case EquipmentType.RATING_D:
-	    			return new Color(59,82,139);
-	    		case EquipmentType.RATING_C:
-	    			return new Color(33,144,140);
-	    		case EquipmentType.RATING_B:
-	    			return new Color(93,200,99);
-	    		case EquipmentType.RATING_A:
-	    			return new Color(253,231,37);
-	    		default:
-	    			return Color.BLACK;
-	    	}
-    	}
-    	if(null != socio && optIndustry.isSelected()) {
-	    	switch(socio.industry) {
-	    		case EquipmentType.RATING_F:
-	    		case EquipmentType.RATING_E:
-	    			return new Color(0,0,4);
-	    		case EquipmentType.RATING_D:
-	    			return new Color(81,18,124);
-	    		case EquipmentType.RATING_C:
-	    			return new Color(182,54,121);
-	    		case EquipmentType.RATING_B:
-	    			return new Color(251,136,97);
-	    		case EquipmentType.RATING_A:
-	    			return new Color(252,253,191);
-	    		default:
-	    			return Color.BLACK;
-	    	}
-    	}
-    	if(null != socio && optRawMaterials.isSelected()) {
-	    	switch(socio.rawMaterials) {
-	    		case EquipmentType.RATING_F:
-	    		case EquipmentType.RATING_E:
-	    			return new Color(13,8,135);
-	    		case EquipmentType.RATING_D:
-	    			return new Color(126,3,168);
-	    		case EquipmentType.RATING_C:
-	    			return new Color(204,70,120);
-	    		case EquipmentType.RATING_B:
-	    			return new Color(248,148,65);
-	    		case EquipmentType.RATING_A:
-	    			return new Color(240,249,33);
-	    		default:
-	    			return Color.BLACK;
-	    	}
-    	}
-    	if(null != socio && optOutput.isSelected()) {
-	    	switch(socio.output) {
-	    		case EquipmentType.RATING_F:
-	    		case EquipmentType.RATING_E:
-	    			return new Color(0,0,4);
-	    		case EquipmentType.RATING_D:
-	    			return new Color(86,15,110);
-	    		case EquipmentType.RATING_C:
-	    			return new Color(187,55,84);
-	    		case EquipmentType.RATING_B:
-	    			return new Color(249,140,10);
-	    		case EquipmentType.RATING_A:
-	    			return new Color(252,255,164);
-	    		default:
-	    			return Color.BLACK;
-	    	}
-    	}
-    	if(null != socio && optAgriculture.isSelected()) {
-	    	switch(socio.agriculture) {
-	    		case EquipmentType.RATING_F:
-	    		case EquipmentType.RATING_E:
-	    			return new Color(0,32,77);
-	    		case EquipmentType.RATING_D:
-	    			return new Color(66,77,107);
-	    		case EquipmentType.RATING_C:
-	    			return new Color(124,123,120);
-	    		case EquipmentType.RATING_B:
-	    			return new Color(188,175,111);
-	    		case EquipmentType.RATING_A:
-	    			return new Color(255,234,70);
-	    		default:
-	    			return Color.BLACK;
-	    	}
-    	}
+        if (null != socio && optTech.isSelected()) {
+            switch (socio.tech) {
+                case EquipmentType.RATING_F:
+                case EquipmentType.RATING_E:
+                    return new Color(68,1,84);
+                case EquipmentType.RATING_D:
+                    return new Color(59,82,139);
+                case EquipmentType.RATING_C:
+                    return new Color(33,144,140);
+                case EquipmentType.RATING_B:
+                    return new Color(93,200,99);
+                case EquipmentType.RATING_A:
+                    return new Color(253,231,37);
+                default:
+                    return Color.BLACK;
+            }
+        }
+        if (null != socio && optIndustry.isSelected()) {
+            switch (socio.industry) {
+                case EquipmentType.RATING_F:
+                case EquipmentType.RATING_E:
+                    return new Color(0,0,4);
+                case EquipmentType.RATING_D:
+                    return new Color(81,18,124);
+                case EquipmentType.RATING_C:
+                    return new Color(182,54,121);
+                case EquipmentType.RATING_B:
+                    return new Color(251,136,97);
+                case EquipmentType.RATING_A:
+                    return new Color(252,253,191);
+                default:
+                    return Color.BLACK;
+            }
+        }
+        if (null != socio && optRawMaterials.isSelected()) {
+            switch (socio.rawMaterials) {
+                case EquipmentType.RATING_F:
+                case EquipmentType.RATING_E:
+                    return new Color(13,8,135);
+                case EquipmentType.RATING_D:
+                    return new Color(126,3,168);
+                case EquipmentType.RATING_C:
+                    return new Color(204,70,120);
+                case EquipmentType.RATING_B:
+                    return new Color(248,148,65);
+                case EquipmentType.RATING_A:
+                    return new Color(240,249,33);
+                default:
+                    return Color.BLACK;
+            }
+        }
+        if (null != socio && optOutput.isSelected()) {
+            switch (socio.output) {
+                case EquipmentType.RATING_F:
+                case EquipmentType.RATING_E:
+                    return new Color(0,0,4);
+                case EquipmentType.RATING_D:
+                    return new Color(86,15,110);
+                case EquipmentType.RATING_C:
+                    return new Color(187,55,84);
+                case EquipmentType.RATING_B:
+                    return new Color(249,140,10);
+                case EquipmentType.RATING_A:
+                    return new Color(252,255,164);
+                default:
+                    return Color.BLACK;
+            }
+        }
+        if (null != socio && optAgriculture.isSelected()) {
+            switch (socio.agriculture) {
+                case EquipmentType.RATING_F:
+                case EquipmentType.RATING_E:
+                    return new Color(0,32,77);
+                case EquipmentType.RATING_D:
+                    return new Color(66,77,107);
+                case EquipmentType.RATING_C:
+                    return new Color(124,123,120);
+                case EquipmentType.RATING_B:
+                    return new Color(188,175,111);
+                case EquipmentType.RATING_A:
+                    return new Color(255,234,70);
+                default:
+                    return Color.BLACK;
+            }
+        }
 
-    	if(optPopulation.isSelected()) {
-    		//numbers based roughly on deciles of population distribution
-    		//in 2750
-    		if(pop>=3000000000l) {
-    			return new Color(253,231, 37);
-    		} else if(pop>=1500000000l) {
-    			return new Color(180,222,44);
-    		} else if(pop>=1000000000l) {
-    			return new Color(109,205,89);
-    		} else if(pop>=500000000l) {
-    			return new Color(53,183,121);
-    		} else if(pop>=300000000l) {
-    			return new Color(31,158,137);
-    		} else if(pop>=200000000l) {
-    			return new Color(38,130,142);
-    		} else if(pop>=100000000l) {
-    			return new Color(49,104,142);
-    		} else if(pop>=25000000l) {
-    			return new Color(62,74,137);
-    		} else if(pop>=1000000l) {
-    			return new Color(72,40,120);
-    		} else if(pop>0l) {
-    			return new Color(68,1,84);
-    		} else {
-    			return Color.GRAY;
-    		}
-    	}
+        if (optPopulation.isSelected()) {
+            //numbers based roughly on deciles of population distribution
+            //in 2750
+            if (pop >= 3000000000L) {
+                return new Color(253,231, 37);
+            } else if (pop >= 1500000000L) {
+                return new Color(180,222,44);
+            } else if (pop >= 1000000000L) {
+                return new Color(109,205,89);
+            } else if (pop >= 500000000L) {
+                return new Color(53,183,121);
+            } else if (pop >= 300000000L) {
+                return new Color(31,158,137);
+            } else if (pop >= 200000000L) {
+                return new Color(38,130,142);
+            } else if (pop >= 100000000L) {
+                return new Color(49,104,142);
+            } else if (pop >= 25000000L) {
+                return new Color(62,74,137);
+            } else if (pop >= 1000000L) {
+                return new Color(72,40,120);
+            } else if (pop > 0L) {
+                return new Color(68,1,84);
+            } else {
+                return Color.GRAY;
+            }
+        }
 
-    	if(optHPG.isSelected()) {
-    		Integer hpg = p.getHPG(Utilities.getDateTimeDay(campaign.getCalendar()));
-    		if(null == hpg) {
-    			return Color.BLACK;
-    		}
-    		//use two shades of grey for C and D as this is pony express
-    		switch(hpg) {
-    		case EquipmentType.RATING_D:
-    			return new Color(84,84,84);
-    		case EquipmentType.RATING_C:
-    			return new Color(168,168,168);
-    		case EquipmentType.RATING_B:
-    			return new Color(222,73,104);
-    		case EquipmentType.RATING_A:
-    			return new Color(252,253,191);
-    		default:
-    			return Color.BLACK;
-    		}
-    	}
+        if (optHPG.isSelected()) {
+            Integer hpg = p.getHPG(campaign.getLocalDate());
+            if (null == hpg) {
+                return Color.BLACK;
+            }
+            //use two shades of grey for C and D as this is pony express
+            switch(hpg) {
+                case EquipmentType.RATING_D:
+                    return new Color(84,84,84);
+                case EquipmentType.RATING_C:
+                    return new Color(168,168,168);
+                case EquipmentType.RATING_B:
+                    return new Color(222,73,104);
+                case EquipmentType.RATING_A:
+                    return new Color(252,253,191);
+                default:
+                    return Color.BLACK;
+            }
+        }
 
-    	if(optRecharge.isSelected()) {
+        if (optRecharge.isSelected()) {
+            //use two shades of grey for C and D as this is pony express
+            switch (p.getNumberRechargeStations(campaign.getLocalDate())) {
+                case 2:
+                    return new Color(240,249,33);
+                case 1:
+                    return new Color(225,100,98);
+                case 0:
+                    return new Color(128,128,128);
+                default:
+                    return Color.BLACK;
+            }
+        }
 
-    		//use two shades of grey for C and D as this is pony express
-    		switch(p.getNumberRechargeStations(Utilities.getDateTimeDay(campaign.getCalendar()))) {
-    		case 2:
-    			return new Color(240,249,33);
-    		case 1:
-    			return new Color(225,100,98);
-    		case 0:
-    			return new Color(128,128,128);
-    		default:
-    			return Color.BLACK;
-    		}
-    	}
-
-		return Color.GRAY;
+        return Color.GRAY;
     }
 
     /*
@@ -1255,7 +1208,7 @@ public class InterstellarMapPanel extends JPanel {
         NewPlanetaryEventDialog editor = new NewPlanetaryEventDialog(null, campaign, selectedSystem);
         editor.setVisible(true);
         List<Planet.PlanetaryEvent> result = editor.getChangedEvents();
-        if((null != result) && !result.isEmpty()) {
+        if ((null != result) && !result.isEmpty()) {
             Planets.getInstance().updatePlanetaryEvents(p.getId(), result, true);
             Planets.getInstance().recalcHPGNetwork();
             repaint();
@@ -1320,7 +1273,7 @@ public class InterstellarMapPanel extends JPanel {
     }
 
     public boolean isFactionsSelected() {
-    	return optFactions.isSelected();
+        return optFactions.isSelected();
     }
 
 }

--- a/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
+++ b/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 The MegaMek Team. All rights reserved.
+ * Copyright (c) 2019 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui;
 
@@ -40,6 +40,7 @@ import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -51,8 +52,6 @@ import javax.swing.JButton;
 import javax.swing.JLayeredPane;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
-
-import org.joda.time.DateTime;
 
 import megamek.client.ui.swing.util.PlayerColors;
 import megamek.common.Dropship;
@@ -72,13 +71,8 @@ import mekhq.campaign.universe.StarUtil;
  * This panel displays a particular star system with suns and planets and information about
  * the player's unit's position if in the system
  * @author Taharqa (Aaron Gullickson)
- *
  */
 public class PlanetarySystemMapPanel extends JPanel {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 2756160214370516878L;
 
     private JLayeredPane pane;
@@ -89,7 +83,7 @@ public class PlanetarySystemMapPanel extends JPanel {
     private CampaignGUI hqview;
     private DirectoryItems camos;
     private PlanetarySystem system;
-    private int selectedPlanet = 0;
+    private int selectedPlanet;
 
     //get the best dropship and jumpship of the unit for display
     private Unit dropship;
@@ -172,7 +166,7 @@ public class PlanetarySystemMapPanel extends JPanel {
                 g2.fillRect(0, 0, getWidth(), getHeight());
 
                 //tile the space image
-                if(null != imgSpace) {
+                if (null != imgSpace) {
                     int tileWidth = imgSpace.getWidth();
                     int tileHeight = imgSpace.getHeight();
                     for (int y = 0; y < getHeight(); y += tileHeight) {
@@ -203,7 +197,7 @@ public class PlanetarySystemMapPanel extends JPanel {
                 //where is jumpship
                 int jumpshipX = zenithX+jumpPointImgWidth+8;
                 int jumpshipY = zenithY+(jumpPointImgHeight/2)-(shipImgSize/2);
-                if(!campaign.getLocation().isJumpZenith()) {
+                if (!campaign.getLocation().isJumpZenith()) {
                     jumpshipX = nadirX+jumpPointImgWidth+8;;
                     jumpshipY = nadirY+(jumpPointImgHeight/2)-(shipImgSize/2);
                 }
@@ -216,53 +210,53 @@ public class PlanetarySystemMapPanel extends JPanel {
                 g2.drawImage(starIcon, starWidth-starImgSize, y-(starImgSize/2), starImgSize, starImgSize, null);
 
                 //draw nadir and zenith points
-                if(null != imgZenithPoint) {
+                if (null != imgZenithPoint) {
                     g2.drawImage(imgZenithPoint, zenithX, zenithY, jumpPointImgWidth, jumpPointImgHeight, null);
                 }
-                if(system.isZenithCharge(Utilities.getDateTimeDay(campaign.getCalendar())) && null != imgRechargeStation) {
+                if (system.isZenithCharge(campaign.getLocalDate()) && (null != imgRechargeStation)) {
                     drawRotatedImage(g2, imgRechargeStation, 90.0, zenithX, zenithY+12, rechargeImgSize, rechargeImgSize);
                 }
-                if(null != imgNadirPoint) {
+                if (null != imgNadirPoint) {
                     g2.drawImage(imgNadirPoint, nadirX, nadirY, jumpPointImgWidth, jumpPointImgHeight, null);
                 }
-                if(system.isNadirCharge(Utilities.getDateTimeDay(campaign.getCalendar())) && null != imgRechargeStation) {
+                if (system.isNadirCharge(campaign.getLocalDate()) && (null != imgRechargeStation)) {
                     drawRotatedImage(g2, imgRechargeStation, 90.0, nadirX, nadirY+12, rechargeImgSize, rechargeImgSize);
                 }
 
                 //get the biggest diameter allowed within this space for a planet
                 int biggestDiameterPixels = rectWidth-32;
-                if(biggestDiameterPixels < minDiameter) {
+                if (biggestDiameterPixels < minDiameter) {
                     biggestDiameterPixels = minDiameter;
-                } else if(biggestDiameterPixels > maxDiameter) {
+                } else if (biggestDiameterPixels > maxDiameter) {
                     biggestDiameterPixels = maxDiameter;
                 }
 
                 //find the biggest diameter among all planets
                 double biggestDiameter = 0;
-                for(Planet p : system.getPlanets()) {
-                    if(p.getDiameter() > biggestDiameter) {
+                for (Planet p : system.getPlanets()) {
+                    if (p.getDiameter() > biggestDiameter) {
                         biggestDiameter = p.getDiameter();
                     }
                 }
 
-                for(int i = 1; i <= n; i++) {
+                for (int i = 1; i <= n; i++) {
                     x = starWidth+rectWidth*(i-1)+midpoint;
                     Planet p = system.getPlanet(i);
 
-                    if(null != p) {
+                    if (null != p) {
                         //diameters need to be scaled relative to largest planet, but linear
                         //scale will make all but gas/ice giants tiny. log scale made sizes too close,
                         //but cubic root scale seems to work pretty well.
-                        int diameter = (int) ((biggestDiameterPixels) * (Math.cbrt(p.getDiameter())/Math.cbrt(biggestDiameter)));
-                        if(diameter < minDiameter) {
+                        int diameter = (int) ((biggestDiameterPixels) * (Math.cbrt(p.getDiameter()) / Math.cbrt(biggestDiameter)));
+                        if (diameter < minDiameter) {
                             diameter = minDiameter;
-                        } else if(diameter > maxDiameter) {
+                        } else if (diameter > maxDiameter) {
                             diameter = maxDiameter;
                         }
                         int radius = diameter / 2;
 
                         //check for current location - we assume you are on primary planet for now
-                        if(campaign.getLocation().getCurrentSystem().equals(system) && i==system.getPrimaryPlanetPosition()) {
+                        if (campaign.getLocation().getCurrentSystem().equals(system) && i == system.getPrimaryPlanetPosition()) {
                             updateShipImages();
 
                             JumpPath jp = campaign.getLocation().getJumpPath();
@@ -270,10 +264,10 @@ public class PlanetarySystemMapPanel extends JPanel {
                             int lineY1 = y-radius;
                             int lineX2 = jumpshipX+shipImgSize;
                             int lineY2 = jumpshipY+shipImgSize;
-                            if(!campaign.getLocation().isJumpZenith()) {
+                            if (!campaign.getLocation().isJumpZenith()) {
                                 lineY2 = jumpshipY-shipImgSize;
                             }
-                            if(null != jp && (!campaign.getLocation().isAtJumpPoint() || jp.getLastSystem().equals(system))) {
+                            if (null != jp && (!campaign.getLocation().isAtJumpPoint() || jp.getLastSystem().equals(system))) {
                                 //the unit has a flight plan in this system so draw the line
                                 //in transit so draw a path
                                 g2.setColor(Color.YELLOW);
@@ -281,23 +275,23 @@ public class PlanetarySystemMapPanel extends JPanel {
                                 g2.setStroke(dashed);
                                 g2.drawLine(lineX1, lineY1, lineX2, lineY2);
                             }
-                            if(campaign.getLocation().isAtJumpPoint()) {
+                            if (campaign.getLocation().isAtJumpPoint()) {
                                 //draw a ring around jumpship
-                                drawRing(g2, jumpshipX+(shipImgSize/2), jumpshipY+(shipImgSize/2), shipImgSize/2, Color.ORANGE);
-                                if(null != imgJumpshipFleet) {
+                                drawRing(g2, jumpshipX + (shipImgSize / 2), jumpshipY + (shipImgSize / 2), shipImgSize / 2, Color.ORANGE);
+                                if (null != imgJumpshipFleet) {
                                     drawRotatedImage(g2, imgJumpshipFleet, 90, jumpshipX, jumpshipY, shipImgSize, shipImgSize);
                                 }
-                            } else if(campaign.getLocation().isOnPlanet()) {
+                            } else if (campaign.getLocation().isOnPlanet()) {
                                 drawRing(g2, x, y, radius, Color.ORANGE);
-                                if(null != imgDropshipFleet) {
+                                if (null != imgDropshipFleet) {
                                     g2.drawImage(imgDropshipFleet, x-radius-shipImgSize, y-radius-shipImgSize, shipImgSize, shipImgSize, null);
                                 }
                                 //draw jumpship too
-                                if(null != imgJumpshipFleet) {
+                                if (null != imgJumpshipFleet) {
                                     drawRotatedImage(g2, imgJumpshipFleet, 90, jumpshipX, jumpshipY, shipImgSize, shipImgSize);
                                 }
                             } else {
-                                if(null != imgDropshipFleet) {
+                                if (null != imgDropshipFleet) {
                                     int lengthX = lineX1-lineX2;
                                     int lengthY = lineY1-lineY2;
                                     double rotationRequired = getFlightRotation(lengthX, lengthY, null != jp && jp.getLastSystem().equals(system), campaign.getLocation().isJumpZenith());
@@ -307,21 +301,21 @@ public class PlanetarySystemMapPanel extends JPanel {
                                     drawRotatedImage(g2, imgDropshipFleet, rotationRequired, partialX-(shipImgSize/2), partialY-(shipImgSize/2), shipImgSize, shipImgSize);
                                 }
                                 //draw jumpship too
-                                if(null != imgJumpshipFleet) {
+                                if (null != imgJumpshipFleet) {
                                     drawRotatedImage(g2, imgJumpshipFleet, 90, jumpshipX, jumpshipY, shipImgSize, shipImgSize);
                                 }
                             }
                         }
 
                         //add ring for selected planet
-                        if(selectedPlanet==i) {
+                        if (selectedPlanet==i) {
                             drawRing(g2, x, y, radius, Color.WHITE);
                         }
 
                         //draw the planet icon
                         Image planetIcon = ImageUtil.loadImageFromFile("data/" + StarUtil.getIconImage(p));
                         g2.drawImage(planetIcon, x-radius, y-radius, diameter, diameter, null);
-                        final String planetName = p.getPrintableName(Utilities.getDateTimeDay(campaign.getCalendar()));
+                        final String planetName = p.getPrintableName(campaign.getLocalDate());
 
                         //planet name
                         g2.setColor(Color.WHITE);
@@ -358,7 +352,7 @@ public class PlanetarySystemMapPanel extends JPanel {
         getActionMap().put("left", new AbstractAction() {
             public void actionPerformed(ActionEvent e) {
                 int target_pos = selectedPlanet-1;
-                if(target_pos<1) {
+                if (target_pos<1) {
                     return;
                 }
                 changeSelectedPlanet(target_pos);
@@ -374,7 +368,7 @@ public class PlanetarySystemMapPanel extends JPanel {
         getActionMap().put("right", new AbstractAction() {
             public void actionPerformed(ActionEvent e) {
                 int target_pos = selectedPlanet+1;
-                if(target_pos>(system.getPlanets().size())) {
+                if (target_pos>(system.getPlanets().size())) {
                     return;
                 }
                 changeSelectedPlanet(target_pos);
@@ -389,7 +383,7 @@ public class PlanetarySystemMapPanel extends JPanel {
             public void mouseClicked(MouseEvent e) {
                 if (e.getButton() == MouseEvent.BUTTON1) {
                     int target_pos = nearestNeighbour(e.getX(), e.getY());
-                    if(target_pos < 1) {
+                    if (target_pos < 1) {
                         return;
                     }
                     changeSelectedPlanet(target_pos);
@@ -428,34 +422,34 @@ public class PlanetarySystemMapPanel extends JPanel {
         //start with 16
         int fontSize = 16;
         g.setFont(new Font("Helvetica", Font.PLAIN, fontSize));
-        while(areNamesTooBig(g, system, Utilities.getDateTimeDay(campaign.getCalendar()), limit) && fontSize>=10) {
+        while (areNamesTooBig(g, system, campaign.getLocalDate(), limit) && fontSize >= 10) {
             fontSize--;
             g.setFont(new Font("Helvetica", Font.PLAIN, fontSize));
         }
     }
 
     /**
-     * Determin if planet names are too big for the display at current font size
+     * Determine if planet names are too big for the display at current font size
      * @param g - a <code>Graphics</code> device
      * @param system - a <code>PlanetarySystem</code>
      * @param when - <code>DateTime</code> object
      * @param limit - an integer indicating how large the text can be
      * @return
      */
-    private boolean areNamesTooBig(Graphics g, PlanetarySystem system, DateTime when, int limit) {
-        for(Planet p : system.getPlanets()) {
+    private boolean areNamesTooBig(Graphics g, PlanetarySystem system, LocalDate when, int limit) {
+        for (Planet p : system.getPlanets()) {
             String name = p.getName(when);
-            if(g.getFontMetrics().stringWidth(name) > limit) {
+            if (g.getFontMetrics().stringWidth(name) > limit) {
                 //try splitting
-                if(name.contains(" ")) {
+                if (name.contains(" ")) {
                     for (String line : name.split("\\s+")) {
-                        if(g.getFontMetrics().stringWidth(line) > limit) {
+                        if (g.getFontMetrics().stringWidth(line) > limit) {
                             return true;
                         }
                     }
-                } else if(name.contains("-")) {
+                } else if (name.contains("-")) {
                     for (String line : name.split("-")) {
-                        if(g.getFontMetrics().stringWidth(line) > limit) {
+                        if (g.getFontMetrics().stringWidth(line) > limit) {
                             return true;
                         }
                     }
@@ -479,8 +473,8 @@ public class PlanetarySystemMapPanel extends JPanel {
     private void drawCenteredString(Graphics2D g, String text, int x, int y, int limit) {
         FontMetrics metrics = g.getFontMetrics();
         y = y - (metrics.getHeight() / 2);
-        if(metrics.stringWidth(text) > limit && (text.contains(" ") || text.contains("-"))) {
-            if(text.contains(" ")) {
+        if (metrics.stringWidth(text) > limit && (text.contains(" ") || text.contains("-"))) {
+            if (text.contains(" ")) {
                 //try spaces first
                 for (String line : text.split("\\s+")) {
                     g.drawString(line, x- (metrics.stringWidth(line) / 2), y += g.getFontMetrics().getHeight());
@@ -490,7 +484,7 @@ public class PlanetarySystemMapPanel extends JPanel {
                 String[] lines = text.split("-");
                 for (int i = 0; i < lines.length; i++) {
                     String line = lines[i];
-                    if(i != (lines.length-1)) {
+                    if (i != (lines.length-1)) {
                         line = line + "-";
                     }
                     g.drawString(line, x- (metrics.stringWidth(line) / 2), y += g.getFontMetrics().getHeight());
@@ -506,7 +500,7 @@ public class PlanetarySystemMapPanel extends JPanel {
      * @param s - a {@link PlanetarySystem} to paint
      */
     public void updatePlanetarySystem(PlanetarySystem s) {
-        if(null == s) {
+        if (null == s) {
             return;
         }
         this.system = s;
@@ -519,7 +513,7 @@ public class PlanetarySystemMapPanel extends JPanel {
      * @param p - a {@link Planet} to paint.
      */
     public void updatePlanetarySystem(Planet p) {
-        if(null == p) {
+        if (null == p) {
             return;
         }
         this.system = p.getParentSystem();
@@ -556,14 +550,14 @@ public class PlanetarySystemMapPanel extends JPanel {
         int starWidth = Math.min(maxStarWidth, (int) Math.round(0.2 * getWidth()));
         int rectWidth = (getWidth()-starWidth) / n;
         int midpoint = rectWidth / 2;
-        int xTarget = 0;
+        int xTarget;
         int yTarget = getHeight() / 2;
 
-        for(int i = 1; i <= n; i++) {
+        for (int i = 1; i <= n; i++) {
             xTarget = starWidth+rectWidth*(i-1)+midpoint;
             //must be within total possible radius
             int radius = maxDiameter/2;
-            if(x <= (xTarget+radius) & x >= (xTarget-radius) &
+            if (x <= (xTarget+radius) & x >= (xTarget-radius) &
                     y <= (yTarget+radius) & y >= (yTarget-radius)) {
                 return i;
             }
@@ -577,9 +571,9 @@ public class PlanetarySystemMapPanel extends JPanel {
      * @return a <code>BufferedImage</code?
      */
     private BufferedImage getEntityImage(Unit u) {
-        Image img = null;
+        Image img;
         img = hqview.getIconPackage().getMechTiles().imageFor(u.getEntity(), this, -1);
-        if(img == null) {
+        if (img == null) {
             return null;
         }
         int tint = PlayerColors.getColorRGB(campaign.getColorIndex());
@@ -658,7 +652,7 @@ public class PlanetarySystemMapPanel extends JPanel {
     private double getFlightRotation(int lengthX, int lengthY, boolean inbound, boolean zenithJump) {
         double rotation = Math.toDegrees(Math.atan(lengthX / ((1.0 * lengthY))));
         //rotation depends on inbound or outbound
-        if((zenithJump && !inbound) || (!zenithJump && inbound)) {
+        if ((zenithJump && !inbound) || (!zenithJump && inbound)) {
             return 0 - rotation;
         } else  {
             return 180-rotation;
@@ -673,8 +667,8 @@ public class PlanetarySystemMapPanel extends JPanel {
     private Unit getBestDropship() {
         Unit bestUnit = null;
         double bestWeight = 0.0;
-        for(Unit u : campaign.getUnits()) {
-            if(u.getEntity() instanceof Dropship && u.getEntity().getWeight() > bestWeight) {
+        for (Unit u : campaign.getUnits()) {
+            if (u.getEntity() instanceof Dropship && u.getEntity().getWeight() > bestWeight) {
                 bestUnit = u;
                 bestWeight = u.getEntity().getWeight();
             }
@@ -690,8 +684,8 @@ public class PlanetarySystemMapPanel extends JPanel {
     private Unit getBestJumpship() {
         Unit bestUnit = null;
         double bestWeight = 0.0;
-        for(Unit u : campaign.getUnits()) {
-            if(u.getEntity() instanceof Jumpship && u.getEntity().getWeight() > bestWeight) {
+        for (Unit u : campaign.getUnits()) {
+            if (u.getEntity() instanceof Jumpship && u.getEntity().getWeight() > bestWeight) {
                 bestUnit = u;
                 bestWeight = u.getEntity().getWeight();
             }
@@ -706,13 +700,13 @@ public class PlanetarySystemMapPanel extends JPanel {
     public void updateShipImages() {
         dropship = getBestDropship();
         imgDropshipFleet = imgDefaultDropshipFleet;
-        if(null != dropship) {
+        if (null != dropship) {
             imgDropshipFleet = getEntityImage(dropship);
         }
 
         jumpship = getBestJumpship();
         imgJumpshipFleet = imgDefaultJumpshipFleet;
-        if(null != jumpship) {
+        if (null != jumpship) {
             imgJumpshipFleet = getEntityImage(jumpship);
         }
     }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -43,6 +43,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Enumeration;
@@ -4732,6 +4733,7 @@ public class CampaignOptionsDialog extends JDialog {
     private void updateOptions() {
     	campaign.setName(txtName.getText());
     	campaign.setCalendar(date);
+        campaign.setLocalDate(LocalDate.ofYearDay(date.get(Calendar.YEAR), date.get(Calendar.DAY_OF_YEAR)));
         // Ensure that the MegaMek year GameOption matches the campaign year
         GameOptions gameOpts = campaign.getGameOptions();
         int campaignYear = campaign.getGameYear();

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -535,7 +535,7 @@ public class CampaignOptionsDialog extends JDialog {
         // Rules panel
         useEraModsCheckBox.setSelected(options.useEraMods());
         assignedTechFirstCheckBox.setSelected(options.useAssignedTechFirst());
-		resetToFirstTechCheckBox.setSelected(options.useResetToFirstTech());
+        resetToFirstTechCheckBox.setSelected(options.useResetToFirstTech());
         useUnitRatingCheckBox.setSelected(options.useDragoonRating());
         unitRatingMethodCombo.setSelectedItem(options.getUnitRatingMethod().getDescription());
         useTacticsBox.setSelected(options.useTactics());
@@ -627,7 +627,7 @@ public class CampaignOptionsDialog extends JDialog {
         panRandomPortrait = new JPanel();
         useEraModsCheckBox = new JCheckBox();
         assignedTechFirstCheckBox = new JCheckBox();
-		resetToFirstTechCheckBox = new JCheckBox();
+        resetToFirstTechCheckBox = new JCheckBox();
         useUnitRatingCheckBox = new JCheckBox();
         unitRatingMethodCombo = new JComboBox<>(UnitRatingMethod.getUnitRatingMethodNames());
         JLabel clanPriceModifierLabel = new JLabel();
@@ -890,7 +890,7 @@ public class CampaignOptionsDialog extends JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         panSubRepair.add(assignedTechFirstCheckBox, gridBagConstraints);
 
-		resetToFirstTechCheckBox.setText(resourceMap.getString("resetToFirstTechCheckBox.text")); // NOI18N
+        resetToFirstTechCheckBox.setText(resourceMap.getString("resetToFirstTechCheckBox.text")); // NOI18N
         resetToFirstTechCheckBox.setToolTipText(resourceMap.getString("resetToFirstTechCheckBox.toolTipText")); // NOI18N
         resetToFirstTechCheckBox.setName("resetToFirstTechCheckBox"); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -2524,7 +2524,7 @@ public class CampaignOptionsDialog extends JDialog {
         //changing the underlying one in case the user cancels the changes
         tempSPA = new Hashtable<>();
         for(String name : spaNames) {
-        	tempSPA.put(name, SpecialAbility.getAbility(name).clone());
+            tempSPA.put(name, SpecialAbility.getAbility(name).clone());
         }
 
         panXP.setName("panXP"); // NOI18N
@@ -3311,27 +3311,27 @@ public class CampaignOptionsDialog extends JDialog {
             column.setPreferredWidth(ranksModel.getColumnWidth(i));
             column.setCellRenderer(ranksModel.getRenderer());
             if (i == RankTableModel.COL_PAYMULT) {
-            	column.setCellEditor(new SpinnerEditor());
+                column.setCellEditor(new SpinnerEditor());
             }
         }
         tableRanks.getSelectionModel().addListSelectionListener(
                 this::tableRanksValueChanged);
         AbstractAction rankCellAction = new AbstractAction() {
-			private static final long serialVersionUID = -7586376360964669234L;
+            private static final long serialVersionUID = -7586376360964669234L;
 
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				TableCellListener tcl = (TableCellListener)e.getSource();
-				if (!(tcl.getOldValue().equals(tcl.getNewValue()))) {
-					comboRanks.setActionCommand("noFillRanks");
-					comboRanks.setSelectedIndex(Ranks.RS_CUSTOM);
-					comboRanks.setActionCommand("fillRanks");
-				}
-			}
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                TableCellListener tcl = (TableCellListener)e.getSource();
+                if (!(tcl.getOldValue().equals(tcl.getNewValue()))) {
+                    comboRanks.setActionCommand("noFillRanks");
+                    comboRanks.setSelectedIndex(Ranks.RS_CUSTOM);
+                    comboRanks.setActionCommand("fillRanks");
+                }
+            }
 
         };
         @SuppressWarnings("unused") // FIXME:
-		TableCellListener rankCellListener = new TableCellListener(tableRanks, rankCellAction);
+        TableCellListener rankCellListener = new TableCellListener(tableRanks, rankCellAction);
         scrRanks.setViewportView(tableRanks);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -3824,9 +3824,9 @@ public class CampaignOptionsDialog extends JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         panAtB.add(chkUseAtB, gridBagConstraints);
         chkUseAtB.addActionListener(ev -> {
-        	enableAtBComponents(panAtB, chkUseAtB.isSelected());
-        	enableAtBComponents(panSubAtBRat,
-        			chkUseAtB.isSelected() && btnStaticRATs.isSelected());
+            enableAtBComponents(panAtB, chkUseAtB.isSelected());
+            enableAtBComponents(panSubAtBRat,
+                    chkUseAtB.isSelected() && btnStaticRATs.isSelected());
         });
 
         JLabel lblSkillLevel = new JLabel(resourceMap.getString("lblSkillLevel.text"));
@@ -3860,7 +3860,7 @@ public class CampaignOptionsDialog extends JDialog {
         gridBagConstraints.gridy = 1;
         panAtB.add(btnStaticRATs, gridBagConstraints);
         btnStaticRATs.addItemListener(ev -> enableAtBComponents(panSubAtBRat,
-        		btnStaticRATs.isSelected()));
+                btnStaticRATs.isSelected()));
 
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 2;
@@ -3995,18 +3995,18 @@ public class CampaignOptionsDialog extends JDialog {
 
         chosenRatModel = new DefaultListModel<>();
         for (String rat : options.getRATs()) {
-           	List<Integer> eras = RATManager.getAllRATCollections().get(rat);
+            List<Integer> eras = RATManager.getAllRATCollections().get(rat);
             if (eras != null) {
-            	StringBuilder displayName = new StringBuilder(rat);
-            	if (eras.size() > 0) {
-            		displayName.append(" (").append(eras.get(0));
-                	if (eras.size() > 1) {
-                		displayName.append("-").append(eras.get(eras.size() - 1));
-                	}
-                	displayName.append(")");
-            	}
-    			chosenRatModel.addElement(displayName.toString());
-        	}
+                StringBuilder displayName = new StringBuilder(rat);
+                if (eras.size() > 0) {
+                    displayName.append(" (").append(eras.get(0));
+                    if (eras.size() > 1) {
+                        displayName.append("-").append(eras.get(eras.size() - 1));
+                    }
+                    displayName.append(")");
+                }
+                chosenRatModel.addElement(displayName.toString());
+            }
         }
         chosenRats.setModel(chosenRatModel);
         chosenRats.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -4017,20 +4017,20 @@ public class CampaignOptionsDialog extends JDialog {
         });
         availableRatModel = new DefaultListModel<>();
         for (String rat : RATManager.getAllRATCollections().keySet()) {
-           	List<Integer> eras = RATManager.getAllRATCollections().get(rat);
+            List<Integer> eras = RATManager.getAllRATCollections().get(rat);
             if (eras != null) {
-            	StringBuilder displayName = new StringBuilder(rat);
-            	if (eras.size() > 0) {
-            		displayName.append(" (").append(eras.get(0));
-                	if (eras.size() > 1) {
-                		displayName.append("-").append(eras.get(eras.size() - 1));
-                	}
-                	displayName.append(")");
-            	}
-            	if (!chosenRatModel.contains(displayName.toString())) {
-            		availableRatModel.addElement(displayName.toString());
-            	}
-        	}
+                StringBuilder displayName = new StringBuilder(rat);
+                if (eras.size() > 0) {
+                    displayName.append(" (").append(eras.get(0));
+                    if (eras.size() > 1) {
+                        displayName.append("-").append(eras.get(eras.size() - 1));
+                    }
+                    displayName.append(")");
+                }
+                if (!chosenRatModel.contains(displayName.toString())) {
+                    availableRatModel.addElement(displayName.toString());
+                }
+            }
         }
         availableRats.setModel(availableRatModel);
         availableRats.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -4500,9 +4500,9 @@ public class CampaignOptionsDialog extends JDialog {
 
         tabOptions.addTab(resourceMap.getString("panAtB.TabConstraints.tabTitle"),
                 scrAtB); // NOI18N
-		enableAtBComponents(panAtB, chkUseAtB.isSelected());
-		enableAtBComponents(panSubAtBRat, chkUseAtB.isSelected()
-				&& btnStaticRATs.isSelected());
+        enableAtBComponents(panAtB, chkUseAtB.isSelected());
+        enableAtBComponents(panSubAtBRat, chkUseAtB.isSelected()
+                && btnStaticRATs.isSelected());
 
         javax.swing.SwingUtilities.invokeLater(() -> {
             scrSPA.getVerticalScrollBar().setValue(0);
@@ -4598,19 +4598,19 @@ public class CampaignOptionsDialog extends JDialog {
             column.setPreferredWidth(ranksModel.getColumnWidth(i));
             column.setCellRenderer(ranksModel.getRenderer());
             if (i == RankTableModel.COL_PAYMULT) {
-            	column.setCellEditor(new SpinnerEditor());
+                column.setCellEditor(new SpinnerEditor());
             }
         }
     }
 
     @SuppressWarnings("unused") // FIXME:
-	private void tableRanksValueChanged(javax.swing.event.ListSelectionEvent evt) {
+    private void tableRanksValueChanged(javax.swing.event.ListSelectionEvent evt) {
         int row = tableRanks.getSelectedRow();
         //btnDeleteRank.setEnabled(row != -1);
     }
 
     @SuppressWarnings("unused") // FIXME
-	private void addRank() {
+    private void addRank() {
         Object[] rank = {"Unknown", false, 1.0};
         int row = tableRanks.getSelectedRow();
         if (row == -1) {
@@ -4627,13 +4627,13 @@ public class CampaignOptionsDialog extends JDialog {
     }
 
     @SuppressWarnings("unused") // FIXME
-	private void removeRank() {
+    private void removeRank() {
         int row = tableRanks.getSelectedRow();
         if (row > -1) {
             ranksModel.removeRow(row);
         }
         if (tableRanks.getRowCount() == 0) {
-        	return;
+            return;
         }
         if (tableRanks.getRowCount() > row) {
             tableRanks.setRowSelectionInterval(row, row);
@@ -4643,31 +4643,31 @@ public class CampaignOptionsDialog extends JDialog {
     }
 
     private void btnLoadActionPerformed() {
-    	ArrayList<GamePreset> presets = GamePreset.getGamePresetsIn(MekHQ.PRESET_DIR);
+        ArrayList<GamePreset> presets = GamePreset.getGamePresetsIn(MekHQ.PRESET_DIR);
 
-		if (!presets.isEmpty()) {
-			ChooseGamePresetDialog cgpd = new ChooseGamePresetDialog(null, true, presets);
-			cgpd.setVisible(true);
-			if (!cgpd.wasCancelled() && null != cgpd.getSelectedPreset()) {
-				cgpd.getSelectedPreset().apply(campaign);
-				// TODO: it would be nice if we could just update the choices in this dialog now
-				// TODO: rather than closing it, but that is currently not possible given how
-				// TODO: this dialog is set up
-				MekHQ.triggerEvent(new OptionsChangedEvent(campaign));
-				this.setVisible(false);
-			}
-		}
+        if (!presets.isEmpty()) {
+            ChooseGamePresetDialog cgpd = new ChooseGamePresetDialog(null, true, presets);
+            cgpd.setVisible(true);
+            if (!cgpd.wasCancelled() && null != cgpd.getSelectedPreset()) {
+                cgpd.getSelectedPreset().apply(campaign);
+                // TODO: it would be nice if we could just update the choices in this dialog now
+                // TODO: rather than closing it, but that is currently not possible given how
+                // TODO: this dialog is set up
+                MekHQ.triggerEvent(new OptionsChangedEvent(campaign));
+                this.setVisible(false);
+            }
+        }
     }
 
     private void btnSaveActionPerformed() {
         final String METHOD_NAME = "btnSaveActionPerformed()"; //$NON-NLS-1$
-    	if (txtName.getText().length() == 0) {
-    		return;
-    	}
-    	GamePresetDescriptionDialog gpdd = new GamePresetDescriptionDialog(null, true, "Enter a title", "Enter description of preset");
+        if (txtName.getText().length() == 0) {
+            return;
+        }
+        GamePresetDescriptionDialog gpdd = new GamePresetDescriptionDialog(null, true, "Enter a title", "Enter description of preset");
         gpdd.setVisible(true);
         if (!gpdd.wasChanged()) {
-        	return;
+            return;
         }
 
         MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.INFO,
@@ -4727,12 +4727,12 @@ public class CampaignOptionsDialog extends JDialog {
                 backupFile.delete();
             }
         }
-    	this.setVisible(false);
+        this.setVisible(false);
     }
 
     private void updateOptions() {
-    	campaign.setName(txtName.getText());
-    	campaign.setCalendar(date);
+        campaign.setName(txtName.getText());
+        campaign.setCalendar(date);
         campaign.setLocalDate(LocalDate.ofYearDay(date.get(Calendar.YEAR), date.get(Calendar.DAY_OF_YEAR)));
         // Ensure that the MegaMek year GameOption matches the campaign year
         GameOptions gameOpts = campaign.getGameOptions();
@@ -4741,14 +4741,14 @@ public class CampaignOptionsDialog extends JDialog {
             gameOpts.getOption("year").setValue(campaignYear);
         }
         campaign.setFactionCode(Faction.getFactionFromFullNameAndYear
-        		(String.valueOf(comboFaction.getSelectedItem()), date.get(Calendar.YEAR)).getShortName());
+                (String.valueOf(comboFaction.getSelectedItem()), date.get(Calendar.YEAR)).getShortName());
         if (null != comboFactionNames.getSelectedItem()) {
             RandomNameGenerator.getInstance().setChosenFaction((String) comboFactionNames.getSelectedItem());
         }
         RandomGenderGenerator.setPercentFemale(sldGender.getValue());
         campaign.setRankSystem(comboRanks.getSelectedIndex());
         if (comboRanks.getSelectedIndex() == Ranks.RS_CUSTOM) {
-	        campaign.getRanks().setRanksFromModel(ranksModel);
+            campaign.getRanks().setRanksFromModel(ranksModel);
         }
         campaign.setCamoCategory(camoCategory);
         campaign.setCamoFileName(camoFileName);
@@ -4767,7 +4767,7 @@ public class CampaignOptionsDialog extends JDialog {
         // Rules panel
         options.setEraMods(useEraModsCheckBox.isSelected());
         options.setAssignedTechFirst(assignedTechFirstCheckBox.isSelected());
-		options.setResetToFirstTech(resetToFirstTechCheckBox.isSelected());
+        options.setResetToFirstTech(resetToFirstTechCheckBox.isSelected());
         options.setQuirks(useQuirksBox.isSelected());
         campaign.getGameOptions().getOption("stratops_quirks").setValue(useQuirksBox.isSelected());
         options.setClanPriceModifier((Double) spnClanPriceModifier.getModel().getValue());
@@ -5040,7 +5040,7 @@ public class CampaignOptionsDialog extends JDialog {
         //Strip dates used in display name
         String[] ratList = new String[chosenRatModel.size()];
         for (int i = 0; i < chosenRatModel.size(); i++) {
-        	ratList[i] = chosenRatModel.elementAt(i).replaceFirst(" \\(.*?\\)", "");
+            ratList[i] = chosenRatModel.elementAt(i).replaceFirst(" \\(.*?\\)", "");
         }
         options.setRATs(ratList);
         options.setSearchRadius((Integer) spnSearchRadius.getValue());
@@ -5073,7 +5073,7 @@ public class CampaignOptionsDialog extends JDialog {
 
     private void btnOkayActionPerformed() {
         if (txtName.getText().length() > 0) {
-        	updateOptions();
+            updateOptions();
             this.setVisible(false);
         }
     }
@@ -5165,30 +5165,30 @@ public class CampaignOptionsDialog extends JDialog {
     }
 
     private Vector<String> getUnusedSPA() {
-    	Vector<String> unused = new Vector<>();
-    	PilotOptions poptions = new PilotOptions();
-    	for (Enumeration<IOptionGroup> i = poptions.getGroups(); i.hasMoreElements();) {
-    		IOptionGroup group = i.nextElement();
+        Vector<String> unused = new Vector<>();
+        PilotOptions poptions = new PilotOptions();
+        for (Enumeration<IOptionGroup> i = poptions.getGroups(); i.hasMoreElements();) {
+            IOptionGroup group = i.nextElement();
 
-    		if (!group.getKey().equalsIgnoreCase(PilotOptions.LVL3_ADVANTAGES)) {
-    			continue;
-    		}
+            if (!group.getKey().equalsIgnoreCase(PilotOptions.LVL3_ADVANTAGES)) {
+                continue;
+            }
 
-    		for (Enumeration<IOption> j = group.getOptions(); j.hasMoreElements();) {
-    			IOption option = j.nextElement();
-    			if(null == tempSPA.get(option.getName())) {
-    				unused.add(option.getName());
-    			}
-    		}
-    	}
+            for (Enumeration<IOption> j = group.getOptions(); j.hasMoreElements();) {
+                IOption option = j.nextElement();
+                if(null == tempSPA.get(option.getName())) {
+                    unused.add(option.getName());
+                }
+            }
+        }
 
-    	for (String key : SpecialAbility.getAllDefaultSpecialAbilities().keySet()) {
+        for (String key : SpecialAbility.getAllDefaultSpecialAbilities().keySet()) {
             if(null == tempSPA.get(key) && !unused.contains(key)) {
                 unused.add(key);
             }
         }
 
-    	return unused;
+        return unused;
     }
 
     public Hashtable<String, SpecialAbility> getCurrentSPA() {
@@ -5196,10 +5196,10 @@ public class CampaignOptionsDialog extends JDialog {
     }
 
     private void btnAddSPA() {
-    	SelectUnusedAbilityDialog suad = new SelectUnusedAbilityDialog(this.frame, getUnusedSPA(), getCurrentSPA());
-    	suad.setVisible(true);
+        SelectUnusedAbilityDialog suad = new SelectUnusedAbilityDialog(this.frame, getUnusedSPA(), getCurrentSPA());
+        suad.setVisible(true);
 
-    	panSpecialAbilities.removeAll();
+        panSpecialAbilities.removeAll();
 
         GridBagConstraints gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.fill = GridBagConstraints.NONE;
@@ -5232,19 +5232,19 @@ public class CampaignOptionsDialog extends JDialog {
         //we also need to cycle through the existing SPAs and remove this one from
         //any prereqs
         for(String key: tempSPA.keySet()) {
-        	SpecialAbility otherAbil = tempSPA.get(key);
-    		Vector<String> prereq = otherAbil.getPrereqAbilities();
-    		Vector<String> invalid = otherAbil.getInvalidAbilities();
-    		Vector<String> remove = otherAbil.getRemovedAbilities();
-        	if(prereq.remove(name)) {
-        		otherAbil.setPrereqAbilities(prereq);
-        	}
-        	if(invalid.remove(name)) {
-        		otherAbil.setInvalidAbilities(invalid);
-        	}
-        	if(remove.remove(name)) {
-        		otherAbil.setRemovedAbilities(remove);
-        	}
+            SpecialAbility otherAbil = tempSPA.get(key);
+            Vector<String> prereq = otherAbil.getPrereqAbilities();
+            Vector<String> invalid = otherAbil.getInvalidAbilities();
+            Vector<String> remove = otherAbil.getRemovedAbilities();
+            if(prereq.remove(name)) {
+                otherAbil.setPrereqAbilities(prereq);
+            }
+            if(invalid.remove(name)) {
+                otherAbil.setInvalidAbilities(invalid);
+            }
+            if(remove.remove(name)) {
+                otherAbil.setRemovedAbilities(remove);
+            }
         }
 
         panSpecialAbilities.removeAll();
@@ -5306,18 +5306,18 @@ public class CampaignOptionsDialog extends JDialog {
             Image camo = (Image) camos.getItem(camoCategory, camoFileName);
             btnCamo.setIcon(new ImageIcon(camo));
         } catch (Exception err) {
-        	JOptionPane.showMessageDialog(
-        			this,
-        			"Cannot find your camo file.\n"
-        			+ "Setting to default color.\n"
-        			+ "You should browse to the correct camo file,\n"
-        			+ "or if it isn't available copy it into MekHQ's"
-        			+ "data/images/camo folder.",
-        			"Missing Camo File",
-        			JOptionPane.WARNING_MESSAGE);
-        	camoCategory = Player.NO_CAMO;
-        	colorIndex = 0;
-        	setCamoIcon();
+            JOptionPane.showMessageDialog(
+                    this,
+                    "Cannot find your camo file.\n"
+                    + "Setting to default color.\n"
+                    + "You should browse to the correct camo file,\n"
+                    + "or if it isn't available copy it into MekHQ's"
+                    + "data/images/camo folder.",
+                    "Missing Camo File",
+                    JOptionPane.WARNING_MESSAGE);
+            camoCategory = Player.NO_CAMO;
+            colorIndex = 0;
+            setCamoIcon();
         }
     }
 
@@ -5348,25 +5348,25 @@ public class CampaignOptionsDialog extends JDialog {
     }
 
     private void enableAtBComponents(JPanel panel, boolean enabled) {
-    	for (Component c : panel.getComponents()) {
-    		if (c.equals(chkUseAtB)) {
-    			continue;
-    		}
-    		if (c instanceof JPanel) {
-    			enableAtBComponents((JPanel)c, enabled);
-    		} else if (enabled && c.equals(btnAddRat)) {
-    			c.setEnabled(availableRats.getSelectedIndex() >= 0);
-    		} else if (enabled && c.equals(btnRemoveRat)) {
-    			c.setEnabled(chosenRats.getSelectedIndex() >= 0);
-    		} else if (enabled && c.equals(btnMoveRatUp)) {
-				c.setEnabled(chosenRats.getSelectedIndex() > 0);
-    		} else if (enabled && c.equals(btnMoveRatDown)) {
-				c.setEnabled(availableRats.getSelectedIndex() >= 0 &&
-						chosenRatModel.size() > chosenRats.getSelectedIndex() + 1);
-    		} else {
-    			c.setEnabled(enabled);
-    		}
-    	}
+        for (Component c : panel.getComponents()) {
+            if (c.equals(chkUseAtB)) {
+                continue;
+            }
+            if (c instanceof JPanel) {
+                enableAtBComponents((JPanel)c, enabled);
+            } else if (enabled && c.equals(btnAddRat)) {
+                c.setEnabled(availableRats.getSelectedIndex() >= 0);
+            } else if (enabled && c.equals(btnRemoveRat)) {
+                c.setEnabled(chosenRats.getSelectedIndex() >= 0);
+            } else if (enabled && c.equals(btnMoveRatUp)) {
+                c.setEnabled(chosenRats.getSelectedIndex() > 0);
+            } else if (enabled && c.equals(btnMoveRatDown)) {
+                c.setEnabled(availableRats.getSelectedIndex() >= 0 &&
+                        chosenRatModel.size() > chosenRats.getSelectedIndex() + 1);
+            } else {
+                c.setEnabled(enabled);
+            }
+        }
     }
 
     private void updateBattleChances() {
@@ -5524,8 +5524,8 @@ public class CampaignOptionsDialog extends JDialog {
     }
 
     public static class SpinnerEditor extends DefaultCellEditor {
-		private static final long serialVersionUID = -2711422398394960413L;
-		JSpinner spinner;
+        private static final long serialVersionUID = -2711422398394960413L;
+        JSpinner spinner;
         JSpinner.NumberEditor editor;
         JTextField textField;
         boolean valueSet;

--- a/MekHQ/src/mekhq/gui/dialog/ChooseFactionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseFactionsDialog.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2016 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
 package mekhq.gui.dialog;
 
 import java.awt.Component;
@@ -7,6 +25,7 @@ import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -24,26 +43,25 @@ import javax.swing.JScrollPane;
 import mekhq.MekHQ;
 import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
-import org.joda.time.DateTime;
 
 import megamek.common.util.EncodeControl;
 import mekhq.campaign.universe.Faction;
 
 public class ChooseFactionsDialog extends JDialog {
     private static final long serialVersionUID = 805616085217507489L;
-    
-    private DateTime date;
-    
+
+    private LocalDate date;
+
     ResourceBundle resourceMap;
     private JList<Faction> factionList;
     private List<String> result;
     private boolean changed;
-    
-    public ChooseFactionsDialog(Frame parent, DateTime date, List<String> defaults) {
+
+    public ChooseFactionsDialog(Frame parent, LocalDate date, List<String> defaults) {
         this(parent, date, defaults, true);
     }
-    
-    public ChooseFactionsDialog(Frame parent, DateTime date, List<String> defaults, boolean modal) {
+
+    public ChooseFactionsDialog(Frame parent, LocalDate date, List<String> defaults, boolean modal) {
         super(parent, modal);
         this.date = Objects.requireNonNull(date);
         this.result = defaults;
@@ -78,16 +96,16 @@ public class ChooseFactionsDialog extends JDialog {
             public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
                     boolean cellHasFocus) {
                 DefaultListCellRenderer result = (DefaultListCellRenderer) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                if(value instanceof Faction) {
+                if (value instanceof Faction) {
                     result.setText(((Faction)value).getFullName(date.getYear()));
                 }
                 return result;
             }
-            
+
         });
         scrollPane.setViewportView(factionList);
         content.add(scrollPane, gbc);
-        
+
         gbc.gridy = 1;
         gbc.gridwidth = 1;
         gbc.weighty = 0.0;
@@ -99,7 +117,7 @@ public class ChooseFactionsDialog extends JDialog {
             @Override
             public void actionPerformed(ActionEvent e) {
                 result = new ArrayList<>();
-                for(Faction faction : factionList.getSelectedValuesList()) {
+                for (Faction faction : factionList.getSelectedValuesList()) {
                     result.add(faction.getShortName());
                 }
                 changed = true;
@@ -109,7 +127,7 @@ public class ChooseFactionsDialog extends JDialog {
 
         gbc.gridx = 1;
         gbc.anchor = GridBagConstraints.EAST;
-        content.add(new JButton(new AbstractAction(resourceMap.getString("cancel.label")){ //$NON-NLS-1$
+        content.add(new JButton(new AbstractAction(resourceMap.getString("cancel.label")) { //$NON-NLS-1$
             private static final long serialVersionUID = -8920630119126015955L;
 
             @Override
@@ -130,24 +148,24 @@ public class ChooseFactionsDialog extends JDialog {
     public List<String> getResult() {
         return result;
     }
-    
+
     public boolean isChanged() {
         return changed;
     }
 
     private static class FactionListModel extends AbstractListModel<Faction> {
         private static final long serialVersionUID = 2779479232585980171L;
-        
+
         private TreeMap<String, Faction> factionMap = new TreeMap<>();
         private List<String> names;
-        
-        public FactionListModel(DateTime date) {
-            for(Faction faction : Faction.getFactions()) {
+
+        public FactionListModel(LocalDate date) {
+            for (Faction faction : Faction.getFactions()) {
                 factionMap.put(faction.getFullName(date.getYear()), faction);
             }
             names = new ArrayList<>(factionMap.navigableKeySet());
         }
-        
+
         @Override
         public int getSize() {
             return names.size();

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -12,13 +12,12 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
 import java.awt.BorderLayout;
@@ -53,7 +52,6 @@ import megamek.common.Player;
 import megamek.common.util.DirectoryItems;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.universe.Faction;
@@ -68,13 +66,8 @@ import mekhq.preferences.PreferencesNode;
 
 /**
  * @author Neoancient
- *
  */
 public class CustomizeAtBContractDialog extends JDialog {
-
-	/**
-	 *
-	 */
 	private static final long serialVersionUID = -7018467869340880912L;
 	private Frame frame;
 	private AtBContract contract;
@@ -284,7 +277,7 @@ public class CustomizeAtBContractDialog extends JDialog {
         leftPanel.add(lblPlanetName, gbc);
 
         suggestPlanet = new JSuggestField(this, campaign.getSystemNames());
-        suggestPlanet.setText(contract.getSystemName(Utilities.getDateTimeDay(campaign.getCalendar())));
+        suggestPlanet.setText(contract.getSystemName(campaign.getLocalDate()));
         gbc.gridx = 1;
         gbc.gridy = y++;
         gbc.gridwidth = 2;
@@ -626,7 +619,7 @@ public class CustomizeAtBContractDialog extends JDialog {
     	contract.setEnemyColorIndex(enemyColorIndex);
 
     	PlanetarySystem canonSystem = Systems.getInstance().getSystemByName(suggestPlanet.getText(),
-                Utilities.getDateTimeDay(campaign.getCalendar()));
+                campaign.getLocalDate());
 
         if(canonSystem != null) {
             contract.setSystemId(canonSystem.getId());

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeMissionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeMissionDialog.java
@@ -12,13 +12,12 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
 import java.awt.Dimension;
@@ -26,7 +25,6 @@ import java.util.ResourceBundle;
 
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Mission;
 import mekhq.gui.preferences.JWindowPreference;
@@ -37,7 +35,6 @@ import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.preferences.PreferencesNode;
 
 /**
- *
  * @author  Taharqa
  */
 public class CustomizeMissionDialog extends javax.swing.JDialog {
@@ -138,8 +135,8 @@ public class CustomizeMissionDialog extends javax.swing.JDialog {
         getContentPane().add(lblPlanetName, gridBagConstraints);
 
         suggestPlanet = new JSuggestField(this, campaign.getSystemNames());
-        if(!newMission) {
-            suggestPlanet.setText(mission.getSystemName(Utilities.getDateTimeDay(campaign.getCalendar())));
+        if (!newMission) {
+            suggestPlanet.setText(mission.getSystemName(campaign.getLocalDate()));
         }
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
@@ -167,12 +164,7 @@ public class CustomizeMissionDialog extends javax.swing.JDialog {
 
         btnOK.setText(resourceMap.getString("btnOkay.text")); // NOI18N
         btnOK.setName("btnOK"); // NOI18N
-        btnOK.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnOKActionPerformed(evt);
-            }
-        });
+        btnOK.addActionListener(this::btnOKActionPerformed);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 4;
@@ -183,12 +175,7 @@ public class CustomizeMissionDialog extends javax.swing.JDialog {
 
         btnClose.setText(resourceMap.getString("btnCancel.text")); // NOI18N
         btnClose.setName("btnClose"); // NOI18N
-        btnClose.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnCloseActionPerformed(evt);
-            }
-        });
+        btnClose.addActionListener(this::btnCloseActionPerformed);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 4;
@@ -211,19 +198,19 @@ public class CustomizeMissionDialog extends javax.swing.JDialog {
 
     	mission.setName(txtName.getText());
     	mission.setType(txtType.getText());
-    	
+
     	PlanetarySystem canonSystem = Systems.getInstance().getSystemByName(suggestPlanet.getText(),
-                Utilities.getDateTimeDay(campaign.getCalendar()));
-    	
-    	if(canonSystem != null) {
+                campaign.getLocalDate());
+
+    	if (canonSystem != null) {
     	    mission.setSystemId(canonSystem.getId());
     	} else {
     	    mission.setSystemId(null);
     	    mission.setLegacyPlanetName(suggestPlanet.getText());
     	}
-    	
+
     	mission.setDesc(txtDesc.getText());
-    	if(newMission) {
+    	if (newMission) {
     		campaign.addMission(mission);
     	}
     	this.setVisible(false);

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1,7 +1,20 @@
 /*
- * NewPilotDialog.java
+ * Copyright (C) 2013, 2020 - The MegaMek Team. All Rights Reserved.
  *
- * Created on July 16, 2009, 5:30 PM
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui.dialog;
 
@@ -21,10 +34,8 @@ import megamek.client.generator.RandomNameGenerator;
 import megamek.common.enums.Gender;
 import megamek.client.ui.swing.DialogOptionComponent;
 import megamek.client.ui.swing.DialogOptionListener;
-import megamek.common.AmmoType;
 import megamek.common.Crew;
 import megamek.common.EquipmentType;
-import megamek.common.WeaponType;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.Option;
@@ -48,13 +59,12 @@ import mekhq.gui.control.EditPersonnelLogControl;
 import mekhq.gui.preferences.JWindowPreference;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.preferences.PreferencesNode;
-import org.joda.time.DateTime;
 
 /**
  * This dialog is used to both hire new pilots and to edit existing ones
  * @author  Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class CustomizePersonDialog extends javax.swing.JDialog implements DialogOptionListener {
+public class CustomizePersonDialog extends JDialog implements DialogOptionListener {
     private static final long serialVersionUID = -6265589976779860566L;
 
     private Person person;
@@ -379,7 +389,7 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
                                                    cellHasFocus);
                 if (value instanceof PlanetarySystem) {
                     PlanetarySystem system = (PlanetarySystem)value;
-                    setText(system.getName(campaign.getDateTime()));
+                    setText(system.getName(campaign.getLocalDate()));
                 }
 
                 return this;
@@ -439,7 +449,7 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
                                                    cellHasFocus);
                 if (value instanceof Planet) {
                     Planet planet = (Planet)value;
-                    setText(planet.getName(campaign.getDateTime()));
+                    setText(planet.getName(campaign.getLocalDate()));
                 }
 
                 return this;
@@ -800,7 +810,7 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
         DefaultComboBoxModel<Faction> factionsModel = new DefaultComboBoxModel<>();
         for (Faction faction : orderedFactions) {
             // Always include the person's faction
-            if (faction == person.getOriginFaction()) {
+            if (faction.equals(person.getOriginFaction())) {
                 factionsModel.addElement(faction);
             } else {
                 if (faction.is(Tag.HIDDEN) || faction.is(Tag.SPECIAL)) {
@@ -825,9 +835,8 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel() {
         DefaultComboBoxModel<PlanetarySystem> model = new DefaultComboBoxModel<>();
 
-        DateTime currentYear = new DateTime(campaign.getCalendar());
         List<PlanetarySystem> orderedSystems = campaign.getSystems().stream()
-            .sorted(Comparator.comparing(a -> a.getName(currentYear)))
+            .sorted(Comparator.comparing(a -> a.getName(campaign.getLocalDate())))
             .collect(Collectors.toList());
         for (PlanetarySystem system : orderedSystems) {
             model.addElement(system);
@@ -838,10 +847,9 @@ public class CustomizePersonDialog extends javax.swing.JDialog implements Dialog
     private DefaultComboBoxModel<PlanetarySystem> getPlanetarySystemsComboBoxModel(Faction faction) {
         DefaultComboBoxModel<PlanetarySystem> model = new DefaultComboBoxModel<>();
 
-        DateTime birthYear = new DateTime(Instant.from(person.getBirthday().atStartOfDay(ZoneId.systemDefault())));
         List<PlanetarySystem> orderedSystems = campaign.getSystems().stream()
-            .filter(a -> a.getFactionSet(birthYear).contains(faction))
-            .sorted(Comparator.comparing(a -> a.getName(birthYear)))
+            .filter(a -> a.getFactionSet(person.getBirthday()).contains(faction))
+            .sorted(Comparator.comparing(a -> a.getName(person.getBirthday())))
             .collect(Collectors.toList());
         for (PlanetarySystem system : orderedSystems) {
             model.addElement(system);

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -21,7 +21,9 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.ResourceBundle;
 
 import javax.swing.ImageIcon;
@@ -233,12 +235,14 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
                 }
             }
             setProgress(4);
-            if(newCampaign) {
+            if (newCampaign) {
                 // show the date chooser
                 DateChooser dc = new DateChooser(frame, campaign.getCalendar());
                 // user can either choose a date or cancel by closing
                 if (dc.showDateChooser() == DateChooser.OK_OPTION) {
                     campaign.setCalendar(dc.getDate());
+                    campaign.setLocalDate(LocalDate.ofYearDay(dc.getDate().get(Calendar.YEAR),
+                            dc.getDate().get(Calendar.DAY_OF_YEAR)));
                     // Ensure that the MegaMek year GameOption matches the campaign year
                     GameOptions gameOpts = campaign.getGameOptions();
                     int campaignYear = campaign.getGameYear();

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
@@ -1,7 +1,5 @@
 /*
- * EditPersonnelInjuriesDialog.java
- *
- * Copyright (C) 2009-2018 MegaMek team
+ * Copyright (C) 2009-2018 - The MegaMek Team. All Rights Reserved.
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
  *
  * This file is part of MekHQ.
@@ -13,13 +11,12 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
 import java.awt.BorderLayout;
@@ -53,7 +50,6 @@ import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
 
 /**
- *
  * @author  Ralgith
  */
 public class EditPersonnelInjuriesDialog extends JDialog {
@@ -80,7 +76,6 @@ public class EditPersonnelInjuriesDialog extends JDialog {
     }
 
     private void initComponents() {
-
         JButton btnOK = new JButton();
         JButton btnAdd = new JButton();
         btnEdit = new JButton();
@@ -157,7 +152,7 @@ public class EditPersonnelInjuriesDialog extends JDialog {
     }
 
     private void addEntry() {
-        EditInjuryEntryDialog eied = new EditInjuryEntryDialog(frame, true, new Injury(campaign.getDateTime()));
+        EditInjuryEntryDialog eied = new EditInjuryEntryDialog(frame, true, new Injury(campaign.getLocalDate()));
         eied.setAlwaysOnTop(true);
         eied.setVisible(true);
         if (null != eied.getEntry()) {
@@ -231,23 +226,23 @@ public class EditPersonnelInjuriesDialog extends JDialog {
 
         @Override
         public String getColumnName(int column) {
-            switch(column) {
-            case COL_DAYS:
-                return "Days Remaining";
-            case COL_LOCATION:
-                return "Location on Body";
-            case COL_TYPE:
-                return "Type of Injury";
-            case COL_FLUFF:
-                return "Fluff Message";
-            case COL_HITS:
-                return "Number of Hits";
-            case COL_PERMANENT:
-                return "Is Permanent";
-            case COL_WORKEDON:
-                return "Doctor Has Worked On";
-            case COL_EXTENDED:
-                return "Was Extended Time";
+            switch (column) {
+                case COL_DAYS:
+                    return "Days Remaining";
+                case COL_LOCATION:
+                    return "Location on Body";
+                case COL_TYPE:
+                    return "Type of Injury";
+                case COL_FLUFF:
+                    return "Fluff Message";
+                case COL_HITS:
+                    return "Number of Hits";
+                case COL_PERMANENT:
+                    return "Is Permanent";
+                case COL_WORKEDON:
+                    return "Doctor Has Worked On";
+                case COL_EXTENDED:
+                    return "Was Extended Time";
                 default:
                     return "?";
             }
@@ -299,7 +294,7 @@ public class EditPersonnelInjuriesDialog extends JDialog {
         }
 
          public int getColumnWidth(int c) {
-            switch(c) {
+            switch (c) {
                 case COL_DAYS:
                 case COL_HITS:
                 case COL_PERMANENT:
@@ -317,7 +312,7 @@ public class EditPersonnelInjuriesDialog extends JDialog {
         }
 
         public int getAlignment(int col) {
-            switch(col) {
+            switch (col) {
                 case COL_DAYS:
                 case COL_HITS:
                 case COL_PERMANENT:

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -54,30 +54,30 @@ import mekhq.preferences.PreferencesNode;
  * @author Neoancient
  */
 public class NewAtBContractDialog extends NewContractDialog {
-	private static final long serialVersionUID = 7965491540448120578L;
+    private static final long serialVersionUID = 7965491540448120578L;
 
-	protected FactionComboBox cbEmployer;
-	protected FactionComboBox cbEnemy;
-	protected JCheckBox chkShowAllFactions;
-	protected JComboBox<String> cbPlanets;
-	protected JCheckBox chkShowAllPlanets;
-	protected JComboBox<String> cbMissionType;
-	protected JComboBox<String> cbAllySkill;
-	protected JComboBox<String> cbAllyQuality;
-	protected JComboBox<String> cbEnemySkill;
-	protected JComboBox<String> cbEnemyQuality;
-	protected JSpinner spnShares;
-	protected JLabel lblRequiredLances;
+    protected FactionComboBox cbEmployer;
+    protected FactionComboBox cbEnemy;
+    protected JCheckBox chkShowAllFactions;
+    protected JComboBox<String> cbPlanets;
+    protected JCheckBox chkShowAllPlanets;
+    protected JComboBox<String> cbMissionType;
+    protected JComboBox<String> cbAllySkill;
+    protected JComboBox<String> cbAllyQuality;
+    protected JComboBox<String> cbEnemySkill;
+    protected JComboBox<String> cbEnemyQuality;
+    protected JSpinner spnShares;
+    protected JLabel lblRequiredLances;
 
-	Set<String> currentFactions;
-	Set<String> employerSet;
+    Set<String> currentFactions;
+    Set<String> employerSet;
 
-	int dragoonRating;
+    int dragoonRating;
 
-	public NewAtBContractDialog(java.awt.Frame parent, boolean modal, Campaign c) {
-		super(parent, modal, c);
-		setUserPreferences();
-	}
+    public NewAtBContractDialog(java.awt.Frame parent, boolean modal, Campaign c) {
+        super(parent, modal, c);
+        setUserPreferences();
+    }
 
     private void setUserPreferences() {
         PreferencesNode preferences = MekHQ.getPreferences().forClass(NewAtBContractDialog.class);
@@ -86,26 +86,26 @@ public class NewAtBContractDialog extends NewContractDialog {
         preferences.manage(new JWindowPreference(this));
     }
 
-	@Override
-	protected void initComponents() {
-		currentFactions = RandomFactionGenerator.getInstance().getCurrentFactions();
-		employerSet = RandomFactionGenerator.getInstance().getEmployerSet();
-    	contract = new AtBContract("New Contract");
+    @Override
+    protected void initComponents() {
+        currentFactions = RandomFactionGenerator.getInstance().getCurrentFactions();
+        employerSet = RandomFactionGenerator.getInstance().getEmployerSet();
+        contract = new AtBContract("New Contract");
         contract.calculateContract(campaign);
         ((AtBContract)contract).initContractDetails(campaign);
-    	IUnitRating rating = campaign.getUnitRating();
-    	dragoonRating = rating.getUnitRatingAsInteger();
-    	super.initComponents();
+        IUnitRating rating = campaign.getUnitRating();
+        dragoonRating = rating.getUnitRatingAsInteger();
+        super.initComponents();
 
         updateEnemies();
         updatePlanets();
 
         if (getCurrentEmployerCode() != null) {
-        	((AtBContract)contract).setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
+            ((AtBContract)contract).setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
         }
 
         if (getCurrentEnemyCode() != null) {
-        	((AtBContract)contract).setEnemyCode(getCurrentEnemyCode());
+            ((AtBContract)contract).setEnemyCode(getCurrentEnemyCode());
         }
 
 
@@ -120,25 +120,25 @@ public class NewAtBContractDialog extends NewContractDialog {
         this.doUpdateContract(cbPlanets);
 
         addAllListeners();
-	}
+    }
 
-	@Override
-	protected void initDescPanel(ResourceBundle resourceMap, JPanel descPanel) {
-		AtBContract contract = (AtBContract)(this.contract);
+    @Override
+    protected void initDescPanel(ResourceBundle resourceMap, JPanel descPanel) {
+        AtBContract contract = (AtBContract)(this.contract);
 
-		java.awt.GridBagConstraints gbc;
-		txtName = new javax.swing.JTextField();
+        java.awt.GridBagConstraints gbc;
+        txtName = new javax.swing.JTextField();
         JLabel lblName = new JLabel();
         cbEmployer = new FactionComboBox();
         cbEmployer.addFactionEntries(employerSet, campaign.getGameYear());
         JLabel lblEmployer = new JLabel();
-		cbEnemy = new FactionComboBox();
+        cbEnemy = new FactionComboBox();
         JLabel lblEnemy = new JLabel();
-    	chkShowAllFactions = new JCheckBox();
-    	cbPlanets = new JComboBox<String>();
-    	cbPlanets.setModel(new SortedComboBoxModel<String>());
-    	chkShowAllPlanets = new JCheckBox();
-    	cbMissionType = new JComboBox<String>(AtBContract.missionTypeNames);
+        chkShowAllFactions = new JCheckBox();
+        cbPlanets = new JComboBox<String>();
+        cbPlanets.setModel(new SortedComboBoxModel<String>());
+        chkShowAllPlanets = new JCheckBox();
+        cbMissionType = new JComboBox<String>(AtBContract.missionTypeNames);
         JLabel lblType = new JLabel();
         btnOK = new javax.swing.JButton();
         btnClose = new javax.swing.JButton();
@@ -148,17 +148,17 @@ public class NewAtBContractDialog extends NewContractDialog {
         String[] skillNames = {"Green", "Regular", "Veteran", "Elite"};
         // TODO : Switch me to use IUnitRating
         String[] ratingNames = {"F", "D", "C", "B", "A"};
-    	cbAllySkill = new JComboBox<>(skillNames);
-    	cbAllyQuality = new JComboBox<>(ratingNames);
+        cbAllySkill = new JComboBox<>(skillNames);
+        cbAllyQuality = new JComboBox<>(ratingNames);
         JLabel lblAllyRating = new JLabel();
-    	cbEnemySkill = new JComboBox<>(skillNames);
-    	cbEnemyQuality = new JComboBox<>(ratingNames);;
+        cbEnemySkill = new JComboBox<>(skillNames);
+        cbEnemyQuality = new JComboBox<>(ratingNames);;
         JLabel lblEnemyRating = new JLabel();
         JLabel lblShares = new JLabel();
         spnShares = new JSpinner(new SpinnerNumberModel(20, 20, 50, 10));
-    	lblRequiredLances = new JLabel();
+        lblRequiredLances = new JLabel();
 
-    	int y = 0;
+        int y = 0;
 
         lblName.setText(resourceMap.getString("lblName.text")); // NOI18N
         lblName.setName("lblName"); // NOI18N
@@ -182,23 +182,23 @@ public class NewAtBContractDialog extends NewContractDialog {
         descPanel.add(txtName, gbc);
 
         if (campaign.getFactionCode().equals("MERC")) {
-        	lblEmployer.setText(resourceMap.getString("lblEmployer.text")); // NOI18N
-        	lblEmployer.setName("lblEmployer"); // NOI18N
-        	gbc.gridx = 0;
-        	gbc.gridy = y;
-        	gbc.gridwidth = 1;
-        	gbc.anchor = java.awt.GridBagConstraints.WEST;
-        	gbc.insets = new java.awt.Insets(5, 5, 5, 5);
-        	descPanel.add(lblEmployer, gbc);
+            lblEmployer.setText(resourceMap.getString("lblEmployer.text")); // NOI18N
+            lblEmployer.setName("lblEmployer"); // NOI18N
+            gbc.gridx = 0;
+            gbc.gridy = y;
+            gbc.gridwidth = 1;
+            gbc.anchor = java.awt.GridBagConstraints.WEST;
+            gbc.insets = new java.awt.Insets(5, 5, 5, 5);
+            descPanel.add(lblEmployer, gbc);
 
 //        	cbEmployer.setSelectedIndex(0);
-        	gbc.gridx = 1;
-        	gbc.gridy = y++;
-        	gbc.gridwidth = 2;
-        	gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        	gbc.anchor = java.awt.GridBagConstraints.WEST;
-        	gbc.insets = new java.awt.Insets(5, 5, 5, 5);
-        	descPanel.add(cbEmployer, gbc);
+            gbc.gridx = 1;
+            gbc.gridy = y++;
+            gbc.gridwidth = 2;
+            gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
+            gbc.anchor = java.awt.GridBagConstraints.WEST;
+            gbc.insets = new java.awt.Insets(5, 5, 5, 5);
+            descPanel.add(cbEmployer, gbc);
         }
 
         lblEnemy.setText(resourceMap.getString("lblEnemy.text")); // NOI18N
@@ -232,10 +232,10 @@ public class NewAtBContractDialog extends NewContractDialog {
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         descPanel.add(chkShowAllFactions, gbc);
         chkShowAllFactions.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent arg0) {
-				showAllFactions(chkShowAllFactions.isSelected());
-			}
+            @Override
+            public void actionPerformed(ActionEvent arg0) {
+                showAllFactions(chkShowAllFactions.isSelected());
+            }
         });
 
         lblPlanetName.setText(resourceMap.getString("lblPlanetName.text")); // NOI18N
@@ -270,10 +270,10 @@ public class NewAtBContractDialog extends NewContractDialog {
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         descPanel.add(chkShowAllPlanets, gbc);
         chkShowAllPlanets.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent arg0) {
-				showAllPlanets(chkShowAllPlanets.isSelected());
-			}
+            @Override
+            public void actionPerformed(ActionEvent arg0) {
+                showAllPlanets(chkShowAllPlanets.isSelected());
+            }
         });
 
         lblType.setText(resourceMap.getString("lblType.text")); // NOI18N
@@ -307,7 +307,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         descPanel.add(lblAllyRating, gbc);
 
-		cbAllySkill.setSelectedIndex(contract.getAllySkill());
+        cbAllySkill.setSelectedIndex(contract.getAllySkill());
 
         gbc.gridx = 1;
         gbc.gridy = y;
@@ -318,7 +318,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         descPanel.add(cbAllySkill, gbc);
 
-		cbAllyQuality.setSelectedIndex(contract.getAllyQuality());
+        cbAllyQuality.setSelectedIndex(contract.getAllyQuality());
         gbc.gridx = 2;
         gbc.gridy = y++;
         gbc.gridwidth = 1;
@@ -336,7 +336,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         descPanel.add(lblEnemyRating, gbc);
 
-		cbEnemySkill.setSelectedIndex(contract.getEnemySkill());
+        cbEnemySkill.setSelectedIndex(contract.getEnemySkill());
         gbc.gridx = 1;
         gbc.gridy = y;
         gbc.gridwidth = 1;
@@ -346,7 +346,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         descPanel.add(cbEnemySkill, gbc);
 
-		cbEnemyQuality.setSelectedIndex(contract.getEnemyQuality());
+        cbEnemyQuality.setSelectedIndex(contract.getEnemyQuality());
         gbc.gridx = 2;
         gbc.gridy = y++;
         gbc.gridwidth = 1;
@@ -385,166 +385,166 @@ public class NewAtBContractDialog extends NewContractDialog {
         gbc.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gbc.insets = new java.awt.Insets(5, 5, 5, 5);
         descPanel.add(txtDesc, gbc);
-	}
+    }
 
-	private void addAllListeners() {
+    private void addAllListeners() {
         cbPlanets.addActionListener(contractUpdateActionListener);
-		cbMissionType.addActionListener(contractUpdateActionListener);
+        cbMissionType.addActionListener(contractUpdateActionListener);
         cbEmployer.addActionListener(contractUpdateActionListener);
-	    cbEnemy.addActionListener(contractUpdateActionListener);
+        cbEnemy.addActionListener(contractUpdateActionListener);
         cbAllySkill.addActionListener(contractUpdateActionListener);
         cbAllyQuality.addActionListener(contractUpdateActionListener);
         cbEnemySkill.addActionListener(contractUpdateActionListener);
         cbEnemyQuality.addActionListener(contractUpdateActionListener);
         suggestPlanet.addFocusListener(contractUpdateFocusListener);
         suggestPlanet.addActionListener(contractUpdateActionListener);
-	}
+    }
 
-	private void removeAllListeners() {
+    private void removeAllListeners() {
         cbPlanets.removeActionListener(contractUpdateActionListener);
-		cbMissionType.removeActionListener(contractUpdateActionListener);
+        cbMissionType.removeActionListener(contractUpdateActionListener);
         cbEmployer.removeActionListener(contractUpdateActionListener);
-	    cbEnemy.removeActionListener(contractUpdateActionListener);
+        cbEnemy.removeActionListener(contractUpdateActionListener);
         cbAllySkill.removeActionListener(contractUpdateActionListener);
         cbAllyQuality.removeActionListener(contractUpdateActionListener);
         cbEnemySkill.removeActionListener(contractUpdateActionListener);
         cbEnemyQuality.removeActionListener(contractUpdateActionListener);
         suggestPlanet.removeFocusListener(contractUpdateFocusListener);
         suggestPlanet.removeActionListener(contractUpdateActionListener);
-	}
+    }
 
-	private String getCurrentEmployerCode() {
-		if (campaign.getFactionCode().equals("MERC")) {
-			return cbEmployer.getSelectedItemKey();
-		} else {
-			return campaign.getFactionCode();
-		}
-	}
+    private String getCurrentEmployerCode() {
+        if (campaign.getFactionCode().equals("MERC")) {
+            return cbEmployer.getSelectedItemKey();
+        } else {
+            return campaign.getFactionCode();
+        }
+    }
 
-	private String getCurrentEnemyCode() {
-		return cbEnemy.getSelectedItemKey();
-	}
+    private String getCurrentEnemyCode() {
+        return cbEnemy.getSelectedItemKey();
+    }
 
-	private void updateEnemies() {
-		if (chkShowAllFactions.isSelected()) {
-			return;
-		}
-		cbEnemy.removeAllItems();
-		if (getCurrentEmployerCode() == null) {
-			return;
-		}
-		cbEnemy.addFactionEntries(RandomFactionGenerator.getInstance().
-				getEnemyList(getCurrentEmployerCode()), campaign.getGameYear());
-		cbEnemy.setSelectedItemByKey(((AtBContract)contract).getEnemyCode());
-	}
+    private void updateEnemies() {
+        if (chkShowAllFactions.isSelected()) {
+            return;
+        }
+        cbEnemy.removeAllItems();
+        if (getCurrentEmployerCode() == null) {
+            return;
+        }
+        cbEnemy.addFactionEntries(RandomFactionGenerator.getInstance().
+                getEnemyList(getCurrentEmployerCode()), campaign.getGameYear());
+        cbEnemy.setSelectedItemByKey(((AtBContract)contract).getEnemyCode());
+    }
 
-	private void showAllFactions(boolean show) {
-		removeAllListeners();
+    private void showAllFactions(boolean show) {
+        removeAllListeners();
 
-		if (show) {
-			cbEmployer.removeAllItems();
-			cbEnemy.removeAllItems();
-			cbEmployer.addFactionEntries(currentFactions, campaign.getGameYear());
-			cbEnemy.addFactionEntries(currentFactions, campaign.getGameYear());
-			cbEmployer.setSelectedItemByKey(((AtBContract)contract).getEmployerCode());
-			cbEnemy.setSelectedItemByKey(((AtBContract)contract).getEnemyCode());
-		} else {
-			cbEmployer.removeAllItems();
-			cbEmployer.addFactionEntries(employerSet, campaign.getGameYear());
-			cbEmployer.setSelectedItemByKey(((AtBContract)contract).getEmployerCode());
-			updateEnemies();
-		}
-		addAllListeners();
-	}
+        if (show) {
+            cbEmployer.removeAllItems();
+            cbEnemy.removeAllItems();
+            cbEmployer.addFactionEntries(currentFactions, campaign.getGameYear());
+            cbEnemy.addFactionEntries(currentFactions, campaign.getGameYear());
+            cbEmployer.setSelectedItemByKey(((AtBContract)contract).getEmployerCode());
+            cbEnemy.setSelectedItemByKey(((AtBContract)contract).getEnemyCode());
+        } else {
+            cbEmployer.removeAllItems();
+            cbEmployer.addFactionEntries(employerSet, campaign.getGameYear());
+            cbEmployer.setSelectedItemByKey(((AtBContract)contract).getEmployerCode());
+            updateEnemies();
+        }
+        addAllListeners();
+    }
 
-	private void showAllPlanets(boolean show) {
-		removeAllListeners();
-		updatePlanets();
-		suggestPlanet.setVisible(show);
-		cbPlanets.setVisible(!show);
-		addAllListeners();
-	}
+    private void showAllPlanets(boolean show) {
+        removeAllListeners();
+        updatePlanets();
+        suggestPlanet.setVisible(show);
+        cbPlanets.setVisible(!show);
+        addAllListeners();
+    }
 
-	private void updatePlanets() {
-		if (chkShowAllPlanets.isSelected() ||
-				getCurrentEmployerCode() == null ||
-				getCurrentEnemyCode()== null) {
-			return;
-		}
-		AtBContract contract = (AtBContract) this.contract;
-		HashSet<String> systems = new HashSet<>();
-		if (contract.getMissionType() >= AtBContract.MT_PLANETARYASSAULT ||
-				getCurrentEnemyCode().equals("REB") ||
-				getCurrentEnemyCode().equals("PIR")) {
-			for (PlanetarySystem p : RandomFactionGenerator.getInstance().
-					getMissionTargetList(getCurrentEmployerCode(), getCurrentEnemyCode())) {
-			    systems.add(p.getName(campaign.getLocalDate()));
-			}
-		}
-		if ((contract.getMissionType() < AtBContract.MT_PLANETARYASSAULT ||
-				contract.getMissionType() == AtBContract.MT_RELIEFDUTY) &&
-				!contract.getEnemyCode().equals("REB")) {
-			for (PlanetarySystem p : RandomFactionGenerator.getInstance().
-					getMissionTargetList(getCurrentEnemyCode(), getCurrentEmployerCode())) {
-				systems.add(p.getName(campaign.getLocalDate()));
-			}
-		}
-		cbPlanets.removeAllItems();
-		for (String system : systems) {
-			cbPlanets.addItem(system);
-		}
-	}
+    private void updatePlanets() {
+        if (chkShowAllPlanets.isSelected() ||
+                getCurrentEmployerCode() == null ||
+                getCurrentEnemyCode()== null) {
+            return;
+        }
+        AtBContract contract = (AtBContract) this.contract;
+        HashSet<String> systems = new HashSet<>();
+        if (contract.getMissionType() >= AtBContract.MT_PLANETARYASSAULT ||
+                getCurrentEnemyCode().equals("REB") ||
+                getCurrentEnemyCode().equals("PIR")) {
+            for (PlanetarySystem p : RandomFactionGenerator.getInstance().
+                    getMissionTargetList(getCurrentEmployerCode(), getCurrentEnemyCode())) {
+                systems.add(p.getName(campaign.getLocalDate()));
+            }
+        }
+        if ((contract.getMissionType() < AtBContract.MT_PLANETARYASSAULT ||
+                contract.getMissionType() == AtBContract.MT_RELIEFDUTY) &&
+                !contract.getEnemyCode().equals("REB")) {
+            for (PlanetarySystem p : RandomFactionGenerator.getInstance().
+                    getMissionTargetList(getCurrentEnemyCode(), getCurrentEmployerCode())) {
+                systems.add(p.getName(campaign.getLocalDate()));
+            }
+        }
+        cbPlanets.removeAllItems();
+        for (String system : systems) {
+            cbPlanets.addItem(system);
+        }
+    }
 
-	protected void updatePaymentMultiplier() {
-    	if (((AtBContract)contract).getEmployerCode() != null &&
-    			((AtBContract)contract).getEnemyCode() != null) {
-    		((AtBContract)contract).calculatePaymentMultiplier(campaign);
-    		spnMultiplier.setValue(contract.getMultiplier());
-    	}
-	}
+    protected void updatePaymentMultiplier() {
+        if (((AtBContract)contract).getEmployerCode() != null &&
+                ((AtBContract)contract).getEnemyCode() != null) {
+            ((AtBContract)contract).calculatePaymentMultiplier(campaign);
+            spnMultiplier.setValue(contract.getMultiplier());
+        }
+    }
 
-	@Override
-	protected void btnOKActionPerformed(ActionEvent evt) {//GEN-FIRST:event_btnHireActionPerformed
+    @Override
+    protected void btnOKActionPerformed(ActionEvent evt) {//GEN-FIRST:event_btnHireActionPerformed
         if (!btnOK.equals(evt.getSource())) {
             return;
         }
 
         AtBContract contract = (AtBContract)this.contract;
 
-    	contract.setName(txtName.getText());
-		if (chkShowAllPlanets.isSelected()) {
-	    	//contract.setPlanetName(suggestPlanet.getText());
-		} else {
+        contract.setName(txtName.getText());
+        if (chkShowAllPlanets.isSelected()) {
+            //contract.setPlanetName(suggestPlanet.getText());
+        } else {
             contract.setSystemId((Systems.getInstance().getSystemByName((String) cbPlanets.getSelectedItem(),
                     campaign.getLocalDate())).getId());
-		}
-    	contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
-    	contract.setMissionType(cbMissionType.getSelectedIndex());
-    	contract.setDesc(txtDesc.getText());
-    	contract.setCommandRights(choiceCommand.getSelectedIndex());
+        }
+        contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
+        contract.setMissionType(cbMissionType.getSelectedIndex());
+        contract.setDesc(txtDesc.getText());
+        contract.setCommandRights(choiceCommand.getSelectedIndex());
 
-    	contract.setEnemyCode(getCurrentEnemyCode());
-    	contract.setAllySkill(cbAllySkill.getSelectedIndex());
-    	contract.setAllyQuality(cbAllyQuality.getSelectedIndex());
-    	contract.setEnemySkill(cbEnemySkill.getSelectedIndex());
-    	contract.setEnemyQuality(cbEnemyQuality.getSelectedIndex());
-    	contract.setAllyBotName(contract.getEmployerName(campaign.getGameYear()));
-    	contract.setEnemyBotName(contract.getEnemyName(campaign.getGameYear()));
-    	contract.setSharesPct((Integer)spnShares.getValue());
+        contract.setEnemyCode(getCurrentEnemyCode());
+        contract.setAllySkill(cbAllySkill.getSelectedIndex());
+        contract.setAllyQuality(cbAllyQuality.getSelectedIndex());
+        contract.setEnemySkill(cbEnemySkill.getSelectedIndex());
+        contract.setEnemyQuality(cbEnemyQuality.getSelectedIndex());
+        contract.setAllyBotName(contract.getEmployerName(campaign.getGameYear()));
+        contract.setEnemyBotName(contract.getEnemyName(campaign.getGameYear()));
+        contract.setSharesPct((Integer)spnShares.getValue());
 
-    	contract.calculatePartsAvailabilityLevel(campaign);
+        contract.calculatePartsAvailabilityLevel(campaign);
 
-    	campaign.getFinances().credit(contract.getTotalAdvanceAmount(), Transaction.C_CONTRACT, "Advance monies for " + contract.getName(), campaign.getCalendar().getTime());
-    	campaign.addMission(contract);
-    	this.setVisible(false);
+        campaign.getFinances().credit(contract.getTotalAdvanceAmount(), Transaction.C_CONTRACT, "Advance monies for " + contract.getName(), campaign.getCalendar().getTime());
+        campaign.addMission(contract);
+        this.setVisible(false);
     }
 
     @Override
     protected void doUpdateContract(Object source) {
-		removeAllListeners();
+        removeAllListeners();
 
-		boolean needUpdatePayment = false;
-    	AtBContract contract = (AtBContract)this.contract;
+        boolean needUpdatePayment = false;
+        AtBContract contract = (AtBContract)this.contract;
         if (cbPlanets.equals(source) && null != cbPlanets.getSelectedItem()) {
             contract.setSystemId((Systems.getInstance().getSystemByName((String) cbPlanets.getSelectedItem(),
                     campaign.getLocalDate())).getId());
@@ -552,46 +552,46 @@ public class NewAtBContractDialog extends NewContractDialog {
             contract.setStartDate(null);
             needUpdatePayment = true;
         } else if (source.equals(cbEmployer)) {
-        	MekHQ.getLogger().info(getClass(), "doUpdateContract",
+            MekHQ.getLogger().info(getClass(), "doUpdateContract",
                     "Setting employer code to " + getCurrentEmployerCode());
-        	long time = System.currentTimeMillis();
-    		contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
+            long time = System.currentTimeMillis();
+            contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
             MekHQ.getLogger().info(getClass(), "doUpdateContract",
                     "to set employer code: " + (System.currentTimeMillis() - time));
-        	time = System.currentTimeMillis();
-    		updateEnemies();
+            time = System.currentTimeMillis();
+            updateEnemies();
             MekHQ.getLogger().info(getClass(), "doUpdateContract",
                     "to update enemies: " + (System.currentTimeMillis() - time));
-        	time = System.currentTimeMillis();
-    		updatePlanets();
+            time = System.currentTimeMillis();
+            updatePlanets();
             MekHQ.getLogger().info(getClass(), "doUpdateContract",
                     "to update planets: " + (System.currentTimeMillis() - time));
-    		needUpdatePayment = true;
-     	} else if (source.equals(cbEnemy)) {
-    		contract.setEnemyCode(getCurrentEnemyCode());
-    		updatePlanets();
-    		needUpdatePayment = true;
-    	} else if (source.equals(cbMissionType)) {
-    		contract.setMissionType(cbMissionType.getSelectedIndex());
-    		contract.calculateLength(campaign.getCampaignOptions().getVariableContractLength());
-    		spnLength.setValue(contract.getLength());
-    		updatePlanets();
-    		needUpdatePayment = true;
-    	} else if (source.equals(cbAllySkill)) {
-    		contract.setAllySkill(cbAllySkill.getSelectedIndex());
-    	} else if (source.equals(cbAllyQuality)) {
-    		contract.setAllyQuality(cbAllyQuality.getSelectedIndex());
-    	} else if (source.equals(cbEnemySkill)) {
-    		contract.setEnemySkill(cbEnemySkill.getSelectedIndex());
-    	} else if (source.equals(cbEnemyQuality)) {
-    		contract.setEnemyQuality(cbEnemyQuality.getSelectedIndex());
-    	}
+            needUpdatePayment = true;
+        } else if (source.equals(cbEnemy)) {
+            contract.setEnemyCode(getCurrentEnemyCode());
+            updatePlanets();
+            needUpdatePayment = true;
+        } else if (source.equals(cbMissionType)) {
+            contract.setMissionType(cbMissionType.getSelectedIndex());
+            contract.calculateLength(campaign.getCampaignOptions().getVariableContractLength());
+            spnLength.setValue(contract.getLength());
+            updatePlanets();
+            needUpdatePayment = true;
+        } else if (source.equals(cbAllySkill)) {
+            contract.setAllySkill(cbAllySkill.getSelectedIndex());
+        } else if (source.equals(cbAllyQuality)) {
+            contract.setAllyQuality(cbAllyQuality.getSelectedIndex());
+        } else if (source.equals(cbEnemySkill)) {
+            contract.setEnemySkill(cbEnemySkill.getSelectedIndex());
+        } else if (source.equals(cbEnemyQuality)) {
+            contract.setEnemyQuality(cbEnemyQuality.getSelectedIndex());
+        }
 
-    	if (needUpdatePayment) {
+        if (needUpdatePayment) {
             updatePaymentMultiplier();
         }
-    	super.doUpdateContract(source);
+        super.doUpdateContract(source);
 
-    	addAllListeners();
+        addAllListeners();
    }
 }

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -12,11 +12,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui.dialog;
 
@@ -28,17 +28,14 @@ import java.util.HashSet;
 import java.util.ResourceBundle;
 import java.util.Set;
 
-import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 
 import mekhq.MekHQ;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Transaction;
 import mekhq.campaign.mission.AtBContract;
@@ -55,14 +52,8 @@ import mekhq.preferences.PreferencesNode;
 
 /**
  * @author Neoancient
- *
  */
-
 public class NewAtBContractDialog extends NewContractDialog {
-
-    /**
-	 *
-	 */
 	private static final long serialVersionUID = 7965491540448120578L;
 
 	protected FactionComboBox cbEmployer;
@@ -118,10 +109,9 @@ public class NewAtBContractDialog extends NewContractDialog {
         }
 
 
-        if(cbPlanets.getSelectedItem() != null) {
-            ((AtBContract) contract)
-                .setSystemId((Systems.getInstance().getSystemByName((String) cbPlanets.getSelectedItem(),
-                    Utilities.getDateTimeDay(campaign.getCalendar()))).getId());
+        if (cbPlanets.getSelectedItem() != null) {
+            contract.setSystemId((Systems.getInstance().getSystemByName((String) cbPlanets.getSelectedItem(),
+                    campaign.getLocalDate())).getId());
         }
 
         spnMultiplier.setModel(new SpinnerNumberModel(contract.getMultiplier(), 0.1, 10.0, 0.1));
@@ -158,11 +148,11 @@ public class NewAtBContractDialog extends NewContractDialog {
         String[] skillNames = {"Green", "Regular", "Veteran", "Elite"};
         // TODO : Switch me to use IUnitRating
         String[] ratingNames = {"F", "D", "C", "B", "A"};
-    	cbAllySkill = new JComboBox<String>(skillNames);
-    	cbAllyQuality = new JComboBox<String>(ratingNames);
+    	cbAllySkill = new JComboBox<>(skillNames);
+    	cbAllyQuality = new JComboBox<>(ratingNames);
         JLabel lblAllyRating = new JLabel();
-    	cbEnemySkill = new JComboBox<String>(skillNames);
-    	cbEnemyQuality = new JComboBox<String>(ratingNames);;
+    	cbEnemySkill = new JComboBox<>(skillNames);
+    	cbEnemyQuality = new JComboBox<>(ratingNames);;
         JLabel lblEnemyRating = new JLabel();
         JLabel lblShares = new JLabel();
         spnShares = new JSpinner(new SpinnerNumberModel(20, 20, 50, 10));
@@ -481,14 +471,14 @@ public class NewAtBContractDialog extends NewContractDialog {
 				getCurrentEnemyCode()== null) {
 			return;
 		}
-		AtBContract contract = (AtBContract)this.contract;
-		HashSet<String> systems = new HashSet<String>();
+		AtBContract contract = (AtBContract) this.contract;
+		HashSet<String> systems = new HashSet<>();
 		if (contract.getMissionType() >= AtBContract.MT_PLANETARYASSAULT ||
 				getCurrentEnemyCode().equals("REB") ||
 				getCurrentEnemyCode().equals("PIR")) {
 			for (PlanetarySystem p : RandomFactionGenerator.getInstance().
 					getMissionTargetList(getCurrentEmployerCode(), getCurrentEnemyCode())) {
-			    systems.add(p.getName(Utilities.getDateTimeDay(campaign.getCalendar())));
+			    systems.add(p.getName(campaign.getLocalDate()));
 			}
 		}
 		if ((contract.getMissionType() < AtBContract.MT_PLANETARYASSAULT ||
@@ -496,7 +486,7 @@ public class NewAtBContractDialog extends NewContractDialog {
 				!contract.getEnemyCode().equals("REB")) {
 			for (PlanetarySystem p : RandomFactionGenerator.getInstance().
 					getMissionTargetList(getCurrentEnemyCode(), getCurrentEmployerCode())) {
-				systems.add(p.getName(Utilities.getDateTimeDay(campaign.getCalendar())));
+				systems.add(p.getName(campaign.getLocalDate()));
 			}
 		}
 		cbPlanets.removeAllItems();
@@ -526,7 +516,7 @@ public class NewAtBContractDialog extends NewContractDialog {
 	    	//contract.setPlanetName(suggestPlanet.getText());
 		} else {
             contract.setSystemId((Systems.getInstance().getSystemByName((String) cbPlanets.getSelectedItem(),
-                    Utilities.getDateTimeDay(campaign.getCalendar()))).getId());
+                    campaign.getLocalDate())).getId());
 		}
     	contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
     	contract.setMissionType(cbMissionType.getSelectedIndex());
@@ -557,7 +547,7 @@ public class NewAtBContractDialog extends NewContractDialog {
     	AtBContract contract = (AtBContract)this.contract;
         if (cbPlanets.equals(source) && null != cbPlanets.getSelectedItem()) {
             contract.setSystemId((Systems.getInstance().getSystemByName((String) cbPlanets.getSelectedItem(),
-                    Utilities.getDateTimeDay(campaign.getCalendar()))).getId());
+                    campaign.getLocalDate())).getId());
             //reset the start date as null so we recalculate travel time
             contract.setStartDate(null);
             needUpdatePayment = true;

--- a/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
@@ -12,13 +12,12 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
 import java.awt.Dimension;
@@ -46,7 +45,6 @@ import javax.swing.event.ChangeListener;
 
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Transaction;
 import mekhq.campaign.mission.Contract;
@@ -61,7 +59,6 @@ import mekhq.gui.view.ContractPaymentBreakdown;
 import mekhq.preferences.PreferencesNode;
 
 /**
- *
  * @author  Taharqa
  */
 public class NewContractDialog extends javax.swing.JDialog {
@@ -771,7 +768,7 @@ public class NewContractDialog extends javax.swing.JDialog {
     protected void doUpdateContract(Object source) {
         if (suggestPlanet.equals(source)) {
             contract.setSystemId((Systems.getInstance().getSystemByName(suggestPlanet.getText(),
-                    Utilities.getDateTimeDay(campaign.getCalendar()))).getId());
+                    campaign.getLocalDate())).getId());
             //reset the start date as null so we recalculate travel time
             contract.setStartDate(null);
         } else if (choiceOverhead.equals(source)) {

--- a/MekHQ/src/mekhq/gui/dialog/NewsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewsReportDialog.java
@@ -1,56 +1,66 @@
 /*
- * NewsReportDialog.java
+ * Copyright (c) 2013 - The MegaMek Team. All Rights Reserved.
  *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 
-import javax.swing.JScrollPane;
-import javax.swing.JTextPane;
+import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 
 import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
 
 /**
- *
  * @author Jay Lawson
  */
-public class NewsReportDialog extends javax.swing.JDialog {
-    
+public class NewsReportDialog extends JDialog {
     private static final long serialVersionUID = 3624327778807359294L;
 
     private JTextPane txtNews;
 
-    public NewsReportDialog(java.awt.Frame parent, NewsItem news) {
+    public NewsReportDialog(JFrame parent, NewsItem news, Campaign campaign) {
         super(parent, false);
         setTitle(news.getHeadline());
-        initComponents();     
-        txtNews.setText(news.getFullDescription());
+        initComponents();
+        txtNews.setText(news.getFullDescription(campaign));
         txtNews.setCaretPosition(0);
         setMinimumSize(new Dimension(500, 300));
         setPreferredSize(new Dimension(500, 300));
         setLocationRelativeTo(parent);
         setUserPreferences();
     }
-    
-    private void initComponents() {
 
+    private void initComponents() {
         txtNews = new JTextPane();
         txtNews.setContentType("text/html");
         txtNews.setEditable(false);
         JScrollPane scrNews = new JScrollPane(txtNews);
         scrNews.setBorder( new EmptyBorder(2,10,2,2));
 
-        setLayout(new java.awt.BorderLayout());
-        
+        setLayout(new BorderLayout());
+
         txtNews.setEditable(false);
-        
+
         getContentPane().add(scrNews, BorderLayout.CENTER);
     }
 

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The MegaMek Team. All rights reserved.
+ * Copyright (c) 2020 - The MegaMek Team. All rights reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui.model;
 
@@ -646,7 +646,7 @@ public class PersonnelTableModel extends DataTableModel {
             case COL_ORIGIN_PLANET:
                 Planet originPlanet = p.getOriginPlanet();
                 if (originPlanet != null) {
-                    return originPlanet.getName(getCampaign().getDateTime());
+                    return originPlanet.getName(getCampaign().getLocalDate());
                 }
                 break;
             case COL_TOUGH:

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -13,11 +13,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui.view;
 
@@ -25,12 +25,12 @@ import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.ResourceBundle;
 
 import javax.swing.*;
 
 import megamek.common.util.EncodeControl;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.market.ContractMarket;
@@ -205,7 +205,7 @@ public class ContractSummaryPanel extends JPanel {
         mainPanel.add(lblLocation, gridBagConstraintsLabels);
 
         JLabel txtLocation = new JLabel(String.format("<html><a href='#'>%s</a></html>",
-                contract.getSystemName(Utilities.getDateTimeDay(campaign.getCalendar()))));
+                contract.getSystemName(campaign.getLocalDate())));
         txtLocation.setName("txtLocation");
         txtLocation.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         txtLocation.addMouseListener(new MouseAdapter() {
@@ -226,7 +226,9 @@ public class ContractSummaryPanel extends JPanel {
             mainPanel.add(lblDistance, gridBagConstraintsLabels);
 
             JumpPath path = campaign.calculateJumpPath(campaign.getCurrentSystem(), contract.getSystem());
-            int days = (int) Math.ceil(path.getTotalTime(Utilities.getDateTimeDay(contract.getStartDate()),
+
+            int days = (int) Math.ceil(path.getTotalTime(
+                    contract.getStartDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
                     campaign.getLocation().getTransitTime()));
             int jumps = path.getJumps();
             if (campaign.getCurrentSystem().getId().equals(contract.getSystemId())

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -1,19 +1,29 @@
 /*
- * JumpPathViewPanel
+ * Copyright (C) 2009-2020 - The MegaMek Team. All Rights Reserved.
  *
- * Created on July 26, 2009, 11:32 PM
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.view;
 
+import java.time.LocalDate;
 import java.util.ResourceBundle;
 
 import javax.swing.BorderFactory;
 
-import org.joda.time.DateTime;
-
 import megamek.common.util.EncodeControl;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.universe.PlanetarySystem;
@@ -92,15 +102,15 @@ public class JumpPathViewPanel extends ScrollablePanel {
         pnlPath.setLayout(new java.awt.GridBagLayout());
         int i = 0;
         javax.swing.JLabel lblPlanet;
-        DateTime currentDate = Utilities.getDateTimeDay(campaign.getCalendar());
-        for(PlanetarySystem system : path.getSystems()) {
+        LocalDate currentDate = campaign.getLocalDate();
+        for (PlanetarySystem system : path.getSystems()) {
             lblPlanet = new javax.swing.JLabel(system.getPrintableName(currentDate) + " (" + system.getRechargeTimeText(currentDate) + ")");
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = i;
             gridBagConstraints.gridwidth = 1;
             gridBagConstraints.weightx = 1.0;
-            if(i >= (path.getSystems().size()-1)) {
+            if (i >= (path.getSystems().size() - 1)) {
                 gridBagConstraints.weighty = 1.0;
             }
             gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 0);
@@ -112,7 +122,6 @@ public class JumpPathViewPanel extends ScrollablePanel {
     }
 
     private void fillStats() {
-
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.JumpPathViewPanel", new EncodeControl()); //$NON-NLS-1$
 
         lblJumps = new javax.swing.JLabel();
@@ -128,7 +137,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         lblCost = new javax.swing.JLabel();
         txtCost = new javax.swing.JLabel();
 
-        DateTime currentDate = Utilities.getDateTimeDay(campaign.getCalendar());
+        LocalDate currentDate = campaign.getLocalDate();
         String startName = (path.getFirstSystem() == null) ? "?" : path.getFirstSystem().getPrintableName(currentDate);
         String endName = (path.getLastSystem() == null) ? "?" : path.getLastSystem().getPrintableName(currentDate);
 
@@ -235,7 +244,7 @@ public class JumpPathViewPanel extends ScrollablePanel {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         pnlStats.add(txtTotalTime, gridBagConstraints);
 
-        if(campaign.getCampaignOptions().payForTransport()) {
+        if (campaign.getCampaignOptions().payForTransport()) {
             lblCost.setName("lblCost1"); // NOI18N
             lblCost.setText(resourceMap.getString("lblCost1.text"));
             gridBagConstraints = new java.awt.GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -1,9 +1,21 @@
 /*
- * MissionViewPanel
+ * Copyright (c) 2009 - The MegaMek Team. All Rights Reserved.
  *
- * Created on July 26, 2009, 11:32 PM
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.view;
 
 import java.awt.*;
@@ -15,7 +27,6 @@ import java.util.ResourceBundle;
 import javax.swing.*;
 
 import megamek.common.util.EncodeControl;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Mission;
@@ -29,10 +40,6 @@ import mekhq.gui.utilities.MarkdownRenderer;
  * @author  Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class MissionViewPanel extends ScrollablePanel {
-
-	/**
-	 *
-	 */
 	private static final long serialVersionUID = 7004741688464105277L;
 
 	private Mission mission;
@@ -619,7 +626,7 @@ public class MissionViewPanel extends ScrollablePanel {
         pnlStats.add(lblLocation, gridBagConstraints);
 
         txtLocation.setName("txtLocation"); // NOI18N
-        String systemName = contract.getSystemName(Utilities.getDateTimeDay(campaign.getCalendar()));
+        String systemName = contract.getSystemName(campaign.getLocalDate());
         txtLocation.setText(String.format("<html><a href='#'>%s</a></html>", systemName));
         txtLocation.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         txtLocation.addMouseListener(new MouseAdapter() {
@@ -994,5 +1001,4 @@ public class MissionViewPanel extends ScrollablePanel {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlStats.add(txtDesc, gridBagConstraints);
     }
-
 }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1,9 +1,21 @@
 /*
- * PersonViewPanel
+ * Copyright (C) 2013-2020 - The MegaMek Team. All Rights Reserved.
  *
- * Created on July 26, 2009, 11:32 PM
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.view;
 
 import java.awt.*;
@@ -31,7 +43,6 @@ import javax.swing.table.TableColumn;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.FormerSpouse;
 import mekhq.campaign.personnel.enums.GenderDescriptors;
-import org.joda.time.DateTime;
 
 import megamek.common.Crew;
 import megamek.common.options.PilotOptions;
@@ -526,9 +537,9 @@ public class PersonViewPanel extends ScrollablePanel {
             pnlInfo.add(lblOrigin1, gridBagConstraints);
 
             lblOrigin2.setName("lblOrigin2"); // NOI18N
-            String factionName = person.getOriginFaction().getFullName(person.getCampaign().getGameYear());
+            String factionName = person.getOriginFaction().getFullName(campaign.getGameYear());
             if (person.getOriginPlanet() != null) {
-                String planetName = person.getOriginPlanet().getName(new DateTime(person.getCampaign().getCalendar()));
+                String planetName = person.getOriginPlanet().getName(campaign.getLocalDate());
                 lblOrigin2.setText(String.format("<html><a href='#'>%s</a> (%s)</html>", planetName, factionName));
                 lblOrigin2.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
                 lblOrigin2.addMouseListener(new MouseAdapter() {

--- a/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
@@ -1,9 +1,21 @@
 /*
- * PlanetViewPanel
+ * Copyright (C) 2009-2020 - The MegaMek Team. All Rights Reserved.
  *
- * Created on July 26, 2009, 11:32 PM
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.view;
 
 import java.awt.Color;
@@ -16,6 +28,7 @@ import java.awt.Insets;
 import java.awt.RenderingHints;
 import java.awt.geom.Arc2D;
 import java.text.NumberFormat;
+import java.time.LocalDate;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -25,8 +38,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextPane;
 import javax.swing.text.DefaultCaret;
-
-import org.joda.time.DateTime;
 
 import megamek.common.util.EncodeControl;
 import mekhq.Utilities;
@@ -64,31 +75,30 @@ public class PlanetViewPanel extends ScrollablePanel {
     }
 
     private void initComponents() {
-
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PlanetViewPanel", new EncodeControl()); //$NON-NLS-1
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
         pnlSystem = getSystemPanel();
-        pnlSystem.setBorder(BorderFactory.createTitledBorder(system.getPrintableName(Utilities.getDateTimeDay(campaign.getCalendar())) + " " + resourceMap.getString("system.text")));
+        pnlSystem.setBorder(BorderFactory.createTitledBorder(system.getPrintableName(campaign.getLocalDate()) + " " + resourceMap.getString("system.text")));
         add(pnlSystem);
 
         Planet planet = system.getPlanet(planetPos);
-        if(null == planet) {
+        if (null == planet) {
             //try the primary - but still could be null
             planet = system.getPrimaryPlanet();
         }
-        if(null != planet) {
+        if (null != planet) {
             pnlPlanet = getPlanetPanel(planet);
-            pnlPlanet.setBorder(BorderFactory.createTitledBorder(planet.getPrintableName(Utilities.getDateTimeDay(campaign.getCalendar()))));
+            pnlPlanet.setBorder(BorderFactory.createTitledBorder(planet.getPrintableName(campaign.getLocalDate())));
             add(pnlPlanet);
-        };
+        }
     }
 
     @Override
     protected void paintChildren(Graphics g) {
         super.paintChildren(g);
 
-        if(null != planetIcon) {
+        if (null != planetIcon) {
             Graphics2D gfx = (Graphics2D) g;
             final int width = getWidth();
             final int offset = 6;
@@ -105,13 +115,12 @@ public class PlanetViewPanel extends ScrollablePanel {
     }
 
     private JPanel getPlanetPanel(Planet planet) {
-
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PlanetViewPanel", new EncodeControl()); //$NON-NLS-1
         JPanel panel = new JPanel();
         panel.setLayout(new GridBagLayout());
-        DateTime currentDate = Utilities.getDateTimeDay(campaign.getCalendar());
+        LocalDate currentDate = campaign.getLocalDate();
 
-        JLabel lblOwner = new JLabel("<html><nobr><i>" + planet.getFactionDesc(currentDate) + "</i></nobr></html>");
+        JLabel lblOwner = new JLabel("<html><nobr><i>" + planet.getFactionDesc(campaign.getLocalDate()) + "</i></nobr></html>");
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
@@ -190,7 +199,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         ++ infoRow;
 
         //Year length
-        if(null != planet.getYearLength()) {
+        if (null != planet.getYearLength()) {
             JLabel lblYear = new JLabel(resourceMap.getString("lblYear1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblYear, gbcLabel);
@@ -201,7 +210,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //day length
-        if(null != planet.getDayLength(currentDate)) {
+        if (null != planet.getDayLength(currentDate)) {
             JLabel lblDay = new JLabel(resourceMap.getString("lblDay1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblDay, gbcLabel);
@@ -212,7 +221,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //Gravity
-        if(null != planet.getGravity()) {
+        if (null != planet.getGravity()) {
             JLabel lblGravity = new JLabel(resourceMap.getString("lblGravity1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblGravity, gbcLabel);
@@ -223,7 +232,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //Atmosphere
-        if(null != planet.getAtmosphere(currentDate)) {
+        if (null != planet.getAtmosphere(currentDate)) {
             JLabel lblAtmosphere = new JLabel(resourceMap.getString("lblAtmosphere.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblAtmosphere, gbcLabel);
@@ -234,7 +243,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //Atmospheric Pressure
-        if(null != planet.getPressure(currentDate)) {
+        if (null != planet.getPressure(currentDate)) {
             JLabel lblPressure = new JLabel(resourceMap.getString("lblPressure1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblPressure, gbcLabel);
@@ -245,7 +254,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //Atmospheric composition
-        if(null != planet.getComposition(currentDate)) {
+        if (null != planet.getComposition(currentDate)) {
             JLabel lblComposition = new JLabel(resourceMap.getString("lblComposition.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblComposition, gbcLabel);
@@ -256,7 +265,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //Temperature
-        if((null != planet.getTemperature(currentDate))) {
+        if ((null != planet.getTemperature(currentDate))) {
             JLabel lblTemp = new JLabel(resourceMap.getString("lblTemp1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblTemp, gbcLabel);
@@ -268,7 +277,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //Water
-        if(null != planet.getPercentWater(currentDate)) {
+        if (null != planet.getPercentWater(currentDate)) {
             JLabel lblWater = new JLabel(resourceMap.getString("lblWater1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblWater, gbcLabel);
@@ -279,7 +288,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //native life forms
-        if(null != planet.getLifeForm(currentDate)) {
+        if (null != planet.getLifeForm(currentDate)) {
             JLabel lblAnimal = new JLabel(resourceMap.getString("lblAnimal1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblAnimal, gbcLabel);
@@ -290,7 +299,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //satellites
-        if(null != planet.getSatellites() || planet.getSmallMoons()>0) {
+        if (null != planet.getSatellites() || planet.getSmallMoons()>0) {
         	JLabel lblSatellite = new JLabel(resourceMap.getString("lblSatellite1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblSatellite, gbcLabel);
@@ -301,7 +310,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //landmasses
-        if(null != planet.getLandMasses()) {
+        if (null != planet.getLandMasses()) {
             JLabel lblLandMass = new JLabel(resourceMap.getString("lblLandMass1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblLandMass, gbcLabel);
@@ -312,7 +321,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //Population
-        if(null != planet.getPopulation(currentDate)) {
+        if (null != planet.getPopulation(currentDate)) {
             JLabel lblPopulation = new JLabel(resourceMap.getString("lblPopulation.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblPopulation, gbcLabel);
@@ -323,7 +332,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //SIC codes
-        if(null != planet.getSocioIndustrial(currentDate)) {
+        if (null != planet.getSocioIndustrial(currentDate)) {
             JLabel lblSocioIndustrial = new JLabel(resourceMap.getString("lblSocioIndustrial1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblSocioIndustrial, gbcLabel);
@@ -336,7 +345,7 @@ public class PlanetViewPanel extends ScrollablePanel {
         }
 
         //HPG status
-        if(null != planet.getHPGClass(currentDate)) {
+        if (null != planet.getHPGClass(currentDate)) {
             JLabel lblHPG = new JLabel(resourceMap.getString("lblHPG1.text"));
             gbcLabel.gridy = infoRow;
             panel.add(lblHPG, gbcLabel);
@@ -346,7 +355,7 @@ public class PlanetViewPanel extends ScrollablePanel {
             ++ infoRow;
         }
 
-        if(null != planet.getDescription()) {
+        if (null != planet.getDescription()) {
             JTextPane txtDesc = new JTextPane();
             txtDesc.setEditable(false);
             txtDesc.setContentType("text/html");
@@ -368,11 +377,10 @@ public class PlanetViewPanel extends ScrollablePanel {
     }
 
     private JPanel getSystemPanel() {
-
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PlanetViewPanel", new EncodeControl()); //$NON-NLS-1$
         JPanel panel = new JPanel();
         panel.setLayout(new GridBagLayout());
-        DateTime currentDate = Utilities.getDateTimeDay(campaign.getCalendar());
+        LocalDate currentDate = campaign.getLocalDate();
 
         //Set up grid bag constraints
         GridBagConstraints gbcLabel = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
@@ -178,10 +178,10 @@ public class PlanetViewPanel extends ScrollablePanel {
             				planet.getOrbitRadius());
             	} else {
             		text = String.format("%s (%.3f AU)", //$NON-NLS-1$
-            				planet.getDiplayableSystemPosition(), planet.getOrbitRadius());
+            				planet.getDisplayableSystemPosition(), planet.getOrbitRadius());
             	}
             } else {
-                text = planet.getDiplayableSystemPosition();
+                text = planet.getDisplayableSystemPosition();
             }
             JLabel txtPosition = new JLabel(text);
             gbcText.gridy = infoRow;

--- a/MekHQ/unittests/mekhq/campaign/universe/FactionBordersTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/FactionBordersTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2018 - The MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,32 +23,32 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
 public class FactionBordersTest {
-    
+
     private Faction factionUs;
     private Faction factionThem;
-    
+
     @Before
     public void init() {
         factionUs = createFaction("us", false);
         factionThem = createFaction("them", false);
     }
-    
+
     private Faction createFaction(final String key, final boolean periphery) {
         Faction faction = mock(Faction.class);
         when(faction.getShortName()).thenReturn(key);
         when(faction.isPeriphery()).thenReturn(periphery);
         return faction;
     }
-    
+
     private PlanetarySystem createSystem(final double x, final double y, Faction owner) {
         PlanetarySystem system = mock(PlanetarySystem.class);
         when(system.getX()).thenReturn(x);
@@ -61,7 +61,7 @@ public class FactionBordersTest {
 
     @Test
     public void testGetBorderPlanetsFactionBorders() {
-        DateTime when = new DateTime();
+        LocalDate when = LocalDate.now();
         List<PlanetarySystem> systems = new ArrayList<>();
         for (int x = -3; x <= 3; x += 2) {
             for (int y = -2; y <= 2; y += 2) {
@@ -71,14 +71,13 @@ public class FactionBordersTest {
         systems.add(createSystem(0, 0, factionUs));
         FactionBorders us = new FactionBorders(factionUs, when, systems);
         FactionBorders them = new FactionBorders(factionThem, when, systems);
-        
+
         List<PlanetarySystem> border = us.getBorderSystems(them, 1.1);
-        
+
         assertEquals(border.size(), 2);
         for (PlanetarySystem p : border) {
             assertEquals(Math.abs(p.getX()), 1, RegionPerimeter.EPSILON);
             assertEquals(p.getY(), 0, RegionPerimeter.EPSILON);
         }
     }
-
 }

--- a/MekHQ/unittests/mekhq/campaign/universe/FactionHintsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/FactionHintsTest.java
@@ -10,33 +10,30 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.universe;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Calendar;
+import java.time.LocalDate;
 import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
 
 import org.junit.Test;
 
 public class FactionHintsTest {
-    
+
     private Faction createTestFaction(final String id) {
         Faction f = mock(Faction.class);
         when(f.getShortName()).thenReturn(id);
         return f;
     }
-    
+
     @Test
     public void testIsAlliedWith() {
         FactionHints hints = new FactionHints();
@@ -44,8 +41,8 @@ public class FactionHintsTest {
         Faction f2 = createTestFaction("F2");
         Faction f3 = createTestFaction("F3");
         hints.addAlliance("", null, null, f1, f2);
-        Date date = new Date();
-        
+        LocalDate date = LocalDate.now();
+
         assertTrue(hints.isAlliedWith(f1, f2, date));
         assertTrue(hints.isAlliedWith(f2, f1, date));
         assertFalse(hints.isAlliedWith(f1, f3, date));
@@ -59,8 +56,8 @@ public class FactionHintsTest {
         Faction f2 = createTestFaction("F2");
         Faction f3 = createTestFaction("F3");
         hints.addRivalry("", null, null, f1, f2);
-        Date date = new Date();
-        
+        LocalDate date = LocalDate.now();
+
         assertTrue(hints.isRivalOf(f1, f2, date));
         assertTrue(hints.isRivalOf(f2, f1, date));
         assertFalse(hints.isRivalOf(f1, f3, date));
@@ -74,8 +71,8 @@ public class FactionHintsTest {
         Faction f2 = createTestFaction("F2");
         Faction f3 = createTestFaction("F3");
         hints.addWar("", null, null, f1, f2);
-        Date date = new Date();
-        
+        LocalDate date = LocalDate.now();
+
         assertTrue(hints.isAtWarWith(f1, f2, date));
         assertTrue(hints.isAtWarWith(f2, f1, date));
         assertFalse(hints.isAtWarWith(f1, f3, date));
@@ -88,16 +85,17 @@ public class FactionHintsTest {
         FactionHints hints = new FactionHints();
         Faction f1 = createTestFaction("F1");
         Faction f2 = createTestFaction("F2");
-        Calendar start = new GregorianCalendar(3000, 1, 1);
-        Calendar end = new GregorianCalendar(3010, 1, 1);
-        
-        hints.addWar(WAR_NAME, start.getTime(), end.getTime(), f1, f2);
-        Calendar now = new GregorianCalendar(3005, 1, 1); 
+        LocalDate start = LocalDate.of(3000, 1, 1);
+        LocalDate end = LocalDate.of(3010, 1, 1);
 
-        assertEquals(hints.getCurrentWar(f1, f2, now.getTime()), WAR_NAME);
-        assertEquals(hints.getCurrentWar(f2, f1, now.getTime()), WAR_NAME);
+        hints.addWar(WAR_NAME, start, end, f1, f2);
+
+        LocalDate now = LocalDate.of(3005, 1, 1);
+
+        assertEquals(hints.getCurrentWar(f1, f2, now), WAR_NAME);
+        assertEquals(hints.getCurrentWar(f2, f1, now), WAR_NAME);
         // This test will fail if run between 3000 and 3010
-        assertEquals(hints.getCurrentWar(f1, f2, new Date()), null);
+        assertEquals(hints.getCurrentWar(f1, f2, LocalDate.now()), null);
     }
 
     @Test
@@ -106,8 +104,8 @@ public class FactionHintsTest {
         Faction f1 = createTestFaction("F1");
         Faction f2 = createTestFaction("F2");
         Faction f3 = createTestFaction("F3");
-        Date now = new Date();
-        
+        LocalDate now = LocalDate.now();
+
         hints.addNeutralFaction(f1);
         hints.addNeutralExceptions("", null, null, f1, f3);
 
@@ -122,10 +120,10 @@ public class FactionHintsTest {
         Faction outer = createTestFaction("outer");
         Faction inner = createTestFaction("inner");
         Faction opponent = createTestFaction("opponent");
-        Date now = new Date();
-        
+        LocalDate now = LocalDate.now();
+
         hints.addContainedFaction(outer, inner, null, null, 0.5);
-        
+
         assertTrue(hints.getContainedFactions(outer, now).contains(inner));
         assertEquals(hints.getContainedFactionHost(inner, now), outer);
         assertTrue(hints.isContainedFactionOpponent(outer, inner, opponent, now));
@@ -139,10 +137,10 @@ public class FactionHintsTest {
         Faction inner = createTestFaction("inner");
         Faction opponent = createTestFaction("opponent");
         Faction nonOpponent = createTestFaction("nonOpponent");
-        Date now = new Date();
-        
+        LocalDate now = LocalDate.now();
+
         hints.addContainedFaction(outer, inner, null, null, 0.5, Collections.singletonList(opponent));
-        
+
         assertTrue(hints.isContainedFactionOpponent(outer, inner, opponent, now));
         assertFalse(hints.isContainedFactionOpponent(outer, inner, nonOpponent, now));
     }


### PR DESCRIPTION
This removes Joda DateTime completely from MekHQ, and replaces it with LocalDate. This needed to be done in a single large PR because of the integration between the different places that use DateTime.

Part of this fixes #1797, fixes #1820, because the time zone difference no longer applies.

To review: Whitespace differences off, and I apologize for the difficulty in this review.