### PR TITLE
order personnel for campaign subset export by role

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -278,7 +278,9 @@ public class CampaignExportWizard extends JDialog {
     private void setupPersonList() {
         personList = new JList<>();
         DefaultListModel<Person> personListModel = new DefaultListModel<>();
-        for (Person person : sourceCampaign.getActivePersonnel()) {
+        List<Person> people = sourceCampaign.getActivePersonnel();
+        people.sort(Comparator.comparingInt(Person::getPrimaryRole));
+        for (Person person : people) {
             personListModel.addElement(person);
         }
         personList.setModel(personListModel);


### PR DESCRIPTION
The "campaign subset export" wizard's personnel section is basically unusable for larger units because personnel are sorted more or less in the order in which they were loaded into memory.  This PR changes that behavior so that they're now sorted by role.