### PR TITLE
Fixing Duplicate Transient Campaign Run Failure

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -163,7 +163,7 @@ public class Planet implements Serializable {
      * <p>
      */
     @XmlTransient
-    private transient TreeMap<LocalDate, PlanetaryEvent> events;
+    private TreeMap<LocalDate, PlanetaryEvent> events;
 
     /**
      * This is a cache of the current event data based


### PR DESCRIPTION
This fixes MekHQ failing to load a campaign because of the transient property.