### PR TITLE
1847: Fixing Time in Service

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -499,9 +499,8 @@ public class Person implements Serializable, MekHqXmlSerializable {
      * @param log whether to log the change or not
      */
     public void setPrisonerStatus(PrisonerStatus prisonerStatus, boolean log) {
-        if (getPrisonerStatus() == prisonerStatus) {
-            return;
-        }
+        // This must be processed completely, as the unchanged prisoner status of Free to Free is
+        // used during recruitment
 
         final boolean freed = !getPrisonerStatus().isFree();
         final boolean isPrisoner = prisonerStatus.isPrisoner();
@@ -1372,11 +1371,10 @@ public class Person implements Serializable, MekHqXmlSerializable {
                     .generateBabySurname(this, campaign.getPerson(fatherId), baby.getGender());
             baby.setSurname(surname);
             baby.setBirthday(campaign.getLocalDate());
-            baby.setPrisonerStatus(prisonerStatus);
             baby.setAncestorsId(ancId);
 
             // Recruit the baby
-            campaign.recruitPerson(baby, baby.getPrisonerStatus(), baby.isDependent(), true, false);
+            campaign.recruitPerson(baby, prisonerStatus, baby.isDependent(), true, true);
 
             // Create reports and log the birth
             campaign.addReport(String.format("%s has given birth to %s, a baby %s!", getHyperlinkedName(),

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PrisonerStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PrisonerStatus.java
@@ -10,15 +10,14 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.personnel.enums;
 
-import chat.In;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -644,7 +644,9 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 try {
                     PrisonerStatus status = PrisonerStatus.valueOf(data[1]);
                     for (Person person : people) {
-                        person.setPrisonerStatus(status);
+                        if (person.getPrisonerStatus() != status) {
+                            person.setPrisonerStatus(status);
+                        }
                     }
                 } catch (Exception e) {
                     MekHQ.getLogger().error(getClass(), "actionPerformed",


### PR DESCRIPTION
This fixes #1847 by removing the same prisoner status check and moving it to the PersonnelTabMouseAdapter.

This ensures that both prisoner status and the personnel logging is done properly.