### PR TITLE
LocalDate: Ship Search and Filename Date Switchover

### DIFF
--- a/MekHQ/src/mekhq/MekHqConstants.java
+++ b/MekHQ/src/mekhq/MekHqConstants.java
@@ -1,7 +1,7 @@
 /*
  * MekHqConstants.java
  *
- * Copyright (c) 2019 MekHQ Team. All rights reserved.
+ * Copyright (c) 2019 - The MegaMek Team. All rights reserved.
  *
  * This file is part of MekHQ.
  *
@@ -12,11 +12,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq;
 
@@ -31,4 +31,7 @@ public final class MekHqConstants {
     public static final String MAXIMUM_NUMBER_SAVES_KEY = "maximumNumberAutoSaves";
 
     public static final int DEFAULT_NUMBER_SAVES = 5;
+
+    /** This is used in creating the name of save files, e.g. the MekHQ campaign file */
+    public static final String FILENAME_DATE_FORMAT = "yyyyMMdd";
 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -30,7 +30,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -268,10 +267,10 @@ public class Campaign implements Serializable, ITechManager {
     private int fatigueLevel; //AtB
     private AtBConfiguration atbConfig; //AtB
     private AtBEventProcessor atbEventProcessor; //AtB
-    private Calendar shipSearchStart; //AtB
+    private LocalDate shipSearchStart; //AtB
     private int shipSearchType;
     private String shipSearchResult; //AtB
-    private Calendar shipSearchExpiration; //AtB
+    private LocalDate shipSearchExpiration; //AtB
     private IUnitGenerator unitGenerator;
     private IUnitRating unitRating;
     private CampaignSummary campaignSummary;
@@ -442,11 +441,6 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     @Deprecated
-    public DateFormat getShortDateFormatter() {
-        return new SimpleDateFormat(shortDateFormat);
-    }
-
-    @Deprecated
     public Date getDate() {
         return calendar.getTime();
     }
@@ -454,11 +448,6 @@ public class Campaign implements Serializable, ITechManager {
     @Deprecated
     public String getDateAsString() {
         return getDateFormatter().format(calendar.getTime());
-    }
-
-    @Deprecated
-    public String getShortDateAsString() {
-        return getShortDateFormatter().format(calendar.getTime());
     }
 
     public String getCurrentSystemName() {
@@ -610,18 +599,18 @@ public class Campaign implements Serializable, ITechManager {
         return atbConfig;
     }
 
+    //region Ship Search
     /**
      * Sets the date a ship search was started, or null if no search is in progress.
      */
-    public void setShipSearchStart(@Nullable Calendar c) {
-        shipSearchStart = c;
+    public void setShipSearchStart(@Nullable LocalDate shipSearchStart) {
+        this.shipSearchStart = shipSearchStart;
     }
 
     /**
-     *
      * @return The date a ship search was started, or null if none is in progress.
      */
-    public Calendar getShipSearchStart() {
+    public LocalDate getShipSearchStart() {
         return shipSearchStart;
     }
 
@@ -633,7 +622,6 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     /**
-     *
      * @return The lookup name of the available ship, or null if none is available
      */
     public String getShipSearchResult() {
@@ -641,15 +629,14 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     /**
-     *
      * @return The date the ship is no longer available, if there is one.
      */
-    public Calendar getShipSearchExpiration() {
+    public LocalDate getShipSearchExpiration() {
         return shipSearchExpiration;
     }
 
-    public void setShipSearchExpiration(Calendar c) {
-        shipSearchExpiration = c;
+    public void setShipSearchExpiration(LocalDate shipSearchExpiration) {
+        this.shipSearchExpiration = shipSearchExpiration;
     }
 
     /**
@@ -660,16 +647,16 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public void startShipSearch(int unitType) {
-        shipSearchStart = (Calendar) calendar.clone();
+        setShipSearchStart(getLocalDate());
         setShipSearchType(unitType);
     }
 
     public void endShipSearch() {
-        shipSearchStart = null;
+        setShipSearchStart(null);
     }
 
     private void processShipSearch() {
-        if (shipSearchStart == null) {
+        if (getShipSearchStart() == null) {
             return;
         }
         StringBuilder report = new StringBuilder();
@@ -681,7 +668,7 @@ public class Campaign implements Serializable, ITechManager {
             shipSearchStart = null;
             return;
         }
-        long numDays = TimeUnit.MILLISECONDS.toDays(calendar.getTimeInMillis() - shipSearchStart.getTimeInMillis());
+        long numDays = ChronoUnit.DAYS.between(getLocalDate(), getShipSearchStart());
         if (numDays > 21) {
             int roll = Compute.d6(2);
             TargetRoll target = getAtBConfig().shipSearchTargetRoll(shipSearchType, this);
@@ -697,14 +684,12 @@ public class Campaign implements Serializable, ITechManager {
                     ms = getAtBConfig().findShip(shipSearchType);
                 }
                 if (ms != null) {
-                    DateFormat df = getShortDateFormatter();
                     shipSearchResult = ms.getName();
-                    shipSearchExpiration = (Calendar) getCalendar().clone();
-                    shipSearchExpiration.add(Calendar.DAY_OF_MONTH, 31);
+                    setShipSearchExpiration(getLocalDate().plusMonths(1));
                     report.append(shipSearchResult).append(" is available for purchase for ")
                             .append(Money.of(ms.getCost()).toAmountAndSymbolString())
                             .append(" until ")
-                            .append(df.format(shipSearchExpiration.getTime()));
+                            .append(getCampaignOptions().getDisplayFormattedDate(getShipSearchExpiration()));
                 } else {
                     report.append(" <font color=\"red\">Could not determine ship type.</font>");
                 }
@@ -716,11 +701,11 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public void purchaseShipSearchResult() {
-        final String METHOD_NAME = "purchaseShipSearchResult()"; //$NON-NLS-1$
-        MechSummary ms = MechSummaryCache.getInstance().getMech(shipSearchResult);
+        final String METHOD_NAME = "purchaseShipSearchResult()";
+        MechSummary ms = MechSummaryCache.getInstance().getMech(getShipSearchResult());
         if (ms == null) {
-            MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
-                    "Cannot find entry for " + shipSearchResult); //$NON-NLS-1$
+            MekHQ.getLogger().error(getClass(), METHOD_NAME,
+                    "Cannot find entry for " + getShipSearchResult());
             return;
         }
 
@@ -731,13 +716,13 @@ public class Campaign implements Serializable, ITechManager {
             return;
         }
 
-        MechFileParser mechFileParser = null;
+        MechFileParser mechFileParser;
         try {
             mechFileParser = new MechFileParser(ms.getSourceFile(),
                     ms.getEntryName());
         } catch (Exception ex) {
             MekHQ.getLogger().log(getClass(), METHOD_NAME, LogLevel.ERROR,
-                    "Unable to load unit: " + ms.getEntryName()); //$NON-NLS-1$
+                    "Unable to load unit: " + ms.getEntryName());
             MekHQ.getLogger().error(getClass(), METHOD_NAME, ex);
             return;
         }
@@ -751,9 +736,10 @@ public class Campaign implements Serializable, ITechManager {
         if (!getCampaignOptions().getInstantUnitMarketDelivery()) {
             addReport("<font color='green'>Unit will be delivered in " + transitDays + " days.</font>");
         }
-        shipSearchResult = null;
-        shipSearchExpiration = null;
+        setShipSearchResult(null);
+        setShipSearchExpiration(null);
     }
+    //endregion Ship Search
 
     /**
      * Process retirements for retired personnel, if any.
@@ -3467,11 +3453,11 @@ public class Campaign implements Serializable, ITechManager {
         contractMarket.generateContractOffers(this);
         unitMarket.generateUnitOffers(this);
 
-        if (shipSearchExpiration != null && !shipSearchExpiration.after(calendar)) {
-            shipSearchExpiration = null;
-            if (shipSearchResult != null) {
+        if ((getShipSearchExpiration() != null) && !getShipSearchExpiration().isAfter(getLocalDate())) {
+            setShipSearchExpiration(null);
+            if (getShipSearchResult() != null) {
                 addReport("Opportunity for purchase of " + shipSearchResult + " has expired.");
-                shipSearchResult = null;
+                setShipSearchResult(null);
             }
         }
 
@@ -4785,7 +4771,6 @@ public class Campaign implements Serializable, ITechManager {
 
         // Against the Bot
         if (getCampaignOptions().getUseAtB()) {
-            DateFormat sdf = getShortDateFormatter();
             contractMarket.writeToXml(pw1, 1);
             unitMarket.writeToXml(pw1, 1);
             MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "colorIndex", colorIndex);
@@ -4801,13 +4786,13 @@ public class Campaign implements Serializable, ITechManager {
             retirementDefectionTracker.writeToXml(pw1, 1);
             if (shipSearchStart != null) {
                 MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchStart",
-                        sdf.format(shipSearchStart.getTime()));
+                        MekHqXmlUtil.saveFormattedDate(getShipSearchStart()));
             }
             MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchType", shipSearchType);
             MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchResult", shipSearchResult);
             if (shipSearchExpiration != null) {
                 MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchExpiration",
-                        sdf.format(shipSearchExpiration.getTime()));
+                        MekHqXmlUtil.saveFormattedDate(getShipSearchExpiration()));
             }
         }
 
@@ -8507,7 +8492,7 @@ public class Campaign implements Serializable, ITechManager {
 
     @Override
     public int getTechIntroYear() {
-        if (campaignOptions.limitByYear()) {
+        if (getCampaignOptions().limitByYear()) {
             return getGameYear();
         } else {
             return Integer.MAX_VALUE;

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -21,6 +21,8 @@ package mekhq.campaign;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -784,6 +786,10 @@ public class CampaignOptions implements Serializable {
     //region General Tab
     public String getDisplayDateFormat() {
         return displayDateFormat;
+    }
+
+    public String getDisplayFormattedDate(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern(getDisplayDateFormat()));
     }
 
     public void setDisplayDateFormat(String s) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -28,7 +28,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -316,17 +315,13 @@ public class CampaignXmlParser {
                 } else if (xn.equalsIgnoreCase("retirementDefectionTracker")) {
                     retVal.setRetirementDefectionTracker(RetirementDefectionTracker.generateInstanceFromXML(wn, retVal));
                 } else if (xn.equalsIgnoreCase("shipSearchStart")) {
-                    Calendar c = new GregorianCalendar();
-                    c.setTime(parseDate(retVal.getShortDateFormatter(), wn.getTextContent()));
-                    retVal.setShipSearchStart(c);
+                    retVal.setShipSearchStart(MekHqXmlUtil.parseDate(wn.getTextContent().trim()));
                 } else if (xn.equalsIgnoreCase("shipSearchType")) {
                     retVal.setShipSearchType(Integer.parseInt(wn.getTextContent()));
                 } else if (xn.equalsIgnoreCase("shipSearchResult")) {
                     retVal.setShipSearchResult(wn.getTextContent());
                 } else if (xn.equalsIgnoreCase("shipSearchExpiration")) {
-                    Calendar c = new GregorianCalendar();
-                    c.setTime(parseDate(retVal.getShortDateFormatter(), wn.getTextContent()));
-                    retVal.setShipSearchExpiration(c);
+                    retVal.setShipSearchExpiration(MekHqXmlUtil.parseDate(wn.getTextContent().trim()));
                 } else if (xn.equalsIgnoreCase("customPlanetaryEvents")) {
                     updatePlanetaryEventsFromXML(wn);
                 }

--- a/MekHQ/src/mekhq/campaign/personnel/Award.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Award.java
@@ -21,7 +21,6 @@ package mekhq.campaign.personnel;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -272,8 +271,7 @@ public class Award implements MekHqXmlSerializable, Comparable<Award>, Serializa
     public List<String> getFormattedDates(Campaign campaign) {
         List<String> formattedDates = new ArrayList<>();
         for (LocalDate date : dates) {
-            formattedDates.add(date.format(DateTimeFormatter.ofPattern(campaign.getCampaignOptions()
-                    .getDisplayDateFormat())));
+            formattedDates.add(campaign.getCampaignOptions().getDisplayFormattedDate(date));
         }
         return formattedDates;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/FormerSpouse.java
+++ b/MekHQ/src/mekhq/campaign/personnel/FormerSpouse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The MegaMek Team. All rights reserved.
+ * Copyright (c) 2020 - The MegaMek Team. All rights reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.personnel;
 
@@ -27,17 +27,17 @@ import org.w3c.dom.NodeList;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 public class FormerSpouse implements Serializable, MekHqXmlSerializable {
     //region Variables
+    private static final long serialVersionUID = 3700554959779939695L;
+
     //mutable private variables
     private UUID formerSpouseId;
     private LocalDate date;
     private int reason; //why the spouse became a former spouse
     //constants
-    private final static long serialVersionUID = 19161521195L; //spouse in a letter-number cypher
     public final static int REASON_WIDOWED = 0;
     public final static int REASON_DIVORCE = 1;
     public final static int REASON_UNKNOWN = 2;
@@ -63,10 +63,6 @@ public class FormerSpouse implements Serializable, MekHqXmlSerializable {
 
     public LocalDate getDate() {
         return date;
-    }
-
-    public String getDateAsString(String dateFormat) {
-        return date.format(DateTimeFormatter.ofPattern(dateFormat));
     }
 
     public void setDate(LocalDate date) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -25,7 +25,6 @@ import java.awt.event.KeyEvent;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.IntSupplier;
@@ -1162,8 +1161,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         if (getRecruitment() == null) {
             return "";
         } else {
-            return getRecruitment().format(DateTimeFormatter.ofPattern(
-                    campaign.getCampaignOptions().getDisplayDateFormat()));
+            return campaign.getCampaignOptions().getDisplayFormattedDate(getRecruitment());
         }
     }
 
@@ -1179,8 +1177,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
         if (getLastRankChangeDate() == null) {
             return "";
         } else {
-            return getLastRankChangeDate().format(DateTimeFormatter.ofPattern(
-                    campaign.getCampaignOptions().getDisplayDateFormat()));
+            return campaign.getCampaignOptions().getDisplayFormattedDate(getLastRankChangeDate());
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/universe/NewsItem.java
+++ b/MekHQ/src/mekhq/campaign/universe/NewsItem.java
@@ -182,7 +182,7 @@ public class NewsItem {
 
     public String getFullDescription(Campaign campaign) {
         return "<html><h1>" + getHeadline() + "</h1>("
-                + date.format(DateTimeFormatter.ofPattern(campaign.getCampaignOptions().getDisplayDateFormat()))
+                + campaign.getCampaignOptions().getDisplayFormattedDate(date)
                 + ")<br><p>" + getPrefix() + description + "</p></html>";
     }
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1508,12 +1508,14 @@ public class CampaignGUI extends JPanel {
     }
 
     private void miExportOptionsActionPerformed(java.awt.event.ActionEvent evt) {
-        saveOptionsFile(FileType.XML, resourceMap.getString("dlgSaveCampaignXML.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedCampaignSettings");
+        saveOptionsFile(FileType.XML, resourceMap.getString("dlgSaveCampaignXML.text"),
+                getCampaign().getName() + getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedCampaignSettings");
     }
 
     private void miExportPlanetsXMLActionPerformed(java.awt.event.ActionEvent evt) {
         try {
-            exportPlanets(FileType.XML, resourceMap.getString("dlgSavePlanetsXML.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedPlanets");
+            exportPlanets(FileType.XML, resourceMap.getString("dlgSavePlanetsXML.text"),
+                    getCampaign().getName() + getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedPlanets");
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
@@ -1521,7 +1523,8 @@ public class CampaignGUI extends JPanel {
 
     private void miExportFinancesCSVActionPerformed(java.awt.event.ActionEvent evt) {
         try {
-            exportFinances(FileType.CSV, resourceMap.getString("dlgSaveFinancesCSV.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedFinances");
+            exportFinances(FileType.CSV, resourceMap.getString("dlgSaveFinancesCSV.text"),
+                    getCampaign().getName() + getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedFinances");
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
@@ -1529,7 +1532,8 @@ public class CampaignGUI extends JPanel {
 
     private void miExportPersonnelCSVActionPerformed(java.awt.event.ActionEvent evt) {
         try {
-            exportPersonnel(FileType.CSV, resourceMap.getString("dlgSavePersonnelCSV.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedPersonnel");
+            exportPersonnel(FileType.CSV, resourceMap.getString("dlgSavePersonnelCSV.text"),
+                    getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedPersonnel");
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
@@ -1537,7 +1541,8 @@ public class CampaignGUI extends JPanel {
 
     private void miExportUnitCSVActionPerformed(java.awt.event.ActionEvent evt) {
         try {
-            exportUnits(FileType.CSV, resourceMap.getString("dlgSaveUnitsCSV.text"), getCampaign().getName() + getCampaign().getShortDateAsString() + "_ExportedUnits");
+            exportUnits(FileType.CSV, resourceMap.getString("dlgSaveUnitsCSV.text"),
+                    getCampaign().getName() + getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedUnits");
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
@@ -1589,7 +1594,7 @@ public class CampaignGUI extends JPanel {
             List<String> techList = new ArrayList<>();
             String skillLvl;
             int TimePerDay;
-            
+
             List<Person> techs = getCampaign().getTechs();
             techs.sort(Comparator.comparingInt(Person::getPrimaryRole));
             for (Person tech : techs) {
@@ -1616,15 +1621,15 @@ public class CampaignGUI extends JPanel {
                 techHash.put(name, tech);
                 techList.add(name);
             }
-            
+
             String s = (String) JOptionPane.showInputDialog(frame,
                     "Which tech should work on the refit?", "Select Tech",
                     JOptionPane.PLAIN_MESSAGE, null, techList.toArray(), techList.get(0));
-            
+
             if (null == s) {
                 return;
             }
-            
+
             r.setTeamId(techHash.get(s).getId());
         } else {
             JOptionPane.showMessageDialog(frame,

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -26,6 +26,7 @@ import java.io.*;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.time.DayOfWeek;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
@@ -36,6 +37,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.xml.parsers.DocumentBuilder;
 
+import mekhq.MekHqConstants;
 import mekhq.campaign.finances.Money;
 import mekhq.gui.dialog.*;
 import mekhq.gui.preferences.JWindowPreference;
@@ -1509,13 +1511,13 @@ public class CampaignGUI extends JPanel {
 
     private void miExportOptionsActionPerformed(java.awt.event.ActionEvent evt) {
         saveOptionsFile(FileType.XML, resourceMap.getString("dlgSaveCampaignXML.text"),
-                getCampaign().getName() + getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedCampaignSettings");
+                getCampaign().getName() + getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedCampaignSettings");
     }
 
     private void miExportPlanetsXMLActionPerformed(java.awt.event.ActionEvent evt) {
         try {
             exportPlanets(FileType.XML, resourceMap.getString("dlgSavePlanetsXML.text"),
-                    getCampaign().getName() + getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedPlanets");
+                    getCampaign().getName() + getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedPlanets");
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
@@ -1524,7 +1526,7 @@ public class CampaignGUI extends JPanel {
     private void miExportFinancesCSVActionPerformed(java.awt.event.ActionEvent evt) {
         try {
             exportFinances(FileType.CSV, resourceMap.getString("dlgSaveFinancesCSV.text"),
-                    getCampaign().getName() + getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedFinances");
+                    getCampaign().getName() + getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedFinances");
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
@@ -1533,7 +1535,7 @@ public class CampaignGUI extends JPanel {
     private void miExportPersonnelCSVActionPerformed(java.awt.event.ActionEvent evt) {
         try {
             exportPersonnel(FileType.CSV, resourceMap.getString("dlgSavePersonnelCSV.text"),
-                    getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedPersonnel");
+                    getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedPersonnel");
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }
@@ -1542,7 +1544,7 @@ public class CampaignGUI extends JPanel {
     private void miExportUnitCSVActionPerformed(java.awt.event.ActionEvent evt) {
         try {
             exportUnits(FileType.CSV, resourceMap.getString("dlgSaveUnitsCSV.text"),
-                    getCampaign().getName() + getCampaign().getCampaignOptions().getDisplayFormattedDate(getCampaign().getLocalDate()) + "_ExportedUnits");
+                    getCampaign().getName() + getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedUnits");
         } catch (Exception ex) {
             MekHQ.getLogger().error(getClass(), "miExportOptionsActionPerformed(ActionEvent)", ex);
         }

--- a/MekHQ/src/mekhq/gui/FileDialogs.java
+++ b/MekHQ/src/mekhq/gui/FileDialogs.java
@@ -65,7 +65,7 @@ public class FileDialogs {
         String fileName = String.format(
                 "%s%s_ExportedPersonnel.prsx", //$NON-NLS-1$
                 campaign.getName(),
-                campaign.getShortDateAsString() );
+                campaign.getCampaignOptions().getDisplayFormattedDate(campaign.getLocalDate()));
 
         Optional<File> value = GUI.fileDialogSave(
                 frame,
@@ -136,7 +136,7 @@ public class FileDialogs {
         String fileName = String.format(
                 "%s%s_ExportedParts.parts", //$NON-NLS-1$
                 campaign.getName(),
-                campaign.getShortDateAsString() );
+                campaign.getCampaignOptions().getDisplayFormattedDate(campaign.getLocalDate()));
 
         Optional<File> value =  GUI.fileDialogSave(
                 frame,
@@ -204,11 +204,10 @@ public class FileDialogs {
      * @return the file selected, if any
      */
     public static Optional<File> saveCampaign(JFrame frame, Campaign campaign) {
-
         String fileName = String.format(
                 "%s%s.%s", //$NON-NLS-1$
                 campaign.getName(),
-                campaign.getShortDateAsString(),
+                campaign.getCampaignOptions().getDisplayFormattedDate(campaign.getLocalDate()),
                 campaign.getPreferGzippedOutput() ? "cpnx.gz" : "cpnx" );
 
         Optional<File> value = GUI.fileDialogSave( frame,

--- a/MekHQ/src/mekhq/gui/FileDialogs.java
+++ b/MekHQ/src/mekhq/gui/FileDialogs.java
@@ -10,21 +10,22 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui;
 
 import java.io.File;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import javax.swing.JFrame;
 
 import mekhq.MekHQ;
+import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.ScenarioTemplate;
@@ -63,9 +64,9 @@ public class FileDialogs {
     public static Optional<File> savePersonnel(JFrame frame, Campaign campaign) {
 
         String fileName = String.format(
-                "%s%s_ExportedPersonnel.prsx", //$NON-NLS-1$
+                "%s%s_ExportedPersonnel.prsx",
                 campaign.getName(),
-                campaign.getCampaignOptions().getDisplayFormattedDate(campaign.getLocalDate()));
+                campaign.getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)));
 
         Optional<File> value = GUI.fileDialogSave(
                 frame,
@@ -134,9 +135,9 @@ public class FileDialogs {
      */
     public static Optional<File> saveParts(JFrame frame, Campaign campaign) {
         String fileName = String.format(
-                "%s%s_ExportedParts.parts", //$NON-NLS-1$
+                "%s%s_ExportedParts.parts",
                 campaign.getName(),
-                campaign.getCampaignOptions().getDisplayFormattedDate(campaign.getLocalDate()));
+                campaign.getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)));
 
         Optional<File> value =  GUI.fileDialogSave(
                 frame,
@@ -207,7 +208,7 @@ public class FileDialogs {
         String fileName = String.format(
                 "%s%s.%s", //$NON-NLS-1$
                 campaign.getName(),
-                campaign.getCampaignOptions().getDisplayFormattedDate(campaign.getLocalDate()),
+                campaign.getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)),
                 campaign.getPreferGzippedOutput() ? "cpnx.gz" : "cpnx" );
 
         Optional<File> value = GUI.fileDialogSave( frame,

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.time.Period;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -338,8 +337,7 @@ public class MedicalViewDialog extends JDialog {
             surname = p.getBloodname();
         }
 
-        String birthdayString = p.getBirthday().format(DateTimeFormatter.ofPattern(
-                c.getCampaignOptions().getDisplayDateFormat()));
+        String birthdayString = campaign.getCampaignOptions().getDisplayFormattedDate(p.getBirthday());
 
         Period age = Period.between(p.getBirthday(), c.getLocalDate());
 
@@ -465,17 +463,17 @@ public class MedicalViewDialog extends JDialog {
                 .forEachOrdered(inj -> {
                     JLabel injLabel;
                     if (inj.getType().isPermanent()) {
-                        injLabel = genWrittenText(String.format(resourceMap.getString("injuriesText.format"), //$NON-NLS-1$
-                            inj.getType().getSimpleName(), inj.getStart().format(DateTimeFormatter.ofPattern(
-                                        c.getCampaignOptions().getDisplayDateFormat()))));
+                        injLabel = genWrittenText(String.format(resourceMap.getString("injuriesText.format"),
+                                inj.getType().getSimpleName(),
+                                c.getCampaignOptions().getDisplayFormattedDate(inj.getStart())));
                     } else if (inj.isPermanent() || (inj.getTime() <= 0)) {
-                        injLabel = genWrittenText(String.format(resourceMap.getString("injuriesPermanent.format"), //$NON-NLS-1$
-                            inj.getType().getSimpleName(), inj.getStart().format(DateTimeFormatter.ofPattern(
-                                        c.getCampaignOptions().getDisplayDateFormat()))));
+                        injLabel = genWrittenText(String.format(resourceMap.getString("injuriesPermanent.format"),
+                                inj.getType().getSimpleName(),
+                                c.getCampaignOptions().getDisplayFormattedDate(inj.getStart())));
                     } else {
-                        injLabel = genWrittenText(String.format(resourceMap.getString("injuriesTextAndDuration.format"), //$NON-NLS-1$
-                            inj.getType().getSimpleName(), inj.getStart().format(DateTimeFormatter.ofPattern(
-                                    c.getCampaignOptions().getDisplayDateFormat())),
+                        injLabel = genWrittenText(String.format(resourceMap.getString("injuriesTextAndDuration.format"),
+                                inj.getType().getSimpleName(),
+                                c.getCampaignOptions().getDisplayFormattedDate(inj.getStart()),
                                 genTimePeriod(inj.getTime())));
                     }
 

--- a/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
@@ -30,7 +30,6 @@ import java.awt.event.FocusEvent;
 import java.awt.event.KeyEvent;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
@@ -487,7 +486,7 @@ public class NewPlanetaryEventDialog extends JDialog {
     }
 
     private void updateDate(Campaign campaign) {
-        dateButton.setText(date.format(DateTimeFormatter.ofPattern(campaign.getCampaignOptions().getDisplayDateFormat())));
+        dateButton.setText(campaign.getCampaignOptions().getDisplayFormattedDate(date));
         Planet.PlanetaryEvent event = getCurrentEvent();
 
         messageField.setText((null != event) ? event.message : null);

--- a/MekHQ/src/mekhq/gui/dialog/ShipSearchDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ShipSearchDialog.java
@@ -12,13 +12,12 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
 import java.awt.BorderLayout;
@@ -27,7 +26,6 @@ import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.text.NumberFormat;
 import java.util.ResourceBundle;
 
 import javax.swing.ButtonGroup;
@@ -51,36 +49,31 @@ import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
 
 /**
- * Manages searches for Dropships or Jumpships for Against the Bot.
- * 
- * @author Neoancient
+ * Manages searches for DropShips or JumpShips for Against the Bot.
  *
+ * @author Neoancient
  */
 public class ShipSearchDialog extends JDialog {
+    private static final long serialVersionUID = -5200817760228732045L;
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = -5200817760228732045L;
-	
-	private JRadioButton btnDropship = new JRadioButton();
-	private JRadioButton btnJumpship = new JRadioButton();
-	private JRadioButton btnWarship = new JRadioButton();
-	
-	private JLabel lblDropshipTarget = new JLabel();
-	private JLabel lblJumpshipTarget = new JLabel();
-	private JLabel lblWarshipTarget = new JLabel();
-	
-	CampaignGUI gui;
-	
-	public ShipSearchDialog(Frame frame, CampaignGUI gui) {
-		super(frame, true);
-		this.gui = gui;
-		
-		init();
-		setUserPreferences();
-	}
-	
+    private JRadioButton btnDropship = new JRadioButton();
+    private JRadioButton btnJumpship = new JRadioButton();
+    private JRadioButton btnWarship = new JRadioButton();
+
+    private JLabel lblDropshipTarget = new JLabel();
+    private JLabel lblJumpshipTarget = new JLabel();
+    private JLabel lblWarshipTarget = new JLabel();
+
+    CampaignGUI gui;
+
+    public ShipSearchDialog(Frame frame, CampaignGUI gui) {
+        super(frame, true);
+        this.gui = gui;
+
+        init();
+        setUserPreferences();
+    }
+
     private void init() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ShipSearchDialog",
                 new EncodeControl()); //$NON-NLS-1$
@@ -212,7 +205,6 @@ public class ShipSearchDialog extends JDialog {
             button = new JButton(resourceMap.getString("btnEndSearch.text"));
             button.setToolTipText(resourceMap.getString("btnEndSearch.toolTipText"));
             button.addActionListener(ev -> endSearch());
-            panButtons.add(button);
         } else {
             button = new JButton(resourceMap.getString("btnStartSearch.text"));
             button.setToolTipText(String.format(resourceMap.getString("btnStartSearch.toolTipText"),
@@ -220,8 +212,8 @@ public class ShipSearchDialog extends JDialog {
                     gui.getCampaign().getAtBConfig().getShipSearchLengthWeeks()));
             button.addActionListener(ev -> startSearch());
             button.setEnabled(!isInContract());
-            panButtons.add(button);
         }
+        panButtons.add(button);
 
         button = new JButton(resourceMap.getString("btnCancel.text"));
         button.addActionListener(ev -> setVisible(false));
@@ -248,55 +240,55 @@ public class ShipSearchDialog extends JDialog {
         preferences.manage(new JWindowPreference(this));
     }
 
-	public TargetRoll getDSTarget() {
-		return gui.getCampaign().getAtBConfig().shipSearchTargetRoll(UnitType.DROPSHIP,
-				gui.getCampaign());
-	}
-	
-	public TargetRoll getJSTarget() {
-		return gui.getCampaign().getAtBConfig().shipSearchTargetRoll(UnitType.JUMPSHIP,
-				gui.getCampaign());
-	}
-	
-	public TargetRoll getWSTarget() {
-		return gui.getCampaign().getAtBConfig().shipSearchTargetRoll(UnitType.WARSHIP,
-				gui.getCampaign());
-	}
-	
-	private int getUnitType() {
-		if (btnJumpship.isSelected()) {
-			return UnitType.JUMPSHIP;
-		} else if (btnWarship.isSelected()) {
-			return UnitType.WARSHIP;
-		} else {
-			return UnitType.DROPSHIP;			
-		}
-	}
-	
-	private boolean isInContract() {
-		return gui.getCampaign().getMissions().stream().anyMatch(m ->
-			m.isActive()
-			&& m instanceof Contract
-			&& ((Contract)m).getStartDate().before(gui.getCampaign().getDate())
-		);
-	}
+    public TargetRoll getDSTarget() {
+        return gui.getCampaign().getAtBConfig().shipSearchTargetRoll(UnitType.DROPSHIP,
+                gui.getCampaign());
+    }
 
-	private boolean isInSearch() {
-		return gui.getCampaign().getShipSearchStart() != null;
-	}
-	
-	private void startSearch() {
-		gui.getCampaign().startShipSearch(getUnitType());
-		setVisible(false);
-	}
-	
-	private void endSearch() {
-		gui.getCampaign().endShipSearch();
-		setVisible(false);
-	}
-	
-	private void purchase() {
-		gui.getCampaign().purchaseShipSearchResult();
-		setVisible(false);
-	}
+    public TargetRoll getJSTarget() {
+        return gui.getCampaign().getAtBConfig().shipSearchTargetRoll(UnitType.JUMPSHIP,
+                gui.getCampaign());
+    }
+
+    public TargetRoll getWSTarget() {
+        return gui.getCampaign().getAtBConfig().shipSearchTargetRoll(UnitType.WARSHIP,
+                gui.getCampaign());
+    }
+
+    private int getUnitType() {
+        if (btnJumpship.isSelected()) {
+            return UnitType.JUMPSHIP;
+        } else if (btnWarship.isSelected()) {
+            return UnitType.WARSHIP;
+        } else {
+            return UnitType.DROPSHIP;
+        }
+    }
+
+    private boolean isInContract() {
+        return gui.getCampaign().getMissions().stream().anyMatch(m ->
+            m.isActive()
+            && m instanceof Contract
+            && ((Contract)m).getStartDate().before(gui.getCampaign().getDate())
+        );
+    }
+
+    private boolean isInSearch() {
+        return gui.getCampaign().getShipSearchStart() != null;
+    }
+
+    private void startSearch() {
+        gui.getCampaign().startShipSearch(getUnitType());
+        setVisible(false);
+    }
+
+    private void endSearch() {
+        gui.getCampaign().setShipSearchStart(null);
+        setVisible(false);
+    }
+
+    private void purchase() {
+        gui.getCampaign().purchaseShipSearchResult();
+        setVisible(false);
+    }
 }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -23,7 +23,6 @@ import java.awt.Dialog.ModalityType;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.Image;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -639,8 +638,6 @@ public class PersonViewPanel extends ScrollablePanel {
         firsty++;
 
         if (person.isPregnant()) {
-            String dueDate;
-
             lblDueDate1.setName("lblDueDate1");
             lblDueDate1.setText(resourceMap.getString("lblDueDate1.text"));
             gridBagConstraints = new GridBagConstraints();
@@ -650,13 +647,10 @@ public class PersonViewPanel extends ScrollablePanel {
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
             pnlInfo.add(lblDueDate1, gridBagConstraints);
 
-            if (campaign.getCampaignOptions().getDisplayTrueDueDate()) {
-                dueDate = person.getDueDate().format(DateTimeFormatter.ofPattern(campaign
-                        .getCampaignOptions().getDisplayDateFormat()));
-            } else {
-                dueDate = person.getExpectedDueDate().format(DateTimeFormatter.ofPattern(campaign
-                        .getCampaignOptions().getDisplayDateFormat()));
-            }
+            String dueDate = campaign.getCampaignOptions().getDisplayFormattedDate(
+                    campaign.getCampaignOptions().getDisplayTrueDueDate()
+                            ? person.getDueDate()
+                            : person.getExpectedDueDate());
 
             lblDueDate2.setName("lblDueDate2");
             lblDueDate2.setText(dueDate);
@@ -866,9 +860,9 @@ public class PersonViewPanel extends ScrollablePanel {
                 lblFormerSpouses2 = new JLabel();
                 lblFormerSpouses2.setName("lblFormerSpouses2"); // NOI18N //$NON-NLS-1$
                 lblFormerSpouses2.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-                lblFormerSpouses2.setText(String.format("<html><a href='#'>%s</a>, %s, %s</html>", ex.getFullName(),
-                        formerSpouse.getReasonString(), formerSpouse.getDateAsString(
-                                campaign.getCampaignOptions().getDisplayDateFormat())));
+                lblFormerSpouses2.setText(String.format("<html><a href='#'>%s</a>, %s, %s</html>",
+                        ex.getFullName(), formerSpouse.getReasonString(),
+                        campaign.getCampaignOptions().getDisplayFormattedDate(formerSpouse.getDate())));
                 lblFormerSpouses2.addMouseListener(new MouseAdapter() {
                     @Override
                     public void mouseClicked(MouseEvent e) {

--- a/MekHQ/src/mekhq/service/AutosaveService.java
+++ b/MekHQ/src/mekhq/service/AutosaveService.java
@@ -145,7 +145,7 @@ public class AutosaveService implements IAutosaveService {
                         "Autosave-%d-%s-%s.cpnx.gz",
                         index++,
                         campaign.getName(),
-                        campaign.getShortDateAsString());
+                        campaign.getCampaignOptions().getDisplayFormattedDate(campaign.getLocalDate()));
 
                 repeatedName = false;
                 for (File file : autosaveFiles) {

--- a/MekHQ/src/mekhq/service/AutosaveService.java
+++ b/MekHQ/src/mekhq/service/AutosaveService.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
@@ -145,7 +146,8 @@ public class AutosaveService implements IAutosaveService {
                         "Autosave-%d-%s-%s.cpnx.gz",
                         index++,
                         campaign.getName(),
-                        campaign.getCampaignOptions().getDisplayFormattedDate(campaign.getLocalDate()));
+                        campaign.getLocalDate().format(DateTimeFormatter.ofPattern(
+                                MekHqConstants.FILENAME_DATE_FORMAT)));
 
                 repeatedName = false;
                 for (File file : autosaveFiles) {


### PR DESCRIPTION
This switches Ship Search and Filenames to LocalDate, and moves the format for filenames into the Constants file. It also refactors the majority of LocalDate display formats back to Campaign Options to improve readability.