### PR TITLE
fix compilation errors due to damage overlay PR

### DIFF
--- a/MekHQ/src/mekhq/IconPackage.java
+++ b/MekHQ/src/mekhq/IconPackage.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.Vector;
 
-import megamek.client.ui.swing.MechTileset;
+import megamek.client.ui.swing.tileset.MechTileset;
 import megamek.client.ui.swing.util.ImageFileFactory;
 import megamek.common.Configuration;
 import megamek.common.Crew;

--- a/MekHQ/src/mekhq/gui/dialog/UnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnitSelectorDialog.java
@@ -40,7 +40,7 @@ import javax.swing.table.TableRowSorter;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.AdvancedSearchDialog;
-import megamek.client.ui.swing.MechTileset;
+import megamek.client.ui.swing.tileset.MechTileset;
 import megamek.client.ui.swing.MechViewPanel;
 import megamek.common.Configuration;
 import megamek.common.Entity;

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -15,7 +15,7 @@ import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 
-import megamek.client.ui.swing.MechTileset;
+import megamek.client.ui.swing.tileset.MechTileset;
 import megamek.client.ui.swing.util.FluffImageHelper;
 import megamek.client.ui.swing.util.PlayerColors;
 import megamek.common.Entity;


### PR DESCRIPTION
A namespace in MegaMek was moved, and this causes MekHQ to be unable to compile. This PR addresses the compilation errors.