### PR TITLE
Fixing the Retirement Nag Popup Calculcation

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8384,8 +8384,8 @@ public class Campaign implements Serializable, ITechManager {
 
     public boolean checkYearlyRetirements() {
         if (getCampaignOptions().getUseAtB()
-                && (ChronoUnit.YEARS.between(getRetirementDefectionTracker()
-                .getLastRetirementRoll(), getLocalDate()) == 1L)) {
+                && (ChronoUnit.DAYS.between(getRetirementDefectionTracker().getLastRetirementRoll(),
+                getLocalDate()) == getRetirementDefectionTracker().getLastRetirementRoll().lengthOfYear())) {
             Object[] options = { "Show Retirement Dialog", "Not Now" };
             return JOptionPane.YES_OPTION == JOptionPane
                     .showOptionDialog(


### PR DESCRIPTION
This fixes the Retirement Nag popup calculation due to a mistake in the modified logic. This was pointed out in the review but I misunderstood why, and didn't notice the functionality change until today.