### PR TITLE
Campaign writeToXml: Fixing Output Spacing Issues

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1094,7 +1094,7 @@ public class Campaign implements Serializable, ITechManager {
         units.put(id, unit);
 
         // now lets grab the parts from the test unit and set them up with this unit
-        for(Part p : tu.getParts()) {
+        for (Part p : tu.getParts()) {
             unit.addPart(p);
             addPart(p, 0);
         }
@@ -1878,10 +1878,10 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     private int getQuantity(Part p) {
-        if(p instanceof Armor) {
+        if (p instanceof Armor) {
             return ((Armor) p).getAmount();
         }
-        if(p instanceof AmmoStorage) {
+        if (p instanceof AmmoStorage) {
             return ((AmmoStorage) p).getShots();
         }
         return ((p.getUnit() != null) || (p.getUnitId() != null)) ? 1 : p.getQuantity();
@@ -1900,7 +1900,7 @@ public class Campaign implements Serializable, ITechManager {
             return null;
         }
         // Replace a "missing" part with a corresponding "new" one.
-        if(p instanceof MissingPart) {
+        if (p instanceof MissingPart) {
             p = ((MissingPart) p).getNewPart();
         }
         PartInUse result = new PartInUse(p);
@@ -1911,7 +1911,7 @@ public class Campaign implements Serializable, ITechManager {
         if ((p.getUnit() != null) || (p.getUnitId() != null) || (p instanceof MissingPart)) {
             piu.setUseCount(piu.getUseCount() + getQuantity(p));
         } else {
-            if(p.isPresent()) {
+            if (p.isPresent()) {
                 piu.setStoreCount(piu.getStoreCount() + getQuantity(p));
             } else {
                 piu.setTransferCount(piu.getTransferCount() + getQuantity(p));
@@ -1925,15 +1925,15 @@ public class Campaign implements Serializable, ITechManager {
         piu.setStoreCount(0);
         piu.setTransferCount(0);
         piu.setPlannedCount(0);
-        for(Part p : getParts()) {
+        for (Part p : getParts()) {
             PartInUse newPiu = getPartInUse(p);
-            if(piu.equals(newPiu)) {
+            if (piu.equals(newPiu)) {
                 updatePartInUseData(piu, p);
             }
         }
-        for(IAcquisitionWork maybePart : shoppingList.getPartList()) {
+        for (IAcquisitionWork maybePart : shoppingList.getPartList()) {
             PartInUse newPiu = getPartInUse((Part) maybePart);
-            if(piu.equals(newPiu)) {
+            if (piu.equals(newPiu)) {
                 piu.setPlannedCount(piu.getPlannedCount()
                         + getQuantity((maybePart instanceof MissingPart) ? ((MissingPart) maybePart).getNewPart()
                                 : (Part) maybePart) * maybePart.getQuantity());
@@ -1944,27 +1944,27 @@ public class Campaign implements Serializable, ITechManager {
     public Set<PartInUse> getPartsInUse() {
         // java.util.Set doesn't supply a get(Object) method, so we have to use a java.util.Map
         Map<PartInUse, PartInUse> inUse = new HashMap<>();
-        for(Part p : getParts()) {
+        for (Part p : getParts()) {
             PartInUse piu = getPartInUse(p);
-            if(null == piu) {
+            if (null == piu) {
                 continue;
             }
-            if( inUse.containsKey(piu) ) {
+            if ( inUse.containsKey(piu) ) {
                 piu = inUse.get(piu);
             } else {
                 inUse.put(piu, piu);
             }
             updatePartInUseData(piu, p);
         }
-        for(IAcquisitionWork maybePart : shoppingList.getPartList()) {
-            if(!(maybePart instanceof Part)) {
+        for (IAcquisitionWork maybePart : shoppingList.getPartList()) {
+            if (!(maybePart instanceof Part)) {
                 continue;
             }
             PartInUse piu = getPartInUse((Part) maybePart);
-            if(null == piu) {
+            if (null == piu) {
                 continue;
             }
-            if( inUse.containsKey(piu) ) {
+            if ( inUse.containsKey(piu) ) {
                 piu = inUse.get(piu);
             } else {
                 inUse.put(piu, piu);
@@ -2153,7 +2153,7 @@ public class Campaign implements Serializable, ITechManager {
         List<Person> techs = getTechs(false, null, false, false);
         List<Person> retval = new ArrayList<>();
 
-        for(Person tech : techs) {
+        for (Person tech : techs) {
             if((tech.getPrimaryRole() == roleType) ||
                (tech.getSecondaryRole() == roleType)) {
                 retval.add(tech);
@@ -2626,7 +2626,7 @@ public class Campaign implements Serializable, ITechManager {
      */
     public boolean canPayFor(IAcquisitionWork acquisition) {
         //SHOULD we check to see if this acquisition needs to be paid for
-        if( (acquisition instanceof UnitOrder && getCampaignOptions().payForUnits())
+        if ( (acquisition instanceof UnitOrder && getCampaignOptions().payForUnits())
                 ||(acquisition instanceof Part && getCampaignOptions().payForParts()) ) {
             //CAN the acquisition actually be paid for
             return getFunds().isGreaterOrEqualThan(acquisition.getBuyCost());
@@ -2739,7 +2739,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         int xpGained = 0;
         if (roll >= target.getValue()) {
-            if(transitDays < 0) {
+            if (transitDays < 0) {
                 transitDays = calculatePartTransitTime(mos);
             }
             report = report + acquisition.find(transitDays);
@@ -3780,7 +3780,7 @@ public class Campaign implements Serializable, ITechManager {
 
     public Money getMaintenanceCosts() {
         Money costs = Money.zero();
-        if(campaignOptions.payForMaintain()) {
+        if (campaignOptions.payForMaintain()) {
             for (Map.Entry<UUID, Unit> mu : units.entrySet()) {
                 Unit u = mu.getValue();
                 if (u.requiresMaintenance() && null != u.getTech()) {
@@ -3890,7 +3890,7 @@ public class Campaign implements Serializable, ITechManager {
             Unit trainerUnit = getUnit(trainerId);
 
             // not sure how this occurs, but it probably shouldn't halt processing of a new day.
-            if(trainerUnit == null) {
+            if (trainerUnit == null) {
                 continue;
             }
 
@@ -3908,7 +3908,7 @@ public class Campaign implements Serializable, ITechManager {
                     for (UUID traineeId : forceIds.get(l.getForceId()).getAllUnits()) {
                         Unit traineeUnit = getUnit(traineeId);
 
-                        if(traineeUnit == null) {
+                        if (traineeUnit == null) {
                             continue;
                         }
 
@@ -4003,7 +4003,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         parts.remove(part.getId());
         //remove child parts as well
-        for(int childId : part.getChildPartIds()) {
+        for (int childId : part.getChildPartIds()) {
             Part childPart = getPart(childId);
             if (null != childPart) {
                 removePart(childPart);
@@ -4013,7 +4013,7 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public void removeKill(Kill k) {
-        if(kills.containsKey(k.getPilotId())) {
+        if (kills.containsKey(k.getPilotId())) {
             kills.get(k.getPilotId()).remove(k);
         }
     }
@@ -4123,19 +4123,19 @@ public class Campaign implements Serializable, ITechManager {
         for (Part part : getParts()) {
             if (part instanceof EquipmentPart) {
                 ((EquipmentPart) part).restore();
-                if(null == ((EquipmentPart) part).getType()) {
+                if (null == ((EquipmentPart) part).getType()) {
                     partsToRemove.add(part);
                 }
             }
             if (part instanceof MissingEquipmentPart) {
                 ((MissingEquipmentPart) part).restore();
-                if(null == ((MissingEquipmentPart) part).getType()) {
+                if (null == ((MissingEquipmentPart) part).getType()) {
                     partsToRemove.add(part);
                 }
             }
         }
 
-        for(Part remove : partsToRemove) {
+        for (Part remove : partsToRemove) {
             if (null != remove.getUnitId() && !unitsToCheck.contains(remove.getUnitId())) {
                 unitsToCheck.add(remove.getUnitId());
             }
@@ -4158,7 +4158,7 @@ public class Campaign implements Serializable, ITechManager {
             unit.resetEngineer();
         }
 
-        for(UUID uid : unitsToCheck) {
+        for (UUID uid : unitsToCheck) {
             Unit u = getUnit(uid);
             if (null != u) {
                 u.initializeParts(true);
@@ -4307,7 +4307,7 @@ public class Campaign implements Serializable, ITechManager {
 
     private void addReportInternal(String r) {
         currentReport.add(r);
-        if( currentReportHTML.length() > 0 ) {
+        if ( currentReportHTML.length() > 0 ) {
             currentReportHTML = currentReportHTML + REPORT_LINEBREAK + r;
             newReports.add(REPORT_LINEBREAK);
         } else {
@@ -4586,6 +4586,8 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public void writeToXml(PrintWriter pw1) {
+        int indent = 1;
+
         // File header
         pw1.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
 
@@ -4594,157 +4596,150 @@ public class Campaign implements Serializable, ITechManager {
         pw1.println("<campaign version=\""
                 + resourceMap.getString("Application.version") + "\">");
 
-        // Basic Campaign Info
-        pw1.println("\t<info>");
+        //region Basic Campaign Info
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, "info");
 
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "id", id.toString());
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "name", name);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "faction", factionCode);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "id", id.toString());
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "name", name);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "faction", factionCode);
         if (retainerEmployerCode != null) {
-            MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "retainerEmployerCode", retainerEmployerCode);
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "retainerEmployerCode", retainerEmployerCode);
         }
 
         // Ranks
-        ranks.writeToXml(pw1, 3);
+        ranks.writeToXml(pw1, indent + 1);
 
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "nameGen",
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "nameGen",
                 RandomNameGenerator.getInstance().getChosenFaction());
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "percentFemale",
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "percentFemale",
                 RandomGenderGenerator.getPercentFemale());
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "overtime", overtime);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "gmMode", gmMode);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "astechPool", astechPool);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "astechPoolMinutes",
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "overtime", overtime);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "gmMode", gmMode);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "astechPool", astechPool);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "astechPoolMinutes",
                 astechPoolMinutes);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "astechPoolOvertime",
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "astechPoolOvertime",
                 astechPoolOvertime);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "medicPool", medicPool);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "camoCategory", camoCategory);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "camoFileName", camoFileName);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "iconCategory", iconCategory);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "iconFileName", iconFileName);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "colorIndex", colorIndex);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "lastPartId", lastPartId);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "lastForceId", lastForceId);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "lastMissionId", lastMissionId);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "lastScenarioId", lastScenarioId);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "medicPool", medicPool);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "camoCategory", camoCategory);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "camoFileName", camoFileName);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "iconCategory", iconCategory);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "iconFileName", iconFileName);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "colorIndex", colorIndex);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "lastPartId", lastPartId);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "lastForceId", lastForceId);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "lastMissionId", lastMissionId);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "lastScenarioId", lastScenarioId);
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "calendar",
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "calendar",
                 df.format(calendar.getTime()));
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "fatigueLevel", fatigueLevel);
-        {
-            pw1.println("\t\t<nameGen>");
-            pw1.print("\t\t\t<faction>");
-            pw1.print(MekHqXmlUtil.escape(RandomNameGenerator.getInstance().getChosenFaction()));
-            pw1.println("</faction>");
-            pw1.print("\t\t\t<percentFemale>");
-            pw1.print(RandomGenderGenerator.getPercentFemale());
-            pw1.println("</percentFemale>");
-            pw1.println("\t\t</nameGen>");
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "fatigueLevel", fatigueLevel);
+
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent + 1, "nameGen");
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 2, "faction", RandomNameGenerator.getInstance().getChosenFaction());
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 2, "percentFemale", RandomGenderGenerator.getPercentFemale());
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent + 1, "nameGen");
+
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent + 1, "currentReport");
+        for (String s : currentReport) {
+            // This cannot use the MekHQXMLUtil as it cannot be escaped
+            pw1.println(MekHqXmlUtil.indentStr(indent + 2) + "<reportLine><![CDATA[" + s + "]]></reportLine>");
         }
-        {
-            pw1.println("\t\t<currentReport>");
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent + 1, "currentReport");
 
-            for (String s : currentReport) {
-                pw1.print("\t\t\t<reportLine><![CDATA[");
-                pw1.print(s);
-                pw1.println("]]></reportLine>");
-            }
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "info");
+        //endregion Basic Campaign Info
 
-            pw1.println("\t\t</currentReport>");
-        }
-
-        pw1.println("\t</info>");
-
-        // Campaign Options
-        // private CampaignOptions campaignOptions = new CampaignOptions();
+        //region Campaign Options
         if (getCampaignOptions() != null) {
-            getCampaignOptions().writeToXml(pw1, 1);
+            getCampaignOptions().writeToXml(pw1, indent);
         }
+        //endregion Campaign Options
 
         // Lists of objects:
-        writeMapToXml(pw1, 1, "units", units); // Units
-        writeMapToXml(pw1, 1, "personnel", personnel); // Personnel
-        writeMapToXml(pw1, 1, "missions", missions); // Missions
+        writeMapToXml(pw1, indent, "units", units); // Units
+        writeMapToXml(pw1, indent, "personnel", personnel); // Personnel
+        writeMapToXml(pw1, indent, "missions", missions); // Missions
         // the forces structure is hierarchical, but that should be handled
-        // internally
-        // from with writeToXML function for Force
-        pw1.println("\t<forces>");
-        forces.writeToXml(pw1, 2);
-        pw1.println("\t</forces>");
-        finances.writeToXml(pw1, 1);
-        location.writeToXml(pw1, 1);
-        shoppingList.writeToXml(pw1, 1);
-        pw1.println("\t<kills>");
+        // internally from with writeToXML function for Force
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, "forces");
+        forces.writeToXml(pw1, indent + 1);
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "forces");
+        finances.writeToXml(pw1, indent);
+        location.writeToXml(pw1, indent);
+        shoppingList.writeToXml(pw1, indent);
+
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, "kills");
         for (List<Kill> kills : kills.values()) {
-            for(Kill k : kills) {
-                k.writeToXml(pw1, 2);
+            for (Kill k : kills) {
+                k.writeToXml(pw1, indent + 1);
             }
         }
-        pw1.println("\t</kills>");
-        pw1.println("\t<skillTypes>");
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "kills");
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, "skillTypes");
         for (String name : SkillType.skillList) {
             SkillType type = SkillType.getType(name);
             if (null != type) {
-                type.writeToXml(pw1, 2);
+                type.writeToXml(pw1, indent + 1);
             }
         }
-        pw1.println("\t</skillTypes>");
-        pw1.println("\t<specialAbilities>");
-        for(String key : SpecialAbility.getAllSpecialAbilities().keySet()) {
-            SpecialAbility.getAbility(key).writeToXml(pw1, 2);
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "skillTypes");
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, "specialAbilities");
+        for (String key : SpecialAbility.getAllSpecialAbilities().keySet()) {
+            SpecialAbility.getAbility(key).writeToXml(pw1, indent + 1);
         }
-        pw1.println("\t</specialAbilities>");
-        rskillPrefs.writeToXml(pw1, 1);
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "specialAbilities");
+        rskillPrefs.writeToXml(pw1, indent);
         // parts is the biggest so it goes last
-        writeMapToXml(pw1, 1, "parts", parts); // Parts
+        writeMapToXml(pw1, indent, "parts", parts); // Parts
 
         writeGameOptions(pw1);
 
         // Personnel Market
-        personnelMarket.writeToXml(pw1, 1);
+        personnelMarket.writeToXml(pw1, indent);
 
         // Against the Bot
         if (getCampaignOptions().getUseAtB()) {
-            contractMarket.writeToXml(pw1, 1);
-            unitMarket.writeToXml(pw1, 1);
-            MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "colorIndex", colorIndex);
+            contractMarket.writeToXml(pw1, indent);
+            unitMarket.writeToXml(pw1, indent);
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "colorIndex", colorIndex);
             if (lances.size() > 0)   {
-                pw1.println("\t<lances>");
+                MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, "lances");
                 for (Lance l : lances.values()) {
                     if (forceIds.containsKey(l.getForceId())) {
-                        l.writeToXml(pw1, 2);
+                        l.writeToXml(pw1, indent + 1);
                     }
                 }
-                pw1.println("\t</lances>");
+                MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "lances");
             }
-            retirementDefectionTracker.writeToXml(pw1, 1);
+            retirementDefectionTracker.writeToXml(pw1, indent);
             if (shipSearchStart != null) {
-                MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchStart",
+                MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "shipSearchStart",
                         MekHqXmlUtil.saveFormattedDate(getShipSearchStart()));
             }
-            MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchType", shipSearchType);
-            MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchResult", shipSearchResult);
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "shipSearchType", shipSearchType);
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "shipSearchResult", shipSearchResult);
             if (shipSearchExpiration != null) {
-                MekHqXmlUtil.writeSimpleXmlTag(pw1, 2, "shipSearchExpiration",
+                MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "shipSearchExpiration",
                         MekHqXmlUtil.saveFormattedDate(getShipSearchExpiration()));
             }
         }
 
         // Customised planetary events
-        pw1.println("\t<customPlanetaryEvents>");
-        for(PlanetarySystem psystem : Systems.getInstance().getSystems().values()) {
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, "customPlanetaryEvents");
+        for (PlanetarySystem psystem : Systems.getInstance().getSystems().values()) {
             //first check for system-wide events
             List<PlanetarySystem.PlanetarySystemEvent> customSysEvents = new ArrayList<>();
-            for(PlanetarySystem.PlanetarySystemEvent event : psystem.getEvents()) {
-                if(event.custom) {
+            for (PlanetarySystem.PlanetarySystemEvent event : psystem.getEvents()) {
+                if (event.custom) {
                     customSysEvents.add(event);
                 }
             }
             boolean startedSystem = false;
-            if(!customSysEvents.isEmpty()) {
-                pw1.println("\t\t<system><id>" + psystem.getId() + "</id>");
-                for(PlanetarySystem.PlanetarySystemEvent event : customSysEvents) {
+            if (!customSysEvents.isEmpty()) {
+                MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent + 1, "system");
+                MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 2, "id", psystem.getId());
+                for (PlanetarySystem.PlanetarySystemEvent event : customSysEvents) {
                     Systems.getInstance().writePlanetarySystemEvent(pw1, event);
                     pw1.println();
                 }
@@ -4756,28 +4751,30 @@ public class Campaign implements Serializable, ITechManager {
                 if (!customEvents.isEmpty()) {
                     if (!startedSystem) {
                         //only write this if we haven't already started the system
-                        pw1.println("\t\t<system><id>" + psystem.getId() + "</id>");
+                        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent + 1, "system");
+                        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 2, "id", psystem.getId());
                     }
-                    pw1.println("\t\t\t<planet><sysPos>" + p.getSystemPosition() + "</sysPos>");
+                    MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent + 2, "planet");
+                    MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 3, "sysPos", p.getSystemPosition());
                     for (Planet.PlanetaryEvent event : customEvents) {
                         Systems.getInstance().writePlanetaryEvent(pw1, event);
                         pw1.println();
                     }
-                    pw1.println("\t\t\t</planet>");
+                    MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent + 2, "planet");
                     startedSystem = true;
                 }
             }
             if (startedSystem) {
                 //close the system
-                pw1.println("\t\t</system>");
+                MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent + 1, "system");
             }
         }
-        pw1.println("\t</customPlanetaryEvents>");
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "customPlanetaryEvents");
 
         writeCustoms(pw1);
         // Okay, we're done.
         // Close everything out and be done with it.
-        pw1.println("</campaign>");
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent - 1, "campaign");
     }
 
     public void writeGameOptions(PrintWriter pw1) {
@@ -4946,7 +4943,7 @@ public class Campaign implements Serializable, ITechManager {
 
     public List<String> getAllRankNamesFor(int p) {
         List<String> retVal = new ArrayList<>();
-        for(Rank rank : getRanks().getAllRanks()) {
+        for (Rank rank : getRanks().getAllRanks()) {
             // Grab rank from correct profession as needed
             while (rank.getName(p).startsWith("--") && p != Ranks.RPROF_MW) {
                 if (rank.getName(p).equals("--")) {
@@ -5645,12 +5642,12 @@ public class Campaign implements Serializable, ITechManager {
             return new TargetRoll(TargetRoll.IMPOSSIBLE,
                     "You cannot acquire parts of this tech level");
         }
-        if(getCampaignOptions().limitByYear()
+        if (getCampaignOptions().limitByYear()
                 && !acquisition.isIntroducedBy(getGameYear(), useClanTechBase(), getTechFaction())) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE,
                     "It has not been invented yet!");
         }
-        if(getCampaignOptions().disallowExtinctStuff() &&
+        if (getCampaignOptions().disallowExtinctStuff() &&
                 (acquisition.isExtinctIn(getGameYear(), useClanTechBase(), getTechFaction())
                         || acquisition.getAvailability() == EquipmentType.RATING_X)) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE,
@@ -6064,7 +6061,7 @@ public class Campaign implements Serializable, ITechManager {
      * @param k A {@link Kill} to import into the campaign.
      */
     public void importKill(Kill k) {
-        if(!kills.containsKey(k.getPilotId())) {
+        if (!kills.containsKey(k.getPilotId())) {
             kills.put(k.getPilotId(), new ArrayList<>());
         }
 
@@ -6486,7 +6483,7 @@ public class Campaign implements Serializable, ITechManager {
                     if (!(m.getType() instanceof BombType)) {
                         continue;
                     }
-                    if(m.getBaseShotsLeft() == 1) {
+                    if (m.getBaseShotsLeft() == 1) {
                         bombChoices[BombType.getBombTypeFromInternalName(m.getType().getInternalName())] += 1;
                     }
                 }
@@ -6501,7 +6498,7 @@ public class Campaign implements Serializable, ITechManager {
         } else if (entity instanceof Aero) {
             Aero a = (Aero) entity;
 
-            if(a.isSpheroid()) {
+            if (a.isSpheroid()) {
                 entity.setMovementMode(EntityMovementMode.SPHEROID);
             } else {
                 entity.setMovementMode(EntityMovementMode.AERODYNE);
@@ -6509,7 +6506,7 @@ public class Campaign implements Serializable, ITechManager {
             a.setAltitude(5);
             a.setCurrentVelocity(0);
             a.setNextVelocity(0);
-        } else if(entity instanceof Tank) {
+        } else if (entity instanceof Tank) {
             Tank t = (Tank) entity;
             t.unjamTurret(t.getLocTurret());
             t.unjamTurret(t.getLocTurret2());
@@ -6704,7 +6701,7 @@ public class Campaign implements Serializable, ITechManager {
         Vector<String[]> networks = new Vector<>();
         Vector<String> networkNames = new Vector<>();
 
-        for(Unit u : getUnits()) {
+        for (Unit u : getUnits()) {
 
             if (u.getForceId() < 0) {
                 // only units currently in the TO&E
@@ -6737,7 +6734,7 @@ public class Campaign implements Serializable, ITechManager {
         Vector<String[]> networks = new Vector<>();
         Vector<String> networkNames = new Vector<>();
 
-        for(Unit u : getUnits()) {
+        for (Unit u : getUnits()) {
 
             if (u.getForceId() < 0) {
                 // only units currently in the TO&E
@@ -6765,7 +6762,7 @@ public class Campaign implements Serializable, ITechManager {
         Vector<String[]> networks = new Vector<>();
         Vector<String> networkNames = new Vector<>();
 
-        for(Unit u : getUnits()) {
+        for (Unit u : getUnits()) {
 
             if (u.getForceId() < 0) {
                 // only units currently in the TO&E
@@ -6799,7 +6796,7 @@ public class Campaign implements Serializable, ITechManager {
         Vector<String[]> networks = new Vector<>();
         Vector<String> networkNames = new Vector<>();
 
-        for(Unit u : getUnits()) {
+        for (Unit u : getUnits()) {
 
             if (u.getForceId() < 0) {
                 // only units currently in the TO&E

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -12,13 +12,12 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
@@ -250,39 +249,39 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 
     public static String getQualityName(int quality, boolean reverse) {
-        switch(quality) {
-        case QUALITY_A:
-            if(reverse) {
-                return "F";
-            }
-            return "A";
-        case QUALITY_B:
-            if(reverse) {
-                return "E";
-            }
-            return "B";
-        case QUALITY_C:
-            if(reverse) {
-                return "D";
-            }
-            return "C";
-        case QUALITY_D:
-            if(reverse) {
-                return "C";
-            }
-            return "D";
-        case QUALITY_E:
-            if(reverse) {
-                return "B";
-            }
-            return "E";
-        case QUALITY_F:
-            if(reverse) {
+        switch (quality) {
+            case QUALITY_A:
+                if (reverse) {
+                    return "F";
+                }
                 return "A";
-            }
-            return "F";
-        default:
-            return "?";
+            case QUALITY_B:
+                if (reverse) {
+                    return "E";
+                }
+                return "B";
+            case QUALITY_C:
+                if (reverse) {
+                    return "D";
+                }
+                return "C";
+            case QUALITY_D:
+                if (reverse) {
+                    return "C";
+                }
+                return "D";
+            case QUALITY_E:
+                if (reverse) {
+                    return "B";
+                }
+                return "E";
+            case QUALITY_F:
+                if (reverse) {
+                    return "A";
+                }
+                return "F";
+            default:
+                return "?";
         }
     }
 
@@ -343,17 +342,17 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     protected Money adjustCostsForCampaignOptions(Money cost) {
         // if the part doesn't cost anything, no amount of multiplication will change it
-        if(cost.isZero()) {
+        if (cost.isZero()) {
             return cost;
         }
 
-        if(getTechBase() == T_CLAN) {
+        if (getTechBase() == T_CLAN) {
             cost = cost.multipliedBy(campaign.getCampaignOptions().getClanPriceModifier());
         }
-        if(needsFixing() && !isPriceAdjustedForAmount()) {
+        if (needsFixing() && !isPriceAdjustedForAmount()) {
             cost = cost.multipliedBy(campaign.getCampaignOptions().getDamagedPartsValue());
             //TODO: parts that cant be fixed should also be further reduced in price
-        } else if(!isBrandNew()) {
+        } else if (!isBrandNew()) {
             cost = cost.multipliedBy(campaign.getCampaignOptions().getUsedPartsValue(getQuality()));
         }
 
@@ -388,7 +387,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public void setUnit(Unit u) {
         this.unit = u;
-        if(null != unit) {
+        if (null != unit) {
             unitId = unit.getId();
             unitTonnage = (int) unit.getEntity().getWeight();
         } else {
@@ -398,22 +397,22 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public String getStatus() {
         String toReturn = "Functional";
-        if(needsFixing()) {
+        if (needsFixing()) {
             toReturn = "Damaged";
         }
-        if(isReservedForRefit()) {
+        if (isReservedForRefit()) {
             toReturn = "Reserved for Refit";
         }
-        if(isReservedForReplacement()) {
+        if (isReservedForReplacement()) {
             toReturn = "Reserved for Repair";
         }
-        if(isBeingWorkedOn()) {
+        if (isBeingWorkedOn()) {
             toReturn = "Being worked on";
         }
-        if(!isPresent()) {
+        if (!isPresent()) {
             //toReturn = "" + getDaysToArrival() + " days to arrival";
             String dayName = "day";
-            if(getDaysToArrival() > 1) {
+            if (getDaysToArrival() > 1) {
                 dayName += "s";
             }
             toReturn = "In transit (" + getDaysToArrival() + " " + dayName + ")";
@@ -433,7 +432,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         bonus = "(" + bonus + ")";
         String toReturn = "<html><font size='2'";
         String action = "Repair ";
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             action = "Salvage ";
         }
         String scheduled = "";
@@ -444,11 +443,11 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         toReturn += ">";
         toReturn += "<b>" + action + getName() + "</b><br/>";
         toReturn += getDetails() + "<br/>";
-        if(getSkillMin() > SkillType.EXP_ELITE) {
+        if (getSkillMin() > SkillType.EXP_ELITE) {
             toReturn += "<font color='red'>Impossible</font>";
         } else {
             toReturn += "" + getTimeLeft() + " minutes" + scheduled;
-            if(!getCampaign().getCampaignOptions().isDestroyByMargin()) {
+            if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
                 toReturn += ", " + SkillType.getExperienceLevelName(getSkillMin());
             }
             toReturn += " " + bonus;
@@ -462,7 +461,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public String getRepairDesc() {
         String toReturn = "";
-        if(needsFixing()) {
+        if (needsFixing()) {
             String scheduled = "";
             if (getTeamId() != null) {
                 scheduled = " (scheduled) ";
@@ -487,17 +486,17 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 
     public static String getTechBaseName(int base) {
-        switch(base) {
-        case T_BOTH:
-            return "IS/Clan";
-        case T_CLAN:
-            return "Clan";
-        case T_IS:
-            return "IS";
-        case T_UNKNOWN:
-            return "UNKNOWN";
-        default:
-            return "??";
+        switch (base) {
+            case T_BOTH:
+                return "IS/Clan";
+            case T_CLAN:
+                return "Clan";
+            case T_IS:
+                return "IS";
+            case T_UNKNOWN:
+                return "UNKNOWN";
+            default:
+                return "??";
         }
     }
 
@@ -556,7 +555,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public boolean isSameStatus(Part part) {
         //parts that are reserved for refit or being worked on are never the same status
-        if(isReservedForRefit() || isBeingWorkedOn() || isReservedForReplacement() || hasParentPart()
+        if (isReservedForRefit() || isBeingWorkedOn() || isReservedForReplacement() || hasParentPart()
                 || part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || part.hasParentPart()) {
             return false;
         }
@@ -567,6 +566,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         return getTechBase() == TECH_BASE_CLAN;
     }
 
+    @Override
     public abstract void writeToXml(PrintWriter pw1, int indent);
 
     protected void writeToXmlBegin(PrintWriter pw1, int indent) {
@@ -589,7 +589,8 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             .append(level1)
             .append("<name>")
             .append(MekHqXmlUtil.escape(name))
-            .append("</name>");
+            .append("</name>")
+            .append(NL);
         if (omniPodded) {
             builder.append(level1)
                 .append("<omniPodded/>")
@@ -615,7 +616,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             .append(mode)
             .append("</mode>")
             .append(NL);
-        if(null != teamId) {
+        if (null != teamId) {
             builder.append(level1)
                 .append("<teamId>")
                 .append(teamId)
@@ -627,7 +628,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             .append(skillMin)
             .append("</skillMin>")
             .append(NL);
-        if(null != unitId) {
+        if (null != unitId) {
             builder.append(level1)
                 .append("<unitId>")
                 .append(unitId)
@@ -689,7 +690,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             .append(parentPartId)
             .append("</parentPartId>")
             .append(NL);
-        for(int childId : childPartIds) {
+        for (int childId : childPartIds) {
             builder.append(level1)
                 .append("<childPartId>")
                 .append(childId)
@@ -711,34 +712,25 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         String className = classNameNode.getTextContent();
 
         //reverse compatibility checks
-        if(className.equalsIgnoreCase("mekhq.campaign.parts.MekEngine")) {
+        if (className.equalsIgnoreCase("mekhq.campaign.parts.MekEngine")) {
             className = "mekhq.campaign.parts.EnginePart";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.MissingMekEngine")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.MissingMekEngine")) {
             className = "mekhq.campaign.parts.MissingEnginePart";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.EquipmentPart")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.EquipmentPart")) {
             className = "mekhq.campaign.parts.equipment.EquipmentPart";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.MissingEquipmentPart")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.MissingEquipmentPart")) {
             className = "mekhq.campaign.parts.equipment.MissingEquipmentPart";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.AmmoBin")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.AmmoBin")) {
             className = "mekhq.campaign.parts.equipment.AmmoBin";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.MissingAmmoBin")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.MissingAmmoBin")) {
             className = "mekhq.campaign.parts.equipment.MissingAmmoBin";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.JumpJet")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.JumpJet")) {
             className = "mekhq.campaign.parts.equipment.JumpJet";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.MissingJumpJet")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.MissingJumpJet")) {
             className = "mekhq.campaign.parts.equipment.MissingJumpJet";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.HeatSink")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.HeatSink")) {
             className = "mekhq.campaign.parts.equipment.HeatSink";
-        }
-        else if(className.equalsIgnoreCase("mekhq.campaign.parts.MissingHeatSink")) {
+        } else if (className.equalsIgnoreCase("mekhq.campaign.parts.MissingHeatSink")) {
             className = "mekhq.campaign.parts.equipment.MissingHeatSink";
         }
 
@@ -751,10 +743,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             // Okay, now load Part-specific fields!
             NodeList nl = wn.getChildNodes();
 
-            for (int x=0; x<nl.getLength(); x++) {
+            for (int x = 0; x < nl.getLength(); x++) {
                 Node wn2 = nl.item(x);
 
-                 if (wn2.getNodeName().equalsIgnoreCase("id")) {
+                if (wn2.getNodeName().equalsIgnoreCase("id")) {
                     retVal.id = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("name")) {
                     retVal.name = wn2.getTextContent();
@@ -778,7 +770,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                     if (version.getMajorVersion() == 0 && version.getMinorVersion() < 2 && version.getSnapshot() < 14) {
                         retVal.oldTeamId = Integer.parseInt(wn2.getTextContent());
                     } else {
-                        if(!wn2.getTextContent().equals("null")) {
+                        if (!wn2.getTextContent().equals("null")) {
                             retVal.teamId = UUID.fromString(wn2.getTextContent());
                         }
                     }
@@ -786,7 +778,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                     if (version.getMajorVersion() == 0 && version.getMinorVersion() < 2 && version.getSnapshot() < 14) {
                         retVal.oldUnitId = Integer.parseInt(wn2.getTextContent());
                     } else {
-                        if(!wn2.getTextContent().equals("null")) {
+                        if (!wn2.getTextContent().equals("null")) {
                             retVal.unitId = UUID.fromString(wn2.getTextContent());
                         }
                     }
@@ -796,7 +788,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                     if (version.getMajorVersion() == 0 && version.getMinorVersion() < 2 && version.getSnapshot() < 14) {
                         retVal.oldRefitId = Integer.parseInt(wn2.getTextContent());
                     } else {
-                        if(!wn2.getTextContent().equals("null")) {
+                        if (!wn2.getTextContent().equals("null")) {
                             retVal.refitId = UUID.fromString(wn2.getTextContent());
                         }
                     }
@@ -818,142 +810,142 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                 } else if (wn2.getNodeName().equalsIgnoreCase("childPartId")) {
                     retVal.childPartIds.add(Integer.parseInt(wn2.getTextContent()));
                 }
-			}
+            }
 
-			// Refit protection of unit id
-			if (retVal.unitId != null && retVal.refitId != null) {
-				retVal.setUnit(null);
-			}
-		} catch (Exception ex) {
-			// Errrr, apparently either the class name was invalid...
-			// Or the listed name doesn't exist.
-			// Doh!
-		    MekHQ.getLogger().error(Part.class, METHOD_NAME, ex);
-		}
+            // Refit protection of unit id
+            if (retVal.unitId != null && retVal.refitId != null) {
+                retVal.setUnit(null);
+            }
+        } catch (Exception ex) {
+            // Errrr, apparently either the class name was invalid...
+            // Or the listed name doesn't exist.
+            // Doh!
+            MekHQ.getLogger().error(Part.class, METHOD_NAME, ex);
+        }
 
-		return retVal;
-	}
+        return retVal;
+    }
 
-	protected abstract void loadFieldsFromXmlNode(Node wn);
+    protected abstract void loadFieldsFromXmlNode(Node wn);
 
-	@Override
-	public int getActualTime() {
-	    return (int) Math.ceil(getBaseTime() * mode.timeMultiplier);
-	}
+    @Override
+    public int getActualTime() {
+        return (int) Math.ceil(getBaseTime() * mode.timeMultiplier);
+    }
 
-	@Override
-	public int getTimeLeft() {
-		// Cannot be less than 0 time left.
-		return Math.max(0, getActualTime() - getTimeSpent());
-	}
+    @Override
+    public int getTimeLeft() {
+        // Cannot be less than 0 time left.
+        return Math.max(0, getActualTime() - getTimeSpent());
+    }
 
-	@Override
-	public int getTimeSpent() {
-		return timeSpent;
-	}
+    @Override
+    public int getTimeSpent() {
+        return timeSpent;
+    }
 
-	public void addTimeSpent(int m) {
-		this.timeSpent += m;
-	}
+    public void addTimeSpent(int m) {
+        this.timeSpent += m;
+    }
 
-	public void resetTimeSpent() {
-		this.timeSpent = 0;
-	}
+    public void resetTimeSpent() {
+        this.timeSpent = 0;
+    }
 
-	public void resetOvertime() {
-		this.workingOvertime = false;
-	}
+    public void resetOvertime() {
+        this.workingOvertime = false;
+    }
 
-	@Override
-	public int getSkillMin() {
-		return skillMin;
-	}
+    @Override
+    public int getSkillMin() {
+        return skillMin;
+    }
 
-	public void setSkillMin(int i) {
-		this.skillMin = i;
-	}
+    public void setSkillMin(int i) {
+        this.skillMin = i;
+    }
 
-	public WorkTime getMode() {
-		return mode;
-	}
+    public WorkTime getMode() {
+        return mode;
+    }
 
-	public void setMode(WorkTime wt) {
-	    if (canChangeWorkMode()) {
-	        this.mode = wt;
-	    } else {
-	        this.mode = WorkTime.NORMAL;
-	    }
-	}
+    public void setMode(WorkTime wt) {
+        if (canChangeWorkMode()) {
+            this.mode = wt;
+        } else {
+            this.mode = WorkTime.NORMAL;
+        }
+    }
 
-	/*
-	 * Reset our WorkTime back to normal so that we can adjust as
-	 * necessary
-	 */
-	public void resetModeToNormal() {
-		setMode(WorkTime.NORMAL);
-	}
+    /*
+     * Reset our WorkTime back to normal so that we can adjust as
+     * necessary
+     */
+    public void resetModeToNormal() {
+        setMode(WorkTime.NORMAL);
+    }
 
-	@Override
-	public boolean canChangeWorkMode() {
-	    return !(isOmniPodded() && isSalvaging());
-	}
+    @Override
+    public boolean canChangeWorkMode() {
+        return !(isOmniPodded() && isSalvaging());
+    }
 
-	@Override
-	public TargetRoll getAllMods(Person tech) {
-	    int difficulty = getDifficulty();
+    @Override
+    public TargetRoll getAllMods(Person tech) {
+        int difficulty = getDifficulty();
 
-	    if (isOmniPodded() && (isSalvaging() || this instanceof MissingPart)
-	            && (null != unit) && !(unit.getEntity() instanceof Tank)) {
-	        difficulty -= 2;
-	    }
+        if (isOmniPodded() && (isSalvaging() || this instanceof MissingPart)
+                && (null != unit) && !(unit.getEntity() instanceof Tank)) {
+            difficulty -= 2;
+        }
 
-	    if (null == mode) {
-	    	mode = WorkTime.NORMAL;
-	    }
+        if (null == mode) {
+            mode = WorkTime.NORMAL;
+        }
 
-		TargetRoll mods = new TargetRoll(difficulty, "difficulty");
-		int modeMod = mode.getMod(campaign.getCampaignOptions().isDestroyByMargin());
-		if (modeMod != 0) {
-			mods.addModifier(modeMod, getCurrentModeName());
-		}
-		if(null != unit) {
-			mods.append(unit.getSiteMod());
-	        if(unit.getEntity().hasQuirk("easy_maintain")) {
-	            mods.addModifier(-1, "easy to maintain");
-	        }
-	        else if(unit.getEntity().hasQuirk("difficult_maintain")) {
-	            mods.addModifier(1, "difficult to maintain");
-	        }
-		}
-		if(isClanTechBase() || (this instanceof MekLocation && this.getUnit() != null && this.getUnit().getEntity().isClan())) {
-			if (null != tech && !tech.isClanner()
-			        && !tech.getOptions().booleanOption(PersonnelOptions.TECH_CLAN_TECH_KNOWLEDGE)) {
-				mods.addModifier(2, "Clan tech");
-			}
-		}
-		if(null != tech
-				&& tech.getOptions().booleanOption(PersonnelOptions.TECH_WEAPON_SPECIALIST)
-				&& (IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.WEAPON
-				|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.PHYSICAL_WEAPON)) {
-			mods.addModifier(-1, "Weapon specialist");
-		}
-		if(null != tech
-				&& tech.getOptions().booleanOption(PersonnelOptions.TECH_ARMOR_SPECIALIST)
-						&& IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.ARMOR) {
-			mods.addModifier(-1, "Armor specialist");
-		}
-		if(null != tech
-				&& tech.getOptions().booleanOption(PersonnelOptions.TECH_INTERNAL_SPECIALIST)
-				&& (IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.ACTUATOR
-			 	|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.ELECTRONICS
-			 	|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.ENGINE
-			 	|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.GYRO
-			 	|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.MEK_LOCATION
-			 	|| IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.GENERAL_LOCATION)) {
-			mods.addModifier(-1, "Internal specialist");
-		}
+        TargetRoll mods = new TargetRoll(difficulty, "difficulty");
+        int modeMod = mode.getMod(campaign.getCampaignOptions().isDestroyByMargin());
+        if (modeMod != 0) {
+            mods.addModifier(modeMod, getCurrentModeName());
+        }
+        if (null != unit) {
+            mods.append(unit.getSiteMod());
+            if (unit.getEntity().hasQuirk("easy_maintain")) {
+                mods.addModifier(-1, "easy to maintain");
+            }
+            else if (unit.getEntity().hasQuirk("difficult_maintain")) {
+                mods.addModifier(1, "difficult to maintain");
+            }
+        }
+        if (isClanTechBase() || (this instanceof MekLocation && this.getUnit() != null && this.getUnit().getEntity().isClan())) {
+            if (null != tech && !tech.isClanner()
+                    && !tech.getOptions().booleanOption(PersonnelOptions.TECH_CLAN_TECH_KNOWLEDGE)) {
+                mods.addModifier(2, "Clan tech");
+            }
+        }
+        if (null != tech
+                && tech.getOptions().booleanOption(PersonnelOptions.TECH_WEAPON_SPECIALIST)
+                && (IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.WEAPON
+                || IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.PHYSICAL_WEAPON)) {
+            mods.addModifier(-1, "Weapon specialist");
+        }
+        if (null != tech
+                && tech.getOptions().booleanOption(PersonnelOptions.TECH_ARMOR_SPECIALIST)
+                        && IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.ARMOR) {
+            mods.addModifier(-1, "Armor specialist");
+        }
+        if (null != tech
+                && tech.getOptions().booleanOption(PersonnelOptions.TECH_INTERNAL_SPECIALIST)
+                && (IPartWork.findCorrectRepairType(this) == Part.REPAIR_PART_TYPE.ACTUATOR
+                || IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.ELECTRONICS
+                || IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.ENGINE
+                || IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.GYRO
+                || IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.MEK_LOCATION
+                || IPartWork.findCorrectMassRepairType(this) == Part.REPAIR_PART_TYPE.GENERAL_LOCATION)) {
+            mods.addModifier(-1, "Internal specialist");
+        }
 
-		mods = getQualityMods(mods, tech);
+        mods = getQualityMods(mods, tech);
 
         return mods;
     }
@@ -983,7 +975,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             }
         }
 
-        if(campaign.getCampaignOptions().useQualityMaintenance()) {
+        if (campaign.getCampaignOptions().useQualityMaintenance()) {
             mods = getQualityMods(mods, getUnit().getTech());
         }
         return mods;
@@ -1024,7 +1016,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             //fixers can ignore the first point of penalty for poor quality
             mods.addModifier(-1, "Mr/Ms Fix-it");
         }
-	    return mods;
+        return mods;
     }
 
     public String getCurrentModeName() {
@@ -1040,9 +1032,9 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     public void setTeamId(UUID i) {
         //keep track of whether this was a salvage operation
         //because the entity may change
-        if(null == i) {
+        if (null == i) {
             this.isTeamSalvaging = false;
-        } else if(null == teamId) {
+        } else if (null == teamId) {
             this.isTeamSalvaging = isSalvaging();
         }
         this.teamId = i;
@@ -1096,7 +1088,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     @Override
     public String succeed() {
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             remove(true);
             return " <font color='green'><b> salvaged.</b></font>";
         } else {
@@ -1162,7 +1154,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     @Override
     public boolean isSalvaging() {
-        if(null != unit) {
+        if (null != unit) {
             return unit.isSalvage() || isMountedOnDestroyedLocation() || isTeamSalvaging();
         }
         return false;
@@ -1253,7 +1245,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 
     public boolean checkArrival() {
-        if(daysToArrival > 0) {
+        if (daysToArrival > 0) {
             daysToArrival--;
             return (daysToArrival == 0);
         }
@@ -1276,7 +1268,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     /*
     public void resetRepairStatus() {
-        if(null != unit) {
+        if (null != unit) {
             setSalvaging(unit.isSalvage());
             updateConditionFromEntity(false);
         }
@@ -1309,10 +1301,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public void decrementQuantity() {
         quantity--;
-        if(quantity <= 0) {
-            for(int childId : childPartIds) {
+        if (quantity <= 0) {
+            for (int childId : childPartIds) {
                 Part p = campaign.getPart(childId);
-                if(null != p) {
+                if (null != p) {
                     campaign.removePart(p);
                 }
             }
@@ -1326,10 +1318,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
      */
     public void setQuantity(int number) {
         quantity = number;
-        if(quantity <= 0) {
-            for(int childId : childPartIds) {
+        if (quantity <= 0) {
+            for (int childId : childPartIds) {
                 Part p = campaign.getPart(childId);
-                if(null != p) {
+                if (null != p) {
                     campaign.removePart(p);
                 }
             }
@@ -1358,7 +1350,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 
     public void decrementDaysToWait() {
-        if(daysToWait > 0) {
+        if (daysToWait > 0) {
             daysToWait--;
         }
     }
@@ -1373,7 +1365,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public String getQuantityName(int quantity) {
         String answer = "" + quantity + " " + getName();
-        if(quantity > 1) {
+        if (quantity > 1) {
             answer += "s";
         }
         return answer;
@@ -1445,10 +1437,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public void removeChildPart(int childId) {
         ArrayList<Integer> tempArray = new ArrayList<>();
-        for(int cid : childPartIds) {
-            if(cid == childId) {
+        for (int cid : childPartIds) {
+            if (cid == childId) {
                 Part part = campaign.getPart(childId);
-                if(null != part) {
+                if (null != part) {
                     part.setParentPartId(-1);
                 }
             } else {
@@ -1459,9 +1451,9 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 
     public void removeAllChildParts() {
-        for(int childId : childPartIds) {
+        for (int childId : childPartIds) {
             Part part = campaign.getPart(childId);
-            if(null != part) {
+            if (null != part) {
                 part.setParentPartId(-1);
             }
         }
@@ -1502,7 +1494,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         sb.append(getDetails());
         sb.append(", q: "); //$NON-NLS-1$
         sb.append(quantity);
-        if(null != unit) {
+        if (null != unit) {
             sb.append(", mounted: "); //$NON-NLS-1$
             sb.append(unit);
         }
@@ -1513,28 +1505,20 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         switch (type) {
             case Part.REPAIR_PART_TYPE.ARMOR:
                 return "Armor";
-
             case Part.REPAIR_PART_TYPE.AMMO:
                 return "Ammo";
-
             case Part.REPAIR_PART_TYPE.WEAPON:
                 return "Weapons";
-
             case Part.REPAIR_PART_TYPE.GENERAL_LOCATION:
                 return "Locations";
-
             case Part.REPAIR_PART_TYPE.ENGINE:
                 return "Engines";
-
             case Part.REPAIR_PART_TYPE.GYRO:
                 return "Gyros";
-
             case Part.REPAIR_PART_TYPE.ACTUATOR:
                 return "Actuators";
-
             case Part.REPAIR_PART_TYPE.ELECTRONICS:
                 return "Cockpit/Life Support/Sensors";
-
             default:
                 return "Other Items";
         }


### PR DESCRIPTION
This implements the MekHqXmlUtil functions fully in writeToXML and implements indent based on a constant value instead of being specified numbers

The offsets have been annoying me for a while, so I've fixed them here.

Review with whitespace differences off, as I fixed what was left of the primary formatting issues.