### PR TITLE
retain force structure in destination campaign

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -648,12 +648,12 @@ public class CampaignExportWizard extends JDialog {
     
     private void attemptToAssignToForce(Unit unit, int sourceForceID, Campaign sourceCampaign, Campaign destinationCampaign) {
         Force sourceForce = sourceCampaign.getForce(sourceForceID);
-        if(sourceForce == null) {
+        if (sourceForce == null) {
             return;
         }
         
         // this indicates a unit assigned to the root-level force
-        if(sourceForce.getParentForce() == null) {
+        if (sourceForce.getParentForce() == null) {
             destinationCampaign.getForces().addUnit(unit.getId());
         }
         
@@ -662,22 +662,22 @@ public class CampaignExportWizard extends JDialog {
         // otherwise, chain-add forces
 
         // hack: the root forces are irrelevant, so we replace the source root force name with the destination root force name
-        String sourceForceFullName = getDestinationFullName(sourceForce, sourceCampaign, destinationCampaign);
+        String sourceForceFullName = getDestinationFullName (sourceForce, sourceCampaign, destinationCampaign);
         
         Force destForce = findForce(sourceForceFullName, destinationCampaign.getForces());
-        if(destForce != null) {
+        if (destForce != null) {
             destForce.addUnit(unit.getId());
         } else {
             List<Force> parentForces = getForceAndParents(sourceForce);
             Force currentDestinationForce = destinationCampaign.getForces();
             
-            for(int x = parentForces.size() - 1; x >= 0; x--) {
+            for (int x = parentForces.size() - 1; x >= 0; x--) {
                 Force nextSourceForce = parentForces.get(x);
                 String nextSourceForceFullName = getDestinationFullName(nextSourceForce, sourceCampaign, destinationCampaign);
                 Force nextDestinationForce = findForce(nextSourceForceFullName, currentDestinationForce);
                 
                 // if this level doesn't exist yet, add it to where we currently are
-                if(nextDestinationForce == null) {
+                if (nextDestinationForce == null) {
                     Force forceCopy = new Force(nextSourceForce.getName());
                     destinationCampaign.addForce(forceCopy, currentDestinationForce);
                     currentDestinationForce = forceCopy;
@@ -703,7 +703,7 @@ public class CampaignExportWizard extends JDialog {
      * Recurses through a Force structure to look for a force with the given "full force name"
      */
     private Force findForce(String forceName, Force force) {
-        if(force.getFullName().equals(forceName)) {
+        if (force.getFullName().equals(forceName)) {
             return force;
         } else {
             for(Force subForce : force.getSubForces()) {
@@ -727,11 +727,11 @@ public class CampaignExportWizard extends JDialog {
         retval.add(force);
         
         Force ancestorForce;
-        while(force.getParentForce() != null) {
+        while (force.getParentForce() != null) {
             ancestorForce = force.getParentForce();
             
             // we don't want the top-level force
-            if(ancestorForce.getParentForce() != null) {
+            if (ancestorForce.getParentForce() != null) {
                 retval.add(ancestorForce);
             }
             

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -706,10 +706,10 @@ public class CampaignExportWizard extends JDialog {
         if (force.getFullName().equals(forceName)) {
             return force;
         } else {
-            for(Force subForce : force.getSubForces()) {
+            for (Force subForce : force.getSubForces()) {
                 Force foundForce = findForce(forceName, subForce);
                 
-                if(foundForce != null) {
+                if (foundForce != null) {
                     return foundForce;
                 }
             }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -662,7 +662,7 @@ public class CampaignExportWizard extends JDialog {
         // otherwise, chain-add forces
 
         // hack: the root forces are irrelevant, so we replace the source root force name with the destination root force name
-        String sourceForceFullName = getDestinationFullName (sourceForce, sourceCampaign, destinationCampaign);
+        String sourceForceFullName = getDestinationFullName(sourceForce, sourceCampaign, destinationCampaign);
         
         Force destForce = findForce(sourceForceFullName, destinationCampaign.getForces());
         if (destForce != null) {

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -25,10 +25,12 @@ import java.awt.Insets;
 import java.io.File;
 import java.io.FileInputStream;
 import java.text.NumberFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -515,6 +517,8 @@ public class CampaignExportWizard extends JDialog {
         // to be exported
 
         for (Unit unit : unitList.getSelectedValuesList()) {
+            int sourceForceID = unit.getForceId();
+            
             if (destinationCampaign.getUnit(unit.getId()) != null) {
                 destinationCampaign.removeUnit(unit.getId());
             }
@@ -528,6 +532,10 @@ public class CampaignExportWizard extends JDialog {
             if (!unit.getTransportedUnits().isEmpty()) {
                 unit.unloadTransportShip();
             }
+            
+            // make an attempt to re-construct the force structure in the destination campaign
+            // or assign the unit to the same force
+            attemptToAssignToForce(unit, sourceForceID, sourceCampaign, destinationCampaign);
         }
 
         // overwrite any people with the same ID.
@@ -633,7 +641,89 @@ public class CampaignExportWizard extends JDialog {
 
         return saved;
     }
+    
+    private void attemptToAssignToForce(Unit unit, int sourceForceID, Campaign sourceCampaign, Campaign destinationCampaign) {
+        Force sourceForce = sourceCampaign.getForce(sourceForceID);
+        if(sourceForce == null) {
+            return;
+        }
+        
+        // this indicates a unit assigned to the root-level force
+        if(sourceForce.getParentForce() == null) {
+            destinationCampaign.getForces().addUnit(unit.getId());
+        }
+        
+        // first thing we will try is to identify a force with the same name and tree structure in the destination campaign
+        // if we find one, add the unit to it
+        // otherwise,
+        Force destForce = findForce(sourceForce.getFullName(), destinationCampaign.getForces());
+        if(destForce != null) {
+            destForce.addUnit(unit.getId());
+        } else {
+            List<Force> parentForces = getForceAndParents(sourceForce);
+            Force currentDestinationForce = destinationCampaign.getForces();
+            
+            for(int x = parentForces.size() - 1; x >= 0; x--) {
+                Force nextSourceForce = parentForces.get(x);
+                Force nextDestinationForce = findForce(nextSourceForce.getFullName(), currentDestinationForce);
+                
+                // if this level doesn't exist yet, add it to where we currently are
+                if(nextDestinationForce == null) {
+                    Force forceCopy = new Force(nextSourceForce.getName());
+                    destinationCampaign.addForce(forceCopy, currentDestinationForce);
+                    currentDestinationForce = forceCopy;
+                // otherwise, update current location and move to next level
+                } else {
+                    currentDestinationForce = nextDestinationForce;
+                }
+            }
+            
+            currentDestinationForce.addUnit(unit.getId());
+        }
+    }
+    
+    /**
+     * Recurses through a Force structure to look for a force with the given "full force name"
+     */
+    private Force findForce(String forceName, Force force) {
+        if(force.getFullName().equals(forceName)) {
+            return force;
+        } else {
+            for(Force subForce : force.getSubForces()) {
+                Force foundForce = findForce(forceName, subForce);
+                
+                if(foundForce != null) {
+                    return foundForce;
+                }
+            }
+            
+            return null;
+        }
+    }
 
+    /** 
+     * Moves through a force's ancestors and returns a flattened list of force names in order
+     * from me to furtherst ancestor.
+     */
+    private List<Force> getForceAndParents(Force force) {
+        List<Force> retval = new ArrayList<>();
+        retval.add(force);
+        
+        Force ancestorForce;
+        while(force.getParentForce() != null) {
+            ancestorForce = force.getParentForce();
+            
+            // we don't want the top-level force
+            if(ancestorForce.getParentForce() != null) {
+                retval.add(ancestorForce);
+            }
+            
+            force = ancestorForce;
+        }
+        
+        return retval;
+    }
+    
     private String getPersonSelectionStatus() {
         Map<String, Integer> roleCounts = new HashMap<>();
         for (Person person : personList.getSelectedValuesList()) {
@@ -704,7 +794,15 @@ public class CampaignExportWizard extends JDialog {
                                                       boolean isSelected, boolean cellHasFocus) {
             Component cmp = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             Person person = (Person) value;
-            String cellValue = String.format("%s (%s)", person.getFullName(), person.getPrimaryRoleDesc());
+            String callsign = "";
+            if((person.getCallsign() != null) && (person.getCallsign().trim().length() > 0)) {
+                callsign = String.format("\"%s\" ", person.getCallsign());
+            }
+            
+            String cellValue = String.format("%s %s(%s)", 
+                    person.getFullName(),
+                    callsign,
+                    person.getPrimaryRoleDesc());
             ((JLabel) cmp).setText(cellValue);
             return cmp;
         }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -812,7 +812,7 @@ public class CampaignExportWizard extends JDialog {
             Component cmp = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             Person person = (Person) value;
             String callsign = "";
-            if((person.getCallsign() != null) && (person.getCallsign().trim().length() > 0)) {
+            if ((person.getCallsign() != null) && (person.getCallsign().trim().length() > 0)) {
                 callsign = String.format("\"%s\" ", person.getCallsign());
             }
             


### PR DESCRIPTION
Two changes in this one:

First, the campaign export wizard now tries to re-construct force structure for exported units. So, if a mech was in Alpha Company/Fire Lance in the source campaign, it'll either create that force structure in the destination or place the mech there if it exists already.

Second, the personnel selection list in the export wizard displays the call sign of a person in addition to the role.