### PR TITLE
Add jitpack for serialkiller mm dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ allprojects {
             url 'https://github.com/MegaMek/mavenrepo/raw/master'
         }
         jcenter()
+        maven {
+            url 'https://jitpack.io'
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the jitpack maven repository for Megamek's SerialKiller library dependency in [#2132](https://github.com/MegaMek/megamek/pull/2132). After adding it, I was able to build with the `assembleDist` task and run the game, and dangerous Java object payloads were correctly blocked by SerialKiller.