### PR TITLE
Fixing bug with fill transports

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1133,7 +1133,12 @@ public class AtBDynamicScenarioFactory {
      * @param campaign
      * @return transportedUnits List of units being transported
      */
-    public static List<Entity> fillTransports(AtBScenario scenario, List<Entity> transports, String factionCode, int skill, int quality, Campaign campaign) {
+    public static List<Entity> fillTransports(AtBScenario scenario, List<Entity> transports,
+                                              String factionCode, int skill, int quality, Campaign campaign) {
+        if ((transports == null) || transports.isEmpty()) {
+            return new ArrayList<>();
+        }
+
         List<Entity> transportedUnits = new ArrayList<>();
 
         UnitGeneratorParameters params = new UnitGeneratorParameters();
@@ -1151,7 +1156,8 @@ public class AtBDynamicScenarioFactory {
     /**
      * Worker function that generates a battle armor unit to attach to a unit of clan mechs
      */
-    public static List<Entity> generateBAForNova(AtBScenario scenario, List<Entity> starUnits, String factionCode, int skill, int quality, Campaign campaign) {
+    public static List<Entity> generateBAForNova(AtBScenario scenario, List<Entity> starUnits,
+                                                 String factionCode, int skill, int quality, Campaign campaign) {
         List<Entity> transportedUnits = new ArrayList<>();
 
         // determine if this should be a nova

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -907,11 +907,11 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      * @param weightMod        Modifier to the weight class of enemy lances.
      * @param campaign
      */
-    protected void addEnemyForce(List<Entity> list, int weightClass,
-            int maxWeight, int rollMod, int weightMod, Campaign campaign) {
+    protected void addEnemyForce(List<Entity> list, int weightClass, int maxWeight, int rollMod,
+                                 int weightMod, Campaign campaign) {
         String org = AtBConfiguration.getParentFactionType(getContract(campaign).getEnemyCode());
 
-        String lances = campaign.getAtBConfig().selectBotLances(org, weightClass, rollMod/20f);
+        String lances = campaign.getAtBConfig().selectBotLances(org, weightClass, rollMod / 20f);
         int maxLances = Math.min(lances.length(), campaign.getCampaignOptions().getSkillLevel() + 1);
 
         for (int i = 0; i < maxLances; i++) {
@@ -921,10 +921,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
         if (campaign.getCampaignOptions().getAllowOpforLocalUnits()) {
             list.addAll(AtBDynamicScenarioFactory.fillTransports(this, list,
-                    getContract(campaign).getEnemyCode(),
-                    getContract(campaign).getEnemySkill(), getContract(campaign).getEnemyQuality(),
-                    campaign));
-
+                    getContract(campaign).getEnemyCode(), getContract(campaign).getEnemySkill(),
+                    getContract(campaign).getEnemyQuality(), campaign));
         }
     }
 


### PR DESCRIPTION
This fixes a NPE relating to fill transports if it is called with a null or empty list. This bug was raised on Discord.