### PR TITLE
1922: CrewSkillUpgrader Infinite Loop Fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -115,7 +115,9 @@ public class CrewSkillUpgrader {
         // every time we generate an SPA, we reduce the max available XP
         // this logic also prevents attempting to assign an SPA when there are no SPAs
         // that cost less XP than the remaining cap
-        for (int x = 0; (x < spaCap) && (xpCap > minAbilityCost); x++) {
+        // We also want to ensure this only happens a maximum of a thousand times, to prevent an
+        // infinite loop
+        for (int x = 0, y = 0; (x < spaCap) && (xpCap > minAbilityCost) && (y < 1000); x++, y++) {
             int spaCost = addSingleSPA(entity, xpCap);
             // if we didn't assign an SPA, let's reroll it.
             if (spaCost == 0) {

--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -1,17 +1,21 @@
 /*
- * MegaMek - Copyright (C) 2019 Megamek Team
+ * Copyright (C) 2019, 2020 - The MegaMek Team. All Rights Reserved.
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This file is part of MekHQ.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.mission;
 
 import java.util.ArrayList;
@@ -34,7 +38,6 @@ import mekhq.campaign.personnel.SpecialAbility;
 /**
  * This class handles randomly generating SPAs for bot-controlled entities
  * @author NickAragua
- *
  */
 public class CrewSkillUpgrader {
 	// complex data structure
@@ -42,39 +45,39 @@ public class CrewSkillUpgrader {
 	// second key is the XP cost of the SPA
     private Map<Integer, Map<Integer, List<SpecialAbility>>> specialAbilitiesByUnitType;
     private double maxAbilityXPCost = 0;
-    private double twoThirdsXPCost = 0;
-    private double oneThirdXPCost = 0;
+    private double twoThirdsXPCost;
+    private double oneThirdXPCost;
     private double minAbilityCost = Double.MAX_VALUE;
-    
-    
+
+
     /**
      * Constructor. Initializes updated SPA list, broken down by unit type.
      */
     public CrewSkillUpgrader() {
         specialAbilitiesByUnitType = new HashMap<>();
-        
-        for(SpecialAbility spa : SpecialAbility.getWeightedSpecialAbilities()) {
-            if(spa.getCost() > maxAbilityXPCost) {
+
+        for (SpecialAbility spa : SpecialAbility.getWeightedSpecialAbilities()) {
+            if (spa.getCost() > maxAbilityXPCost) {
                 maxAbilityXPCost = spa.getCost();
             }
-            
-            if(spa.getCost() < minAbilityCost) {
+
+            if (spa.getCost() < minAbilityCost) {
                 minAbilityCost = spa.getCost();
             }
-            
-            for(int unitType = 0; unitType < UnitType.SIZE; unitType++) {
+
+            for (int unitType = 0; unitType < UnitType.SIZE; unitType++) {
                 specialAbilitiesByUnitType.putIfAbsent(unitType, new HashMap<>());
-                if(spa.isEligible(unitType)) {
+                if (spa.isEligible(unitType)) {
                     specialAbilitiesByUnitType.get(unitType).putIfAbsent(spa.getCost(), new ArrayList<>());
                     specialAbilitiesByUnitType.get(unitType).get(spa.getCost()).add(spa);
                 }
             }
         }
-        
+
         twoThirdsXPCost = maxAbilityXPCost / 3.0 * 2.0;
         oneThirdXPCost = maxAbilityXPCost / 3.0;
     }
-    
+
     /**
      * Upgrades an entity's crew as per Campaign Ops rules.
      * @param entity The entity to potentially upgrade.
@@ -85,34 +88,34 @@ public class CrewSkillUpgrader {
         // this sets the weight limit and how many SPAs we can assign
         // this is described in some detail in CamOps page 70 (Special Pilot Abilities)
         int upgradeRoll = Compute.randomInt(4);
-        if(upgradeRoll != 3) {
+        if (upgradeRoll != 3) {
             return;
         }
-        
+
         double skillAvg = (entity.getCrew().getGunnery() + entity.getCrew().getPiloting()) / 2.0;
         double xpCap = 0;
         int spaCap = 0;
-        
+
         // elite
-        if(skillAvg < 3) {
+        if (skillAvg < 3) {
             xpCap = maxAbilityXPCost;
             spaCap = 3;
         // veteran
-        } else if(skillAvg < 4) {
+        } else if (skillAvg < 4) {
             xpCap = twoThirdsXPCost;
             spaCap = 2;
         // regular
-        } else if(skillAvg < 5) {
+        } else if (skillAvg < 5) {
             xpCap = oneThirdXPCost;
             spaCap = 1;
         }
-        
-        // algorithm: 
+
+        // algorithm:
         // we want a maximum # of SPAs, capped, in total at a max XP cost
         // every time we generate an SPA, we reduce the max available XP
         // this logic also prevents attempting to assign an SPA when there are no SPAs
         // that cost less XP than the remaining cap
-        for(int x = 0; (x < spaCap) && (xpCap > minAbilityCost); x++) {
+        for (int x = 0; (x < spaCap) && (xpCap > minAbilityCost); x++) {
             int spaCost = addSingleSPA(entity, xpCap);
             // if we didn't assign an SPA, let's reroll it.
             if (spaCost == 0) {
@@ -121,32 +124,32 @@ public class CrewSkillUpgrader {
             xpCap -= spaCost;
         }
     }
-    
+
     /**
      * Upgrade an entity with a single SPA
      * @param entity
      * @return the xp cost of the added SPA
      */
-    public int addSingleSPA(Entity entity, double xpCap) {
+    private int addSingleSPA(Entity entity, double xpCap) {
         int unitType = entity.getUnitType();
-        
+
         List<SpecialAbility> choices = coalescedSPAList(unitType, xpCap);
-        if(choices.size() == 0) {
+        if (choices.size() == 0) {
         	return 0;
         }
-        
+
         int spaIndex;
         SpecialAbility spa = null;
-        
+
         // if the ability is disqualified by some weird circumstances,
         // because the entity already has it
-        // or because it exceeds the weight limit 
+        // or because it exceeds the weight limit
         // then try to generate another one
-        while(choices.size() > 0) {
+        while (choices.size() > 0) {
         	spaIndex = Compute.randomInt(choices.size());
         	spa = choices.get(spaIndex);
-        	
-        	if(entity.hasAbility(spa.getName()) ||
+
+        	if (entity.hasAbility(spa.getName()) ||
         			!extraEligibilityCheck(spa, entity)) {
         		choices.remove(spaIndex);
         		spa = null;
@@ -154,43 +157,43 @@ public class CrewSkillUpgrader {
         		break;
         	}
         }
-        
-        if(spa == null) {
+
+        if (spa == null) {
         	return 0;
         }
 
         String spaValue;
-        
-        switch(spa.getName()) {
-        case OptionsConstants.MISC_HUMAN_TRO:
-            spaValue = pickRandomHumanTRO();
-            break;
-        case OptionsConstants.GUNNERY_RANGE_MASTER:
-            spaValue = pickRandomRangeMaster();
-            break;
-        case OptionsConstants.GUNNERY_SPECIALIST:
-            spaValue = pickRandomGunnerySpecialization(entity);
-            break;
-        case OptionsConstants.GUNNERY_WEAPON_SPECIALIST:
-            spaValue = pickRandomWeapon(entity, false);
-            break;
-        case OptionsConstants.GUNNERY_SANDBLASTER:
-            spaValue = pickRandomWeapon(entity, true);
-            break;
-        default:
-            entity.getCrew().getOptions().getOption(spa.getName()).setValue(true);
-            return spa.getCost();
+
+        switch (spa.getName()) {
+            case OptionsConstants.MISC_HUMAN_TRO:
+                spaValue = pickRandomHumanTRO();
+                break;
+            case OptionsConstants.GUNNERY_RANGE_MASTER:
+                spaValue = pickRandomRangeMaster();
+                break;
+            case OptionsConstants.GUNNERY_SPECIALIST:
+                spaValue = pickRandomGunnerySpecialization(entity);
+                break;
+            case OptionsConstants.GUNNERY_WEAPON_SPECIALIST:
+                spaValue = pickRandomWeapon(entity, false);
+                break;
+            case OptionsConstants.GUNNERY_SANDBLASTER:
+                spaValue = pickRandomWeapon(entity, true);
+                break;
+            default:
+                entity.getCrew().getOptions().getOption(spa.getName()).setValue(true);
+                return spa.getCost();
         }
-        
+
         // if we fail to pick a random weapon/specialization for whatever reason, don't assign the SPA
         if (spaValue.equals(Crew.SPECIAL_NONE)) {
             return 0;
         }
-        
+
         entity.getCrew().getOptions().getOption(spa.getName()).setValue(spaValue);
         return spa.getCost();
     }
-    
+
     /**
      * Utility function that returns all the SPAs for the given unit type at or below the given cap
      * @param unitType Unit type
@@ -199,16 +202,16 @@ public class CrewSkillUpgrader {
      */
     private List<SpecialAbility> coalescedSPAList(int unitType, double xpCap) {
     	List<SpecialAbility> coalescedList = new ArrayList<>();
-    	
-    	for(int cost : specialAbilitiesByUnitType.get(unitType).keySet()) {
-    		if(cost <= xpCap) {
+
+    	for (int cost : specialAbilitiesByUnitType.get(unitType).keySet()) {
+    		if (cost <= xpCap) {
     			coalescedList.addAll(specialAbilitiesByUnitType.get(unitType).get(cost));
     		}
     	}
-    	
+
     	return coalescedList;
     }
-    
+
     /**
      * Contains "special" logic to ensure SPA is appropriate for the entity, beyond the simple unit type check.
      * @param spa
@@ -216,14 +219,14 @@ public class CrewSkillUpgrader {
      * @return
      */
     private boolean extraEligibilityCheck(SpecialAbility spa, Entity entity) {
-        switch(spa.getName()) {
-        case OptionsConstants.PILOT_ANIMAL_MIMIC:
-            return entity.entityIsQuad() || entity.hasQuirk(OptionsConstants.QUIRK_POS_ANIMALISTIC);
+        switch (spa.getName()) {
+            case OptionsConstants.PILOT_ANIMAL_MIMIC:
+                return entity.entityIsQuad() || entity.hasQuirk(OptionsConstants.QUIRK_POS_ANIMALISTIC);
+            default:
+                return true;
         }
-        
-        return true;
     }
-    
+
     /**
      * Picks a random weapon specialization for a weapon that the entity has mounted,
      * and returns the weapon's name so that a weapon specialist value may be set.
@@ -233,21 +236,21 @@ public class CrewSkillUpgrader {
     private String pickRandomWeapon(Entity entity, boolean clusterOnly) {
         List<Mounted> weapons = entity.getIndividualWeaponList();
         List<Mounted> eligibleWeapons = new ArrayList<>();
-        
-        for(Mounted weapon : weapons) {
-            if(SpecialAbility.isWeaponEligibleForSPA(weapon.getType(), Person.T_NONE, clusterOnly)) {
+
+        for (Mounted weapon : weapons) {
+            if (SpecialAbility.isWeaponEligibleForSPA(weapon.getType(), Person.T_NONE, clusterOnly)) {
                 eligibleWeapons.add(weapon);
             }
         }
-        
-        if(eligibleWeapons.size() == 0) {
+
+        if (eligibleWeapons.size() == 0) {
             return Crew.SPECIAL_NONE;
         }
-        
+
         int weaponIndex = Compute.randomInt(eligibleWeapons.size());
         return eligibleWeapons.get(weaponIndex).getName();
     }
-    
+
     /**
      * Picks a random gunnery specialization for the given entity. Naturally weighted
      * towards weapon categories contained in the entity.
@@ -257,25 +260,25 @@ public class CrewSkillUpgrader {
     private String pickRandomGunnerySpecialization(Entity entity) {
         int weaponIndex = Compute.randomInt(entity.getIndividualWeaponList().size());
         WeaponType weaponType = (WeaponType) entity.getIndividualWeaponList().get(weaponIndex).getType();
-        
-        if(weaponType.hasFlag(WeaponType.F_BALLISTIC)) {
+
+        if (weaponType.hasFlag(WeaponType.F_BALLISTIC)) {
             return Crew.SPECIAL_BALLISTIC;
-        } else if(weaponType.hasFlag(WeaponType.F_ENERGY)) {
+        } else if (weaponType.hasFlag(WeaponType.F_ENERGY)) {
             return Crew.SPECIAL_ENERGY;
-        } else if(weaponType.hasFlag(WeaponType.F_MISSILE)) {
+        } else if (weaponType.hasFlag(WeaponType.F_MISSILE)) {
             return Crew.SPECIAL_MISSILE;
         } else {
             return Crew.SPECIAL_NONE;
         }
     }
-    
+
     private String pickRandomRangeMaster() {
         return Utilities.getRandomItem(
-                Arrays.asList(new String[]{Crew.RANGEMASTER_MEDIUM, Crew.RANGEMASTER_LONG, Crew.RANGEMASTER_EXTREME})).toString();
+                Arrays.asList(Crew.RANGEMASTER_MEDIUM, Crew.RANGEMASTER_LONG, Crew.RANGEMASTER_EXTREME));
     }
-    
+
     private String pickRandomHumanTRO() {
         return Utilities.getRandomItem(
-                Arrays.asList(new String[]{Crew.HUMANTRO_MECH, Crew.HUMANTRO_AERO, Crew.HUMANTRO_VEE, Crew.HUMANTRO_BA})).toString();
+                Arrays.asList(Crew.HUMANTRO_MECH, Crew.HUMANTRO_AERO, Crew.HUMANTRO_VEE, Crew.HUMANTRO_BA));
     }
 }


### PR DESCRIPTION
This fixes #1922, which is a stallout caused by an infinite loop in assigning SPAs.

To review: The first commit is a formatting cleanup, the second is the code change for this branch.