### PR TITLE
1829: Fixing Duplicated Nags in AdvanceDaysDialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -158,16 +158,7 @@ public class AdvanceDaysDialog extends JDialog implements ActionListener {
 
             List<String> reports = new ArrayList<>();
             for (; days > 0; days--) {
-                if (gui.getCampaign().checkOverDueLoans()
-                        || gui.nagShortMaintenance()
-                        || (gui.getCampaign().getCampaignOptions().getUseAtB())
-                        && (gui.nagShortDeployments() || gui.nagOutstandingScenarios())) {
-                    break;
-                } else if (gui.getCampaign().checkRetirementDefections()
-                        || gui.getCampaign().checkYearlyRetirements()) {
-                    gui.showRetirementDefectionDialog();
-                    break;
-                } else if (!gui.getCampaign().newDay()) {
+                if (!gui.getCampaign().newDay()) {
                     break;
                 }
                 String report = gui.getCampaign().getCurrentReportHTML();


### PR DESCRIPTION
This fixes #1829. Campaign::newDay triggers a DayEndingEvent that is then handled by CampaignGUI::handleDayEnding to force the overdue loans, Retirement Defections, Yearly Retirements, Short Maintenance, Short Deployments, and Outstanding Scenarios. Therefore the checks are not required, and this fixes issues where they can show up twice.