### PR TITLE
fix refits involving ammo-based weapons

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -294,11 +294,11 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return part instanceof AmmoStorage
                 && part.isPresent()
                 && ((AmmoType)((AmmoStorage)part).getType()).equals(curType)
-                && curType.getMunitionType() == ((AmmoType)((AmmoStorage)part).getType()).getMunitionType();
+                && curType.getMunitionType() == ((AmmoType) ((AmmoStorage) part).getType()).getMunitionType();
     }
     
     public void changeAmountAvailable(int amount, final AmmoType curType) {
-        AmmoStorage a = (AmmoStorage)campaign.findSparePart(part -> {
+        AmmoStorage a = (AmmoStorage) campaign.findSparePart(part -> {
             return IsRightAmmo(part, curType);
         });
 
@@ -419,4 +419,3 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return isExtinct(year, clan, techFaction);
     }
 }
-

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -286,13 +286,20 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return "<font color='red'><b> part not found</b>.</font>";
     }
 
-    public void changeAmountAvailable(int amount, final AmmoType curType) {
-        final long curMunition = curType.getMunitionType();
-        AmmoStorage a = (AmmoStorage)campaign.findSparePart(part -> {
-            return part instanceof AmmoStorage
+    /**
+     * Boolean function that determines if the given part is of the correct ammo. 
+     * Useful as a predicate for campaign.findSparePart()
+     */
+    public static boolean IsRightAmmo(Part part, AmmoType curType) {
+        return part instanceof AmmoStorage
                 && part.isPresent()
                 && ((AmmoType)((AmmoStorage)part).getType()).equals(curType)
-                && curMunition == ((AmmoType)((AmmoStorage)part).getType()).getMunitionType();
+                && curType.getMunitionType() == ((AmmoType)((AmmoStorage)part).getType()).getMunitionType();
+    }
+    
+    public void changeAmountAvailable(int amount, final AmmoType curType) {
+        AmmoStorage a = (AmmoStorage)campaign.findSparePart(part -> {
+            return IsRightAmmo(part, curType);
         });
 
         if (null != a) {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1179,7 +1179,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                 AmmoBin bin = (AmmoBin) part;
                 Part foundAmmo = getCampaign().findSparePart(campaignPart -> AmmoStorage.IsRightAmmo(campaignPart, (AmmoType) bin.getType()));
 
-                if (foundAmmo == null || (((AmmoStorage) foundAmmo).getShots() < bin.getShotsNeeded())) {
+                if ((foundAmmo == null) || (((AmmoStorage) foundAmmo).getShots() < bin.getShotsNeeded())) {
                     missingAmmo = true;
                     // if we've found even one ammo bin that we can't load, we're not ready to refit, so bug out early
                     break;

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1140,20 +1140,20 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
     }
 
     public boolean acquireParts() {
-        if(!customJob) {
+        if (!customJob) {
             checkForArmorSupplies();
             return kitFound && !partsInTransit() && (null == newArmorSupplies || (armorNeeded - newArmorSupplies.getAmount()) <= 0);
         }
         ArrayList<Part> newShoppingList = new ArrayList<>();
-        for(Part part : shoppingList) {            
-            if(part instanceof IAcquisitionWork) {
+        for (Part part : shoppingList) {
+            if (part instanceof IAcquisitionWork) {
                 //check to see if we found a replacement
                 Part replacement = part;
                 if (part instanceof MissingPart) {
                     replacement = ((MissingPart)part).findReplacement(true);
                 }
                 
-                if(null != replacement) {
+                if (null != replacement) {
                     if(replacement.getQuantity() > 1) {
                         Part actualReplacement = replacement.clone();
                         actualReplacement.setRefitId(oldUnit.getId());
@@ -1172,14 +1172,16 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         
         // Cycle through newUnitParts, find any ammo bins and see if we have the ammo to load them
         boolean missingAmmo = false;
-        for(int pid : newUnitParts) {
+        for (int pid : newUnitParts) {
             Part part = getCampaign().getPart(pid);
             
-            if(part instanceof AmmoBin) {
+            if (part instanceof AmmoBin) {
                 AmmoBin bin = (AmmoBin) part;
                 Part foundAmmo = getCampaign().findSparePart(campaignPart -> AmmoStorage.IsRightAmmo(campaignPart, (AmmoType) bin.getType()));
-                if(foundAmmo == null || (((AmmoStorage) foundAmmo).getShots() < bin.getShotsNeeded())) {
+
+                if (foundAmmo == null || (((AmmoStorage) foundAmmo).getShots() < bin.getShotsNeeded())) {
                     missingAmmo = true;
+                    // if we've found even one ammo bin that we can't load, we're not ready to refit, so bug out early
                     break;
                 }
             }
@@ -2526,19 +2528,5 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
     @Override
     public boolean isExtinctIn(int year, boolean clan, int techFaction) {
         return isExtinct(year, clan, techFaction);
-    }
-    
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder(super.toString());
-        
-        for(int partID : getNewUnitPartIds()) {
-            Part part = getCampaign().getPart(partID);
-            if(part != null && !part.isPresent()) {
-                sb.append("<br/>").append(part.getName()).append("-").append(part.getDaysToWait()).append(" days to arrival");
-            }
-        }
-        
-        return sb.toString();
     }
 }


### PR DESCRIPTION
Took a while, but this fixes an observed and reported issue where units being customized would not begin refit once all parts had arrived. Turns out that the "is there enough of the right type of ammo present" check wasn't working (it would attempt to load an ammo bin, and the call would immediately fail because the bin wasn't attached to a unit yet).