### PR TITLE
1982: Fixing AtBBattleChance for unassigned lances

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -2768,7 +2768,7 @@ public class CampaignOptions implements Serializable {
      * @return the chance of having a battle for the specified role
      */
     public double getAtBBattleChance(AtBLanceRole role) {
-        return atbBattleChance[role.ordinal()];
+        return (role == AtBLanceRole.UNASSIGNED) ? 0.0 : atbBattleChance[role.ordinal()];
     }
 
     /**


### PR DESCRIPTION
This fixes #1982 by fixing the return for any unassigned lances.