### PR TITLE
Fixing Incorrect Initial Report Date Format

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -280,7 +280,7 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
                     campaign.generateNewPersonnelMarket();
                     campaign.reloadNews();
                     campaign.readNews();
-                    campaign.beginReport("<b>" + MekHQ.getMekHQOptions().getDisplayFormattedDate(campaign.getLocalDate()) + "</b>");
+                    campaign.beginReport("<b>" + MekHQ.getMekHQOptions().getLongDisplayFormattedDate(campaign.getLocalDate()) + "</b>");
                     if (campaign.getCampaignOptions().getUseAtB()) {
                         campaign.initAtB(true);
                     }


### PR DESCRIPTION
This fixes a minor display oddity for an initial report in a new campaign that I noticed while testing #1997 