### PR TITLE
Parts for small support vehicle ammo tracking

### DIFF
--- a/MekHQ/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/RRV.blk
+++ b/MekHQ/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/RRV.blk
@@ -38,8 +38,8 @@ Tracked
 
 <transporters>
 cargobay:1.054:1:1
-troopspace:1.0
 standardseats:3.0:0
+troopspace:1.0
 </transporters>
 
 <cruiseMP>
@@ -68,12 +68,12 @@ HHSearchlight
 </Front Equipment>
 
 <Right Equipment>
-InfantryAssaultRifle(PT)
+InfantryAssaultRifle(PT):SIZE:10.0
 PintleTurret
 </Right Equipment>
 
 <Left Equipment>
-InfantryAssaultRifle(PT)
+InfantryAssaultRifle(PT):SIZE:10.0
 PintleTurret
 </Left Equipment>
 
@@ -81,7 +81,7 @@ PintleTurret
 </Rear Equipment>
 
 <Turret Equipment>
-Support Laser
+Support Laser:SIZE:2.0
 </Turret Equipment>
 
 <barrating>
@@ -92,10 +92,16 @@ Support Laser
 3
 </structural_tech_rating>
 
+<engine_tech_rating>
+3
+</engine_tech_rating>
+
+<armor_tech_rating>
+3
+</armor_tech_rating>
+
 <notes>
 Extra ammo:
-Support Laser: 30
-Auto-rifle: 600
 </notes>
 
 <source>

--- a/MekHQ/resources/mekhq/resources/SmallSVAmmoSwapDialog.properties
+++ b/MekHQ/resources/mekhq/resources/SmallSVAmmoSwapDialog.properties
@@ -3,3 +3,4 @@ cancel=Cancel
 shotsPerClip.format=Shots per clip: %d
 standard=Standard:
 inferno=Inferno:
+noStandardBin=Configuration error: No bin found for standard ammo

--- a/MekHQ/resources/mekhq/resources/SmallSVAmmoSwapDialog.properties
+++ b/MekHQ/resources/mekhq/resources/SmallSVAmmoSwapDialog.properties
@@ -1,0 +1,5 @@
+ok=Ok
+cancel=Cancel
+shotsPerClip.format=Shots per clip: %d
+standard=Standard:
+inferno=Inferno:

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.parts;
+
+import megamek.common.*;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+
+/**
+ * Storage for infantry weapon ammo. The AmmoType is a placeholder and distinguishes between
+ * standard and inferno munitions, but does not distinguish the type of weapon.
+ */
+public class InfantryAmmoStorage extends AmmoStorage {
+
+    private InfantryWeapon weaponType;
+
+    @SuppressWarnings("unused")
+    public InfantryAmmoStorage() {
+        this(0, null, 0, null, null);
+    }
+
+    public InfantryAmmoStorage(int tonnage, EquipmentType et, int shots,
+                               InfantryWeapon weaponType, Campaign c) {
+        super(tonnage, et, shots, c);
+        this.weaponType = weaponType;
+    }
+
+    /**
+     * @return The type of weapon this ammo is for
+     */
+    public InfantryWeapon getWeaponType() {
+        return weaponType;
+    }
+
+    public InfantryAmmoStorage clone() {
+        InfantryAmmoStorage storage = new InfantryAmmoStorage(0, getType(), shots, weaponType, campaign);
+        storage.copyBaseData(this);
+        storage.munition = this.munition;
+        return storage;
+    }
+
+
+    @Override
+    public double getTonnage() {
+        return weaponType.getAmmoWeight() * getShots() / weaponType.getShots();
+    }
+
+    @Override
+    public Money getStickerPrice() {
+        return Money.of(weaponType.getAmmoCost() * (double) getShots() / weaponType.getShots());
+    }
+
+    @Override
+    public Money getCurrentValue() {
+        return getStickerPrice();
+    }
+
+    @Override
+    public boolean isSamePartType(Part part) {
+        return (part instanceof InfantryAmmoStorage)
+                && (getType() == ((InfantryAmmoStorage) part).getType())
+                && (getWeaponType() == ((InfantryAmmoStorage) part).getWeaponType());
+    }
+
+    @Override
+    public void writeToXmlEnd(PrintWriter pw, int indent) {
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "weaponType", weaponType.getInternalName());
+        super.writeToXmlEnd(pw, indent);
+    }
+
+    @Override
+    protected void loadFieldsFromXmlNode(Node node) {
+        NodeList nl = node.getChildNodes();
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn = nl.item(x);
+            if (wn.getNodeName().equals("weaponType")) {
+                weaponType = (InfantryWeapon) EquipmentType.get(wn.getTextContent());
+            }
+        }
+        super.loadFieldsFromXmlNode(node);
+    }
+
+    @Override
+    public TechAdvancement getTechAdvancement() {
+        return weaponType.getTechAdvancement();
+    }
+
+    /**
+     * Boolean function that determines if the given part is of the correct ammo.
+     * Useful as a predicate for campaign.findSparePart()
+     */
+    public static boolean isRightAmmo(Part part, AmmoType curType, WeaponType weaponType) {
+        return part instanceof InfantryAmmoStorage
+                && part.isPresent()
+                && (((InfantryAmmoStorage) part).getType()).equals(curType)
+                && curType.getMunitionType() == ((AmmoType) ((AmmoStorage) part).getType()).getMunitionType()
+                && (((InfantryAmmoStorage) part).getWeaponType()).equals(weaponType);
+    }
+
+    public void changeAmountAvailable(int amount, final AmmoType curType) {
+        InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.findSparePart(part ->
+                isRightAmmo(part, curType, weaponType));
+
+        if (null != a) {
+            a.changeShots(amount);
+            if (a.getShots() <= 0) {
+                campaign.removePart(a);
+            }
+        } else if (amount > 0) {
+            campaign.addPart(new InfantryAmmoStorage(1, curType, amount, weaponType, campaign), 0);
+        }
+    }
+
+    @Override
+    public String getAcquisitionExtraDesc() {
+        return weaponType.getShots() + " shots (1 clip)";
+    }
+
+    public Part getNewPart() {
+        return new InfantryAmmoStorage(1, type, weaponType.getShots(),
+                weaponType, campaign);
+    }
+}

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -45,10 +45,17 @@ public class InfantryAmmoStorage extends AmmoStorage {
                                InfantryWeapon weaponType, Campaign c) {
         super(tonnage, et, shots, c);
         this.weaponType = weaponType;
-        if (weaponType.hasInfernoAmmo()) {
-            this.name = weaponType.getShortName() + name;
-        } else {
-            this.name = weaponType.getShortName() + " Ammo";
+    }
+
+    @Override
+    public void restore() {
+        super.restore();
+        if (weaponType != null) {
+            if (weaponType.hasInfernoAmmo()) {
+                this.name = weaponType.getShortName() + getType().getName();
+            } else {
+                this.name = weaponType.getShortName() + " Ammo";
+            }
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -45,6 +45,11 @@ public class InfantryAmmoStorage extends AmmoStorage {
                                InfantryWeapon weaponType, Campaign c) {
         super(tonnage, et, shots, c);
         this.weaponType = weaponType;
+        if (weaponType.hasInfernoAmmo()) {
+            this.name = weaponType.getShortName() + name;
+        } else {
+            this.name = weaponType.getShortName() + " Ammo";
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.parts;
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts.equipment;
+
+import megamek.common.*;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.*;
+import mekhq.campaign.work.IAcquisitionWork;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.function.Predicate;
+
+/**
+ * Ammo bin for infantry weapons used by small support vehicles
+ */
+public class InfantryAmmoBin extends AmmoBin {
+
+    private InfantryWeapon weaponType;
+
+    // Used in deserialization
+    @SuppressWarnings("unused")
+    public InfantryAmmoBin() {
+        this(0, null, 0, 0, null, 0, false, null);
+    }
+
+    /**
+     * Construct a new bin for infantry ammo
+     *
+     * @param tonnage     The weight of the unit it's installed on
+     * @param ammoType    The type of ammo
+     * @param equipNum    The equipment index on the unit
+     * @param shots       The number of shots of ammo contained in the bin
+     * @param weaponType  The weapon this ammo is for
+     * @param omniPodded  Whether the weapon is pod-mounted on an omnivehicle
+     * @param c           The campaign instance
+     */
+    public InfantryAmmoBin(int tonnage, EquipmentType ammoType, int equipNum, int shots,
+                           InfantryWeapon weaponType, double size, boolean omniPodded, Campaign c) {
+        super(tonnage, ammoType, equipNum, shots, false, omniPodded, c);
+        this.size = size;
+        this.weaponType = weaponType;
+        name = weaponType.getName() + " Ammo Bin";
+    }
+
+    /**
+     * @return The weapon this ammo is for
+     */
+    public InfantryWeapon getWeaponType() {
+        return weaponType;
+    }
+
+    @Override
+    public InfantryAmmoBin clone() {
+        InfantryAmmoBin clone = new InfantryAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), shotsNeeded,
+                weaponType, size, omniPodded, campaign);
+        clone.copyBaseData(this);
+        clone.shotsNeeded = this.shotsNeeded;
+        clone.munition = this.munition;
+        return clone;
+    }
+
+    @Override
+    public String getLocationName() {
+        int loc = getLocation();
+        if ((loc >= 0) && (loc < unit.getEntity().locations())) {
+            return unit.getEntity().getLocationName(loc);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public int getLocation() {
+        if (unit != null) {
+            Mounted m = unit.getEntity().getEquipment(equipmentNum);
+            while (m.getLinkedBy() != null) {
+                m = m.getLinkedBy();
+            }
+            return m.getLocation();
+        }
+        return Entity.LOC_NONE;
+    }
+
+    @Override
+    public double getTonnage() {
+        return super.getTonnage() * weaponType.getAmmoWeight();
+    }
+
+    @Override
+    public int getFullShots() {
+        if (unit != null) {
+            Mounted m = unit.getEntity().getEquipment(equipmentNum);
+            if ((m != null) && (m.getOriginalShots() > 0)) {
+                return m.getOriginalShots();
+            }
+        }
+        return weaponType.getShots() * (int) getSize();
+    }
+
+    @Override
+    protected Money getPricePerTon() {
+        return Money.of(weaponType.getAmmoCost() / weaponType.getAmmoWeight());
+    }
+
+    @Override
+    protected int getShotsPerTon() {
+        return (int) Math.floor(weaponType.getShots() / weaponType.getAmmoWeight());
+    }
+
+    @Override
+    public void writeToXmlEnd(PrintWriter pw, int indent) {
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "weaponType", weaponType.getInternalName());
+        super.writeToXmlEnd(pw, indent);
+    }
+
+    @Override
+    protected void loadFieldsFromXmlNode(Node node) {
+        NodeList nl = node.getChildNodes();
+
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn = nl.item(x);
+            if (wn.getNodeName().equals("weaponType")) {
+                this.weaponType = (InfantryWeapon) EquipmentType.get(wn.getTextContent().trim());
+            }
+        }
+    }
+
+    @Override
+    public MissingPart getMissingPart() {
+        return new MissingInfantryAmmoBin(getUnitTonnage(), type, equipmentNum, weaponType,
+                size, omniPodded, campaign);
+    }
+
+    @Override
+    public boolean isSamePartType(Part part) {
+        return  (part instanceof InfantryAmmoBin)
+                && super.isSamePartType(part)
+                && (weaponType == ((InfantryAmmoBin) part).weaponType)
+                && size == ((InfantryAmmoBin) part).size;
+    }
+
+    @Override
+    public void changeAmountAvailable(int amount, final AmmoType curType) {
+        InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.findSparePart(part ->
+            InfantryAmmoStorage.isRightAmmo(part, (AmmoType) getType(), getWeaponType()));
+
+        if (a != null) {
+            a.changeShots(amount);
+            if (a.getShots() <= 0) {
+                campaign.removePart(a);
+            }
+        } else if (amount > 0) {
+            campaign.addPart(new InfantryAmmoStorage(1, curType, amount, weaponType, campaign), 0);
+        }
+    }
+
+    @Override
+    public boolean isCompatibleAmmo(AmmoType a1, AmmoType a2) {
+        return false;
+    }
+
+    public int getAmountAvailable() {
+        final AmmoType thisType = (AmmoType) getType();
+        return campaign.streamSpareParts()
+            .filter(part -> part instanceof InfantryAmmoStorage && part.isPresent()
+                    && InfantryAmmoStorage.isRightAmmo(part, thisType, weaponType))
+            .mapToInt(part -> ((InfantryAmmoStorage) part).getShots())
+            .sum();
+    }
+
+    @Override
+    public String getAcquisitionExtraDesc() {
+        return weaponType.getShots() + " shots (1 clip)";
+    }
+
+    public Part getNewPart() {
+        return new InfantryAmmoStorage(1, type, weaponType.getShots(), weaponType, campaign);
+    }
+
+    @Override
+    public TechAdvancement getTechAdvancement() {
+        return weaponType.getTechAdvancement();
+    }
+}

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -60,7 +60,15 @@ public class InfantryAmmoBin extends AmmoBin {
                            InfantryWeapon weaponType, double size, boolean omniPodded, Campaign c) {
         super(tonnage, ammoType, equipNum, shots, false, omniPodded, c);
         this.size = size;
-        this.weaponType = weaponType;
+        if (weaponType != null) {
+            this.weaponType = weaponType;
+            name = weaponType.getName() + " Ammo Bin";
+        }
+    }
+
+    @Override
+    public void restore() {
+        super.restore();
         name = weaponType.getName() + " Ammo Bin";
     }
 
@@ -187,6 +195,11 @@ public class InfantryAmmoBin extends AmmoBin {
                     && InfantryAmmoStorage.isRightAmmo(part, thisType, weaponType))
             .mapToInt(part -> ((InfantryAmmoStorage) part).getShots())
             .sum();
+    }
+
+    @Override
+    public String getAcquisitionDisplayName() {
+        return weaponType.getName() + ": " + type.getName();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq.campaign.parts.equipment;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -51,7 +51,7 @@ public class InfantryAmmoBin extends AmmoBin {
      * @param tonnage     The weight of the unit it's installed on
      * @param ammoType    The type of ammo
      * @param equipNum    The equipment index on the unit
-     * @param shots       The number of shots of ammo contained in the bin
+     * @param shots       The number of shots of ammo needed to refill the bin
      * @param weaponType  The weapon this ammo is for
      * @param omniPodded  Whether the weapon is pod-mounted on an omnivehicle
      * @param c           The campaign instance
@@ -76,7 +76,6 @@ public class InfantryAmmoBin extends AmmoBin {
         InfantryAmmoBin clone = new InfantryAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), shotsNeeded,
                 weaponType, size, omniPodded, campaign);
         clone.copyBaseData(this);
-        clone.shotsNeeded = this.shotsNeeded;
         clone.munition = this.munition;
         return clone;
     }
@@ -105,7 +104,7 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public double getTonnage() {
-        return super.getTonnage() * weaponType.getAmmoWeight();
+        return weaponType.getAmmoWeight();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -86,16 +86,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-            Part actualReplacement;
-
-            //Check to see if munition types are different
-            if (getType() == ((AmmoBin)replacement).getType()) {
-                actualReplacement = replacement.clone();
-            } else {
-                actualReplacement = new AmmoBin(getUnitTonnage(), getType(), getEquipmentNum(),
-                        getFullShots(), isOneShot(), isOmniPodded(), campaign);
-            }
-
+            Part actualReplacement = getActualReplacement((AmmoBin) replacement);
             unit.addPart(actualReplacement);
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();
@@ -103,6 +94,16 @@ public class MissingAmmoBin extends MissingEquipmentPart {
             remove(false);
             //assign the replacement part to the unit
             actualReplacement.updateConditionFromPart();
+        }
+    }
+
+    protected Part getActualReplacement(AmmoBin found) {
+        //Check to see if munition types are different
+        if (getType() == found.getType()) {
+            return found.clone();
+        } else {
+            return new AmmoBin(getUnitTonnage(), getType(), getEquipmentNum(),
+                    getFullShots(), isOneShot(), isOmniPodded(), campaign);
         }
     }
 
@@ -121,8 +122,8 @@ public class MissingAmmoBin extends MissingEquipmentPart {
         return oneShot;
     }
 
-    private int getFullShots() {
-        int fullShots = ((AmmoType)type).getShots();
+    protected int getFullShots() {
+        int fullShots = ((AmmoType) type).getShots();
         if(oneShot) {
             fullShots = 1;
         }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
@@ -59,6 +59,14 @@ public class MissingInfantryAmmoBin extends MissingAmmoBin {
         super(tonnage, ammoType, equipNum, false, omniPodded, c);
         this.weaponType = weaponType;
         this.size = size;
+        if (weaponType != null) {
+            name = weaponType.getName() + " Ammo Bin";
+        }
+    }
+
+    @Override
+    public void restore() {
+        super.restore();
         name = weaponType.getName() + " Ammo Bin";
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq.campaign.parts.equipment;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts.equipment;
+
+import megamek.common.Entity;
+import megamek.common.EquipmentType;
+import megamek.common.Mounted;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.Part;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+
+/**
+ * Ammo bin missing from a small support vehicle
+ */
+public class MissingInfantryAmmoBin extends MissingAmmoBin {
+
+    private InfantryWeapon weaponType;
+
+    // Used in deserialization
+    @SuppressWarnings("unused")
+    public MissingInfantryAmmoBin() {
+        this(0, null, 0, null, 0, false, null);
+    }
+
+    /**
+     * Construct a new placeholder for a missing infantry ammo bin
+     *
+     * @param tonnage     The weight of the unit it's installed on
+     * @param ammoType    The type of ammo
+     * @param equipNum    The equipment index on the unit
+     * @param weaponType  The weapon this ammo is for
+     * @param omniPodded  Whether the weapon is pod-mounted on an omnivehicle
+     * @param c           The campaign instance
+     */
+    public MissingInfantryAmmoBin(int tonnage, EquipmentType ammoType, int equipNum, InfantryWeapon weaponType,
+                                  double size, boolean omniPodded, Campaign c) {
+        super(tonnage, ammoType, equipNum, false, omniPodded, c);
+        this.weaponType = weaponType;
+        this.size = size;
+        name = weaponType.getName() + " Ammo Bin";
+    }
+
+    public InfantryWeapon getWeaponType() {
+        return weaponType;
+    }
+
+    @Override
+    public String getLocationName() {
+        int loc = getLocation();
+        if ((loc >= 0) && (loc < unit.getEntity().locations())) {
+            return unit.getEntity().getLocationName(loc);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public int getLocation() {
+        if (unit != null) {
+            Mounted m = unit.getEntity().getEquipment(equipmentNum);
+            while (m.getLinkedBy() != null) {
+                m = m.getLinkedBy();
+            }
+            return m.getLocation();
+        }
+        return Entity.LOC_NONE;
+    }
+
+    protected Part getActualReplacement(AmmoBin found) {
+        //Check to see if munition types are different
+        if (getType() == found.getType()) {
+            return found.clone();
+        } else {
+            return new InfantryAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(),
+                    getFullShots(), getWeaponType(), getSize(), isOmniPodded(), campaign);
+        }
+    }
+
+    @Override
+    public boolean isAcceptableReplacement(Part part, boolean refit) {
+        if (part instanceof InfantryAmmoBin) {
+            InfantryAmmoBin bin = (InfantryAmmoBin) part;
+            return type.equals(bin.getType()) && weaponType.equals(bin.getWeaponType())
+                    && (bin.getFullShots() == getFullShots());
+        }
+        return false;
+    }
+
+    @Override
+    protected int getFullShots() {
+        return weaponType.getShots() * (int) size;
+    }
+
+    @Override
+    public Part getNewPart() {
+        return new InfantryAmmoBin(getUnitTonnage(), type, -1, getFullShots(),
+                weaponType, size, omniPodded, campaign);
+    }
+
+    @Override
+    public void writeToXmlEnd(PrintWriter pw, int indent) {
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "weaponType", weaponType.getInternalName());
+        super.writeToXmlEnd(pw, indent);
+    }
+
+    @Override
+    protected void loadFieldsFromXmlNode(Node node) {
+        NodeList nl = node.getChildNodes();
+
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn = nl.item(x);
+            if (wn.getNodeName().equals("weaponType")) {
+                this.weaponType = (InfantryWeapon) EquipmentType.get(wn.getTextContent().trim());
+            }
+        }
+    }
+
+}

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2614,8 +2614,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             }
         }
         for (Mounted m : entity.getEquipment()) {
-            if (m.getLocation() == Entity.LOC_NONE) {
-                //FIXME: is this ok? - are there any valid parts in LOC_NONE?
+            if ((m.getLocation() == Entity.LOC_NONE) && !(m.getType() instanceof AmmoType)) {
                 continue;
             }
             // We want to ignore weapon groups so that we don't get phantom weapons
@@ -2641,12 +2640,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             if (m.getType() instanceof AmmoType) {
                 int eqnum = entity.getEquipmentNum(m);
                 Part apart = ammoParts.get(eqnum);
-                int fullShots = ((AmmoType)m.getType()).getShots();
-                boolean oneShot = false;
-                if (m.getLocation() == Entity.LOC_NONE) {
-                    fullShots = 1;
-                    oneShot = true;
-                }
+                boolean oneShot = m.isOneShotAmmo();
+                int fullShots = oneShot ? 1 : ((AmmoType) m.getType()).getShots();
                 if (null == apart) {
                     if (entity instanceof BattleArmor) {
                         apart = new BattleArmorAmmoBin((int) entity.getWeight(), m.getType(), eqnum,
@@ -2656,7 +2651,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                         apart = new LargeCraftAmmoBin((int) entity.getWeight(), m.getType(), eqnum,
                                 fullShots - m.getBaseShotsLeft(), m.getSize(), getCampaign());
                         ((LargeCraftAmmoBin) apart).setBay(entity.getBayByAmmo(m));
-                    } else if (entity.isSupportVehicle() && (m.getType() instanceof InfantryWeapon)) {
+                    } else if (entity.isSupportVehicle()
+                            && (((AmmoType) m.getType()).getAmmoType() == AmmoType.T_INFANTRY)) {
                         Mounted weapon = m.getLinkedBy();
                         while (weapon.getType() instanceof AmmoType) {
                             weapon = weapon.getLinkedBy();

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -34,6 +34,7 @@ import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.parts.*;
 
+import mekhq.campaign.parts.equipment.*;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -56,20 +57,6 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PersonCrewAssignmentEvent;
 import mekhq.campaign.event.PersonTechAssignmentEvent;
 import mekhq.campaign.event.UnitArrivedEvent;
-import mekhq.campaign.parts.equipment.AmmoBin;
-import mekhq.campaign.parts.equipment.BattleArmorAmmoBin;
-import mekhq.campaign.parts.equipment.BattleArmorEquipmentPart;
-import mekhq.campaign.parts.equipment.EquipmentPart;
-import mekhq.campaign.parts.equipment.HeatSink;
-import mekhq.campaign.parts.equipment.InfantryWeaponPart;
-import mekhq.campaign.parts.equipment.JumpJet;
-import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
-import mekhq.campaign.parts.equipment.MASC;
-import mekhq.campaign.parts.equipment.MissingAmmoBin;
-import mekhq.campaign.parts.equipment.MissingBattleArmorEquipmentPart;
-import mekhq.campaign.parts.equipment.MissingEquipmentPart;
-import mekhq.campaign.parts.equipment.MissingHeatSink;
-import mekhq.campaign.parts.equipment.MissingJumpJet;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.SkillType;
@@ -2667,8 +2654,17 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                                 oneShot, getCampaign());
                     } else if (entity.usesWeaponBays()) {
                         apart = new LargeCraftAmmoBin((int) entity.getWeight(), m.getType(), eqnum,
-                                fullShots - m.getBaseShotsLeft(), m.getAmmoCapacity(), getCampaign());
+                                fullShots - m.getBaseShotsLeft(), m.getSize(), getCampaign());
                         ((LargeCraftAmmoBin) apart).setBay(entity.getBayByAmmo(m));
+                    } else if (entity.isSupportVehicle() && (m.getType() instanceof InfantryWeapon)) {
+                        Mounted weapon = m.getLinkedBy();
+                        while (weapon.getType() instanceof AmmoType) {
+                            weapon = weapon.getLinkedBy();
+                        }
+                        int size = m.getOriginalShots() / ((InfantryWeapon) weapon.getType()).getShots();
+                        apart = new InfantryAmmoBin((int) entity.getWeight(), m.getType(), eqnum,
+                                m.getOriginalShots() - m.getBaseShotsLeft(),
+                                (InfantryWeapon) weapon.getType(), size, weapon.isOmniPodMounted(), getCampaign());
                     } else {
                         apart = new AmmoBin((int) entity.getWeight(), m.getType(), eqnum,
                                 fullShots - m.getBaseShotsLeft(), oneShot, m.isOmniPodMounted(), getCampaign());

--- a/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
@@ -20,6 +20,7 @@
 package mekhq.gui.dialog;
 
 import megamek.common.AmmoType;
+import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.equipment.InfantryAmmoBin;
@@ -31,6 +32,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ResourceBundle;
 
 /**
  * Configures amount of standard and inferno ammo available to small support vehicle weapons.
@@ -39,6 +41,8 @@ public class SmallSVAmmoSwapDialog extends JDialog {
 
     private final List<WeaponRow> rows = new ArrayList<>();
     private boolean canceled = true;
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.SmallSVAmmoSwapDialog",
+            new EncodeControl());
 
     public SmallSVAmmoSwapDialog(Frame frame, Unit unit) {
         super(frame, true);
@@ -59,10 +63,10 @@ public class SmallSVAmmoSwapDialog extends JDialog {
         }
 
         JPanel panButtons = new JPanel();
-        JButton button = new JButton("Cancel");
+        JButton button = new JButton(resourceMap.getString("cancel"));
         button.addActionListener(ev -> setVisible(false));
         panButtons.add(button);
-        button = new JButton("Ok");
+        button = new JButton(resourceMap.getString("ok"));
         button.addActionListener(ev -> {
             rows.forEach(WeaponRow::apply);
             canceled = false;
@@ -86,7 +90,7 @@ public class SmallSVAmmoSwapDialog extends JDialog {
         return canceled;
     }
 
-    private static class WeaponRow extends JPanel {
+    private class WeaponRow extends JPanel {
         private final InfantryAmmoBin standardBin;
         private final InfantryAmmoBin infernoBin;
         private final int totalClips;
@@ -113,15 +117,16 @@ public class SmallSVAmmoSwapDialog extends JDialog {
             add(new JLabel(title), gbc);
             gbc.gridx = 4;
             gbc.gridwidth = 1;
-            add(new JLabel(String.format("Shots per clip: %d", infernoBin.getWeaponType().getShots())), gbc);
+            add(new JLabel(String.format(resourceMap.getString("shotsPerClip.format"),
+                    infernoBin.getWeaponType().getShots())), gbc);
             gbc.gridx = 0;
             gbc.gridy++;
-            add(new JLabel("Standard"), gbc);
+            add(new JLabel(resourceMap.getString("standard")), gbc);
             gbc.gridx++;
             lblStandardClips.setText(String.valueOf((int) standardBin.getSize()));
             add(lblStandardClips, gbc);
             gbc.gridx++;
-            add(new JLabel("Inferno"), gbc);
+            add(new JLabel(resourceMap.getString("inferno")), gbc);
             gbc.gridx++;
             add(spnInferno, gbc);
             spnInferno.addChangeListener(ev ->

--- a/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2017 - The MegaMek Team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.gui.dialog;
+
+import megamek.common.AmmoType;
+import mekhq.MekHQ;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.equipment.InfantryAmmoBin;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.preferences.JWindowPreference;
+import mekhq.preferences.PreferencesNode;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configures amount of standard and inferno ammo available to small support vehicle weapons.
+ */
+public class SmallSVAmmoSwapDialog extends JDialog {
+
+    private final List<WeaponRow> rows = new ArrayList<>();
+    private boolean canceled = true;
+
+    public SmallSVAmmoSwapDialog(Frame frame, Unit unit) {
+        super(frame, true);
+        getContentPane().setLayout(new BorderLayout());
+        JPanel panMain = new JPanel();
+        panMain.setLayout(new BoxLayout(panMain, BoxLayout.Y_AXIS));
+        getContentPane().add(panMain, BorderLayout.CENTER);
+        // Since we only care about weapons that have the option of inferno ammo,
+        // we can search for all the ammo bins with inferno ammo and build
+        // from there.
+        for (Part part : unit.getParts()) {
+            if ((part instanceof InfantryAmmoBin)
+                    && (((AmmoType) ((InfantryAmmoBin) part).getType()).getMunitionType() == AmmoType.M_INFERNO)) {
+                WeaponRow row = new WeaponRow((InfantryAmmoBin) part);
+                rows.add(row);
+                panMain.add(row);
+            }
+        }
+
+        JPanel panButtons = new JPanel();
+        JButton button = new JButton("Cancel");
+        button.addActionListener(ev -> setVisible(false));
+        panButtons.add(button);
+        button = new JButton("Ok");
+        button.addActionListener(ev -> {
+            rows.forEach(WeaponRow::apply);
+            canceled = false;
+            setVisible(false);
+        });
+        panButtons.add(button);
+        getContentPane().add(panButtons, BorderLayout.SOUTH);
+
+        pack();
+        setUserPreferences();
+    }
+
+    private void setUserPreferences() {
+        PreferencesNode preferences = MekHQ.getPreferences().forClass(SmallSVAmmoSwapDialog.class);
+
+        this.setName("dialog");
+        preferences.manage(new JWindowPreference(this));
+    }
+
+    public boolean wasCanceled() {
+        return canceled;
+    }
+
+    private static class WeaponRow extends JPanel {
+        private final InfantryAmmoBin standardBin;
+        private final InfantryAmmoBin infernoBin;
+        private final int totalClips;
+        private final JSpinner spnInferno = new JSpinner();
+        private final JLabel lblStandardClips = new JLabel();
+
+        WeaponRow(InfantryAmmoBin infernoBin) {
+            this.infernoBin = infernoBin;
+            this.standardBin = infernoBin.findPartnerBin();
+            totalClips = (int) (infernoBin.getSize() + standardBin.getSize());
+            initUI(String.format("%s (%s)", infernoBin.getWeaponType().getName(),
+                    infernoBin.getUnit().getEntity().getLocationAbbr(infernoBin.getLocation())));
+        }
+
+        private void initUI(String title) {
+            spnInferno.setModel(new SpinnerNumberModel((int) infernoBin.getSize(), 0, totalClips, 1));
+            setLayout(new GridBagLayout());
+            GridBagConstraints gbc = new GridBagConstraints();
+            gbc.anchor = GridBagConstraints.WEST;
+            gbc.insets = new Insets(5, 5, 5, 5);
+            gbc.gridx = 0;
+            gbc.gridy = 0;
+            gbc.gridwidth = 4;
+            add(new JLabel(title), gbc);
+            gbc.gridx = 4;
+            gbc.gridwidth = 1;
+            add(new JLabel(String.format("Shots per clip: %d", infernoBin.getWeaponType().getShots())), gbc);
+            gbc.gridx = 0;
+            gbc.gridy++;
+            add(new JLabel("Standard"), gbc);
+            gbc.gridx++;
+            lblStandardClips.setText(String.valueOf((int) standardBin.getSize()));
+            add(lblStandardClips, gbc);
+            gbc.gridx++;
+            add(new JLabel("Inferno"), gbc);
+            gbc.gridx++;
+            add(spnInferno, gbc);
+            spnInferno.addChangeListener(ev ->
+                    lblStandardClips.setText(String.valueOf(totalClips - ((Integer) spnInferno.getValue()))));
+        }
+
+        void apply() {
+            int infernoClips = (Integer) spnInferno.getValue();
+            infernoBin.changeCapacity(infernoClips);
+            standardBin.changeCapacity(totalClips - infernoClips);
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
@@ -46,6 +46,7 @@ public class SmallSVAmmoSwapDialog extends JDialog {
 
     public SmallSVAmmoSwapDialog(Frame frame, Unit unit) {
         super(frame, true);
+        setTitle(unit.getName());
         getContentPane().setLayout(new BorderLayout());
         JPanel panMain = new JPanel();
         panMain.setLayout(new BoxLayout(panMain, BoxLayout.Y_AXIS));

--- a/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - The MegaMek Team
+ * Copyright (c) 2020 - The MegaMek Team
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq.gui.dialog;


### PR DESCRIPTION
Adds InfantryAmmoBin and InfantryAmmoStorage for handling small support vehicle ammo repairs and reloading. Each weapon has at least one ammo bin. If it can use inferno ammo it has two. There is also a dialog for redistributing space between standard and inferno ammo.

Depends on MegaMek/megamek#2219.