### PR TITLE
crew skill upgrader bulletproofing

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -167,9 +167,9 @@ public class CrewSkillUpgrader {
                         spaValue = pickRandomWeapon(entity, true);
                         break;
                     default:
-                        if(entity.getCrew() == null ||
-                            entity.getCrew().getOptions() == null || 
-                            entity.getCrew().getOptions(spa.getName()) == null) {
+                        if ((entity.getCrew() == null) ||
+                                (entity.getCrew().getOptions() == null) || 
+                                (entity.getCrew().getOptions(spa.getName()) == null)) {
                             return 0;
                         }
                         
@@ -253,7 +253,7 @@ public class CrewSkillUpgrader {
      */
     private String pickRandomGunnerySpecialization(Entity entity) {
         // if you've got no weapons, tough
-        if(entity.getIndividualWeaponList().size() <= 0) {
+        if (entity.getIndividualWeaponList().size() <= 0) {
             return Crew.SPECIAL_NONE;
         }
         

--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -167,6 +167,12 @@ public class CrewSkillUpgrader {
                         spaValue = pickRandomWeapon(entity, true);
                         break;
                     default:
+                        if(entity.getCrew() == null ||
+                            entity.getCrew().getOptions() == null || 
+                            entity.getCrew().getOptions(spa.getName()) == null) {
+                            return 0;
+                        }
+                        
                         entity.getCrew().getOptions().getOption(spa.getName()).setValue(true);
                         return spa.getCost();
                 }
@@ -246,6 +252,11 @@ public class CrewSkillUpgrader {
      * @return Gunnery specialization name
      */
     private String pickRandomGunnerySpecialization(Entity entity) {
+        // if you've got no weapons, tough
+        if(entity.getIndividualWeaponList().size() <= 0) {
+            return Crew.SPECIAL_NONE;
+        }
+        
         int weaponIndex = Compute.randomInt(entity.getIndividualWeaponList().size());
         WeaponType weaponType = (WeaponType) entity.getIndividualWeaponList().get(weaponIndex).getType();
 


### PR DESCRIPTION
This fixes a few exceptions I ran into while working on another project - sometimes, a unit without weapons rolls a "Weapon Specialization" SPA, and sometimes, a unit gets generated without a crew or the options data structure isn't initialized.

Now, instead of failing the whole process, we just don't generate an SPA and move on.