### PR TITLE
On refit don't temporarily add new parts to old unit

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -497,9 +497,6 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         HashMap<Integer,Integer> partQuantity = new HashMap<>();
         List<Part> plannedReplacementParts = new ArrayList<>();
         for(Part nPart : newPartList) {
-            //TODO: I don't think we need this here anymore
-            nPart.setUnit(oldUnit);
-
             //We don't actually want to order new BA suits; we're just pretending that we're altering the
             //existing suits.
             if (nPart instanceof MissingBattleArmorSuit) {


### PR DESCRIPTION
Fixes #1252 

https://github.com/MegaMek/mekhq/blob/8dc44e93b4d772cf54cb94263616810cc3b1f34c/MekHQ/src/mekhq/campaign/parts/Refit.java#L499-L502

Line 501 above causes the size of target computers (and possibly other variable equipment) to be recalculated based on the old unit's weapon config. This can cause a mismatch when checking the warehouse for a correctly-sized replacement. (It's corrected back later when the actual refit is done, so the only issue here is that new parts are ordered when spares are available.)

I can't see any reason why nPart would need to be assigned to oldUnit here, so I think the comment in line 500 is correct.