### PR TITLE
Aero Fighter refit heat sink tracking improvements

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -2462,7 +2462,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             return Math.min(((Mech) entity).heatSinks(), entity.getEngine().integralHeatSinkCapacity(((Mech) entity).hasCompactHeatSinks()));
         } else if ((entity instanceof Aero)
                 && (entity.getEntityType() & (Entity.ETYPE_CONV_FIGHTER | Entity.ETYPE_SMALL_CRAFT | Entity.ETYPE_JUMPSHIP)) == 0) {
-            return entity.getEngine().integralHeatSinkCapacity(false);
+            return entity.getEngine().getWeightFreeEngineHeatSinks();
         } else {
             EntityVerifier verifier = EntityVerifier.getInstance(new File(
                     "data/mechfiles/UnitVerifierOptions.xml"));

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1437,7 +1437,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                 (Entity.ETYPE_CONV_FIGHTER | Entity.ETYPE_SMALL_CRAFT | Entity.ETYPE_JUMPSHIP)) == 0)) {
             // Only Aerospace Fighters are expected to have heat sink parts (Mechs handled separately)
             // SmallCraft, Dropship, Jumpship, Warship, and SpaceStation use SpacecraftCoolingSystem instead
-            expectedHeatSinkParts = ((Aero)newEntity).getHeatSinks() - ((Aero)newEntity).getPodHeatSinks() -
+            expectedHeatSinkParts = ((Aero) newEntity).getHeatSinks() - ((Aero) newEntity).getPodHeatSinks() -
                     untrackedHeatSinkCount(newEntity);
         }
         for(int pid : newUnitParts) {
@@ -1447,7 +1447,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                         "part with id " + pid + " not found for refit of " + getDesc()); //$NON-NLS-1$
                 continue;
             }
-            if (part instanceof HeatSink && newEntity instanceof Tank) {
+            if ((part instanceof HeatSink) && (newEntity instanceof Tank)) {
                 // Unit should not have heat sink parts
                 // Remove heat sink parts added for supply chain tracking purposes
                 oldUnit.getCampaign().removePart(part);

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1453,7 +1453,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                 oldUnit.getCampaign().removePart(part);
                 continue;
             }
-            else if (part instanceof AeroHeatSink && newEntity instanceof Aero && !part.isOmniPodded()) {
+            else if ((part instanceof AeroHeatSink) && (newEntity instanceof Aero) && !part.isOmniPodded()) {
                 if (expectedHeatSinkParts > 0) {
                     expectedHeatSinkParts--;
                 } else {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1433,8 +1433,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             }
         }
         int expectedHeatSinkParts = 0;
-        if ((newEntity instanceof Aero) && ((newEntity.getEntityType() &
-                (Entity.ETYPE_CONV_FIGHTER | Entity.ETYPE_SMALL_CRAFT | Entity.ETYPE_JUMPSHIP)) == 0)) {
+        if (newEntity.getClass() == Aero.class) { // Aero but not subclasses
             // Only Aerospace Fighters are expected to have heat sink parts (Mechs handled separately)
             // SmallCraft, Dropship, Jumpship, Warship, and SpaceStation use SpacecraftCoolingSystem instead
             expectedHeatSinkParts = ((Aero) newEntity).getHeatSinks() - ((Aero) newEntity).getPodHeatSinks() -
@@ -2476,8 +2475,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
     private int untrackedHeatSinkCount(Entity entity) {
         if (entity instanceof Mech) {
             return Math.min(((Mech) entity).heatSinks(), entity.getEngine().integralHeatSinkCapacity(((Mech) entity).hasCompactHeatSinks()));
-        } else if ((entity instanceof Aero)
-                && (entity.getEntityType() & (Entity.ETYPE_CONV_FIGHTER | Entity.ETYPE_SMALL_CRAFT | Entity.ETYPE_JUMPSHIP)) == 0) {
+        } else if (newEntity.getClass() == Aero.class) { // Aero but not subclasses
             return entity.getEngine().getWeightFreeEngineHeatSinks();
         } else {
             EntityVerifier verifier = EntityVerifier.getInstance(new File(


### PR DESCRIPTION
First commit fixes the way untracked/integrated heat sinks are calculated for Aero Fighters - should be based on engine type (not engine size/rating)

Second commit make heat sink cleanup for Aero Fighters more careful not to strip valid heat sinks.