### PR TITLE
Fixing Doubled PersonChangedEvents

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5943,7 +5943,7 @@ public class Campaign implements Serializable, ITechManager {
         }
 
         personUpdated(person);
-        MekHQ.triggerEvent(new PersonChangedEvent(person));
+
         if (report) {
             if (rank > oldRank || ((rank == oldRank) && (rankLevel > oldRankLevel))) {
                 ServiceLogger.promotedTo(person, getLocalDate());

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -532,10 +532,10 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 int cost = Integer.parseInt(data[2]);
                 int oldExpLevel = selectedPerson.getExperienceLevel(false);
                 selectedPerson.improveSkill(type);
-                gui.getCampaign().personUpdated(selectedPerson);
                 selectedPerson.awardXP(-cost);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
-                gui.getCampaign().addReport(String.format(resourceMap.getString("improved.format"), selectedPerson.getHyperlinkedName(), type)); //$NON-NLS-1$
+                gui.getCampaign().personUpdated(selectedPerson);
+
+                gui.getCampaign().addReport(String.format(resourceMap.getString("improved.format"), selectedPerson.getHyperlinkedName(), type));
                 if (gui.getCampaign().getCampaignOptions().getUseAtB()
                         && gui.getCampaign().getCampaignOptions().useAbilities()) {
                     if (selectedPerson.getPrimaryRole() > Person.T_NONE
@@ -546,10 +546,9 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         String spa = spaGenerator.rollSPA(selectedPerson);
                         if (null == spa) {
                             if (gui.getCampaign().getCampaignOptions().useEdge()) {
-                                selectedPerson.getOptions().acquireAbility(
-                                        PilotOptions.EDGE_ADVANTAGES, "edge", //$NON-NLS-1$
-                                        selectedPerson.getEdge() + 1);
-                                gui.getCampaign().addReport(String.format(resourceMap.getString("gainedEdge.format"), selectedPerson.getHyperlinkedName())); //$NON-NLS-1$
+                                selectedPerson.getOptions().acquireAbility(PilotOptions.EDGE_ADVANTAGES,
+                                        "edge", selectedPerson.getEdge() + 1);
+                                gui.getCampaign().addReport(String.format(resourceMap.getString("gainedEdge.format"), selectedPerson.getHyperlinkedName()));
                             }
                         } else {
                             gui.getCampaign().addReport(String.format(resourceMap.getString("gained.format"), //$NON-NLS-1$
@@ -564,9 +563,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 int cost = Integer.parseInt(data[2]);
                 selectedPerson.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES,
                         selected, true);
-                gui.getCampaign().personUpdated(selectedPerson);
                 selectedPerson.awardXP(-cost);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
+                gui.getCampaign().personUpdated(selectedPerson);
                 // TODO: add personnelTab.getCampaign() report
                 break;
             }
@@ -575,9 +573,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 int cost = Integer.parseInt(data[2]);
                 selectedPerson.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES,
                         "weapon_specialist", selected);
-                gui.getCampaign().personUpdated(selectedPerson);
                 selectedPerson.awardXP(-cost);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
+                gui.getCampaign().personUpdated(selectedPerson);
                 // TODO: add campaign report
                 break;
             }
@@ -586,9 +583,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 int cost = Integer.parseInt(data[2]);
                 selectedPerson.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES,
                         "specialist", selected);
-                gui.getCampaign().personUpdated(selectedPerson);
                 selectedPerson.awardXP(-cost);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
+                gui.getCampaign().personUpdated(selectedPerson);
                 // TODO: add campaign report
                 break;
             }
@@ -597,9 +593,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 int cost = Integer.parseInt(data[2]);
                 selectedPerson.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES,
                         "range_master", selected);
-                gui.getCampaign().personUpdated(selectedPerson);
                 selectedPerson.awardXP(-cost);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
+                gui.getCampaign().personUpdated(selectedPerson);
                 // TODO: add campaign report
                 break;
             }
@@ -608,9 +603,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 int cost = Integer.parseInt(data[2]);
                 selectedPerson.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES,
                         "human_tro", selected);
-                gui.getCampaign().personUpdated(selectedPerson);
                 selectedPerson.awardXP(-cost);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
+                gui.getCampaign().personUpdated(selectedPerson);
                 // TODO: add campaign report
                 break;
             }
@@ -620,9 +614,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 String ability = data[3];
                 selectedPerson.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES,
                         ability, selected);
-                gui.getCampaign().personUpdated(selectedPerson);
                 selectedPerson.awardXP(-cost);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
+                gui.getCampaign().personUpdated(selectedPerson);
                 // TODO: add campaign report
                 break;
             }
@@ -784,14 +777,12 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         gui.getFrame(), true, selectedPerson, gui.getCampaign());
                 npd.setVisible(true);
                 gui.getCampaign().personUpdated(selectedPerson);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 break;
             }
             case CMD_ROLL_MECH: {
                 GMToolsDialog gmToolsDialog = new GMToolsDialog(gui.getFrame(), gui, selectedPerson);
                 gmToolsDialog.setVisible(true);
                 gui.getCampaign().personUpdated(selectedPerson);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 break;
             }
             case CMD_EDIT_HITS: {
@@ -802,14 +793,12 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             .getNaturalHealingWaitingPeriod());
                 }
                 gui.getCampaign().personUpdated(selectedPerson);
-                MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 break;
             }
             case CMD_RANDOM_PORTRAIT: {
                 for (Person person : people) {
                     gui.getCampaign().assignRandomPortraitFor(person);
                     gui.getCampaign().personUpdated(person);
-                    MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
             }
@@ -829,7 +818,6 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         person.setPortraitCategory(category);
                         person.setPortraitFileName(fileName);
                         gui.getCampaign().personUpdated(person);
-                        MekHQ.triggerEvent(new PersonChangedEvent(person));
                     }
                 }
                 break;
@@ -891,7 +879,6 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     //Make the new edge point available to support personnel, but don't reset until the week ends
                     person.setCurrentEdge(person.getCurrentEdge() + 1);
                     gui.getCampaign().personUpdated(person);
-                    MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
             }
@@ -909,7 +896,6 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     //Reset currentEdge for support people
                     person.resetCurrentEdge();
                     gui.getCampaign().personUpdated(person);
-                    MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
             }
@@ -994,12 +980,10 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             p.setCommander(false);
                             gui.getCampaign().addReport(String.format(resourceMap.getString("removedCommander.format"), p.getHyperlinkedFullTitle())); //$NON-NLS-1$
                             gui.getCampaign().personUpdated(p);
-                            MekHQ.triggerEvent(new PersonChangedEvent(p));
                         }
                     }
                     gui.getCampaign().addReport(String.format(resourceMap.getString("setAsCommander.format"), selectedPerson.getHyperlinkedFullTitle())); //$NON-NLS-1$
                     gui.getCampaign().personUpdated(selectedPerson);
-                    MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 }
                 break;
             }
@@ -1009,12 +993,10 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     for (Person person : people) {
                         person.setDependent(status);
                         gui.getCampaign().personUpdated(person);
-                        MekHQ.triggerEvent(new PersonChangedEvent(person));
                     }
                 } else {
                     selectedPerson.setDependent(!selectedPerson.isDependent());
                     gui.getCampaign().personUpdated(selectedPerson);
-                    MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 }
                 break;
             }
@@ -1024,12 +1006,10 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     for (Person person : people) {
                         person.setTryingToMarry(status);
                         gui.getCampaign().personUpdated(person);
-                        MekHQ.triggerEvent(new PersonChangedEvent(person));
                     }
                 } else {
                     selectedPerson.setTryingToMarry(!selectedPerson.isTryingToMarry());
                     gui.getCampaign().personUpdated(selectedPerson);
-                    MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 }
                 break;
             }
@@ -1039,12 +1019,10 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     for (Person person : people) {
                         person.setTryingToConceive(status);
                         gui.getCampaign().personUpdated(person);
-                        MekHQ.triggerEvent(new PersonChangedEvent(person));
                     }
                 } else {
                     selectedPerson.setTryingToConceive(!selectedPerson.isTryingToConceive());
                     gui.getCampaign().personUpdated(selectedPerson);
-                    MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 }
                 break;
             }
@@ -1054,23 +1032,20 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     for (Person person : people) {
                         person.setFounder(status);
                         gui.getCampaign().personUpdated(person);
-                        MekHQ.triggerEvent(new PersonChangedEvent(person));
                     }
                 } else {
                     selectedPerson.setFounder(!selectedPerson.isFounder());
                     gui.getCampaign().personUpdated(selectedPerson);
-                    MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 }
                 break;
             }
             case CMD_CALLSIGN: {
                 String s = (String) JOptionPane.showInputDialog(gui.getFrame(),
-                        resourceMap.getString("enterNewCallsign.text"), resourceMap.getString("editCallsign.text"), //$NON-NLS-1$ //$NON-NLS-2$
+                        resourceMap.getString("enterNewCallsign.text"), resourceMap.getString("editCallsign.text"),
                         JOptionPane.PLAIN_MESSAGE, null, null,
                         selectedPerson.getCallsign());
                 if (null != s) {
                     selectedPerson.setCallsign(s);
-                    MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                     gui.getCampaign().personUpdated(selectedPerson);
                 }
                 break;
@@ -2654,12 +2629,10 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
 
-                    if (person.getUnitId() == null) {
-                        menuItem = new JMenuItem(resourceMap.getString("rollForUnit.text"));
-                        menuItem.setActionCommand(CMD_ROLL_MECH);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
+                    menuItem = new JMenuItem(resourceMap.getString("rollForUnit.text"));
+                    menuItem.setActionCommand(CMD_ROLL_MECH);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
                 }
                 if (gui.getCampaign().getCampaignOptions().useAdvancedMedical()) {
                     menuItem = new JMenuItem(resourceMap.getString("removeAllInjuries.text"));

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2629,10 +2629,12 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
 
-                    menuItem = new JMenuItem(resourceMap.getString("rollForUnit.text"));
-                    menuItem.setActionCommand(CMD_ROLL_MECH);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
+                    if (person.getUnitId() != null) {
+                        menuItem = new JMenuItem(resourceMap.getString("rollForUnit.text"));
+                        menuItem.setActionCommand(CMD_ROLL_MECH);
+                        menuItem.addActionListener(this);
+                        menu.add(menuItem);
+                    }
                 }
                 if (gui.getCampaign().getCampaignOptions().useAdvancedMedical()) {
                     menuItem = new JMenuItem(resourceMap.getString("removeAllInjuries.text"));

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -49,10 +49,8 @@ import javax.swing.table.TableRowSorter;
 
 import megamek.common.options.PilotOptions;
 import megamek.common.util.EncodeControl;
-import megamek.common.util.StringUtil;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.log.PersonalLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.generator.SingleSpecialAbilityGenerator;
@@ -410,7 +408,6 @@ public final class BatchXPDialog extends JDialog {
 
                 // Improve the skill and deduce the cost
                 p.improveSkill(skillName);
-                campaign.personUpdated(p);
                 p.awardXP(-cost);
 
                 // The next part is bollocks and doesn't belong here, but as long as we hardcode AtB ...
@@ -430,7 +427,7 @@ public final class BatchXPDialog extends JDialog {
                         }
                     }
                 }
-                MekHQ.triggerEvent(new PersonChangedEvent(p));
+                campaign.personUpdated(p);
             }
             // Refresh the filter and continue if we still have anyone available
             updatePersonnelTable();


### PR DESCRIPTION
This fixes a minor issue whereby Campaign::personUpdated method triggers a PersonChangedEvent then the code triggers a second one.

Also, I'm not a fan of how Campaign::personUpdated works nor where it is located... but that's for future development.