### PR TITLE
Fix NPE when getSelectionPaths is null in TOEMouseAdapter

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -610,7 +610,7 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
             JMenuItem menuItem;
             JMenu menu;
             JTree tree = (JTree) e.getSource();
-            if (tree == null || tree.getSelectionPaths() == null) {
+            if ((tree == null) || (tree.getSelectionPaths() == null)) {
                 return;
             }
             // this is a little tricky because we want to

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -610,7 +610,7 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
             JMenuItem menuItem;
             JMenu menu;
             JTree tree = (JTree) e.getSource();
-            if (tree == null) {
+            if (tree == null || tree.getSelectionPaths() == null) {
                 return;
             }
             // this is a little tricky because we want to


### PR DESCRIPTION
Per the documentation, JTree::getSelectionPaths may return `null` if nothing is selected. Fixes:
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at mekhq.gui.adapter.TOEMouseAdapter.maybeShowPopup(TOEMouseAdapter.java:626)
	at mekhq.gui.adapter.TOEMouseAdapter.mouseReleased(TOEMouseAdapter.java:604)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:297)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6631)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3342)
...
```