### PR TITLE
Add daily report entries for AtB scenarios

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -1,1 +1,4 @@
 bonusPartLog.text=Bonus part used to acquire 1x
+newAtBMission.format=New scenario '{0}' will occur on {1}.
+atbMissionToday.format=Scenario '{0}' is today, deploy a force from your TOE!
+atbMissionTodayWithForce.format=Scenario '{0}' is today, {1} has been deployed!

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -1,4 +1,4 @@
 bonusPartLog.text=Bonus part used to acquire 1x
-newAtBMission.format=New scenario '{0}' will occur on {1}.
-atbMissionToday.format=Scenario '{0}' is today, deploy a force from your TOE!
-atbMissionTodayWithForce.format=Scenario '{0}' is today, {1} has been deployed!
+newAtBMission.format=New scenario "{0}" will occur on {1}.
+atbMissionToday.format=Scenario "{0}" is today, deploy a force from your TOE!
+atbMissionTodayWithForce.format=Scenario "{0}" is today, {1} has been deployed!

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -23,6 +23,7 @@ package mekhq.campaign;
 import java.io.File;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.text.MessageFormat;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -938,7 +939,8 @@ public class Campaign implements Serializable, ITechManager {
         m.addScenario(s);
         scenarios.put(id, s);
 
-        addReport(String.format("New scenario '%s' will occur on %s.",
+        addReport(MessageFormat.format(
+            resources.getString("newAtBMission.format"),
             s.getName(), MekHQ.getMekHQOptions().getDisplayFormattedDate(s.getDate())));
 
         MekHQ.triggerEvent(new ScenarioNewEvent(s));
@@ -3248,16 +3250,18 @@ public class Campaign implements Serializable, ITechManager {
                                     u.setScenarioId(s.getId());
                                 }
                             }
-                            addReport(String.format("Scenario '%s' is today, %s has been deployed!",
+
+                            addReport(MessageFormat.format(
+                                resources.getString("atbMissionTodayWithForce.format"),
                                 s.getName(), forceIds.get(forceId).getName()));
                             MekHQ.triggerEvent(new DeploymentChangedEvent(forceIds.get(forceId), s));
                         } else {
-                            addReport(String.format("Scenario '%s' is today, deploy a force from your TOE!",
-                                s.getName()));
+                            addReport(MessageFormat.format(
+                                resources.getString("atbMissionToday.format"), s.getName()));
                         }
                     } else {
-                        addReport(String.format("Scenario '%s' is today, deploy a force from your TOE!",
-                            s.getName()));
+                        addReport(MessageFormat.format(
+                            resources.getString("atbMissionToday.format"), s.getName()));
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -937,6 +937,10 @@ public class Campaign implements Serializable, ITechManager {
         }
         m.addScenario(s);
         scenarios.put(id, s);
+
+        addReport(String.format("New scenario '%s' will occur on %s.",
+            s.getName(), MekHQ.getMekHQOptions().getDisplayFormattedDate(s.getDate())));
+
         MekHQ.triggerEvent(new ScenarioNewEvent(s));
     }
 
@@ -3244,8 +3248,16 @@ public class Campaign implements Serializable, ITechManager {
                                     u.setScenarioId(s.getId());
                                 }
                             }
+                            addReport(String.format("Scenario '%s' is today, %s has been deployed!",
+                                s.getName(), forceIds.get(forceId).getName()));
                             MekHQ.triggerEvent(new DeploymentChangedEvent(forceIds.get(forceId), s));
+                        } else {
+                            addReport(String.format("Scenario '%s' is today, deploy a force from your TOE!",
+                                s.getName()));
                         }
+                    } else {
+                        addReport(String.format("Scenario '%s' is today, deploy a force from your TOE!",
+                            s.getName()));
                     }
                 }
             }


### PR DESCRIPTION
This quick feature helps out with the new Command Center structured MekHQ. Now as AtB scenarios are added you receive daily log entries, along with daily log entries the day of a scenario (along with the force deployed if any).