### PR TITLE
2059: Fixing Incorrect Experience Calculation Method

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -720,12 +720,10 @@ public class CampaignOpsReputation extends AbstractUnitRating {
 
     private String getExperienceDetails() {
         StringBuilder out = new StringBuilder();
-        out.append(String.format("%-" + HEADER_LENGTH + "s %3d", "Experience:",
-                                 getExperienceValue())).append("\n");
-        out.append(String.format("    %-" + SUBHEADER_LENGTH + "s %3s",
-                                 "Average Experience:",
-                                 getExperienceLevelName(calcAverageExperience())))
-           .append("\n");
+        out.append(String.format("%-" + HEADER_LENGTH + "s %3d", "Experience:", getExperienceValue()))
+                .append("\n")
+                .append(String.format("    %-" + SUBHEADER_LENGTH + "s %3s", "Average Experience:", getAverageExperience()))
+                .append("\n");
 
         final String TEMPLATE = "        #%-" + CATEGORY_LENGTH + "s %3d";
         Map<String, Integer> skillRatingCounts = getSkillRatingCounts();

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -398,13 +398,13 @@ public class CampaignOpsReputation extends AbstractUnitRating {
             return SkillType.getExperienceLevelName(-1);
         }
         switch (getExperienceValue()) {
-            case 0:
-                return SkillType.getExperienceLevelName(SkillType.EXP_GREEN);
             case 5:
-                return SkillType.getExperienceLevelName(SkillType.EXP_REGULAR);
+                return SkillType.getExperienceLevelName(SkillType.EXP_GREEN);
             case 10:
-                return SkillType.getExperienceLevelName(SkillType.EXP_VETERAN);
+                return SkillType.getExperienceLevelName(SkillType.EXP_REGULAR);
             case 20:
+                return SkillType.getExperienceLevelName(SkillType.EXP_VETERAN);
+            case 40:
                 return SkillType.getExperienceLevelName(SkillType.EXP_ELITE);
             default:
                 return SkillType.getExperienceLevelName(-1);

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -478,7 +478,7 @@ public class CampaignOpsReputationTest {
     @Test
     public void testGetAverageExperience() {
         spyReputation.initValues();
-        assertEquals(SkillType.getExperienceLevelName(SkillType.EXP_VETERAN),
+        assertEquals(SkillType.getExperienceLevelName(SkillType.EXP_REGULAR),
                      spyReputation.getAverageExperience());
 
         // Test a brand new campaign.


### PR DESCRIPTION
This fixes #2059 by fixing the experience determination, and swaps the method used to calculate the Campaign Ops Unit Rating to the proper getAverageExperience.