### PR TITLE
Preventing null entities in AtBScenario

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -824,7 +824,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
         // aaand for fun, run everyone through the crew upgrader
         if (campaign.getCampaignOptions().useAbilities()) {
-        	AtBDynamicScenarioFactory.upgradeBotCrews(this);
+            AtBDynamicScenarioFactory.upgradeBotCrews(this);
         }
     }
 
@@ -1092,18 +1092,19 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             Entity en = getEntity(faction, skill, quality, unitTypes[i],
                     AtBConfiguration.decodeWeightStr(weights, i),
                     campaign);
-            if (null != en) {
+            if (en != null) {
                 en.setDeployRound(arrivalTurn);
+                list.add(en);
             }
-            list.add(en);
-            if (unitTypes[i] == UnitType.TANK && campaign.getCampaignOptions().getDoubleVehicles()) {
+
+            if ((unitTypes[i] == UnitType.TANK) && campaign.getCampaignOptions().getDoubleVehicles()) {
                 en = getEntity(faction, skill, quality, unitTypes[i],
                         AtBConfiguration.decodeWeightStr(weights, i),
                         campaign);
-                if (null != en) {
+                if (en != null) {
                     en.setDeployRound(arrivalTurn);
+                    list.add(en);
                 }
-                list.add(en);
             }
         }
     }
@@ -1186,21 +1187,22 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 Entity en = getEntity(faction, skill, tmpQuality, unitType,
                         AtBConfiguration.decodeWeightStr(weights, point),
                         campaign);
-                if (null != en) {
+                if (en != null) {
                     en.setDeployRound(arrivalTurn);
+                    list.add(en);
                 }
-                list.add(en);
             }
         }
+
         if (forceType == FORCE_NOVA) {
             unitType = UnitType.BATTLE_ARMOR;
             for (int i = 0; i < 5; i++) {
                 Entity en = getEntity(faction, skill, quality,
                         unitType, -1, campaign);
-                if (null != en) {
+                if (en != null) {
                     en.setDeployRound(arrivalTurn);
+                    list.add(en);
                 }
-                list.add(en);
             }
         }
     }
@@ -1249,18 +1251,19 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             Entity en = getEntity(faction, skill, quality, unitTypes[i],
                     AtBConfiguration.decodeWeightStr(weights, i),
                     campaign);
-            if (null != en) {
+            if (en != null) {
                 en.setDeployRound(arrivalTurn);
+                list.add(en);
             }
-            list.add(en);
+
             if (unitTypes[i] == UnitType.TANK && campaign.getCampaignOptions().getDoubleVehicles()) {
                 en = getEntity(faction, skill, quality, unitTypes[i],
                         AtBConfiguration.decodeWeightStr(weights, i),
                         campaign);
-                if (null != en) {
+                if (en != null) {
                     en.setDeployRound(arrivalTurn);
+                    list.add(en);
                 }
-                list.add(en);
             }
         }
     }


### PR DESCRIPTION
Null entities in the list are not handled and cause NPEs. This prevents that from occurring.