### PR TITLE
Improved refit handling of internals for Aeros and Tanks

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
+++ b/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
@@ -208,7 +208,7 @@ public class StructuralIntegrity extends Part {
 
     @Override
     public void updateConditionFromPart() {
-        //you can't replace this part, so don't do anything here
+        ((Aero) unit.getEntity()).setSI(((Aero) unit.getEntity()).get0SI() - pointsNeeded);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
+++ b/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
@@ -107,8 +107,8 @@ public class StructuralIntegrity extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        //can't be salvaged or scrapped, so ignore
-        return false;
+        return (part instanceof StructuralIntegrity) &&
+                (getUnitTonnage() == ((StructuralIntegrity) part).getUnitTonnage());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -258,7 +258,7 @@ public class TankLocation extends Part {
 
     @Override
     public void updateConditionFromPart() {
-        //shouldn't get here
+        ((Tank) unit.getEntity()).setInternal(((Tank) unit.getEntity()).getOInternal(loc) - damage, loc);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes 4 issues when refitting:
  1) when customizing an Aero, the Mek Lab shows that a Class A change has been made, before actually changing anything
  2) customize/refitting an Aero unit causes "null missing part for Structural Integrity during refit calculations" repeatedly in the error log
  3) when refitting an Aero, damage to internals is not preserved
  4) when refitting a Tank, damage to internals is not preserved

The first commit fixes the first two issues, the second commit fixes the last two issues.
