### PR TITLE
Dev vulpzor campaign ops dropship maintenance cost fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -176,7 +176,6 @@ public class LargeCraftAmmoBin extends AmmoBin {
         }
 
         return getPricePerTon()
-                .multipliedBy(size)
                 .multipliedBy(getCurrentShots())
                 .dividedBy(getShotsPerTon());
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -170,17 +170,6 @@ public class LargeCraftAmmoBin extends AmmoBin {
     }
 
     @Override
-    public Money getStickerPrice() {
-        if (getShotsPerTon() <= 0) {
-            return Money.zero();
-        }
-
-        return getPricePerTon()
-                .multipliedBy(getCurrentShots())
-                .dividedBy(getShotsPerTon());
-    }
-
-    @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "equipmentNum", equipmentNum);


### PR DESCRIPTION
Campaign Ops dropships operation costs due to training munition costs were in the millions - out of line with the examples in the published source book.  The calculations in the base class are correct, and have been used instead of the override that was multiplying for the size of the ammo bay twice.

Note: this fixes the issue, but unclear why there was a size multiplier given that getCurrentShots() / getShotsPerTon() was already giving a 2x cost for a 2 ton bay.

(Note, this is a small bug I've had fixed locally for a while, using as a sample for github contribution workflow before getting larger patches together.)

To verify, compare the patched and unpatched values for a Union-X in the hangar, by right clicking and choosing "Show Monthly Supply Cost Report".  Screenshot of fixed version included below

<img width="332" alt="Screen Shot 2020-09-29 at 7 48 42 AM" src="https://user-images.githubusercontent.com/72076035/94555218-433e4080-0229-11eb-9b1c-9347147929f2.png">
