### PR TITLE
Issue #2066: Do not add zero or NaN costs for ammo during Refits

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -848,7 +848,9 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         for (AmmoType type : ammoNeeded.keySet()) {
             int shotsNeeded = Math.max(ammoNeeded.get(type) - getAmmoAvailable(type), 0);
             int shotsPerTon = type.getShots();
-            cost = cost.plus(Money.of(type.getCost(newEntity, false, -1) * ((double)shotsNeeded/shotsPerTon)));
+            if (shotsNeeded > 0 && shotsPerTon > 0) {
+                cost = cost.plus(Money.of(type.getCost(newEntity, false, -1) * ((double)shotsNeeded/shotsPerTon)));
+            }
         }
 
         /*

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -848,7 +848,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         for (AmmoType type : ammoNeeded.keySet()) {
             int shotsNeeded = Math.max(ammoNeeded.get(type) - getAmmoAvailable(type), 0);
             int shotsPerTon = type.getShots();
-            if (shotsNeeded > 0 && shotsPerTon > 0) {
+            if ((shotsNeeded > 0) && (shotsPerTon > 0)) {
                 cost = cost.plus(Money.of(type.getCost(newEntity, false, -1) * ((double) shotsNeeded / shotsPerTon)));
             }
         }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -849,7 +849,7 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
             int shotsNeeded = Math.max(ammoNeeded.get(type) - getAmmoAvailable(type), 0);
             int shotsPerTon = type.getShots();
             if (shotsNeeded > 0 && shotsPerTon > 0) {
-                cost = cost.plus(Money.of(type.getCost(newEntity, false, -1) * ((double)shotsNeeded/shotsPerTon)));
+                cost = cost.plus(Money.of(type.getCost(newEntity, false, -1) * ((double) shotsNeeded / shotsPerTon)));
             }
         }
 


### PR DESCRIPTION
If an ammo bin has zero shots per ton then the refit cost calculation code will throw a `NumberFormatException` due to `NaN` being passed to `Money.of`. This is a "fix" for the exception seen in #2066, but may not be a fix in the sense that the Refit calculation logic does not have any handling for `InfantryAmmoBin`s (and probably should, a la `LargeCraftAmmoBin`s).