### PR TITLE
Fixing Scenario Template Date NPEs

### DIFF
--- a/MekHQ/src/mekhq/MekHQOptions.java
+++ b/MekHQ/src/mekhq/MekHQOptions.java
@@ -31,7 +31,7 @@ public final class MekHQOptions {
     }
 
     public String getDisplayFormattedDate(LocalDate date) {
-        return date.format(DateTimeFormatter.ofPattern(getDisplayDateFormat()));
+        return (date != null) ? date.format(DateTimeFormatter.ofPattern(getDisplayDateFormat())) : "";
     }
 
     public void setDisplayDateFormat(String value) {
@@ -47,7 +47,7 @@ public final class MekHQOptions {
     }
 
     public String getLongDisplayFormattedDate(LocalDate date) {
-        return date.format(DateTimeFormatter.ofPattern(getLongDisplayDateFormat()));
+        return (date != null) ? date.format(DateTimeFormatter.ofPattern(getLongDisplayDateFormat())) : "";
     }
 
     public void setLongDisplayDateFormat(String value) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -924,20 +924,17 @@ public class Campaign implements Serializable, ITechManager {
      * @param m - the mission to add the new scenario to
      */
     public void addScenario(Scenario s, Mission m) {
-        int id;
-        if (s.getId() == Scenario.S_DEFAULT_ID) {
-            id = ++lastScenarioId;
-            s.setId(id);
-        } else {
-            // Scenario has already been assigned an Id, so just use its assigned value
-            id = s.getId();
-        }
+        final boolean newScenario = s.getId() == Scenario.S_DEFAULT_ID;
+        final int id = newScenario ? ++lastScenarioId : s.getId();
+        s.setId(id);
         m.addScenario(s);
         scenarios.put(id, s);
 
-        addReport(MessageFormat.format(
-            resources.getString("newAtBMission.format"),
-            s.getName(), MekHQ.getMekHQOptions().getDisplayFormattedDate(s.getDate())));
+        if (newScenario) {
+            addReport(MessageFormat.format(
+                    resources.getString("newAtBMission.format"),
+                    s.getName(), MekHQ.getMekHQOptions().getDisplayFormattedDate(s.getDate())));
+        }
 
         MekHQ.triggerEvent(new ScenarioNewEvent(s));
     }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -111,10 +111,11 @@ public class CustomizeScenarioDialog extends javax.swing.JDialog {
             newScenario = false;
         }
         campaign = c;
-        date = scenario.getDate();
-        if (null == date) {
-            date = campaign.getLocalDate();
+        if (scenario.getDate() == null) {
+            scenario.setDate(campaign.getLocalDate());
         }
+        date = scenario.getDate();
+
         loots = new ArrayList<>();
         for (Loot loot : scenario.getLoot()) {
             loots.add((Loot)loot.clone());
@@ -347,6 +348,10 @@ public class CustomizeScenarioDialog extends javax.swing.JDialog {
         }
 
         AtBDynamicScenario scenario = AtBDynamicScenarioFactory.initializeScenarioFromTemplate(scenarioTemplate, (AtBContract) mission, campaign);
+        if (scenario.getDate() == null) {
+            scenario.setDate(date);
+        }
+
         if (newScenario) {
             campaign.addScenario(scenario, mission);
         }


### PR DESCRIPTION
This PR ensures we have a non-null date in the MekHQ Options, as non-null date for a scenario, and that the new AtB scenario message only occurs on new AtB scenarios and not also on re-added AtB scenarios.