### PR TITLE
Bug: Save part repair reservation if present #1967

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -675,6 +675,13 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             .append(replacementId)
             .append("</replacementId>")
             .append(NL);
+        if (reserveId != null) {
+            builder.append(level1)
+                .append("<reserveId>")
+                .append(reserveId)
+                .append("</reserveId>")
+                .append(NL);
+        }
         builder.append(level1)
             .append("<quality>")
             .append(quality)
@@ -809,6 +816,8 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                     retVal.parentPartId = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("childPartId")) {
                     retVal.childPartIds.add(Integer.parseInt(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("reserveId")) {
+                    retVal.reserveId = UUID.fromString(wn2.getTextContent());
                 }
             }
 


### PR DESCRIPTION
This fixes #1967 by saving a part's repair reservation to the campaign XML. I was unable to replicate the bug in a single sitting, but if you save and reload a campaign you'll see this occurs.