### PR TITLE
1376: Hangar Tab Line Colours For Unmaintained and Uncrewed Units

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -246,26 +246,19 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             } else {
                 return "Mothballing (" + getMothballTime() + "m)";
             }
-        }
-        if (isMothballed()) {
+        } else if (isMothballed()) {
             return "Mothballed";
-        }
-        if (isDeployed()) {
+        } else if (isDeployed()) {
             return "Deployed";
-        }
-        if (!isPresent()) {
+        } else if (!isPresent()) {
             return "In transit (" + getDaysToArrival() + " days)";
-        }
-        if (isRefitting()) {
+        } else if (isRefitting()) {
             return "Refitting";
-        }
-        if (!isRepairable()) {
+        } else if (!isRepairable()) {
             return "Salvage";
-        }
-        else if (!isFunctional()) {
+        } else if (!isFunctional()) {
             return "Inoperable";
-        }
-        else {
+        } else {
             return getDamageStateName(getDamageState());
         }
     }
@@ -1679,10 +1672,6 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             cost = cost.multipliedBy(getCampaign().getCampaignOptions().getClanPriceModifier());
         }
         return cost;
-    }
-
-    public int getDamageState() {
-        return getDamageState(getEntity());
     }
 
     @Override
@@ -4121,7 +4110,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     }
 
     public boolean canTakeTech() {
-        return tech == null && requiresMaintenance() && !isSelfCrewed();
+        return isUnmaintained() && !isSelfCrewed();
     }
 
     // TODO : Switch similar tables in person to use this one instead
@@ -5003,6 +4992,10 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         return !(getEntity() instanceof Infantry) || getEntity() instanceof BattleArmor;
     }
 
+    public boolean isUnmaintained() {
+        return requiresMaintenance() && (getTech() == null);
+    }
+
     public boolean isSelfCrewed() {
         return (getEntity() instanceof Dropship || getEntity() instanceof Jumpship
                 || getEntity() instanceof Infantry && !(getEntity() instanceof BattleArmor));
@@ -5023,6 +5016,11 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
     public void setLastMaintenanceReport(String r) {
         lastMaintenanceReport = r;
+    }
+
+
+    public int getDamageState() {
+        return getDamageState(getEntity());
     }
 
     public static int getDamageState(Entity en) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1180,7 +1180,7 @@ public class CampaignGUI extends JPanel {
         Vector<Unit> notMaintained = new Vector<>();
         int totalAstechMinutesNeeded = 0;
         for (Unit u : getCampaign().getUnits()) {
-            if (u.requiresMaintenance() && (u.getTech() == null)) {
+            if (u.isUnmaintained()) {
                 notMaintained.add(u);
             } else if (u.isPresent() && (u.getEngineer() == null)) {
                 // only add astech minutes for non-crewed units who are present

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -291,7 +291,7 @@ public final class HangarTab extends CampaignGuiTab {
                     return unit.isMothballed();
                 } else if (resourceMap.getString("choiceUnit.UnmaintainedUnits.filter")
                         .equals(choiceUnit.getSelectedItem())) {
-                    return unit.requiresMaintenance() && (unit.getTech() == null);
+                    return unit.isUnmaintained();
                 } else {
                     return false;
                 }

--- a/MekHQ/src/mekhq/gui/MekHqColors.java
+++ b/MekHQ/src/mekhq/gui/MekHqColors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The MegaMek Team. All rights reserved.
+ * Copyright (c) 2020 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui;
 
@@ -52,6 +52,7 @@ public class MekHqColors {
     private static ColorPreference notRepairableColors;
     private static ColorPreference nonfunctionalColors;
     private static ColorPreference needsPartsFixedColors;
+    private static ColorPreference unmaintainedColors;
     private static ColorPreference uncrewedColors;
 
     //
@@ -83,7 +84,8 @@ public class MekHqColors {
         notRepairableColors = new ColorPreference("notRepairable", new Color(190, 150, 55), Color.BLACK);
         nonfunctionalColors = new ColorPreference("nonfunctional", new Color(205, 92, 92), Color.BLACK);
         needsPartsFixedColors = new ColorPreference("needsPartsFixed", new Color(238, 238, 0), Color.BLACK);
-        uncrewedColors = new ColorPreference("uncrewed", Color.RED, Color.BLACK);
+        unmaintainedColors = new ColorPreference("unmaintainedColors", Color.ORANGE, Color.BLACK);
+        uncrewedColors = new ColorPreference("uncrewed", Color.MAGENTA, Color.BLACK);
 
         loanOverdueColors = new ColorPreference("loanOverdue", Color.RED, Color.BLACK);
 
@@ -91,9 +93,11 @@ public class MekHqColors {
         healedInjuriesColors = new ColorPreference("healed", new Color(0xee9a00), Color.BLACK);
         paidRetirementColors = new ColorPreference("paidRetirement", Color.LIGHT_GRAY, Color.BLACK);
 
-        preferences.manage(iconButtonColors, deployedColors, belowContractMinimumColors, inTransitColors, refittingColors,
-            mothballingColors, mothballedColors, notRepairableColors, nonfunctionalColors, needsPartsFixedColors,
-            uncrewedColors, loanOverdueColors, injuredColors, healedInjuriesColors, paidRetirementColors);
+        preferences.manage(iconButtonColors, deployedColors, belowContractMinimumColors,
+                inTransitColors, refittingColors, mothballingColors, mothballedColors,
+                notRepairableColors, nonfunctionalColors, needsPartsFixedColors, unmaintainedColors,
+                uncrewedColors, loanOverdueColors, injuredColors, healedInjuriesColors,
+                paidRetirementColors);
     }
 
     public ColorPreference getIconButton() {
@@ -134,6 +138,10 @@ public class MekHqColors {
 
     public ColorPreference getNeedsPartsFixed() {
         return needsPartsFixedColors;
+    }
+
+    public ColorPreference getUnmaintained() {
+        return unmaintainedColors;
     }
 
     public ColorPreference getUncrewed() {

--- a/MekHQ/src/mekhq/gui/MekHqColors.java
+++ b/MekHQ/src/mekhq/gui/MekHqColors.java
@@ -77,7 +77,7 @@ public class MekHqColors {
         deployedColors = new ColorPreference("deployed", Color.LIGHT_GRAY, Color.BLACK);
         belowContractMinimumColors = new ColorPreference("belowContractMinimum", UIManager.getColor("Table.background"), Color.RED);
 
-        inTransitColors = new ColorPreference("inTransit", Color.ORANGE, Color.BLACK);
+        inTransitColors = new ColorPreference("inTransit", Color.MAGENTA, Color.BLACK);
         refittingColors = new ColorPreference("refitting", Color.CYAN, Color.BLACK);
         mothballingColors = new ColorPreference("mothballing", new Color(153,153,255), Color.BLACK);
         mothballedColors = new ColorPreference("mothballed", new Color(204, 204, 255), Color.BLACK);
@@ -85,7 +85,7 @@ public class MekHqColors {
         nonfunctionalColors = new ColorPreference("nonfunctional", new Color(205, 92, 92), Color.BLACK);
         needsPartsFixedColors = new ColorPreference("needsPartsFixed", new Color(238, 238, 0), Color.BLACK);
         unmaintainedColors = new ColorPreference("unmaintainedColors", Color.ORANGE, Color.BLACK);
-        uncrewedColors = new ColorPreference("uncrewed", Color.MAGENTA, Color.BLACK);
+        uncrewedColors = new ColorPreference("uncrewed", new Color(218, 130, 255), Color.BLACK);
 
         loanOverdueColors = new ColorPreference("loanOverdue", Color.RED, Color.BLACK);
 

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2013-2020 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
 package mekhq.gui.model;
 
 import java.awt.Component;
@@ -11,7 +29,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 
 import megamek.common.Entity;
-import megamek.common.Infantry;
 import megamek.common.Jumpship;
 import megamek.common.SmallCraft;
 import megamek.common.TechConstants;
@@ -31,7 +48,7 @@ import mekhq.gui.utilities.MekHqTableCellRenderer;
  * @author Jay lawson
  */
 public class UnitTableModel extends DataTableModel {
-
+    //region Variable Declarations
     private static final long serialVersionUID = -5207167419079014157L;
 
     public final static int COL_NAME    =    0;
@@ -58,6 +75,7 @@ public class UnitTableModel extends DataTableModel {
     private Campaign campaign;
 
     private final MekHqColors colors = new MekHqColors();
+    //endregion Variable Declarations
 
     public UnitTableModel(Campaign c) {
         data = new ArrayList<Unit>();
@@ -331,8 +349,9 @@ public class UnitTableModel extends DataTableModel {
                     applyColors(colors.getNonFunctional());
                 } else if (u.hasPartsNeedingFixing()) {
                     applyColors(colors.getNeedsPartsFixed());
-                } else if (u.getEntity() instanceof Infantry
-                        && u.getActiveCrew().size() < u.getFullCrewSize()) {
+                } else if (u.isUnmaintained()) {
+                    applyColors(colors.getUnmaintained());
+                } else if (u.getActiveCrew().size() < u.getFullCrewSize()) {
                     applyColors(colors.getUncrewed());
                 } else {
                     setBackground(UIManager.getColor("Table.background"));

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -317,11 +317,10 @@ public class UnitTableModel extends DataTableModel {
 
         private static final long serialVersionUID = 9054581142945717303L;
 
-        public Component getTableCellRendererComponent(JTable table,
-                Object value, boolean isSelected, boolean hasFocus,
-                int row, int column) {
-            super.getTableCellRendererComponent(table, value, isSelected,
-                    hasFocus, row, column);
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+                                                       boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             setOpaque(true);
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);

--- a/MekHQ/src/mekhq/gui/sorter/UnitStatusSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/UnitStatusSorter.java
@@ -1,66 +1,73 @@
+/*
+ * Copyright (c) 2013-2020 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
 package mekhq.gui.sorter;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
-     * A comparator for unit status strings
-     * @author Jay Lawson
-     *
-     */
-    public class UnitStatusSorter implements Comparator<String> {
+ * A comparator for unit status strings
+ * @author Jay Lawson
+ */
+public class UnitStatusSorter implements Comparator<String>, Serializable {
+    private static final long serialVersionUID = 7404736496063859617L;
 
-        @Override
-        public int compare(String s0, String s1) {
-            //probably easiest to turn into numbers and then sort that way
-            int l0 = getDamageStateIndex(s0);
-            int l1 = getDamageStateIndex(s1);
+    @Override
+    public int compare(String s0, String s1) {
+        //probably easiest to turn into numbers and then sort that way
+        int l0 = getDamageStateIndex(s0);
+        int l1 = getDamageStateIndex(s1);
 
-            return ((Comparable<Integer>)l0).compareTo(l1);
-        }
-        
-        public static int getDamageStateIndex(String damageState) {
-        	int idx = 0;
-        	
-            if(damageState.contains("Mothballed")) {
-                idx = 1;
-            }
-            if(damageState.contains("Mothballing")) {
-                idx = 2;
-            }
-            if(damageState.contains("Activating")) {
-                idx = 3;
-            }
-            if(damageState.contains("In Transit")) {
-                idx = 4;
-            }
-            if(damageState.contains("Refitting")) {
-                idx = 5;
-            }
-            if(damageState.contains("Deployed")) {
-                idx = 6;
-            }
-            if(damageState.contains("Salvage")) {
-                idx = 7;
-            }
-            if(damageState.contains("Inoperable")) {
-                idx = 8;
-            }
-            if(damageState.contains("Crippled")) {
-                idx = 9;
-            }
-            if(damageState.contains("Heavy")) {
-                idx = 10;
-            }
-            if(damageState.contains("Moderate")) {
-                idx = 11;
-            }
-            if(damageState.contains("Light")) {
-                idx = 12;
-            }
-            if(damageState.contains("Undamaged")) {
-                idx = 13;
-            }
-            
-            return idx;
-        }
+        return ((Comparable<Integer>) l0).compareTo(l1);
     }
+
+    public static int getDamageStateIndex(String damageState) {
+        int idx = 0;
+
+        if (damageState.contains("Mothballed")) {
+            idx = 1;
+        } else if (damageState.contains("Mothballing")) {
+            idx = 2;
+        } else if (damageState.contains("Activating")) {
+            idx = 3;
+        } else if (damageState.contains("In Transit")) {
+            idx = 4;
+        } else if (damageState.contains("Refitting")) {
+            idx = 5;
+        } else if (damageState.contains("Deployed")) {
+            idx = 6;
+        } else if (damageState.contains("Salvage")) {
+            idx = 7;
+        } else if (damageState.contains("Inoperable")) {
+            idx = 8;
+        } else if (damageState.contains("Crippled")) {
+            idx = 9;
+        } else if (damageState.contains("Heavy")) {
+            idx = 10;
+        } else if (damageState.contains("Moderate")) {
+            idx = 11;
+        } else if (damageState.contains("Light")) {
+            idx = 12;
+        } else if (damageState.contains("Undamaged")) {
+            idx = 13;
+        }
+
+        return idx;
+    }
+}


### PR DESCRIPTION
This fixes #1376 by standardizing the Hangar Tab Colours for Unmaintained and Uncrewed Units and adding them for Unmaintained Units.

Here's a sample of every state and their individual colours.

![image](https://user-images.githubusercontent.com/39067288/94837195-ee91f580-03e1-11eb-90b6-2c62a0b4ea77.png)