### PR TITLE
Switch to strong references instead of IDs for child parts

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1634,7 +1634,7 @@ public class Campaign implements Serializable, ITechManager {
             p.setId(-1);
             return;
         }
-        if (null == p.getUnit()) {
+        if (null == p.getUnit() && !p.hasParentPart()) {
             Part spare = checkForExistingSparePart(p);
             if (null != spare) {
                 if (p instanceof Armor) {
@@ -1713,14 +1713,23 @@ public class Campaign implements Serializable, ITechManager {
         }
     }
 
+
+
     /**
-     * Imports a {@link Part} into the campaign.
+     * Imports a collection of parts into the campaign.
      *
-     * @param p The {@link Part} to import into the campaign.
+     * @param newParts The collection of {@link Part} instances
+     *                 to import into the campaign.
      */
-    public void importPart(Part p) {
-        p.setCampaign(this);
-        addPartWithoutId(p);
+    public void importParts(Collection<Part> newParts) {
+        for (Part p : newParts) {
+            p.setCampaign(this);
+            addPartWithoutId(p);
+        }
+
+        for (Part p : newParts) {
+            p.fixupPartReferences(parts);
+        }
     }
 
     public void addPartWithoutId(Part p) {
@@ -3906,11 +3915,8 @@ public class Campaign implements Serializable, ITechManager {
         }
         parts.remove(part.getId());
         //remove child parts as well
-        for (int childId : part.getChildPartIds()) {
-            Part childPart = getPart(childId);
-            if (null != childPart) {
-                removePart(childPart);
-            }
+        for (Part childPart : part.getChildParts()) {
+            removePart(childPart);
         }
         MekHQ.triggerEvent(new PartRemovedEvent(part));
     }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1634,7 +1634,7 @@ public class Campaign implements Serializable, ITechManager {
             p.setId(-1);
             return;
         }
-        if (null == p.getUnit() && !p.hasParentPart()) {
+        if ((null == p.getUnit()) && !p.hasParentPart()) {
             Part spare = checkForExistingSparePart(p);
             if (null != spare) {
                 if (p instanceof Armor) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1483,6 +1483,7 @@ public class CampaignXmlParser {
         NodeList wList = wn.getChildNodes();
 
         // Okay, lets iterate through the children, eh?
+        List<Part> parts = new ArrayList<>();
         for (int x = 0; x < wList.getLength(); x++) {
             Node wn2 = wList.item(x);
 
@@ -1577,9 +1578,11 @@ public class CampaignXmlParser {
             }
 
             if (p != null) {
-                retVal.importPart(p);
+                parts.add(p);
             }
         }
+
+        retVal.importParts(parts);
 
         MekHQ.getLogger().info(CampaignXmlParser.class, "Load Part Nodes Complete!");
     }

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -140,7 +140,7 @@ public class BattleArmorSuit extends Part {
     public double getTonnage() {
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded alternate costs
-        if(null == unit && getChildParts().isEmpty()) {
+        if ((null == unit) && getChildParts().isEmpty()) {
             return alternateTon;
         }
         double tons = 0;
@@ -219,10 +219,10 @@ public class BattleArmorSuit extends Part {
         }
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded extra costs
-        if(null == unit && getChildParts().isEmpty()) {
+        if ((null == unit) && getChildParts().isEmpty()) {
             tons += alternateTon;
         }
-        for(Part p : getChildParts()) {
+        for (Part p : getChildParts()) {
             if (!(p instanceof BattleArmorSuit)) {
                 tons += p.getTonnage();
             }
@@ -234,7 +234,7 @@ public class BattleArmorSuit extends Part {
     public Money getStickerPrice() {
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded alternate costs
-        if(null == unit && getChildParts().isEmpty()) {
+        if ((null == unit) && getChildParts().isEmpty()) {
             return alternateCost;
         }
         Money cost = Money.zero();
@@ -267,7 +267,7 @@ public class BattleArmorSuit extends Part {
             cost = cost.plus(50000 * (jumpMP + 1));
         }
         cost = cost.plus(25000 * (groundMP-1));
-        for(Part p : getChildParts()) {
+        for (Part p : getChildParts()) {
             if (p instanceof BaArmor) {
                 cost = cost.plus(p.getCurrentValue());
             } else if (!(p instanceof BattleArmorSuit)) {

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -76,6 +76,7 @@ public class BattleArmorSuit extends Part {
     private Money alternateCost = Money.zero();
     private double alternateTon;
     private int introYear;
+    private boolean isReplacement;
 
     public BattleArmorSuit() {
         super(0, null);
@@ -139,7 +140,7 @@ public class BattleArmorSuit extends Part {
     public double getTonnage() {
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded alternate costs
-        if(null == unit && getChildPartIds().size()==0) {
+        if(null == unit && getChildParts().isEmpty()) {
             return alternateTon;
         }
         double tons = 0;
@@ -218,12 +219,11 @@ public class BattleArmorSuit extends Part {
         }
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded extra costs
-        if(null == unit && getChildPartIds().size()==0) {
+        if(null == unit && getChildParts().isEmpty()) {
             tons += alternateTon;
         }
-        for(int childId : getChildPartIds()) {
-            Part p = campaign.getPart(childId);
-            if(null != p && !(p instanceof BattleArmorSuit)) {
+        for(Part p : getChildParts()) {
+            if (!(p instanceof BattleArmorSuit)) {
                 tons += p.getTonnage();
             }
         }
@@ -234,7 +234,7 @@ public class BattleArmorSuit extends Part {
     public Money getStickerPrice() {
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded alternate costs
-        if(null == unit && getChildPartIds().size()==0) {
+        if(null == unit && getChildParts().isEmpty()) {
             return alternateCost;
         }
         Money cost = Money.zero();
@@ -267,14 +267,11 @@ public class BattleArmorSuit extends Part {
             cost = cost.plus(50000 * (jumpMP + 1));
         }
         cost = cost.plus(25000 * (groundMP-1));
-        for(int childId : getChildPartIds()) {
-            Part p = campaign.getPart(childId);
-            if(null != p) {
-                if(p instanceof BaArmor) {
-                    cost = cost.plus(p.getCurrentValue());
-                } else if (!(p instanceof BattleArmorSuit)) {
-                    cost = cost.plus(p.getStickerPrice());
-                }
+        for(Part p : getChildParts()) {
+            if (p instanceof BaArmor) {
+                cost = cost.plus(p.getCurrentValue());
+            } else if (!(p instanceof BattleArmorSuit)) {
+                cost = cost.plus(p.getStickerPrice());
             }
         }
 
@@ -445,7 +442,7 @@ public class BattleArmorSuit extends Part {
                 if(part instanceof BaArmor && ((BaArmor)part).getLocation() == trooper) {
                     BaArmor armorClone = (BaArmor)part.clone();
                     armorClone.setAmount(((BaArmor)part).getAmount());
-                    armorClone.setParentPartId(getId());
+                    armorClone.setParentPart(this);
                     campaign.addPart(armorClone, 0);
                     addChildPart(armorClone);
                 }
@@ -529,15 +526,12 @@ public class BattleArmorSuit extends Part {
         } else {
             int nEquip = 0;
             int armor = 0;
-            if(getChildPartIds().size() > 0) {
-                for(int childId : getChildPartIds()) {
-                    Part p = campaign.getPart(childId);
-                    if(null != p) {
-                        if(p instanceof BaArmor) {
-                            armor = ((BaArmor)p).getAmount();
-                        } else {
-                            nEquip++;
-                        }
+            if (!getChildParts().isEmpty()) {
+                for (Part p : getChildParts()) {
+                    if (p instanceof BaArmor) {
+                        armor = ((BaArmor)p).getAmount();
+                    } else {
+                        nEquip++;
                     }
                 }
                 return nEquip + " pieces of equipment; " + armor + " armor points";
@@ -629,14 +623,14 @@ public class BattleArmorSuit extends Part {
             for(Part part : newUnit.getParts()) {
                 if(part instanceof BattleArmorEquipmentPart && ((BattleArmorEquipmentPart)part).getTrooper() == BattleArmor.LOC_TROOPER_1) {
                     Part newEquip = part.clone();
-                    newEquip.setParentPartId(getId());
+                    newEquip.setParentPart(this);
                     campaign.addPart(newEquip, 0);
                     addChildPart(newEquip);
                 }
                 else if(part instanceof BaArmor && ((BaArmor)part).getLocation() == BattleArmor.LOC_TROOPER_1) {
                     BaArmor armorClone = (BaArmor)part.clone();
                     armorClone.setAmount(newUnit.getEntity().getOArmor(BattleArmor.LOC_TROOPER_1));
-                    armorClone.setParentPartId(getId());
+                    armorClone.setParentPart(this);
                     campaign.addPart(armorClone, 0);
                     addChildPart(armorClone);
                 }
@@ -644,9 +638,17 @@ public class BattleArmorSuit extends Part {
         }
     }
 
+    /**
+     * Sets a value indicating whether or not this part
+     * is being used as a replacement.
+     */
+    public void isReplacement(boolean value) {
+        isReplacement = value;
+    }
+
     @Override
     public void postProcessCampaignAddition() {
-        if(getChildPartIds().isEmpty()) {
+        if (!isReplacement && getChildParts().isEmpty()) {
             addSubParts();
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/BayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BayDoor.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2017 - The MegaMek Team. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -34,30 +34,29 @@ import mekhq.campaign.Campaign;
  *
  */
 public class BayDoor extends Part {
-    
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 685375245347077715L;
 
     public BayDoor() {
         this(0, null);
     }
-    
+
     public BayDoor(int tonnage, Campaign c) {
         super(tonnage, false, c);
         name = "Bay Door";
     }
-    
+
     @Override
     public String getName() {
-        Part parent = campaign.getPart(parentPartId);
-        if (null != parent) {
-            return parent.getName() + " Door";
+        if (null != parentPart) {
+            return parentPart.getName() + " Door";
         }
         return super.getName();
     }
-    
+
     @Override
     public int getBaseTime() {
         if (isSalvaging()) {
@@ -75,13 +74,12 @@ public class BayDoor extends Part {
     public void updateConditionFromPart() {
         // This is handled by the transport bay part to coordinate all the doors
     }
-    
+
     @Override
     public void fix() {
         super.fix();
-        Part bayPart = campaign.getPart(parentPartId);
-        if (null != bayPart) {
-            Bay bay = ((TransportBayPart) bayPart).getBay();
+        if (parentPart instanceof TransportBayPart) {
+            Bay bay = ((TransportBayPart) parentPart).getBay();
             if (null != bay) {
                 bay.setCurrentDoors(Math.min(bay.getCurrentDoors() + 1, bay.getDoors()));
             }
@@ -90,8 +88,7 @@ public class BayDoor extends Part {
 
     @Override
     public void remove(boolean salvage) {
-        Part bayPart = campaign.getPart(parentPartId);
-        if (null != bayPart) {
+        if (null != parentPart) {
             Part spare = campaign.checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
@@ -103,9 +100,9 @@ public class BayDoor extends Part {
             Part missing = getMissingPart();
             unit.addPart(missing);
             campaign.addPart(missing, 0);
-            bayPart.removeChildPart(id);
-            bayPart.addChildPart(missing);
-            bayPart.updateConditionFromPart();
+            parentPart.removeChildPart(this);
+            parentPart.addChildPart(missing);
+            parentPart.updateConditionFromPart();
         }
         setUnit(null);
     }

--- a/MekHQ/src/mekhq/campaign/parts/Cubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/Cubicle.java
@@ -59,9 +59,8 @@ public class Cubicle extends Part {
 
     @Override
     public String getName() {
-        Part parent = campaign.getPart(parentPartId);
-        if (null != parent) {
-            return parent.getName() + " Cubicle";
+        if (null != parentPart) {
+            return parentPart.getName() + " Cubicle";
         }
         return super.getName();
     }
@@ -84,8 +83,7 @@ public class Cubicle extends Part {
 
     @Override
     public void remove(boolean salvage) {
-        Part bayPart = campaign.getPart(parentPartId);
-        if (null != bayPart) {
+        if (null != parentPart) {
             Part spare = campaign.checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
@@ -97,9 +95,9 @@ public class Cubicle extends Part {
             Part missing = getMissingPart();
             unit.addPart(missing);
             campaign.addPart(missing, 0);
-            bayPart.removeChildPart(id);
-            bayPart.addChildPart(missing);
-            bayPart.updateConditionFromPart();
+            parentPart.removeChildPart(this);
+            parentPart.addChildPart(missing);
+            parentPart.updateConditionFromPart();
         }
         setUnit(null);
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -230,11 +230,9 @@ public class MissingBattleArmorSuit extends MissingPart {
         	BattleArmorSuit newSuit = (BattleArmorSuit)replacement.clone();
             //lets also clone the subparts
             unit.addPart(newSuit);
-            //this is admittedly hacky, but lets go ahead and add something to the newSuit
-            //so it doesnt generate a whole new set of parts
-            newSuit.childPartIds.add(1);
+            newSuit.isReplacement(true);
             campaign.addPart(newSuit, 0);
-            newSuit.childPartIds.clear();
+            newSuit.isReplacement(false);
             newSuit.setTrooper(trooper);
             newSuit.updateConditionFromPart();
             //cycle through MissingBattleArmorEquipmentPart for trooper and replace
@@ -253,14 +251,13 @@ public class MissingBattleArmorSuit extends MissingPart {
                 }
                 missingStuff.add(missingBaEquip);
             }
-            for(int childId : replacement.getChildPartIds()) {
-        		Part childPart = campaign.getPart(childId);
-        		if(childPart instanceof BaArmor && null != origArmor) {
+            for (Part childPart : replacement.getChildParts()) {
+        		if (childPart instanceof BaArmor && null != origArmor) {
         			unit.getEntity().setArmor(((BaArmor)childPart).getAmount(), trooper);
         			origArmor.updateConditionFromEntity(false);
-        		} else if(childPart instanceof BattleArmorEquipmentPart) {
-        			for(MissingBattleArmorEquipmentPart p : missingStuff) {
-	            		if(null != p.getUnit() && p.isAcceptableReplacement(childPart, false)) {
+        		} else if (childPart instanceof BattleArmorEquipmentPart) {
+        			for (MissingBattleArmorEquipmentPart p : missingStuff) {
+	            		if (null != p.getUnit() && p.isAcceptableReplacement(childPart, false)) {
 	            			//then add child part and remove current part from unit and campaign
 	            			Part newPart = childPart.clone();
 	            			unit.addPart(newPart);
@@ -332,25 +329,19 @@ public class MissingBattleArmorSuit extends MissingPart {
 					int currentPartArmor = 0;
 					int bestPartQuantity = 0;
 					int currentPartQuantity = 0;
-					for(int childId : bestPart.childPartIds) {
-						Part p = campaign.getPart(childId);
-						if(p != null) {
-							if(p instanceof BaArmor) {
-								bestPartArmor = ((BaArmor)p).getAmount();
-							} else {
-								bestPartQuantity++;
-							}
-						}
+					for(Part p : bestPart.getChildParts()) {
+                        if (p instanceof BaArmor) {
+                            bestPartArmor = ((BaArmor)p).getAmount();
+                        } else {
+                            bestPartQuantity++;
+                        }
 					}
-					for(int childId : part.childPartIds) {
-						Part p = campaign.getPart(childId);
-						if(p != null) {
-							if(p instanceof BaArmor) {
-								currentPartArmor = ((BaArmor)p).getAmount();
-							} else {
-								currentPartQuantity++;
-							}
-						}
+					for (Part p : part.getChildParts()) {
+                        if (p instanceof BaArmor) {
+                            currentPartArmor = ((BaArmor)p).getAmount();
+                        } else {
+                            currentPartQuantity++;
+                        }
 					}
 					if(currentPartQuantity > bestPartQuantity) {
 						bestPart = part;

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -329,7 +329,7 @@ public class MissingBattleArmorSuit extends MissingPart {
 					int currentPartArmor = 0;
 					int bestPartQuantity = 0;
 					int currentPartQuantity = 0;
-					for(Part p : bestPart.getChildParts()) {
+					for (Part p : bestPart.getChildParts()) {
                         if (p instanceof BaArmor) {
                             bestPartArmor = ((BaArmor)p).getAmount();
                         } else {

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -80,20 +80,20 @@ public class MissingBattleArmorSuit extends MissingPart {
     }
 
     @Override
-	public int getBaseTime() {
-		return 0;
-	}
+    public int getBaseTime() {
+        return 0;
+    }
 
-	@Override
-	public int getDifficulty() {
-		return 0;
-	}
+    @Override
+    public int getDifficulty() {
+        return 0;
+    }
 
     @Override
     public void updateConditionFromPart() {
-    	if(null != unit) {
-    		unit.getEntity().setInternal(IArmorState.ARMOR_DESTROYED, trooper);
-    	}
+        if(null != unit) {
+            unit.getEntity().setInternal(IArmorState.ARMOR_DESTROYED, trooper);
+        }
     }
 
     @Override
@@ -227,7 +227,7 @@ public class MissingBattleArmorSuit extends MissingPart {
     public void fix() {
         Part replacement = findReplacement(false);
         if(null != replacement) {
-        	BattleArmorSuit newSuit = (BattleArmorSuit)replacement.clone();
+            BattleArmorSuit newSuit = (BattleArmorSuit)replacement.clone();
             //lets also clone the subparts
             unit.addPart(newSuit);
             newSuit.isReplacement(true);
@@ -239,9 +239,9 @@ public class MissingBattleArmorSuit extends MissingPart {
             ArrayList<MissingBattleArmorEquipmentPart> missingStuff = new ArrayList<MissingBattleArmorEquipmentPart>();
             BaArmor origArmor = null;
             for(Part p : unit.getParts()) {
-            	if(p instanceof BaArmor && ((BaArmor)p).getLocation()== trooper) {
-            		origArmor = (BaArmor)p;
-            	}
+                if(p instanceof BaArmor && ((BaArmor)p).getLocation()== trooper) {
+                    origArmor = (BaArmor)p;
+                }
                 if(!(p instanceof MissingBattleArmorEquipmentPart)) {
                     continue;
                 }
@@ -252,23 +252,23 @@ public class MissingBattleArmorSuit extends MissingPart {
                 missingStuff.add(missingBaEquip);
             }
             for (Part childPart : replacement.getChildParts()) {
-        		if (childPart instanceof BaArmor && null != origArmor) {
-        			unit.getEntity().setArmor(((BaArmor)childPart).getAmount(), trooper);
-        			origArmor.updateConditionFromEntity(false);
-        		} else if (childPart instanceof BattleArmorEquipmentPart) {
-        			for (MissingBattleArmorEquipmentPart p : missingStuff) {
-	            		if (null != p.getUnit() && p.isAcceptableReplacement(childPart, false)) {
-	            			//then add child part and remove current part from unit and campaign
-	            			Part newPart = childPart.clone();
-	            			unit.addPart(newPart);
-	            			((EquipmentPart)newPart).setEquipmentNum(p.getEquipmentNum());
-	                        ((BattleArmorEquipmentPart)newPart).setTrooper(trooper);
-	            			p.remove(false);
-	            			newPart.updateConditionFromPart();
-	            			break;
-	            		}
-	            	}
-        		}
+                if (childPart instanceof BaArmor && null != origArmor) {
+                    unit.getEntity().setArmor(((BaArmor)childPart).getAmount(), trooper);
+                    origArmor.updateConditionFromEntity(false);
+                } else if (childPart instanceof BattleArmorEquipmentPart) {
+                    for (MissingBattleArmorEquipmentPart p : missingStuff) {
+                        if (null != p.getUnit() && p.isAcceptableReplacement(childPart, false)) {
+                            //then add child part and remove current part from unit and campaign
+                            Part newPart = childPart.clone();
+                            unit.addPart(newPart);
+                            ((EquipmentPart)newPart).setEquipmentNum(p.getEquipmentNum());
+                            ((BattleArmorEquipmentPart)newPart).setTrooper(trooper);
+                            p.remove(false);
+                            newPart.updateConditionFromPart();
+                            break;
+                        }
+                    }
+                }
             }
             replacement.decrementQuantity();
             unit.getEntity().setInternal(1, trooper);
@@ -277,82 +277,82 @@ public class MissingBattleArmorSuit extends MissingPart {
     }
 
 
-	@Override
-	public String getLocationName() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public String getLocationName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
 
-	@Override
-	public int getLocation() {
-		return trooper;
-	}
+    @Override
+    public int getLocation() {
+        return trooper;
+    }
 
-	@Override
+    @Override
     public String getDetails() {
         return getDetails(true);
     }
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
-    	if(null == unit) {
-    		return super.getDetails(includeRepairDetails);
+        if(null == unit) {
+            return super.getDetails(includeRepairDetails);
 
         }
-    	String toReturn = unit.getEntity().getLocationName(trooper) + "<br>";
-		return toReturn + super.getDetails(includeRepairDetails);
+        String toReturn = unit.getEntity().getLocationName(trooper) + "<br>";
+        return toReturn + super.getDetails(includeRepairDetails);
     }
 
-	@Override
-	public Part findReplacement(boolean refit) {
-		Part bestPart = null;
+    @Override
+    public Part findReplacement(boolean refit) {
+        Part bestPart = null;
 
-		//check to see if we already have a replacement assigned
-		if(replacementId > -1) {
-			bestPart = campaign.getPart(replacementId);
-			if(null != bestPart) {
-				return bestPart;
-			}
-		}
-		// don't just return with the first part if it is damaged
-		for(Part part : campaign.getSpareParts()) {
-			if(part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart()) {
-				continue;
-			}
+        //check to see if we already have a replacement assigned
+        if(replacementId > -1) {
+            bestPart = campaign.getPart(replacementId);
+            if(null != bestPart) {
+                return bestPart;
+            }
+        }
+        // don't just return with the first part if it is damaged
+        for(Part part : campaign.getSpareParts()) {
+            if(part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart()) {
+                continue;
+            }
 
-			if(isAcceptableReplacement(part, refit)) {
-				if(null == bestPart) {
-					bestPart = part;
-				} else {
-					int bestPartArmor = 0;
-					int currentPartArmor = 0;
-					int bestPartQuantity = 0;
-					int currentPartQuantity = 0;
-					for (Part p : bestPart.getChildParts()) {
+            if(isAcceptableReplacement(part, refit)) {
+                if(null == bestPart) {
+                    bestPart = part;
+                } else {
+                    int bestPartArmor = 0;
+                    int currentPartArmor = 0;
+                    int bestPartQuantity = 0;
+                    int currentPartQuantity = 0;
+                    for (Part p : bestPart.getChildParts()) {
                         if (p instanceof BaArmor) {
                             bestPartArmor = ((BaArmor)p).getAmount();
                         } else {
                             bestPartQuantity++;
                         }
-					}
-					for (Part p : part.getChildParts()) {
+                    }
+                    for (Part p : part.getChildParts()) {
                         if (p instanceof BaArmor) {
                             currentPartArmor = ((BaArmor)p).getAmount();
                         } else {
                             currentPartQuantity++;
                         }
-					}
-					if(currentPartQuantity > bestPartQuantity) {
-						bestPart = part;
-					} else if(currentPartArmor > bestPartArmor) {
-						bestPart = part;
-					}
-				}
-			}
-		}
-		return bestPart;
-	}
+                    }
+                    if(currentPartQuantity > bestPartQuantity) {
+                        bestPart = part;
+                    } else if(currentPartArmor > bestPartArmor) {
+                        bestPart = part;
+                    }
+                }
+            }
+        }
+        return bestPart;
+    }
 
     @Override
     public int getIntroductionDate() {

--- a/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2017 - The MegaMek Team. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -30,12 +30,12 @@ import mekhq.campaign.Campaign;
  *
  */
 public class MissingBayDoor extends MissingPart {
-    
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 4652276524852879974L;
-    
+
     public MissingBayDoor() {
         this(0, null);
     }
@@ -44,12 +44,11 @@ public class MissingBayDoor extends MissingPart {
         super(tonnage, false, c);
         name = "Bay Door";
     }
-    
+
     @Override
     public String getName() {
-        Part parent = campaign.getPart(parentPartId);
-        if (null != parent) {
-            return parent.getName() + " Door";
+        if (null != parentPart) {
+            return parentPart.getName() + " Door";
         }
         return super.getName();
     }
@@ -74,10 +73,9 @@ public class MissingBayDoor extends MissingPart {
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();
             remove(false);
-            Part bayPart = campaign.getPart(parentPartId);
-            if (null != bayPart) {
-                bayPart.addChildPart(actualReplacement);
-                bayPart.updateConditionFromPart();
+            if (null != parentPart) {
+                parentPart.addChildPart(actualReplacement);
+                parentPart.updateConditionFromPart();
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
@@ -57,9 +57,8 @@ public class MissingCubicle extends MissingPart {
 
     @Override
     public String getName() {
-        Part parent = campaign.getPart(parentPartId);
-        if (null != parent) {
-            return parent.getName() + " Cubicle";
+        if (null != parentPart) {
+            return parentPart.getName() + " Cubicle";
         }
         return super.getName();
     }
@@ -99,10 +98,9 @@ public class MissingCubicle extends MissingPart {
             campaign.addPart(actualReplacement, 0);
             replacement.decrementQuantity();
             remove(false);
-            Part bayPart = campaign.getPart(parentPartId);
-            if (null != bayPart) {
-                bayPart.addChildPart(actualReplacement);
-                bayPart.updateConditionFromPart();
+            if (null != parentPart) {
+                parentPart.addChildPart(actualReplacement);
+                parentPart.updateConditionFromPart();
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -150,9 +150,8 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 			unit.removePart(this);
 		}
 		setUnit(null);
-		Part parentPart = campaign.getPart(parentPartId);
 		if (null != parentPart) {
-		    parentPart.removeChildPart(this.getId());
+		    parentPart.removeChildPart(this);
 		}
 	}
 

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1798,103 +1798,81 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
         @Override
         public int getBaseTime() {
-            // TODO Auto-generated method stub
             return 0;
         }
 
         @Override
         public void updateConditionFromEntity(boolean checkForDestruction) {
-            // TODO Auto-generated method stub
-
         }
 
         @Override
         public void updateConditionFromPart() {
-            // TODO Auto-generated method stub
-
         }
 
         @Override
         public void remove(boolean salvage) {
-            // TODO Auto-generated method stub
-
         }
 
         @Override
         public MissingPart getMissingPart() {
-            // TODO Auto-generated method stub
             return null;
         }
 
         @Override
         public int getLocation() {
-            // TODO Auto-generated method stub
             return 0;
         }
 
         @Override
         public String checkFixable() {
-            // TODO Auto-generated method stub
             return null;
         }
 
         @Override
         public boolean needsFixing() {
-            // TODO Auto-generated method stub
             return false;
         }
 
         @Override
         public int getDifficulty() {
-            // TODO Auto-generated method stub
             return 0;
         }
 
         @Override
         public Money getStickerPrice() {
-            // TODO Auto-generated method stub
             return null;
         }
 
         @Override
         public double getTonnage() {
-            // TODO Auto-generated method stub
             return 0;
         }
 
         @Override
         public boolean isSamePartType(Part part) {
-            // TODO Auto-generated method stub
             return false;
         }
 
         @Override
         public void writeToXml(PrintWriter pw1, int indent) {
-            // TODO Auto-generated method stub
-
         }
 
         @Override
         protected void loadFieldsFromXmlNode(Node wn) {
-            // TODO Auto-generated method stub
-
         }
 
         @Override
         public Part clone() {
-            // TODO Auto-generated method stub
             return null;
         }
 
         @Override
         public String getLocationName() {
-            // TODO Auto-generated method stub
             return null;
         }
 
         @Override
         public ITechnology getTechAdvancement() {
-            // TODO Auto-generated method stub
             return null;
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1790,9 +1790,6 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 
     public static class PartRef extends Part {
-        /**
-         *
-         */
         private static final long serialVersionUID = 1L;
 
         public PartRef(int id) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1766,7 +1766,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         if (parentPart instanceof PartRef) {
             int id = parentPart.getId();
             parentPart = knownParts.get(id);
-            if (parentPart == null) {
+            if ((parentPart == null) && (id > 0)) {
                 MekHQ.getLogger().error(PartRef.class,
                     String.format("Part %d ('%s') references missing parent part %d",
                         getId(), getName(), id));
@@ -1779,10 +1779,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                 Part realPart = knownParts.get(childPart.getId());
                 if (realPart != null) {
                     childParts.set(ii, realPart);
-                } else {
+                } else if (childPart.getId() > 0) {
                     MekHQ.getLogger().error(PartRef.class,
                         String.format("Part %d ('%s') references missing child part %d",
-                            getId(), getName(), id));
+                            getId(), getName(), childPart.getId()));
                     childParts.remove(ii);
                 }
             }

--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2017 - The MegaMek Team. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -38,37 +38,37 @@ import mekhq.campaign.Campaign;
  *
  */
 public class TransportBayPart extends Part {
-    
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 6555762303379877899L;
-    
+
     private int bayNumber;
     private double size;
-    
+
     public TransportBayPart() {
         this(0, 0, 0, null);
     }
-    
+
     public TransportBayPart(int tonnage, int bayNumber, double size, Campaign c) {
         super(tonnage, c);
         this.bayNumber = bayNumber;
         this.size = size;
         name = "Bay #" + bayNumber;
     }
-    
+
     public int getBayNumber() {
         return bayNumber;
     }
-    
+
     public Bay getBay() {
         if (null != unit) {
             return unit.getEntity().getBayById(bayNumber);
         }
         return null;
     }
-    
+
     @Override
     public String getName() {
         if (null != getBay()) {
@@ -91,8 +91,7 @@ public class TransportBayPart extends Part {
             int prevHits = hits;
             hits = (int) bay.getBayDamage();
             int prevDoorHits = 0;
-            for (int id : childPartIds) {
-                final Part p = campaign.getPart(id);
+            for (Part p : getChildParts()) {
                 if ((p instanceof MissingBayDoor)
                         || ((p instanceof BayDoor) && p.needsFixing())) {
                     prevDoorHits++;
@@ -102,8 +101,7 @@ public class TransportBayPart extends Part {
                 // We need an independent list of child parts so we don't get concurrent modification
                 // exceptions from removing destroyed doors. We might as well filter anything that's
                 // not an undamaged door at the same time.
-                List<Part> doors = childPartIds.stream()
-                        .map(id -> campaign.getPart(id))
+                List<Part> doors = getChildParts().stream()
                         .filter(p -> (p instanceof BayDoor) && !p.needsFixing())
                         .collect(Collectors.toList());
                 for (Part door : doors) {
@@ -122,9 +120,8 @@ public class TransportBayPart extends Part {
             // If checking for destruction we need to remove a number of cubicles (if any)
             // equal to the increase in damage.
             if ((hits > prevHits) && checkForDestruction) {
-                List<Part> cubicles = childPartIds.stream()
-                        .map(id -> campaign.getPart(id))
-                        .filter(p -> (null != p) && (p instanceof Cubicle))
+                List<Part> cubicles = getChildParts().stream()
+                        .filter(p -> p instanceof Cubicle)
                         .collect(Collectors.toList());
                 while ((hits > prevHits) && !cubicles.isEmpty()) {
                     Part cubicle = cubicles.get(Compute.randomInt(cubicles.size()));
@@ -141,23 +138,20 @@ public class TransportBayPart extends Part {
         if (null != bay) {
             int goodDoors = 0;
             int badCubicles = 0;
-            for (int id : childPartIds) {
-                final Part p = campaign.getPart(id);
-                if (null != p) {
-                    if ((p instanceof BayDoor) && !p.needsFixing()) {
-                        goodDoors++;
-                    } else if (p instanceof MissingCubicle) {
-                        badCubicles++;
-                    }
+            for (Part p : getChildParts()) {
+                if ((p instanceof BayDoor) && !p.needsFixing()) {
+                    goodDoors++;
+                } else if (p instanceof MissingCubicle) {
+                    badCubicles++;
                 }
             }
             bay.setCurrentDoors(goodDoors);
-            // Even if the bay is repaired, it still has reduced capacity until the cubicles are replaced. 
+            // Even if the bay is repaired, it still has reduced capacity until the cubicles are replaced.
             bay.setBayDamage(Math.max(hits, badCubicles));
         }
-        
+
     }
-    
+
     @Override
     public void fix() {
         super.fix();
@@ -171,7 +165,7 @@ public class TransportBayPart extends Part {
     public void remove(boolean salvage) {
         // Can't remove a bay
     }
-    
+
     @Override
     public boolean isSalvaging() {
         return false;

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2766,8 +2766,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     }
                 }
             } else {
-                List<Part> doors = bayPart.getChildPartIds().stream()
-                        .map(id -> getCampaign().getPart(id))
+                List<Part> doors = bayPart.getChildParts().stream()
                         .filter(p -> ((p instanceof BayDoor) || (p instanceof MissingBayDoor)))
                         .collect(Collectors.toList());
                 while (bay.getDoors() > doors.size()) {
@@ -2778,8 +2777,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     doors.add(door);
                 }
                 if (btype.getCategory() == BayType.CATEGORY_NON_INFANTRY) {
-                    List<Part> cubicles = bayPart.getChildPartIds().stream()
-                            .map(id -> getCampaign().getPart(id))
+                    List<Part> cubicles = bayPart.getChildParts().stream()
                             .filter(p -> ((p instanceof Cubicle) || (p instanceof MissingCubicle)))
                             .collect(Collectors.toList());
                     while (bay.getCapacity() > cubicles.size()) {


### PR DESCRIPTION
I have never reliably reproduced the issues seen with child parts (such as bay doors, etc), but have always disliked our usage of IDs instead of strong references. MekHQ plays loose with IDs in order to aggregate spare parts and I'm not confident it isn't a cause of these problems.

I'm only confident this will resolve the class of errors where the part ID changed but the child part IDs were not updated.