### PR TITLE
Issue #2089: fix procuring vehicle engines from the parts store

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingEnginePart.java
@@ -211,14 +211,7 @@ public class MissingEnginePart extends MissingPart {
 	@Override
 	public Part getNewPart() {
 		boolean useHover = null != unit && unit.getEntity().getMovementMode() == EntityMovementMode.HOVER && unit.getEntity() instanceof Tank;
-		int flags = 0;
-		if(engine.hasFlag(Engine.CLAN_ENGINE)) {
-			flags = Engine.CLAN_ENGINE;
-		}
-		if(null != unit && unit.getEntity() instanceof Tank) {
-			flags |= Engine.TANK_ENGINE;
-		}
-		return new EnginePart(getUnitTonnage(), new Engine(engine.getRating(), engine.getEngineType(), flags), campaign, useHover);
+		return new EnginePart(getUnitTonnage(), new Engine(engine.getRating(), engine.getEngineType(), engine.getFlags()), campaign, useHover);
 	}
 
 	@Override


### PR DESCRIPTION
When we create a new `EnginePart` from a `MissingEnginePart` we were using heuristics to determine the appropriate engine flags for MegaMek. This is unnecessary as the `MissingEnginePart` has access to the actual flags for the missing engine (courtesy of `engine.getFlags()`. I can't figure out why we didn't just copy the flags in the first place, as the code commit history for that area does not do a good job of explaining those changes.

This fixes #2089.