### PR TITLE
Loot Table: Fixing Money Capitalization and Adding Basic Unit/Part Tooltips

### DIFF
--- a/MekHQ/src/mekhq/gui/model/LootTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/LootTableModel.java
@@ -2,6 +2,7 @@
  * LootTableModel.java
  *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
+ * Copyright (c) 2020 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -12,16 +13,16 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui.model;
 
 import java.awt.Component;
-import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
@@ -30,42 +31,43 @@ import javax.swing.table.DefaultTableCellRenderer;
 
 import mekhq.campaign.mission.Loot;
 
-    /**
-     * A table model for displaying loot for scenarios and missions
-     */
+/**
+ * A table model for displaying loot for scenarios and missions
+ */
 public class LootTableModel extends AbstractTableModel {
-    /**
-     *
-     */
+    //region Variable Declarations
     private static final long serialVersionUID = -58915479895694545L;
     protected String[] columnNames;
-    protected ArrayList<Loot> data;
+    protected List<Loot> data;
 
     public final static int COL_NAME    = 0;
     public final static int COL_MONEY   = 1;
     public final static int COL_MECHS   = 2;
     public final static int COL_PARTS   = 3;
     public final static int N_COL       = 4;
+    //endregion Variable Declarations
 
-    public LootTableModel(ArrayList<Loot> entries) {
+    public LootTableModel(List<Loot> entries) {
         data = entries;
     }
 
+    @Override
     public int getRowCount() {
         return data.size();
     }
 
+    @Override
     public int getColumnCount() {
         return N_COL;
     }
 
     @Override
     public String getColumnName(int column) {
-        switch(column) {
+        switch (column) {
             case COL_NAME:
                 return "Name";
             case COL_MONEY:
-                return "money";
+                return "Money";
             case COL_MECHS:
                 return "# Units";
             case COL_PARTS:
@@ -75,26 +77,27 @@ public class LootTableModel extends AbstractTableModel {
         }
     }
 
+    @Override
     public Object getValueAt(int row, int col) {
         Loot loot;
-        if(data.isEmpty()) {
+        if (data.isEmpty()) {
             return "";
         } else {
             loot = getLootAt(row);
         }
-        if(col == COL_NAME) {
-            return loot.getName();
+
+        switch (col) {
+            case COL_NAME:
+                return loot.getName();
+            case COL_MONEY:
+                return loot.getCash().toAmountAndSymbolString();
+            case COL_MECHS:
+                return loot.getUnits().size();
+            case COL_PARTS:
+                return loot.getParts().size();
+            default:
+                return "?";
         }
-        if(col == COL_MONEY) {
-            return loot.getCash().toAmountAndSymbolString();
-        }
-        if(col == COL_MECHS) {
-            return loot.getUnits().size();
-        }
-        if(col == COL_PARTS) {
-            return loot.getParts().size();
-        }
-        return "?";
     }
 
     @Override
@@ -103,12 +106,12 @@ public class LootTableModel extends AbstractTableModel {
     }
 
     @Override
-    public Class<? extends Object> getColumnClass(int c) {
+    public Class<?> getColumnClass(int c) {
         return getValueAt(0, c).getClass();
     }
 
     public Loot getLootAt(int row) {
-        return (Loot) data.get(row);
+        return data.get(row);
     }
 
     public void addLoot(Loot loot) {
@@ -116,53 +119,50 @@ public class LootTableModel extends AbstractTableModel {
         fireTableDataChanged();
     }
 
-    public ArrayList<Loot> getAllLoot() {
+    public List<Loot> getAllLoot() {
         return data;
     }
 
-     public int getColumnWidth(int c) {
-         switch(c) {
-         case COL_MONEY:
-         case COL_NAME:
-             return 100;
-         default:
-             return 20;
-         }
-     }
+    public int getColumnWidth(int c) {
+        switch (c) {
+            case COL_MONEY:
+            case COL_NAME:
+                return 100;
+            default:
+                return 20;
+        }
+    }
 
-     public int getAlignment(int col) {
-         return SwingConstants.LEFT;
-     }
+    public int getAlignment(int col) {
+        return SwingConstants.LEFT;
+    }
 
-     public String getTooltip(int row, int col) {
-         switch(col) {
-         default:
-             return null;
-         }
-     }
+    public String getTooltip(int row, int col) {
+        switch (col) {
+            default:
+                return null;
+        }
+    }
 
-     //fill table with values
-     public void setData(ArrayList<Loot> loot) {
-         data = loot;
-         fireTableDataChanged();
-     }
+    //fill table with values
+    public void setData(List<Loot> loot) {
+        data = loot;
+        fireTableDataChanged();
+    }
 
-     public LootTableModel.Renderer getRenderer() {
-         return new LootTableModel.Renderer();
-     }
+    public LootTableModel.Renderer getRenderer() {
+        return new LootTableModel.Renderer();
+    }
 
-     public class Renderer extends DefaultTableCellRenderer {
+    public class Renderer extends DefaultTableCellRenderer {
+        private static final long serialVersionUID = -2888173457152182907L;
 
-     /**
-     *
-     */
-    private static final long serialVersionUID = -2888173457152182907L;
-
-    public Component getTableCellRendererComponent(JTable table,
-             Object value, boolean isSelected, boolean hasFocus,
-                int row, int column) {
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                                                       boolean isSelected, boolean hasFocus,
+                                                       int row, int column) {
             super.getTableCellRendererComponent(table, value, isSelected,
-                    hasFocus, row, column);
+            hasFocus, row, column);
             setOpaque(true);
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
@@ -171,5 +171,5 @@ public class LootTableModel extends AbstractTableModel {
 
             return this;
         }
-     }
+    }
 }

--- a/MekHQ/src/mekhq/gui/model/LootTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/LootTableModel.java
@@ -23,13 +23,16 @@ package mekhq.gui.model;
 
 import java.awt.Component;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 
+import megamek.common.Entity;
 import mekhq.campaign.mission.Loot;
+import mekhq.campaign.parts.Part;
 
 /**
  * A table model for displaying loot for scenarios and missions
@@ -139,6 +142,12 @@ public class LootTableModel extends AbstractTableModel {
 
     public String getTooltip(int row, int col) {
         switch (col) {
+            case COL_MECHS:
+                return getLootAt(row).getUnits().stream().map(Entity::getDisplayName)
+                        .collect(Collectors.joining(", "));
+            case COL_PARTS:
+                return getLootAt(row).getParts().stream().map(Part::getPartName)
+                        .collect(Collectors.joining(", "));
             default:
                 return null;
         }
@@ -161,8 +170,7 @@ public class LootTableModel extends AbstractTableModel {
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
-            super.getTableCellRendererComponent(table, value, isSelected,
-            hasFocus, row, column);
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             setOpaque(true);
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);


### PR DESCRIPTION
This fixes a minor capitalization issue and adds some tooltips to the table at the same time.

To review: Whitespace differences off, and the first is a code cleanup plus spelling fix on the money column name, the second adds the tooltips I found as missing when fixing the capitalization.