### PR TITLE
Avoid part ID references in Refits and elsewhere

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7869,7 +7869,7 @@ public class Campaign implements Serializable, ITechManager {
             // don't do actual damage until we clear the for loop to avoid
             // concurrent mod problems
             // put it into a hash - 4 points of damage will mean destruction
-            HashMap<Integer, Integer> partsToDamage = new HashMap<>();
+            Map<Part, Integer> partsToDamage = new HashMap<>();
             StringBuilder maintenanceReport = new StringBuilder("<emph>" + techName + " performing maintenance</emph><br><br>");
             for (Part p : u.getParts()) {
                 String partReport = "<b>" + p.getName() + "</b> (Quality " + p.getQualityName() + ")";
@@ -7895,16 +7895,16 @@ public class Campaign implements Serializable, ITechManager {
                         }
                         if (!campaignOptions.useUnofficialMaintenance()) {
                             if (margin < -6) {
-                                partsToDamage.put(p.getId(), 4);
+                                partsToDamage.put(p, 4);
                             } else if (margin < -4) {
-                                partsToDamage.put(p.getId(), 3);
+                                partsToDamage.put(p, 3);
                             } else if (margin == -4) {
-                                partsToDamage.put(p.getId(), 2);
+                                partsToDamage.put(p, 2);
                             } else if (margin < -1) {
-                                partsToDamage.put(p.getId(), 1);
+                                partsToDamage.put(p, 1);
                             }
                         } else if (margin < -6) {
-                            partsToDamage.put(p.getId(), 1);
+                            partsToDamage.put(p, 1);
                         }
                         break;
                     }
@@ -7916,9 +7916,9 @@ public class Campaign implements Serializable, ITechManager {
                         }
                         if (!campaignOptions.useUnofficialMaintenance()) {
                             if (margin < -6) {
-                                partsToDamage.put(p.getId(), 2);
+                                partsToDamage.put(p, 2);
                             } else if (margin < -2) {
-                                partsToDamage.put(p.getId(), 1);
+                                partsToDamage.put(p, 1);
                             }
                         }
                         break;
@@ -7931,9 +7931,9 @@ public class Campaign implements Serializable, ITechManager {
                         }
                         if (!campaignOptions.useUnofficialMaintenance()) {
                             if (margin < -6) {
-                                partsToDamage.put(p.getId(), 2);
+                                partsToDamage.put(p, 2);
                             } else if (margin < -3) {
-                                partsToDamage.put(p.getId(), 1);
+                                partsToDamage.put(p, 1);
                             }
                         }
                         break;
@@ -7942,7 +7942,7 @@ public class Campaign implements Serializable, ITechManager {
                         if (margin < -3) {
                             p.decreaseQuality();
                             if ((margin < -4) && !campaignOptions.useUnofficialMaintenance()) {
-                                partsToDamage.put(p.getId(), 1);
+                                partsToDamage.put(p, 1);
                             }
                         } else if (margin >= 5) {
                             p.improveQuality();
@@ -7953,7 +7953,7 @@ public class Campaign implements Serializable, ITechManager {
                         if (margin < -2) {
                             p.decreaseQuality();
                             if ((margin < -5) && !campaignOptions.useUnofficialMaintenance()) {
-                                partsToDamage.put(p.getId(), 1);
+                                partsToDamage.put(p, 1);
                             }
                         } else if (margin >= 6) {
                             p.improveQuality();
@@ -7964,7 +7964,7 @@ public class Campaign implements Serializable, ITechManager {
                         if (margin < -2) {
                             p.decreaseQuality();
                             if (margin < -6 && !campaignOptions.useUnofficialMaintenance()) {
-                                partsToDamage.put(p.getId(), 1);
+                                partsToDamage.put(p, 1);
                             }
                         }
                         // TODO: award XP point if margin >= 6 (make this optional)
@@ -7980,8 +7980,8 @@ public class Campaign implements Serializable, ITechManager {
                 } else {
                     partReport += ": quality remains " + p.getQualityName();
                 }
-                if (null != partsToDamage.get(p.getId())) {
-                    if (partsToDamage.get(p.getId()) > 3) {
+                if (null != partsToDamage.get(p)) {
+                    if (partsToDamage.get(p) > 3) {
                         partReport += ", <font color='red'><b>part destroyed</b></font>";
                     } else {
                         partReport += ", <font color='red'><b>part damaged</b></font>";
@@ -7989,19 +7989,17 @@ public class Campaign implements Serializable, ITechManager {
                 }
                 maintenanceReport.append(partReport).append("<br>");
             }
+
             int nDamage = 0;
             int nDestroy = 0;
-            for (int key : partsToDamage.keySet()) {
-                Part p = getPart(key);
-                if (null != p) {
-                    int damage = partsToDamage.get(key);
-                    if (damage > 3) {
-                        nDestroy++;
-                        p.remove(false);
-                    } else {
-                        p.doMaintenanceDamage(damage);
-                        nDamage++;
-                    }
+            for (Map.Entry<Part, Integer> p : partsToDamage.entrySet()) {
+                int damage = p.getValue();
+                if (damage > 3) {
+                    nDestroy++;
+                    p.getKey().remove(false);
+                } else {
+                    p.getKey().doMaintenanceDamage(damage);
+                    nDamage++;
                 }
             }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1634,7 +1634,8 @@ public class Campaign implements Serializable, ITechManager {
             p.setId(-1);
             return;
         }
-        if ((null == p.getUnit()) && !p.hasParentPart()) {
+        if ((null == p.getUnit()) && !p.hasParentPart()
+            && !p.isReservedForRefit() && !p.isReservedForReplacement()) {
             Part spare = checkForExistingSparePart(p);
             if (null != spare) {
                 if (p instanceof Armor) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1635,7 +1635,7 @@ public class Campaign implements Serializable, ITechManager {
             return;
         }
         if ((null == p.getUnit()) && !p.hasParentPart()
-            && !p.isReservedForRefit() && !p.isReservedForReplacement()) {
+                && !p.isReservedForRefit() && !p.isReservedForReplacement()) {
             Part spare = checkForExistingSparePart(p);
             if (null != spare) {
                 if (p instanceof Armor) {
@@ -1748,7 +1748,7 @@ public class Campaign implements Serializable, ITechManager {
         // properly collecting parts
         Part mergedWith = null;
         if (!(p instanceof MissingPart) && (null == p.getUnitId())
-            && !p.isReservedForRefit() && !p.isReservedForReplacement()) {
+                && !p.isReservedForRefit() && !p.isReservedForReplacement()) {
             Part spare = checkForExistingSparePart(p);
             if (null != spare) {
                 if (p instanceof Armor) {
@@ -1775,7 +1775,7 @@ public class Campaign implements Serializable, ITechManager {
             parts.put(p.getId(), p);
             MekHQ.triggerEvent(new PartNewEvent(p));
         } else {
-            // Go through each unit and its refits to see if the new armorshould be updated
+            // Go through each unit and its refits to see if the new armor should be updated
             // CAW: I believe all other parts on a refit have a unit assigned to them.
             if (mergedWith instanceof Armor) {
                 for (Unit u : getUnits()) {
@@ -1786,7 +1786,7 @@ public class Campaign implements Serializable, ITechManager {
                             MekHQ.getLogger().info(
                                 String.format("%s (%d) was merged with %s (%d) used in a refit for %s", p.getName(),
                                     p.getId(), mergedWith.getName(), mergedWith.getId(), u.getName()));
-                            Armor mergedArmor = (Armor)mergedWith;
+                            Armor mergedArmor = (Armor) mergedWith;
                             r.setNewArmorSupplies(mergedArmor);
                         }
                     }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1746,7 +1746,8 @@ public class Campaign implements Serializable, ITechManager {
         // go ahead and check for existing parts because some version weren't
         // properly collecting parts
         Part mergedWith = null;
-        if (!(p instanceof MissingPart) && null == p.getUnitId()) {
+        if (!(p instanceof MissingPart) && (null == p.getUnitId())
+            && !p.isReservedForRefit() && !p.isReservedForReplacement()) {
             Part spare = checkForExistingSparePart(p);
             if (null != spare) {
                 if (p instanceof Armor) {
@@ -1773,40 +1774,19 @@ public class Campaign implements Serializable, ITechManager {
             parts.put(p.getId(), p);
             MekHQ.triggerEvent(new PartNewEvent(p));
         } else {
-            // Go through each unit and its refits to see if the new armor ID should be updated
+            // Go through each unit and its refits to see if the new armorshould be updated
             // CAW: I believe all other parts on a refit have a unit assigned to them.
             for (Unit u : getUnits()) {
                 Refit r = u.getRefit();
-                // If there is a refit and this part matches the new armor, update the ID
+                // If there is a refit and this part matches the new armor, update the armor entry
                 if (null != r) {
                     if (mergedWith instanceof Armor
-                        && r.getNewArmorSuppliesId() == p.getId()) {
-                        MekHQ.getLogger().info(Campaign.class, "addPartWithoutId",
+                        && r.getNewArmorSupplies() == p) {
+                        MekHQ.getLogger().info(Campaign.class,
                             String.format("%s (%d) was merged with %s (%d) used in a refit for %s", p.getName(),
                                 p.getId(), mergedWith.getName(), mergedWith.getId(), u.getName()));
                         Armor mergedArmor = (Armor)mergedWith;
                         r.setNewArmorSupplies(mergedArmor);
-                    } else {
-                        List<Integer> ids = r.getOldUnitPartIds();
-                        for (int ii = 0; ii < ids.size(); ++ii) {
-                            int oid = ids.get(ii);
-                            if (p.getId() == oid) {
-                                MekHQ.getLogger().info(Campaign.class, "addPartWithoutId",
-                                String.format("%s (%d) was merged with %s (%d) used in the old unit in a refit for %s", p.getName(),
-                                    p.getId(), mergedWith.getName(), mergedWith.getId(), u.getName()));
-                                ids.set(ii, mergedWith.getId());
-                            }
-                        }
-                        ids = r.getNewUnitPartIds();
-                        for (int ii = 0; ii < ids.size(); ++ii) {
-                            int nid = ids.get(ii);
-                            if (p.getId() == nid) {
-                                MekHQ.getLogger().info(Campaign.class, "addPartWithoutId",
-                                String.format("%s (%d) was merged with %s (%d) used in the new unit in a refit for %s", p.getName(),
-                                    p.getId(), mergedWith.getName(), mergedWith.getId(), u.getName()));
-                                ids.set(ii, mergedWith.getId());
-                            }
-                        }
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -309,11 +309,8 @@ public class MissingBattleArmorSuit extends MissingPart {
         Part bestPart = null;
 
         //check to see if we already have a replacement assigned
-        if(replacementId > -1) {
-            bestPart = campaign.getPart(replacementId);
-            if(null != bestPart) {
-                return bestPart;
-            }
+        if (hasReplacementPart()) {
+            return getReplacementPart();
         }
         // don't just return with the first part if it is damaged
         for(Part part : campaign.getSpareParts()) {

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -43,71 +43,71 @@ import mekhq.campaign.work.WorkTime;
  */
 public abstract class MissingPart extends Part implements Serializable, MekHqXmlSerializable, IPartWork, IAcquisitionWork {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = 300672661487966982L;
+    /**
+     *
+     */
+    private static final long serialVersionUID = 300672661487966982L;
 
-	public MissingPart(int tonnage, Campaign c) {
-	    super(tonnage, false, c);
-	}
+    public MissingPart(int tonnage, Campaign c) {
+        super(tonnage, false, c);
+    }
 
-	public MissingPart(int tonnage, boolean isOmniPodded, Campaign c) {
-		super(tonnage, isOmniPodded, c);
-	}
+    public MissingPart(int tonnage, boolean isOmniPodded, Campaign c) {
+        super(tonnage, isOmniPodded, c);
+    }
 
-	public MissingPart clone() {
-		//should never be called
-		return null;
-	}
+    public MissingPart clone() {
+        //should never be called
+        return null;
+    }
 
-	@Override
-	public Money getStickerPrice() {
-		//missing parts aren't worth a thing
-		return Money.zero();
-	}
+    @Override
+    public Money getStickerPrice() {
+        //missing parts aren't worth a thing
+        return Money.zero();
+    }
 
-	@Override
-	public Money getBuyCost() {
-	    return getNewPart().getStickerPrice();
-	}
+    @Override
+    public Money getBuyCost() {
+        return getNewPart().getStickerPrice();
+    }
 
-	@Override
-	public boolean isSalvaging() {
-		return false;
-	}
+    @Override
+    public boolean isSalvaging() {
+        return false;
+    }
 
-	@Override
-	public String getStatus() {
-		return "Destroyed";
-	}
+    @Override
+    public String getStatus() {
+        return "Destroyed";
+    }
 
-	@Override
-	public boolean isSamePartType(Part part) {
-		//missing parts should always return false
-		return false;
-	}
+    @Override
+    public boolean isSamePartType(Part part) {
+        //missing parts should always return false
+        return false;
+    }
 
-	public String getDesc() {
-		String bonus = getAllMods(null).getValueAsString();
-		if (getAllMods(null).getValue() > -1) {
-			bonus = "+" + bonus;
-		}
-		bonus = "(" + bonus + ")";
-		String toReturn = "<html><font size='2'";
-		String scheduled = "";
-		if (getTeamId() != null) {
-			scheduled = " (scheduled) ";
-		}
+    public String getDesc() {
+        String bonus = getAllMods(null).getValueAsString();
+        if (getAllMods(null).getValue() > -1) {
+            bonus = "+" + bonus;
+        }
+        bonus = "(" + bonus + ")";
+        String toReturn = "<html><font size='2'";
+        String scheduled = "";
+        if (getTeamId() != null) {
+            scheduled = " (scheduled) ";
+        }
 
-		//if (this instanceof ReplacementItem
-		//		&& !((ReplacementItem) this).hasPart()) {
-		//	toReturn += " color='white'";
-		//}
-		toReturn += ">";
-		toReturn += "<b>Replace " + getName() + "</b><br/>";
-		toReturn += getDetails() + "<br/>";
-		if(getSkillMin() > SkillType.EXP_ELITE) {
+        //if (this instanceof ReplacementItem
+        //		&& !((ReplacementItem) this).hasPart()) {
+        //	toReturn += " color='white'";
+        //}
+        toReturn += ">";
+        toReturn += "<b>Replace " + getName() + "</b><br/>";
+        toReturn += getDetails() + "<br/>";
+        if(getSkillMin() > SkillType.EXP_ELITE) {
             toReturn += "<font color='red'>Impossible</font>";
         } else {
             toReturn += "" + getTimeLeft() + " minutes" + scheduled;
@@ -119,134 +119,134 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
                 toReturn += "<br/><i>" + getCurrentModeName() + "</i>";
             }
         }
-		toReturn += "</font></html>";
-		return toReturn;
-	}
+        toReturn += "</font></html>";
+        return toReturn;
+    }
 
-	@Override
-	public String succeed() {
-		fix();
-		return " <font color='green'><b> replaced.</b></font>";
-	}
+    @Override
+    public String succeed() {
+        fix();
+        return " <font color='green'><b> replaced.</b></font>";
+    }
 
-	@Override
-	public void fix() {
-		Part replacement = findReplacement(false);
-		if(null != replacement) {
-			Part actualReplacement = replacement.clone();
-			unit.addPart(actualReplacement);
-			campaign.addPart(actualReplacement, 0);
-			replacement.decrementQuantity();
-			remove(false);
-			//assign the replacement part to the unit
-			actualReplacement.updateConditionFromPart();
-		}
-	}
+    @Override
+    public void fix() {
+        Part replacement = findReplacement(false);
+        if(null != replacement) {
+            Part actualReplacement = replacement.clone();
+            unit.addPart(actualReplacement);
+            campaign.addPart(actualReplacement, 0);
+            replacement.decrementQuantity();
+            remove(false);
+            //assign the replacement part to the unit
+            actualReplacement.updateConditionFromPart();
+        }
+    }
 
-	@Override
-	public void remove(boolean salvage) {
-		campaign.removePart(this);
-		if(null != unit) {
-			unit.removePart(this);
-		}
-		setUnit(null);
-		if (null != parentPart) {
-		    parentPart.removeChildPart(this);
-		}
-	}
+    @Override
+    public void remove(boolean salvage) {
+        campaign.removePart(this);
+        if(null != unit) {
+            unit.removePart(this);
+        }
+        setUnit(null);
+        if (null != parentPart) {
+            parentPart.removeChildPart(this);
+        }
+    }
 
-	public abstract boolean isAcceptableReplacement(Part part, boolean refit);
+    public abstract boolean isAcceptableReplacement(Part part, boolean refit);
 
-	public Part findReplacement(boolean refit) {
-		Part bestPart = null;
+    public Part findReplacement(boolean refit) {
+        Part bestPart = null;
 
-		//check to see if we already have a replacement assigned
-		if (hasReplacementPart()) {
-			return getReplacementPart();
+        //check to see if we already have a replacement assigned
+        if (hasReplacementPart()) {
+            return getReplacementPart();
         }
 
-		// don't just return with the first part if it is damaged
-		for(Part part : campaign.getSpareParts()) {
-			if (part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart() || part.isUsedForRefitPlanning()) {
-				continue;
-			}
+        // don't just return with the first part if it is damaged
+        for(Part part : campaign.getSpareParts()) {
+            if (part.isReservedForRefit() || part.isBeingWorkedOn() || part.isReservedForReplacement() || !part.isPresent() || part.hasParentPart() || part.isUsedForRefitPlanning()) {
+                continue;
+            }
 
-			if(isAcceptableReplacement(part, refit)) {
-				if(null == bestPart) {
-					bestPart = part;
-				} else if(bestPart.needsFixing() && !part.needsFixing()) {
-					bestPart = part;
-				} else if (bestPart.getQuality() < part.getQuality()) {
-				    bestPart = part;
+            if(isAcceptableReplacement(part, refit)) {
+                if(null == bestPart) {
+                    bestPart = part;
+                } else if(bestPart.needsFixing() && !part.needsFixing()) {
+                    bestPart = part;
+                } else if (bestPart.getQuality() < part.getQuality()) {
+                    bestPart = part;
                 }
-			}
-		}
-		return bestPart;
-	}
+            }
+        }
+        return bestPart;
+    }
 
-	public boolean isReplacementAvailable() {
-		return null != findReplacement(false);
-	}
+    public boolean isReplacementAvailable() {
+        return null != findReplacement(false);
+    }
 
-	@Override
+    @Override
     public String getDetails() {
         return getDetails(true);
     }
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
-		if(isReplacementAvailable()) {
-			return "Replacement part available";
-		} else {
-			PartInventory inventories = campaign.getPartInventory(getNewPart());
-			return "<font color='red'>No replacement (" + inventories.getTransitOrderedDetails() + ")</font>";
-		}
+        if(isReplacementAvailable()) {
+            return "Replacement part available";
+        } else {
+            PartInventory inventories = campaign.getPartInventory(getNewPart());
+            return "<font color='red'>No replacement (" + inventories.getTransitOrderedDetails() + ")</font>";
+        }
     }
 
-	@Override
-	public boolean needsFixing() {
-		//missing parts always need fixing
-		if(null != unit) {
-			return (!unit.isSalvage() || null != getTeamId()) && unit.isRepairable();
-		}
-		return false;
-	}
+    @Override
+    public boolean needsFixing() {
+        //missing parts always need fixing
+        if(null != unit) {
+            return (!unit.isSalvage() || null != getTeamId()) && unit.isRepairable();
+        }
+        return false;
+    }
 
-	@Override
-	public MissingPart getMissingPart() {
-		//do nothing - this should never be accessed
-		return null;
-	}
+    @Override
+    public MissingPart getMissingPart() {
+        //do nothing - this should never be accessed
+        return null;
+    }
 
-	@Override
-	public void updateConditionFromEntity(boolean checkForDestruction) {
-		//do nothing
-	}
+    @Override
+    public void updateConditionFromEntity(boolean checkForDestruction) {
+        //do nothing
+    }
 
-	@Override
-	public String fail(int rating) {
-		skillMin = ++rating;
-		timeSpent = 0;
-		shorthandedMod = 0;
-		if(skillMin > SkillType.EXP_ELITE) {
-			Part part = findReplacement(false);
-			if(null != part) {
-				part.decrementQuantity();
-				skillMin = SkillType.EXP_GREEN;
-			}
-			return " <font color='red'><b> failed and part destroyed.</b></font>";
-		} else {
-			return " <font color='red'><b> failed.</b></font>";
-		}
-	}
+    @Override
+    public String fail(int rating) {
+        skillMin = ++rating;
+        timeSpent = 0;
+        shorthandedMod = 0;
+        if(skillMin > SkillType.EXP_ELITE) {
+            Part part = findReplacement(false);
+            if(null != part) {
+                part.decrementQuantity();
+                skillMin = SkillType.EXP_GREEN;
+            }
+            return " <font color='red'><b> failed and part destroyed.</b></font>";
+        } else {
+            return " <font color='red'><b> failed.</b></font>";
+        }
+    }
 
-	@Override
-	public boolean canChangeWorkMode() {
-	    return !isOmniPodded();
-	}
+    @Override
+    public boolean canChangeWorkMode() {
+        return !isOmniPodded();
+    }
 
-	@Override
-	public TargetRoll getAllAcquisitionMods() {
+    @Override
+    public TargetRoll getAllAcquisitionMods() {
         TargetRoll target = new TargetRoll();
         if(getTechBase() == T_CLAN && campaign.getCampaignOptions().getClanAcquisitionPenalty() > 0) {
             target.addModifier(campaign.getCampaignOptions().getClanAcquisitionPenalty(), "clan-tech");
@@ -268,169 +268,169 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
         return target;
     }
 
-	@Override
-	public String getAcquisitionDesc() {
-		String toReturn = "<html><font size='2'";
+    @Override
+    public String getAcquisitionDesc() {
+        String toReturn = "<html><font size='2'";
 
-		toReturn += ">";
-		toReturn += "<b>" + getAcquisitionDisplayName() + "</b> " + getAcquisitionBonus() + "<br/>";
-		PartInventory inventories = campaign.getPartInventory(getNewPart());
-		toReturn += inventories.getTransitOrderedDetails();
-		if (!isOmniPodded()) {
-		    Part newPart = getAcquisitionPart();
-		    newPart.setOmniPodded(true);
-		    inventories = campaign.getPartInventory(newPart);
-		    if (inventories.getSupply() > 0) {
-		        toReturn += ", " + inventories.supplyAsString() + " OmniPod";
-		    }
-		}
-		toReturn += "<br/>";
-		toReturn += getBuyCost().toAmountAndSymbolString() + "<br/>";
-		toReturn += "</font></html>";
-		return toReturn;
-	}
+        toReturn += ">";
+        toReturn += "<b>" + getAcquisitionDisplayName() + "</b> " + getAcquisitionBonus() + "<br/>";
+        PartInventory inventories = campaign.getPartInventory(getNewPart());
+        toReturn += inventories.getTransitOrderedDetails();
+        if (!isOmniPodded()) {
+            Part newPart = getAcquisitionPart();
+            newPart.setOmniPodded(true);
+            inventories = campaign.getPartInventory(newPart);
+            if (inventories.getSupply() > 0) {
+                toReturn += ", " + inventories.supplyAsString() + " OmniPod";
+            }
+        }
+        toReturn += "<br/>";
+        toReturn += getBuyCost().toAmountAndSymbolString() + "<br/>";
+        toReturn += "</font></html>";
+        return toReturn;
+    }
 
     @Override
     public String getAcquisitionDisplayName() {
-    	return getAcquisitionName();
+        return getAcquisitionName();
     }
 
-	@Override
-	public String getAcquisitionExtraDesc() {
-		return "";
-	}
+    @Override
+    public String getAcquisitionExtraDesc() {
+        return "";
+    }
 
-	@Override
+    @Override
     public String getAcquisitionBonus() {
-		String bonus = getAllAcquisitionMods().getValueAsString();
-		if(getAllAcquisitionMods().getValue() > -1) {
-			bonus = "+" + bonus;
-		}
+        String bonus = getAllAcquisitionMods().getValueAsString();
+        if(getAllAcquisitionMods().getValue() > -1) {
+            bonus = "+" + bonus;
+        }
 
-		return "(" + bonus + ")";
+        return "(" + bonus + ")";
     }
 
-	@Override
-	public Part getAcquisitionPart() {
-		return getNewPart();
-	}
+    @Override
+    public Part getAcquisitionPart() {
+        return getNewPart();
+    }
 
-	@Override
-	public String find(int transitDays) {
-		Part newPart = getNewPart();
-		newPart.setBrandNew(true);
-		newPart.setDaysToArrival(transitDays);
-		if(campaign.buyPart(newPart, transitDays)) {
-		    return "<font color='green'><b> part found</b>.</font> It will be delivered in " + transitDays + " days.";
-		} else {
-		    return "<font color='red'><b> You cannot afford this part. Transaction cancelled</b>.</font>";
-		}
-	}
+    @Override
+    public String find(int transitDays) {
+        Part newPart = getNewPart();
+        newPart.setBrandNew(true);
+        newPart.setDaysToArrival(transitDays);
+        if(campaign.buyPart(newPart, transitDays)) {
+            return "<font color='green'><b> part found</b>.</font> It will be delivered in " + transitDays + " days.";
+        } else {
+            return "<font color='red'><b> You cannot afford this part. Transaction cancelled</b>.</font>";
+        }
+    }
 
-	@Override
-	public Object getNewEquipment() {
-	    return getNewPart();
-	}
+    @Override
+    public Object getNewEquipment() {
+        return getNewPart();
+    }
 
-	public abstract Part getNewPart();
+    public abstract Part getNewPart();
 
-	@Override
-	public String failToFind() {
-		return "<font color='red'><b> part not found</b>.</font>";
-	}
+    @Override
+    public String failToFind() {
+        return "<font color='red'><b> part not found</b>.</font>";
+    }
 
-	@Override
-	public void writeToXmlBegin(PrintWriter pw1, int indent) {
-		super.writeToXmlBegin(pw1, indent);
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<daysToWait>"
-				+daysToWait
+    @Override
+    public void writeToXmlBegin(PrintWriter pw1, int indent) {
+        super.writeToXmlBegin(pw1, indent);
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<daysToWait>"
+                +daysToWait
                 +"</daysToWait>");
         if (hasReplacementPart()) {
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "replacementId", getReplacementPart().getId());
         }
-	}
+    }
 
-	@Override
-	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);
-		writeToXmlEnd(pw1, indent);
-	}
+    @Override
+    public void writeToXml(PrintWriter pw1, int indent) {
+        writeToXmlBegin(pw1, indent);
+        writeToXmlEnd(pw1, indent);
+    }
 
-	@Override
-	public String checkScrappable() {
-		if(!isReplacementAvailable()) {
-			return "Nothing to scrap";
-		}
-		return null;
-	}
+    @Override
+    public String checkScrappable() {
+        if(!isReplacementAvailable()) {
+            return "Nothing to scrap";
+        }
+        return null;
+    }
 
-	@Override
-	public String scrap() {
+    @Override
+    public String scrap() {
         Part replace = findReplacement(false);
-		if(null != replace) {
-			replace.decrementQuantity();
+        if(null != replace) {
+            replace.decrementQuantity();
             return replace.getName() + " scrapped.";
         }
 
-		skillMin = SkillType.EXP_GREEN;
+        skillMin = SkillType.EXP_GREEN;
 
         return getName() + " scrapped.";
-	}
+    }
 
-	@Override
-	public String getAcquisitionName() {
-	    String details = getNewPart().getDetails();
-	    details = details.replaceFirst("\\d+\\shit\\(s\\)", "");
-		return getPartName() + " " + details;
-	}
+    @Override
+    public String getAcquisitionName() {
+        String details = getNewPart().getDetails();
+        details = details.replaceFirst("\\d+\\shit\\(s\\)", "");
+        return getPartName() + " " + details;
+    }
 
-	@Override
-	public int getTechLevel() {
-		return getNewPart().getTechLevel();
-	}
+    @Override
+    public int getTechLevel() {
+        return getNewPart().getTechLevel();
+    }
 
-	@Override
-	public void reservePart() {
-		//this is being set as an overnight repair, so
-		//we also need to reserve the replacement. If the
-		//quantity of the replacement is more than one, we will
-		//also need to split off a separate one
-		//shouldn't be null, but it never hurts to check
-		Part replacement = findReplacement(false);
-		UUID teamId = getTeamId();
-		if ((null != replacement) &&(null != teamId)) {
-			if (replacement.getQuantity() > 1) {
-				Part actualReplacement = replacement.clone();
-				actualReplacement.setReserveId(teamId);
+    @Override
+    public void reservePart() {
+        //this is being set as an overnight repair, so
+        //we also need to reserve the replacement. If the
+        //quantity of the replacement is more than one, we will
+        //also need to split off a separate one
+        //shouldn't be null, but it never hurts to check
+        Part replacement = findReplacement(false);
+        UUID teamId = getTeamId();
+        if ((null != replacement) &&(null != teamId)) {
+            if (replacement.getQuantity() > 1) {
+                Part actualReplacement = replacement.clone();
+                actualReplacement.setReserveId(teamId);
                 campaign.addPart(actualReplacement, 0);
                 setReplacementPart(actualReplacement);
-				replacement.decrementQuantity();
-			} else {
+                replacement.decrementQuantity();
+            } else {
                 replacement.setReserveId(teamId);
                 setReplacementPart(replacement);
-			}
-		}
-	}
+            }
+        }
+    }
 
-	@Override
-	public void cancelReservation() {
-		Part replacement = findReplacement(false);
-		if (hasReplacementPart() && (null != replacement)) {
-			setReplacementPart(null);
-			replacement.setReserveId(null);
-			if (replacement.isSpare()) {
-				Part spare = campaign.checkForExistingSparePart(replacement);
-				if (null != spare) {
-					spare.incrementQuantity();
-					campaign.removePart(replacement);
-				}
-			}
-		}
-	}
+    @Override
+    public void cancelReservation() {
+        Part replacement = findReplacement(false);
+        if (hasReplacementPart() && (null != replacement)) {
+            setReplacementPart(null);
+            replacement.setReserveId(null);
+            if (replacement.isSpare()) {
+                Part spare = campaign.checkForExistingSparePart(replacement);
+                if (null != spare) {
+                    spare.incrementQuantity();
+                    campaign.removePart(replacement);
+                }
+            }
+        }
+    }
 
-	@Override
-	public boolean needsMaintenance() {
+    @Override
+    public boolean needsMaintenance() {
         return false;
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -347,10 +347,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 				+daysToWait
                 +"</daysToWait>");
         if (hasReplacementPart()) {
-            pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                    +"<replacementId>"
-                    + getReplacementPart().getId()
-                    +"</replacementId>");
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "replacementId", getReplacementPart().getId());
         }
 	}
 
@@ -419,7 +416,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
 	@Override
 	public void cancelReservation() {
 		Part replacement = findReplacement(false);
-		if (hasReplacementPart() && null != replacement) {
+		if (hasReplacementPart() && (null != replacement)) {
 			setReplacementPart(null);
 			replacement.setReserveId(null);
 			if (replacement.isSpare()) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1827,7 +1827,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             int id = replacementPart.getId();
             replacementPart = knownParts.get(id);
             if ((replacementPart == null) && (id > 0)) {
-                MekHQ.getLogger().error(PartRef.class,
+                MekHQ.getLogger().error(
                     String.format("Part %d ('%s') references missing replacement part %d",
                         getId(), getName(), id));
             }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -503,13 +503,14 @@ public class Refit extends Part implements IAcquisitionWork {
                 Part replacement = ((MissingPart)nPart).findReplacement(true);
                 //check quantity
                 //TODO: the one weakness here is that we will not pick up damaged parts
-                if (null != replacement && null == partQuantity.get(replacement)) {
+                if ((null != replacement) && (null == partQuantity.get(replacement))) {
                     partQuantity.put(replacement, replacement.getQuantity());
                 }
-                if (null != replacement && partQuantity.get(replacement) > 0) {
+
+                if ((null != replacement) && (partQuantity.get(replacement) > 0)) {
                     newUnitParts.add(replacement);
                     //adjust quantity
-                    partQuantity.put(replacement, partQuantity.get(replacement)-1);
+                    partQuantity.put(replacement, partQuantity.get(replacement) - 1);
                     //If the quantity is now 0 set usedForRefitPlanning flag so findReplacement ignores this item
                     if (partQuantity.get(replacement) == 0) {
                         replacement.setUsedForRefitPlanning(true);
@@ -549,10 +550,11 @@ public class Refit extends Part implements IAcquisitionWork {
                     Part replacement = mab.findReplacement(true);
                     //check quantity
                     //TODO: the one weakness here is that we will not pick up damaged parts
-                    if (null != replacement && null == partQuantity.get(replacement)) {
+                    if ((null != replacement) && (null == partQuantity.get(replacement))) {
                         partQuantity.put(replacement, replacement.getQuantity());
                     }
-                    if (null != replacement && partQuantity.get(replacement) > 0) {
+
+                    if ((null != replacement) && (partQuantity.get(replacement) > 0)) {
                         newUnitParts.add(replacement);
                         //adjust quantity
                         partQuantity.put(replacement, partQuantity.get(replacement)-1);
@@ -1225,7 +1227,7 @@ public class Refit extends Part implements IAcquisitionWork {
         }
 
         return shoppingList.size() == 0
-            && (null == newArmorSupplies || (armorNeeded - newArmorSupplies.getAmount()) <= 0);
+            && ((null == newArmorSupplies) || (armorNeeded - newArmorSupplies.getAmount()) <= 0);
     }
 
     public void checkForArmorSupplies() {
@@ -1280,8 +1282,8 @@ public class Refit extends Part implements IAcquisitionWork {
         for (Part part : newUnitParts) {
             if (part instanceof AmmoStorage) {
                 // merge back into the campaign
-                AmmoStorage ammoStorage = (AmmoStorage)part;
-                AmmoBin.changeAmountAvailable(campaign, ammoStorage.getShots(), (AmmoType)ammoStorage.getType());
+                AmmoStorage ammoStorage = (AmmoStorage) part;
+                AmmoBin.changeAmountAvailable(campaign, ammoStorage.getShots(), (AmmoType) ammoStorage.getType());
                 oldUnit.getCampaign().removePart(part);
             }
         }
@@ -1460,8 +1462,8 @@ public class Refit extends Part implements IAcquisitionWork {
                 }
             } else if (part instanceof AmmoStorage) {
                 // merge back into the campaign before completing the refit
-                AmmoStorage ammoStorage = (AmmoStorage)part;
-                AmmoBin.changeAmountAvailable(campaign, ammoStorage.getShots(), (AmmoType)ammoStorage.getType());
+                AmmoStorage ammoStorage = (AmmoStorage) part;
+                AmmoBin.changeAmountAvailable(campaign, ammoStorage.getShots(), (AmmoType) ammoStorage.getType());
                 oldUnit.getCampaign().removePart(part);
                 continue;
             }
@@ -2587,9 +2589,9 @@ public class Refit extends Part implements IAcquisitionWork {
         if (newArmorSupplies instanceof RefitArmorRef) {
             Part realPart = knownParts.get(newArmorSupplies.getId());
             if (realPart instanceof Armor) {
-                newArmorSupplies = (Armor)realPart;
+                newArmorSupplies = (Armor) realPart;
             } else {
-                MekHQ.getLogger().error(RefitArmorRef.class,
+                MekHQ.getLogger().error(
                     String.format("Refit %s (Unit: %s) references missing armor supplies %d",
                         getRefitId(), getUnitId(), newArmorSupplies.getId()));
                 newArmorSupplies = null;
@@ -2603,7 +2605,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (realPart != null) {
                     oldUnitParts.set(ii, realPart);
                 } else if (part.getId() > 0) {
-                    MekHQ.getLogger().error(RefitPartRef.class,
+                    MekHQ.getLogger().error(
                         String.format("Refit %s (Unit: %s) references missing old unit part %d",
                             getRefitId(), getUnitId(), part.getId()));
                     oldUnitParts.remove(ii);
@@ -2618,7 +2620,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (realPart != null) {
                     newUnitParts.set(ii, realPart);
                 } else if (part.getId() > 0) {
-                    MekHQ.getLogger().error(RefitPartRef.class,
+                    MekHQ.getLogger().error(
                         String.format("Refit %s (Unit: %s) references missing new unit part %d",
                             getRefitId(), getUnitId(), part.getId()));
                     newUnitParts.remove(ii);
@@ -2636,7 +2638,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (realPart != null) {
                     realParts.add(realPart);
                 } else {
-                    MekHQ.getLogger().error(RefitPartRef.class,
+                    MekHQ.getLogger().error(
                         String.format("Refit %s (Unit: %s) references missing large craft ammo bin %d",
                             getRefitId(), getUnitId(), part.getId()));
                 }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1057,11 +1057,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 int tons = (int) Math.ceil((double) shotsToBuy / atype.getShots());
                 AmmoStorage ammo = new AmmoStorage(0, atype, atype.getShots() * tons, campaign);
 
-                // CAW: custom refits manage their shopping list differently...(but they shouldn't)
-                if (!customJob) {
-                    newUnitParts.add(ammo);
-                }
-
+                newUnitParts.add(ammo);
                 shoppingList.add(ammo);
 
                 // Reduce the amount we need by the amount we bought
@@ -1192,6 +1188,10 @@ public class Refit extends Part implements IAcquisitionWork {
 
         ArrayList<Part> newShoppingList = new ArrayList<>();
         for (Part part : shoppingList) {
+            if (part instanceof AmmoStorage) {
+                continue;
+            }
+
             if (part instanceof IAcquisitionWork) {
                 //check to see if we found a replacement
                 Part replacement = part;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -582,7 +582,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 }
             }
         }
-        converted = (int)Math.round((double)converted/curType.getRackSize());
+        converted = (int) Math.round((double) converted / curType.getRackSize());
         changeAmountAvailable(campaign, converted, curType);
     }
 
@@ -692,7 +692,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     public int getAmountAvailable() {
-        return getAmountAvailable(campaign, (AmmoType)getType());
+        return getAmountAvailable(campaign, (AmmoType) getType());
     }
 
     public static int getAmountAvailable(Campaign campaign, AmmoType ammoType) {
@@ -719,9 +719,9 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                            .mapToInt(part -> {
                                AmmoStorage a = (AmmoStorage)part;
                                AmmoType aType = (AmmoType)a.getType();
-                               if (aType.equals(ammoType) && ammoType.getMunitionType() == aType.getMunitionType()) {
+                               if (aType.equals(ammoType) && (ammoType.getMunitionType() == aType.getMunitionType())) {
                                    return a.getShots();
-                               } else if (isCompatibleAmmo(campaign, aType, ammoType) && ammoType.getRackSize() != 0) {
+                               } else if (isCompatibleAmmo(campaign, aType, ammoType) && (ammoType.getRackSize() != 0)) {
                                    return (a.getShots() * aType.getRackSize()) / ammoType.getRackSize();
                                }
                                return 0;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -547,7 +547,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         return null;
     }
 
-    public void swapAmmoFromCompatible(int needed, AmmoStorage as) {
+    public static void swapAmmoFromCompatible(Campaign campaign, int needed, AmmoStorage as) {
         AmmoStorage a;
         AmmoType aType;
         AmmoType curType = (AmmoType)as.getType();
@@ -562,7 +562,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 if (a.isSamePartType(as)) {
                     continue;
                 }
-                if (!isCompatibleAmmo(aType, curType)) {
+                if (!isCompatibleAmmo(campaign, aType, curType)) {
                     continue;
                 }
                 if (a.getShots() == 0) {
@@ -570,10 +570,10 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 }
                 // Finally, do the conversion. Run until the other ammo type runs out or we have enough
                 converted = aType.getRackSize();
-                a.changeAmountAvailable(-1, aType);
+                changeAmountAvailable(campaign, -1, aType);
                 while (converted < needed && a.getShots() > 0) {
                     converted += aType.getRackSize();
-                    a.changeAmountAvailable(-1, aType);
+                    changeAmountAvailable(campaign, -1, aType);
                 }
                 needed -= converted;
                 // If we have enough, we're done.
@@ -582,11 +582,15 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 }
             }
         }
-        converted = Math.round((float)converted/curType.getRackSize());
-        as.changeAmountAvailable(converted, curType);
+        converted = (int)Math.round((double)converted/curType.getRackSize());
+        changeAmountAvailable(campaign, converted, curType);
     }
 
     public void changeAmountAvailable(int amount, final AmmoType curType) {
+        changeAmountAvailable(campaign, amount, curType);
+    }
+
+    public static void changeAmountAvailable(Campaign campaign, int amount, final AmmoType curType) {
         AmmoStorage a = (AmmoStorage)campaign.findSparePart(part -> {
             if (!(part instanceof AmmoStorage) || !part.isPresent()) {
                 return false;
@@ -600,7 +604,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             AmmoType aType = (AmmoType)a.getType();
             if (amount < 0 && campaign.getCampaignOptions().useAmmoByType()
                 && a.getShots() < Math.abs(amount)) {
-                swapAmmoFromCompatible(Math.abs(amount) * aType.getRackSize(), a);
+                swapAmmoFromCompatible(campaign, Math.abs(amount) * aType.getRackSize(), a);
             }
             a.changeShots(amount);
             if (a.getShots() <= 0) {
@@ -612,7 +616,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 && campaign.getCampaignOptions().useAmmoByType()
                 && AmmoBin.ALLOWED_BY_TYPE.contains(curType.getAmmoType())) {
             campaign.addPart(new AmmoStorage(1, curType ,0, campaign), 0);
-            changeAmountAvailable(amount, curType);
+            changeAmountAvailable(campaign, amount, curType);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -592,7 +592,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     public static void changeAmountAvailable(Campaign campaign, int amount, final AmmoType curType) {
         AmmoStorage a = (AmmoStorage)campaign.findSparePart(part -> {
-            if (!(part instanceof AmmoStorage) || !part.isPresent()) {
+            if (!(part instanceof AmmoStorage) || !part.isPresent() || part.isReservedForRefit()) {
                 return false;
             }
             AmmoType ammoType = (AmmoType)((AmmoStorage)part).getType();


### PR DESCRIPTION
This PR is nasty and is not going to be fun to review...but at this point I am happy with just about all of the part ID issues I have been made aware of in the past. Basically: we're not going to reference parts by ID anywhere other than the CPNX file. Everywhere else should be using an actual reference to a Part object. That's about as close to avoiding part ID issues as you can get.

This is a draft because I'm not 100% on the refit code, but close.