### PR TITLE
Campaign Preset Update

### DIFF
--- a/MekHQ/mmconf/mhqPresets/AgainstTheBot.xml
+++ b/MekHQ/mmconf/mhqPresets/AgainstTheBot.xml
@@ -313,7 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
-	<useAtBUnitMarket>true</useAtBUnitMarket>
+		<useAtBUnitMarket>true</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>

--- a/MekHQ/mmconf/mhqPresets/AgainstTheBot.xml
+++ b/MekHQ/mmconf/mhqPresets/AgainstTheBot.xml
@@ -3,11 +3,12 @@
 	<title>Official AtB Options</title>
 	<description>(Release 2) These are the default settings for the Against the Bot campaign system. As always change them to what you like for your style of play.</description>
 	<campaignOptions>
+		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
 		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
-		<unitRatingMethod>FM: Mercenaries (rev)</unitRatingMethod>
+		<unitRatingMethod>FLD_MAN_MERCS_REV</unitRatingMethod>
 		<useEraMods>false</useEraMods>
 		<assignedTechFirst>false</assignedTechFirst>
 		<resetToFirstTech>false</resetToFirstTech>
@@ -96,6 +97,7 @@
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChange>false</logMarriageNameChange>
+		<useManualMarriages>true</useManualMarriages>
 		<useRandomMarriages>false</useRandomMarriages>
 		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
 		<marriageAgeRange>10</marriageAgeRange>
@@ -114,6 +116,11 @@
 		<displayFamilyLevel>0</displayFamilyLevel>
 		<useRandomDeaths>true</useRandomDeaths>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
+		<prisonerCaptureStyle>ATB</prisonerCaptureStyle>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<prisonerBabyStatus>true</prisonerBabyStatus>
+		<useAtBPrisonerDefection>true</useAtBPrisonerDefection>
+		<useAtBPrisonerRansom>true</useAtBPrisonerRansom>
 		<payForParts>true</payForParts>
 		<payForRepairs>false</payForRepairs>
 		<payForUnits>true</payForUnits>
@@ -146,9 +153,8 @@
 		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
 		<useTimeInRank>false</useTimeInRank>
 		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<useRetirementDateTracking>false</useRetirementDateTracking>
 		<trackTotalEarnings>false</trackTotalEarnings>
-		<capturePrisoners>true</capturePrisoners>
-		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
 		<personnelMarketName>Against the Bot</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
@@ -160,13 +166,9 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<probPhenoMW>95</probPhenoMW>
-		<probPhenoAero>95</probPhenoAero>
-		<probPhenoBA>100</probPhenoBA>
-		<probPhenoVee>0</probPhenoVee>
+		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<tougherHealing>true</tougherHealing>
 		<useAtB>true</useAtB>
-        <useAtBUnitMarket>true</useAtBUnitMarket>
 		<useAero>true</useAero>
 		<useVehicles>true</useVehicles>
 		<clanVehicles>true</clanVehicles>
@@ -191,8 +193,10 @@
 		<mercSizeLimited>true</mercSizeLimited>
 		<trackOriginalUnit>true</trackOriginalUnit>
 		<regionalMechVariations>true</regionalMechVariations>
+		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
+		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
 		<searchRadius>800</searchRadius>
-		<intensity>1.0</intensity>
+		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
 		<variableContractLength>true</variableContractLength>
 		<instantUnitMarketDelivery>true</instantUnitMarketDelivery>
@@ -207,16 +211,13 @@
 		<restrictPartsByMission>true</restrictPartsByMission>
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
-		<useAtBCapture>true</useAtBCapture>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
-		<startGameDelay>500</startGameDelay>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>
 		<opforLocalUnitChance>5</opforLocalUnitChance>
-		<historicalDailyLog>false</historicalDailyLog>
 		<massRepairUseExtraTime>true</massRepairUseExtraTime>
 		<massRepairUseRushJob>true</massRepairUseRushJob>
 		<massRepairAllowCarryover>true</massRepairAllowCarryover>
@@ -225,86 +226,86 @@
 		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
 		<massRepairReplacePod>true</massRepairReplacePod>
 		<massRepairOptions>
-			<massRepairOption0>
+			<massRepairOption>
 				<type>0</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption0>
-			<massRepairOption1>
+			</massRepairOption>
+			<massRepairOption>
 				<type>1</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption1>
-			<massRepairOption2>
+			</massRepairOption>
+			<massRepairOption>
 				<type>2</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption2>
-			<massRepairOption3>
+			</massRepairOption>
+			<massRepairOption>
 				<type>3</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption3>
-			<massRepairOption4>
+			</massRepairOption>
+			<massRepairOption>
 				<type>4</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption4>
-			<massRepairOption5>
+			</massRepairOption>
+			<massRepairOption>
 				<type>5</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption5>
-			<massRepairOption6>
+			</massRepairOption>
+			<massRepairOption>
 				<type>6</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption6>
-			<massRepairOption7>
+			</massRepairOption>
+			<massRepairOption>
 				<type>7</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption7>
-			<massRepairOption8>
-				<type>12</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption8>
-			<massRepairOption9>
+			</massRepairOption>
+			<massRepairOption>
 				<type>8</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption9>
+			</massRepairOption>
+			<massRepairOption>
+				<type>9</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</massRepairOption>
 		</massRepairOptions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
@@ -312,6 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+	<useAtBUnitMarket>true</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>
@@ -670,12 +672,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -691,12 +693,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -712,8 +714,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
 				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -736,24 +738,6 @@ Note: Only one Tactical Genius may be utilized per team.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
-			<lookupName>tech_armor_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with armor</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
 			<lookupName>tm_forest_ranger</lookupName>
 			<desc>Movement in woods or jungle costs 1 less MP.
@@ -767,8 +751,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -786,6 +770,24 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -814,12 +816,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -836,8 +838,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -851,12 +853,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -871,12 +873,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit</skill>
 				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Battlesuit</skill>
 				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Vehicle</skill>
+				<skill>Gunnery/Spacecraft</skill>
 				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Vehicle</skill>
 				<skill>Gunnery/Protomech</skill>
 			</skillPrereq>
 		</ability>
@@ -892,8 +894,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -938,12 +940,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -975,12 +977,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -996,8 +998,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1027,8 +1029,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -1084,11 +1086,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1126,20 +1128,6 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<choiceValues></choiceValues>
 		</ability>
 		<ability>
-			<displayName>Zweihander (CamOps)</displayName>
-			<lookupName>zweihander</lookupName>
-			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-			<xpCost>20</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>melee_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Melee Master (aToW)</displayName>
 			<lookupName>melee_master</lookupName>
 			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
@@ -1154,6 +1142,20 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			</skillPrereq>
 		</ability>
 		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>20</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
 			<displayName>Cluster Master (AToW)</displayName>
 			<lookupName>cluster_master</lookupName>
 			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
@@ -1164,12 +1166,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -1187,8 +1189,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1218,12 +1220,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1314,8 +1316,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
 				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
 				<skill>Tech/Mechanic::Veteran</skill>
 				<skill>Tech/Mech::Veteran</skill>
 			</skillPrereq>
@@ -1333,47 +1335,22 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
+			<displayName>Hopping Jack (Unofficial)</displayName>
+			<lookupName>hopping_jack</lookupName>
+			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
+			<invalidAbilities>jumping_jack</invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1397,17 +1374,42 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Hopping Jack (Unofficial)</displayName>
-			<lookupName>hopping_jack</lookupName>
-			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>jumping_jack</invalidAbilities>
+			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1422,26 +1424,26 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
-	<randomSkillPreferences>
-		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
-		<specialAbilBonus>-10,-10,-2,0,1</specialAbilBonus>
-		<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
-		<randomizeSkill>false</randomizeSkill>
-		<useClanBonuses>true</useClanBonuses>
-		<antiMekProb>10</antiMekProb>
-		<combatSmallArmsBonus>-3</combatSmallArmsBonus>
-		<supportSmallArmsBonus>-3</supportSmallArmsBonus>
-		<artilleryProb>10</artilleryProb>
-		<artilleryBonus>-2</artilleryBonus>
-		<secondSkillProb>10</secondSkillProb>
-		<secondSkillBonus>-4</secondSkillBonus>
-	</randomSkillPreferences>
+<randomSkillPreferences>
+	<overallRecruitBonus>0</overallRecruitBonus>
+	<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+	<specialAbilBonus>-10,-10,-2,0,1</specialAbilBonus>
+	<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
+	<randomizeSkill>false</randomizeSkill>
+	<useClanBonuses>true</useClanBonuses>
+	<antiMekProb>10</antiMekProb>
+	<combatSmallArmsBonus>-3</combatSmallArmsBonus>
+	<supportSmallArmsBonus>-3</supportSmallArmsBonus>
+	<artilleryProb>10</artilleryProb>
+	<artilleryBonus>-2</artilleryBonus>
+	<secondSkillProb>10</secondSkillProb>
+	<secondSkillBonus>-4</secondSkillBonus>
+</randomSkillPreferences>
 </gamePreset>

--- a/MekHQ/mmconf/mhqPresets/CamOps.xml
+++ b/MekHQ/mmconf/mhqPresets/CamOps.xml
@@ -313,7 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
-	<useAtBUnitMarket>false</useAtBUnitMarket>
+		<useAtBUnitMarket>false</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>

--- a/MekHQ/mmconf/mhqPresets/CamOps.xml
+++ b/MekHQ/mmconf/mhqPresets/CamOps.xml
@@ -3,11 +3,12 @@
 	<title>Campaign Operations</title>
 	<description>Options to run a unit using the Campaign Operations rules. This preset uses the basic rules and rating system. Optional rules are off by default as well as SPAs, Implants, and Quirks. For games using the older Field Manual Mercenaries system use the Total Warfare (TW) preset instead.</description>
 	<campaignOptions>
+		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
 		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
-		<unitRatingMethod>Campaign Ops</unitRatingMethod>
+		<unitRatingMethod>CAMPAIGN_OPS</unitRatingMethod>
 		<useEraMods>false</useEraMods>
 		<assignedTechFirst>false</assignedTechFirst>
 		<resetToFirstTech>false</resetToFirstTech>
@@ -96,6 +97,7 @@
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChange>false</logMarriageNameChange>
+		<useManualMarriages>true</useManualMarriages>
 		<useRandomMarriages>false</useRandomMarriages>
 		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
 		<marriageAgeRange>10</marriageAgeRange>
@@ -114,6 +116,11 @@
 		<displayFamilyLevel>0</displayFamilyLevel>
 		<useRandomDeaths>true</useRandomDeaths>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
+		<prisonerCaptureStyle>TAHARQA</prisonerCaptureStyle>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<prisonerBabyStatus>true</prisonerBabyStatus>
+		<useAtBPrisonerDefection>false</useAtBPrisonerDefection>
+		<useAtBPrisonerRansom>false</useAtBPrisonerRansom>
 		<payForParts>true</payForParts>
 		<payForRepairs>false</payForRepairs>
 		<payForUnits>true</payForUnits>
@@ -146,9 +153,8 @@
 		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
 		<useTimeInRank>false</useTimeInRank>
 		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<useRetirementDateTracking>false</useRetirementDateTracking>
 		<trackTotalEarnings>false</trackTotalEarnings>
-		<capturePrisoners>true</capturePrisoners>
-		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
 		<personnelMarketName>Strat Ops</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
@@ -160,10 +166,7 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<probPhenoMW>95</probPhenoMW>
-		<probPhenoAero>95</probPhenoAero>
-		<probPhenoBA>100</probPhenoBA>
-		<probPhenoVee>0</probPhenoVee>
+		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<tougherHealing>false</tougherHealing>
 		<useAtB>false</useAtB>
 		<useAero>false</useAero>
@@ -190,8 +193,10 @@
 		<mercSizeLimited>false</mercSizeLimited>
 		<trackOriginalUnit>false</trackOriginalUnit>
 		<regionalMechVariations>false</regionalMechVariations>
+		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
+		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
 		<searchRadius>800</searchRadius>
-		<intensity>1.0</intensity>
+		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
 		<variableContractLength>false</variableContractLength>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
@@ -206,16 +211,13 @@
 		<restrictPartsByMission>true</restrictPartsByMission>
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
-		<useAtBCapture>false</useAtBCapture>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
-		<startGameDelay>500</startGameDelay>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>
 		<opforLocalUnitChance>5</opforLocalUnitChance>
-		<historicalDailyLog>false</historicalDailyLog>
 		<massRepairUseExtraTime>true</massRepairUseExtraTime>
 		<massRepairUseRushJob>true</massRepairUseRushJob>
 		<massRepairAllowCarryover>true</massRepairAllowCarryover>
@@ -224,86 +226,86 @@
 		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
 		<massRepairReplacePod>true</massRepairReplacePod>
 		<massRepairOptions>
-			<massRepairOption0>
+			<massRepairOption>
 				<type>0</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption0>
-			<massRepairOption1>
+			</massRepairOption>
+			<massRepairOption>
 				<type>1</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption1>
-			<massRepairOption2>
+			</massRepairOption>
+			<massRepairOption>
 				<type>2</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption2>
-			<massRepairOption3>
+			</massRepairOption>
+			<massRepairOption>
 				<type>3</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption3>
-			<massRepairOption4>
+			</massRepairOption>
+			<massRepairOption>
 				<type>4</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption4>
-			<massRepairOption5>
+			</massRepairOption>
+			<massRepairOption>
 				<type>5</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption5>
-			<massRepairOption6>
+			</massRepairOption>
+			<massRepairOption>
 				<type>6</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption6>
-			<massRepairOption7>
+			</massRepairOption>
+			<massRepairOption>
 				<type>7</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption7>
-			<massRepairOption8>
+			</massRepairOption>
+			<massRepairOption>
 				<type>8</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption8>
-			<massRepairOption9>
-				<type>12</type>
+			</massRepairOption>
+			<massRepairOption>
+				<type>9</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption9>
+			</massRepairOption>
 		</massRepairOptions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
@@ -311,6 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+	<useAtBUnitMarket>false</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>
@@ -670,8 +673,8 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -685,12 +688,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -706,12 +709,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -727,8 +730,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/Aero</skill>
 				<skill>Tech/BA</skill>
+				<skill>Tech/Aero</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -764,8 +767,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -782,8 +785,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -798,8 +801,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -830,12 +833,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -852,8 +855,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -867,12 +870,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -888,8 +891,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -944,12 +947,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -978,12 +981,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -999,8 +1002,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1030,8 +1033,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -1054,8 +1057,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1086,11 +1089,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1113,8 +1116,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1128,11 +1131,11 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1147,8 +1150,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1176,12 +1179,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -1199,8 +1202,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1215,8 +1218,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1273,8 +1276,8 @@ Note: This ability is only used for BattleMechs.</desc>
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1304,8 +1307,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
 				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
 				<skill>Tech/Mechanic::Veteran</skill>
 				<skill>Tech/Mech::Veteran</skill>
 			</skillPrereq>
@@ -1323,22 +1326,27 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Hopping Jack (Unofficial)</displayName>
-			<lookupName>hopping_jack</lookupName>
-			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>5</xpCost>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>10</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>jumping_jack</invalidAbilities>
+			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1353,32 +1361,27 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>10</xpCost>
+			<displayName>Hopping Jack (Unofficial)</displayName>
+			<lookupName>hopping_jack</lookupName>
+			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
+			<xpCost>5</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
+			<invalidAbilities>jumping_jack</invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1393,26 +1396,26 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
-	<randomSkillPreferences>
-		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
-		<specialAbilBonus>-10,-10,-2,0,1</specialAbilBonus>
-		<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
-		<randomizeSkill>true</randomizeSkill>
-		<useClanBonuses>true</useClanBonuses>
-		<antiMekProb>10</antiMekProb>
-		<combatSmallArmsBonus>-3</combatSmallArmsBonus>
-		<supportSmallArmsBonus>-10</supportSmallArmsBonus>
-		<artilleryProb>10</artilleryProb>
-		<artilleryBonus>-2</artilleryBonus>
-		<secondSkillProb>0</secondSkillProb>
-		<secondSkillBonus>-4</secondSkillBonus>
-	</randomSkillPreferences>
+<randomSkillPreferences>
+	<overallRecruitBonus>0</overallRecruitBonus>
+	<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+	<specialAbilBonus>-10,-10,-2,0,1</specialAbilBonus>
+	<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
+	<randomizeSkill>true</randomizeSkill>
+	<useClanBonuses>true</useClanBonuses>
+	<antiMekProb>10</antiMekProb>
+	<combatSmallArmsBonus>-3</combatSmallArmsBonus>
+	<supportSmallArmsBonus>-10</supportSmallArmsBonus>
+	<artilleryProb>10</artilleryProb>
+	<artilleryBonus>-2</artilleryBonus>
+	<secondSkillProb>0</secondSkillProb>
+	<secondSkillBonus>-4</secondSkillBonus>
+</randomSkillPreferences>
 </gamePreset>

--- a/MekHQ/mmconf/mhqPresets/DefaultTotalWarfare.xml
+++ b/MekHQ/mmconf/mhqPresets/DefaultTotalWarfare.xml
@@ -3,11 +3,12 @@
 	<title>TW Standard Default</title>
 	<description>This is the default settings used by MHQ. It is intended to follow the Total Warfare line of rulebooks whenever possible, and for rules outside of this scope it uses Field Manual: Mercenaries, revised rules.</description>
 	<campaignOptions>
+		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
 		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
-		<unitRatingMethod>FM: Mercenaries (rev)</unitRatingMethod>
+		<unitRatingMethod>FLD_MAN_MERCS_REV</unitRatingMethod>
 		<useEraMods>false</useEraMods>
 		<assignedTechFirst>false</assignedTechFirst>
 		<resetToFirstTech>false</resetToFirstTech>
@@ -96,6 +97,7 @@
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChange>false</logMarriageNameChange>
+		<useManualMarriages>true</useManualMarriages>
 		<useRandomMarriages>false</useRandomMarriages>
 		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
 		<marriageAgeRange>10</marriageAgeRange>
@@ -114,6 +116,11 @@
 		<displayFamilyLevel>0</displayFamilyLevel>
 		<useRandomDeaths>true</useRandomDeaths>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
+		<prisonerCaptureStyle>TAHARQA</prisonerCaptureStyle>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<prisonerBabyStatus>true</prisonerBabyStatus>
+		<useAtBPrisonerDefection>false</useAtBPrisonerDefection>
+		<useAtBPrisonerRansom>false</useAtBPrisonerRansom>
 		<payForParts>false</payForParts>
 		<payForRepairs>false</payForRepairs>
 		<payForUnits>false</payForUnits>
@@ -146,9 +153,8 @@
 		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
 		<useTimeInRank>false</useTimeInRank>
 		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<useRetirementDateTracking>false</useRetirementDateTracking>
 		<trackTotalEarnings>false</trackTotalEarnings>
-		<capturePrisoners>true</capturePrisoners>
-		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
 		<personnelMarketName>FM: Mercenaries Revised</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
@@ -160,10 +166,7 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<probPhenoMW>95</probPhenoMW>
-		<probPhenoAero>95</probPhenoAero>
-		<probPhenoBA>100</probPhenoBA>
-		<probPhenoVee>0</probPhenoVee>
+		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<tougherHealing>false</tougherHealing>
 		<useAtB>false</useAtB>
 		<useAero>false</useAero>
@@ -190,8 +193,10 @@
 		<mercSizeLimited>false</mercSizeLimited>
 		<trackOriginalUnit>false</trackOriginalUnit>
 		<regionalMechVariations>false</regionalMechVariations>
+		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
+		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
 		<searchRadius>800</searchRadius>
-		<intensity>1.0</intensity>
+		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
 		<variableContractLength>false</variableContractLength>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
@@ -206,16 +211,13 @@
 		<restrictPartsByMission>true</restrictPartsByMission>
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
-		<useAtBCapture>false</useAtBCapture>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
-		<startGameDelay>500</startGameDelay>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>
 		<opforLocalUnitChance>5</opforLocalUnitChance>
-		<historicalDailyLog>false</historicalDailyLog>
 		<massRepairUseExtraTime>true</massRepairUseExtraTime>
 		<massRepairUseRushJob>true</massRepairUseRushJob>
 		<massRepairAllowCarryover>true</massRepairAllowCarryover>
@@ -224,86 +226,86 @@
 		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
 		<massRepairReplacePod>true</massRepairReplacePod>
 		<massRepairOptions>
-			<massRepairOption0>
+			<massRepairOption>
 				<type>0</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption0>
-			<massRepairOption1>
+			</massRepairOption>
+			<massRepairOption>
 				<type>1</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption1>
-			<massRepairOption2>
+			</massRepairOption>
+			<massRepairOption>
 				<type>2</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption2>
-			<massRepairOption3>
+			</massRepairOption>
+			<massRepairOption>
 				<type>3</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption3>
-			<massRepairOption4>
+			</massRepairOption>
+			<massRepairOption>
 				<type>4</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption4>
-			<massRepairOption5>
+			</massRepairOption>
+			<massRepairOption>
 				<type>5</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption5>
-			<massRepairOption6>
+			</massRepairOption>
+			<massRepairOption>
 				<type>6</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption6>
-			<massRepairOption7>
+			</massRepairOption>
+			<massRepairOption>
 				<type>7</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption7>
-			<massRepairOption8>
+			</massRepairOption>
+			<massRepairOption>
 				<type>8</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption8>
-			<massRepairOption9>
-				<type>12</type>
+			</massRepairOption>
+			<massRepairOption>
+				<type>9</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption9>
+			</massRepairOption>
 		</massRepairOptions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
@@ -311,6 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+	<useAtBUnitMarket>false</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>
@@ -670,8 +673,8 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -685,12 +688,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -706,12 +709,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -727,8 +730,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/Aero</skill>
 				<skill>Tech/BA</skill>
+				<skill>Tech/Aero</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -764,8 +767,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -782,8 +785,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -798,8 +801,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -830,12 +833,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -852,8 +855,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -867,12 +870,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -887,12 +890,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft</skill>
 				<skill>Gunnery/Battlesuit</skill>
-				<skill>Gunnery/Aerospace</skill>
+				<skill>Gunnery/Aircraft</skill>
 				<skill>Gunnery/Spacecraft</skill>
-				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Aerospace</skill>
 				<skill>Gunnery/Vehicle</skill>
+				<skill>Gunnery/Mech</skill>
 				<skill>Gunnery/Protomech</skill>
 			</skillPrereq>
 		</ability>
@@ -908,8 +911,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -964,12 +967,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -998,12 +1001,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1019,8 +1022,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1051,8 +1054,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -1075,8 +1078,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1107,11 +1110,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1134,8 +1137,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1149,11 +1152,11 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1168,8 +1171,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1197,12 +1200,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -1220,8 +1223,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1236,8 +1239,8 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1252,12 +1255,12 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1315,8 +1318,8 @@ Note: This ability is only used for BattleMechs.</desc>
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1346,8 +1349,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
 				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
 				<skill>Tech/Mechanic::Veteran</skill>
 				<skill>Tech/Mech::Veteran</skill>
 			</skillPrereq>
@@ -1365,22 +1368,26 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Hopping Jack (Unofficial)</displayName>
-			<lookupName>hopping_jack</lookupName>
-			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>5</xpCost>
-			<weight>3</weight>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>jumping_jack</invalidAbilities>
+			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1395,32 +1402,28 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
+			<displayName>Hopping Jack (Unofficial)</displayName>
+			<lookupName>hopping_jack</lookupName>
+			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
+			<xpCost>5</xpCost>
+			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
+			<invalidAbilities>jumping_jack</invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1435,26 +1438,26 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
-	<randomSkillPreferences>
-		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
-		<specialAbilBonus>-10,-10,-2,0,1</specialAbilBonus>
-		<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
-		<randomizeSkill>true</randomizeSkill>
-		<useClanBonuses>true</useClanBonuses>
-		<antiMekProb>10</antiMekProb>
-		<combatSmallArmsBonus>-3</combatSmallArmsBonus>
-		<supportSmallArmsBonus>-10</supportSmallArmsBonus>
-		<artilleryProb>10</artilleryProb>
-		<artilleryBonus>-2</artilleryBonus>
-		<secondSkillProb>0</secondSkillProb>
-		<secondSkillBonus>-4</secondSkillBonus>
-	</randomSkillPreferences>
+<randomSkillPreferences>
+	<overallRecruitBonus>0</overallRecruitBonus>
+	<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+	<specialAbilBonus>-10,-10,-2,0,1</specialAbilBonus>
+	<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
+	<randomizeSkill>true</randomizeSkill>
+	<useClanBonuses>true</useClanBonuses>
+	<antiMekProb>10</antiMekProb>
+	<combatSmallArmsBonus>-3</combatSmallArmsBonus>
+	<supportSmallArmsBonus>-10</supportSmallArmsBonus>
+	<artilleryProb>10</artilleryProb>
+	<artilleryBonus>-2</artilleryBonus>
+	<secondSkillProb>0</secondSkillProb>
+	<secondSkillBonus>-4</secondSkillBonus>
+</randomSkillPreferences>
 </gamePreset>

--- a/MekHQ/mmconf/mhqPresets/DefaultTotalWarfare.xml
+++ b/MekHQ/mmconf/mhqPresets/DefaultTotalWarfare.xml
@@ -313,7 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
-	<useAtBUnitMarket>false</useAtBUnitMarket>
+		<useAtBUnitMarket>false</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>

--- a/MekHQ/mmconf/mhqPresets/SimpleOptions.xml
+++ b/MekHQ/mmconf/mhqPresets/SimpleOptions.xml
@@ -313,7 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
-	<useAtBUnitMarket>false</useAtBUnitMarket>
+		<useAtBUnitMarket>false</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>

--- a/MekHQ/mmconf/mhqPresets/SimpleOptions.xml
+++ b/MekHQ/mmconf/mhqPresets/SimpleOptions.xml
@@ -3,11 +3,12 @@
 	<title>Simple Presets</title>
 	<description>This set of presets attempts to provide the simplest rules settings possible for those who just want to get into the action. Acquisitions are automatic and maintenance is turned off.</description>
 	<campaignOptions>
+		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
 		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
-		<unitRatingMethod>Campaign Ops</unitRatingMethod>
+		<unitRatingMethod>CAMPAIGN_OPS</unitRatingMethod>
 		<useEraMods>false</useEraMods>
 		<assignedTechFirst>false</assignedTechFirst>
 		<resetToFirstTech>false</resetToFirstTech>
@@ -96,6 +97,7 @@
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChange>false</logMarriageNameChange>
+		<useManualMarriages>true</useManualMarriages>
 		<useRandomMarriages>false</useRandomMarriages>
 		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
 		<marriageAgeRange>10</marriageAgeRange>
@@ -114,6 +116,11 @@
 		<displayFamilyLevel>0</displayFamilyLevel>
 		<useRandomDeaths>true</useRandomDeaths>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
+		<prisonerCaptureStyle>TAHARQA</prisonerCaptureStyle>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<prisonerBabyStatus>true</prisonerBabyStatus>
+		<useAtBPrisonerDefection>false</useAtBPrisonerDefection>
+		<useAtBPrisonerRansom>false</useAtBPrisonerRansom>
 		<payForParts>false</payForParts>
 		<payForRepairs>false</payForRepairs>
 		<payForUnits>false</payForUnits>
@@ -146,9 +153,8 @@
 		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
 		<useTimeInRank>false</useTimeInRank>
 		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<useRetirementDateTracking>false</useRetirementDateTracking>
 		<trackTotalEarnings>false</trackTotalEarnings>
-		<capturePrisoners>true</capturePrisoners>
-		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
 		<personnelMarketName>Strat Ops</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
@@ -160,10 +166,7 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<probPhenoMW>95</probPhenoMW>
-		<probPhenoAero>95</probPhenoAero>
-		<probPhenoBA>100</probPhenoBA>
-		<probPhenoVee>0</probPhenoVee>
+		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<tougherHealing>false</tougherHealing>
 		<useAtB>false</useAtB>
 		<useAero>false</useAero>
@@ -190,8 +193,10 @@
 		<mercSizeLimited>false</mercSizeLimited>
 		<trackOriginalUnit>false</trackOriginalUnit>
 		<regionalMechVariations>false</regionalMechVariations>
+		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
+		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
 		<searchRadius>800</searchRadius>
-		<intensity>1.0</intensity>
+		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
 		<variableContractLength>false</variableContractLength>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
@@ -206,16 +211,13 @@
 		<restrictPartsByMission>true</restrictPartsByMission>
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
-		<useAtBCapture>false</useAtBCapture>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
-		<startGameDelay>500</startGameDelay>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>
 		<opforLocalUnitChance>5</opforLocalUnitChance>
-		<historicalDailyLog>false</historicalDailyLog>
 		<massRepairUseExtraTime>true</massRepairUseExtraTime>
 		<massRepairUseRushJob>true</massRepairUseRushJob>
 		<massRepairAllowCarryover>true</massRepairAllowCarryover>
@@ -224,86 +226,86 @@
 		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
 		<massRepairReplacePod>true</massRepairReplacePod>
 		<massRepairOptions>
-			<massRepairOption0>
+			<massRepairOption>
 				<type>0</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption0>
-			<massRepairOption1>
+			</massRepairOption>
+			<massRepairOption>
 				<type>1</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption1>
-			<massRepairOption2>
+			</massRepairOption>
+			<massRepairOption>
 				<type>2</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption2>
-			<massRepairOption3>
+			</massRepairOption>
+			<massRepairOption>
 				<type>3</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption3>
-			<massRepairOption4>
+			</massRepairOption>
+			<massRepairOption>
 				<type>4</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption4>
-			<massRepairOption5>
+			</massRepairOption>
+			<massRepairOption>
 				<type>5</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption5>
-			<massRepairOption6>
+			</massRepairOption>
+			<massRepairOption>
 				<type>6</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption6>
-			<massRepairOption7>
+			</massRepairOption>
+			<massRepairOption>
 				<type>7</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption7>
-			<massRepairOption8>
+			</massRepairOption>
+			<massRepairOption>
 				<type>8</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption8>
-			<massRepairOption9>
-				<type>12</type>
+			</massRepairOption>
+			<massRepairOption>
+				<type>9</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption9>
+			</massRepairOption>
 		</massRepairOptions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
@@ -311,6 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+	<useAtBUnitMarket>false</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>
@@ -670,8 +673,8 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -685,12 +688,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -706,12 +709,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -727,8 +730,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
 				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -764,8 +767,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -782,8 +785,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -798,8 +801,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -830,12 +833,12 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -852,8 +855,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -867,12 +870,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -887,12 +890,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit</skill>
 				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Battlesuit</skill>
 				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Vehicle</skill>
+				<skill>Gunnery/Spacecraft</skill>
 				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Vehicle</skill>
 				<skill>Gunnery/Protomech</skill>
 			</skillPrereq>
 		</ability>
@@ -908,8 +911,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -964,12 +967,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -998,12 +1001,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1019,8 +1022,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1051,8 +1054,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
@@ -1075,8 +1078,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1107,11 +1110,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1134,8 +1137,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1149,11 +1152,11 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1168,8 +1171,8 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1197,12 +1200,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
@@ -1220,8 +1223,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1236,8 +1239,8 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1252,12 +1255,12 @@ Note: This ability is only used for BattleMechs and Protomechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1315,8 +1318,8 @@ Note: This ability is only used for BattleMechs.</desc>
 				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1346,8 +1349,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
 				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
 				<skill>Tech/Mechanic::Veteran</skill>
 				<skill>Tech/Mech::Veteran</skill>
 			</skillPrereq>
@@ -1365,43 +1368,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hopping Jack (Unofficial)</displayName>
-			<lookupName>hopping_jack</lookupName>
-			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>5</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>jumping_jack</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1415,11 +1383,46 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hopping Jack (Unofficial)</displayName>
+			<lookupName>hopping_jack</lookupName>
+			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
+			<xpCost>5</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>jumping_jack</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
 				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
@@ -1435,26 +1438,26 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
-	<randomSkillPreferences>
-		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
-		<specialAbilBonus>-10,-10,-10,-10,-10</specialAbilBonus>
-		<tacticsMod>-10,-10,-10,-10,-10</tacticsMod>
-		<randomizeSkill>false</randomizeSkill>
-		<useClanBonuses>true</useClanBonuses>
-		<antiMekProb>10</antiMekProb>
-		<combatSmallArmsBonus>-10</combatSmallArmsBonus>
-		<supportSmallArmsBonus>-10</supportSmallArmsBonus>
-		<artilleryProb>0</artilleryProb>
-		<artilleryBonus>-2</artilleryBonus>
-		<secondSkillProb>0</secondSkillProb>
-		<secondSkillBonus>-10</secondSkillBonus>
-	</randomSkillPreferences>
+<randomSkillPreferences>
+	<overallRecruitBonus>0</overallRecruitBonus>
+	<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+	<specialAbilBonus>-10,-10,-10,-10,-10</specialAbilBonus>
+	<tacticsMod>-10,-10,-10,-10,-10</tacticsMod>
+	<randomizeSkill>false</randomizeSkill>
+	<useClanBonuses>true</useClanBonuses>
+	<antiMekProb>10</antiMekProb>
+	<combatSmallArmsBonus>-10</combatSmallArmsBonus>
+	<supportSmallArmsBonus>-10</supportSmallArmsBonus>
+	<artilleryProb>0</artilleryProb>
+	<artilleryBonus>-2</artilleryBonus>
+	<secondSkillProb>0</secondSkillProb>
+	<secondSkillBonus>-10</secondSkillBonus>
+</randomSkillPreferences>
 </gamePreset>

--- a/MekHQ/mmconf/mhqPresets/TaharqaMW2ish.xml
+++ b/MekHQ/mmconf/mhqPresets/TaharqaMW2ish.xml
@@ -3,11 +3,12 @@
 	<title>Taharqa&apos;s MW2ish Presets</title>
 	<description>This preset largely affects skill levels and XP costs. Namely, all skills range from level 0 to level 6 and XP costs rise with the level of the skill such that, for example, it costs more XP to advance from Regular to Veteran than from Green to Regular. Special abilities have also been tweaked with these costs in mind.</description>
 	<campaignOptions>
+		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
 		<useFactionForNames>true</useFactionForNames>
 		<repairSystem>0</repairSystem>
 		<useUnitRating>true</useUnitRating>
-		<unitRatingMethod>Campaign Ops</unitRatingMethod>
+		<unitRatingMethod>CAMPAIGN_OPS</unitRatingMethod>
 		<useEraMods>false</useEraMods>
 		<assignedTechFirst>true</assignedTechFirst>
 		<resetToFirstTech>true</resetToFirstTech>
@@ -96,6 +97,7 @@
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChange>false</logMarriageNameChange>
+		<useManualMarriages>true</useManualMarriages>
 		<useRandomMarriages>false</useRandomMarriages>
 		<chanceRandomMarriages>2.5E-4</chanceRandomMarriages>
 		<marriageAgeRange>10</marriageAgeRange>
@@ -114,6 +116,11 @@
 		<displayFamilyLevel>0</displayFamilyLevel>
 		<useRandomDeaths>false</useRandomDeaths>
 		<keepMarriedNameUponSpouseDeath>false</keepMarriedNameUponSpouseDeath>
+		<prisonerCaptureStyle>NONE</prisonerCaptureStyle>
+		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
+		<prisonerBabyStatus>true</prisonerBabyStatus>
+		<useAtBPrisonerDefection>false</useAtBPrisonerDefection>
+		<useAtBPrisonerRansom>false</useAtBPrisonerRansom>
 		<payForParts>true</payForParts>
 		<payForRepairs>false</payForRepairs>
 		<payForUnits>true</payForUnits>
@@ -146,9 +153,8 @@
 		<timeInServiceDisplayFormat>YEARS</timeInServiceDisplayFormat>
 		<useTimeInRank>false</useTimeInRank>
 		<timeInRankDisplayFormat>MONTHS_YEARS</timeInRankDisplayFormat>
+		<useRetirementDateTracking>false</useRetirementDateTracking>
 		<trackTotalEarnings>false</trackTotalEarnings>
-		<capturePrisoners>false</capturePrisoners>
-		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
 		<personnelMarketName>FM: Mercenaries Revised</personnelMarketName>
 		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
 		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
@@ -160,10 +166,7 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<probPhenoMW>95</probPhenoMW>
-		<probPhenoAero>95</probPhenoAero>
-		<probPhenoBA>100</probPhenoBA>
-		<probPhenoVee>0</probPhenoVee>
+		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<tougherHealing>true</tougherHealing>
 		<useAtB>false</useAtB>
 		<useAero>false</useAero>
@@ -190,8 +193,10 @@
 		<mercSizeLimited>false</mercSizeLimited>
 		<trackOriginalUnit>false</trackOriginalUnit>
 		<regionalMechVariations>false</regionalMechVariations>
+		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
+		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
 		<searchRadius>800</searchRadius>
-		<intensity>1.0</intensity>
+		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
 		<variableContractLength>false</variableContractLength>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
@@ -206,16 +211,13 @@
 		<restrictPartsByMission>true</restrictPartsByMission>
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
-		<useAtBCapture>false</useAtBCapture>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
-		<startGameDelay>500</startGameDelay>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>
 		<opforLocalUnitChance>5</opforLocalUnitChance>
-		<historicalDailyLog>false</historicalDailyLog>
 		<massRepairUseExtraTime>true</massRepairUseExtraTime>
 		<massRepairUseRushJob>true</massRepairUseRushJob>
 		<massRepairAllowCarryover>true</massRepairAllowCarryover>
@@ -224,86 +226,86 @@
 		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
 		<massRepairReplacePod>true</massRepairReplacePod>
 		<massRepairOptions>
-			<massRepairOption0>
+			<massRepairOption>
 				<type>0</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption0>
-			<massRepairOption1>
+			</massRepairOption>
+			<massRepairOption>
 				<type>1</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption1>
-			<massRepairOption2>
+			</massRepairOption>
+			<massRepairOption>
 				<type>2</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption2>
-			<massRepairOption3>
+			</massRepairOption>
+			<massRepairOption>
 				<type>3</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption3>
-			<massRepairOption4>
+			</massRepairOption>
+			<massRepairOption>
 				<type>4</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption4>
-			<massRepairOption5>
+			</massRepairOption>
+			<massRepairOption>
 				<type>5</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption5>
-			<massRepairOption6>
+			</massRepairOption>
+			<massRepairOption>
 				<type>6</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption6>
-			<massRepairOption7>
+			</massRepairOption>
+			<massRepairOption>
 				<type>7</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption7>
-			<massRepairOption8>
+			</massRepairOption>
+			<massRepairOption>
 				<type>8</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption8>
-			<massRepairOption9>
-				<type>12</type>
+			</massRepairOption>
+			<massRepairOption>
+				<type>9</type>
 				<active>0</active>
 				<skillMin>0</skillMin>
 				<skillMax>4</skillMax>
 				<btnMin>4</btnMin>
 				<btnMax>4</btnMax>
-			</massRepairOption9>
+			</massRepairOption>
 		</massRepairOptions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
@@ -311,6 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+	<useAtBUnitMarket>false</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>
@@ -684,12 +687,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -705,12 +708,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -726,8 +729,8 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
 				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
@@ -763,8 +766,8 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -796,8 +799,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
 			</skillPrereq>
@@ -831,12 +834,12 @@ Plasma and Flamer).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -854,12 +857,12 @@ RL and ATM).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -874,12 +877,12 @@ RL and ATM).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -896,8 +899,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -911,12 +914,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -932,8 +935,8 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
 			</skillPrereq>
@@ -988,12 +991,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1022,12 +1025,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1043,8 +1046,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1075,8 +1078,8 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
 			</skillPrereq>
@@ -1130,11 +1133,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1171,11 +1174,11 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Artillery::Green</skill>
 			</skillPrereq>
@@ -1219,12 +1222,12 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
@@ -1242,8 +1245,8 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1331,8 +1334,8 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
 			</skillPrereq>
@@ -1350,8 +1353,47 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1369,45 +1411,6 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>6</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
 			<lookupName>tech_weapon_specialist</lookupName>
 			<desc>-1 to repair and maintenance checks when working with weapons</desc>
@@ -1419,8 +1422,8 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/BA::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
 			</skillPrereq>
@@ -1438,29 +1441,29 @@ Gaussrifles).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>
-	<randomSkillPreferences>
-		<overallRecruitBonus>0</overallRecruitBonus>
-		<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
-		<specialAbilBonus>-10,-10,-2,0,0</specialAbilBonus>
-		<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
-		<randomizeSkill>true</randomizeSkill>
-		<useClanBonuses>true</useClanBonuses>
-		<antiMekProb>10</antiMekProb>
-		<combatSmallArmsBonus>-3</combatSmallArmsBonus>
-		<supportSmallArmsBonus>-6</supportSmallArmsBonus>
-		<artilleryProb>10</artilleryProb>
-		<artilleryBonus>-2</artilleryBonus>
-		<secondSkillProb>10</secondSkillProb>
-		<secondSkillBonus>-2</secondSkillBonus>
-	</randomSkillPreferences>
+<randomSkillPreferences>
+	<overallRecruitBonus>0</overallRecruitBonus>
+	<recruitBonuses>0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</recruitBonuses>
+	<specialAbilBonus>-10,-10,-2,0,0</specialAbilBonus>
+	<tacticsMod>-10,-10,-7,-4,-1</tacticsMod>
+	<randomizeSkill>true</randomizeSkill>
+	<useClanBonuses>true</useClanBonuses>
+	<antiMekProb>10</antiMekProb>
+	<combatSmallArmsBonus>-3</combatSmallArmsBonus>
+	<supportSmallArmsBonus>-6</supportSmallArmsBonus>
+	<artilleryProb>10</artilleryProb>
+	<artilleryBonus>-2</artilleryBonus>
+	<secondSkillProb>10</secondSkillProb>
+	<secondSkillBonus>-2</secondSkillBonus>
+</randomSkillPreferences>
 </gamePreset>

--- a/MekHQ/mmconf/mhqPresets/TaharqaMW2ish.xml
+++ b/MekHQ/mmconf/mhqPresets/TaharqaMW2ish.xml
@@ -313,7 +313,7 @@
 		<salaryTypeBase>0 CSB,1500 CSB,1500 CSB,900 CSB,900 CSB,900 CSB,900 CSB,960 CSB,750 CSB,960 CSB,900 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB</salaryTypeBase>
 		<salaryXpMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXpMultiplier>
 		<usePortraitForType>false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
-	<useAtBUnitMarket>false</useAtBUnitMarket>
+		<useAtBUnitMarket>false</useAtBUnitMarket>
 		<rats>Xotl,Total Warfare</rats>
 	</campaignOptions>
 	<skillTypes>


### PR DESCRIPTION
This updates the presets following the removal of more than a few values. This is primarily to remove the automigration of what are now MekHQOptions values on preset load.