### PR TITLE
Workaround for single hex ecm causing smallcraft to be overweight

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -60,6 +60,7 @@ import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
 import megamek.common.MiscType;
 import megamek.common.Mounted;
+import megamek.common.SmallCraft;
 import megamek.common.Tank;
 import megamek.common.TargetRoll;
 import megamek.common.TechAdvancement;
@@ -164,6 +165,13 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
         newEntity = newEn;
         newEntity.setOwner(oldUnit.getEntity().getOwner());
         newEntity.setGame(oldUnit.getEntity().getGame());
+        if (newEntity.getClass() == SmallCraft.class) { // SmallCraft but not subclasses
+            // Entity.setGame() will add a Single Hex ECM part to SmallCraft that otherwise has no ECM
+            // This is required for MegaMek, but causes SmallCraft to be overweight when refitting in MekHQ
+            // Work-around is to remove the ECM part early during a refit
+            // Ref: https://github.com/MegaMek/mekhq/issues/1970
+            newEntity.removeMisc(BattleArmor.SINGLE_HEX_ECM);
+        }
         failedCheck = false;
         timeSpent = 0;
         fixableString = null;


### PR DESCRIPTION
Fixes #1970 

As per discussion with @neoancient in the contributors channel on Slack, redoing this on the MM side to avoid adding the BA ECM part would be a lot of work. Instead, this PR implements a workaround by removing the BA ECM early in a refit to avoid overweight issues.