### PR TITLE
Add refit time for moving a part between locations

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -456,12 +456,8 @@ public class Refit extends Part implements IPartWork, IAcquisitionWork {
                     updateRefitClass(CLASS_C);
                 }
                 if (movedPart instanceof EquipmentPart) {
-                    //TODO: set this as salvaging
-                    //boolean isSalvaging = movedPart.isSalvaging();
-                    //movedPart.setSalvaging(true);
-                    //movedPart.updateConditionFromEntity(false);
-                    time += movedPart.getBaseTime();
-                    //movedPart.setSalvaging(isSalvaging);
+                    // Use equivalent MissingEquipmentPart install time
+                    time += movedPart.getMissingPart().getBaseTime();
                 }
             } else {
                 //its a new part


### PR DESCRIPTION
This is a fix for secondary issue reported in #1079, that during a refit moving a part between locations took no time.