### PR TITLE
Split Unit duties into a Hangar class

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -29,7 +29,6 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.swing.JOptionPane;
@@ -6917,9 +6916,9 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public Money getTotalEquipmentValue() {
-        return Money.zero()
-                .plus(getUnits().stream().map(Unit::getSellValue).collect(Collectors.toList()))
-                .plus(streamSpareParts().map(Part::getActualValue).collect(Collectors.toList()));
+        Money unitsSellValue = getHangar().getUnitCosts(Unit::getSellValue);
+        return streamSpareParts().map(Part::getActualValue)
+            .reduce(unitsSellValue, Money::plus);
     }
 
     /**
@@ -7174,117 +7173,88 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public int getTotalMechBays() {
-        double bays = 0;
-        for (Unit u : getUnits()) {
-            bays += u.getMechCapacity();
-        }
-        return (int)Math.round(bays);
+        return (int)Math.round(getHangar().getUnitsStream()
+            .mapToDouble(Unit::getMechCapacity)
+            .sum());
     }
 
     public int getTotalASFBays() {
-        double bays = 0;
-        for (Unit u : getUnits()) {
-            bays += u.getASFCapacity();
-        }
-        return (int)Math.round(bays);
+        return (int)Math.round(getHangar().getUnitsStream()
+            .mapToDouble(Unit::getASFCapacity)
+            .sum());
     }
 
     public int getTotalSmallCraftBays() {
-        double bays = 0;
-        for (Unit u : getUnits()) {
-            bays += u.getSmallCraftCapacity();
-        }
-        return (int)Math.round(bays);
+        return (int)Math.round(getHangar().getUnitsStream()
+            .mapToDouble(Unit::getSmallCraftCapacity)
+            .sum());
     }
 
     public int getTotalBattleArmorBays() {
-        double bays = 0;
-        for (Unit u : getUnits()) {
-            bays += u.getBattleArmorCapacity();
-        }
-        return (int)Math.round(bays);
+        return (int)Math.round(getHangar().getUnitsStream()
+            .mapToDouble(Unit::getBattleArmorCapacity)
+            .sum());
     }
 
     public int getTotalInfantryBays() {
-        double bays = 0;
-        for (Unit u : getUnits()) {
-            bays += u.getInfantryCapacity();
-        }
-        return (int)Math.round(bays);
+        return (int)Math.round(getHangar().getUnitsStream()
+            .mapToDouble(Unit::getInfantryCapacity)
+            .sum());
     }
 
     public int getTotalHeavyVehicleBays() {
-        double bays = 0;
-        for (Unit u : getUnits()) {
-            bays += u.getHeavyVehicleCapacity();
-        }
-        return (int)Math.round(bays);
+        return (int)Math.round(getHangar().getUnitsStream()
+            .mapToDouble(Unit::getHeavyVehicleCapacity)
+            .sum());
     }
 
     public int getTotalLightVehicleBays() {
-        double bays = 0;
-        for (Unit u : getUnits()) {
-            bays += u.getLightVehicleCapacity();
-        }
-        return (int)Math.round(bays);
+        return (int)Math.round(getHangar().getUnitsStream()
+            .mapToDouble(Unit::getLightVehicleCapacity)
+            .sum());
     }
 
     public int getTotalProtomechBays() {
-        double bays = 0;
-        for (Unit u : getUnits()) {
-            bays += u.getProtomechCapacity();
-        }
-        return (int)Math.round(bays);
+        return (int)Math.round(getHangar().getUnitsStream()
+            .mapToDouble(Unit::getProtomechCapacity)
+            .sum());
     }
 
     public int getTotalDockingCollars() {
-        double collars = 0;
-        for (Unit u : getUnits()) {
-            if (u.getEntity() instanceof Jumpship) {
-                collars += u.getDocks();
-            }
-        }
-        return (int)Math.round(collars);
+        return getHangar().getUnitsStream()
+            .filter(u -> u.getEntity() instanceof Jumpship)
+            .mapToInt(Unit::getDocks)
+            .sum();
     }
 
     public double getTotalInsulatedCargoCapacity() {
-        double capacity = 0;
-        for (Unit u : getUnits()) {
-            capacity += u.getInsulatedCargoCapacity();
-        }
-        return capacity;
+        return getHangar().getUnitsStream()
+            .mapToDouble(Unit::getInsulatedCargoCapacity)
+            .sum();
     }
 
     public double getTotalRefrigeratedCargoCapacity() {
-        double capacity = 0;
-        for (Unit u : getUnits()) {
-            capacity += u.getRefrigeratedCargoCapacity();
-        }
-        return capacity;
+        return getHangar().getUnitsStream()
+            .mapToDouble(Unit::getRefrigeratedCargoCapacity)
+            .sum();
     }
 
     public double getTotalLivestockCargoCapacity() {
-        double capacity = 0;
-        for (Unit u : getUnits()) {
-            capacity += u.getLivestockCargoCapacity();
-        }
-        return capacity;
+        return getHangar().getUnitsStream()
+            .mapToDouble(Unit::getLivestockCargoCapacity)
+            .sum();
     }
 
     public double getTotalLiquidCargoCapacity() {
-        double capacity = 0;
-        for (Unit u : getUnits()) {
-            capacity += u.getLiquidCargoCapacity();
-        }
-        return capacity;
+        return getHangar().getUnitsStream()
+            .mapToDouble(Unit::getLiquidCargoCapacity)
+            .sum();
     }
 
     public double getTotalCargoCapacity() {
-        double capacity = 0;
-        for (Unit u : getUnits()) {
-            capacity += u.getCargoCapacity();
-        }
-        return capacity;
+        return getHangar().getUnitsStream()
+            .mapToDouble(Unit::getCargoCapacity)
+            .sum();
     }
 
     // Liquid not included
@@ -8271,39 +8241,15 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public Money getMonthlySpareParts() {
-        Money partsCost = Money.zero();
-
-        for (Unit u : getUnits()) {
-            if (u.isMothballed()) {
-                continue;
-            }
-            partsCost = partsCost.plus(u.getSparePartsCost());
-        }
-        return partsCost;
+        return getHangar().getUnitCosts(u -> !u.isMothballed(), Unit::getSparePartsCost);
     }
 
     public Money getMonthlyFuel() {
-        Money fuelCost = Money.zero();
-
-        for (Unit u : getUnits()) {
-            if (u.isMothballed()) {
-                continue;
-            }
-            fuelCost = fuelCost.plus(u.getFuelCost());
-        }
-        return fuelCost;
+        return getHangar().getUnitCosts(u -> !u.isMothballed(), Unit::getFuelCost);
     }
 
     public Money getMonthlyAmmo() {
-        Money ammoCost = Money.zero();
-
-        for (Unit u : getUnits()) {
-            if (u.isMothballed()) {
-                continue;
-            }
-            ammoCost = ammoCost.plus(u.getAmmoCost());
-        }
-        return ammoCost;
+        return getHangar().getUnitCosts(u -> !u.isMothballed(), Unit::getAmmoCost);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1113,11 +1113,6 @@ public class Campaign implements Serializable, ITechManager {
         return getHangar().getUnits();
     }
 
-    // Since getUnits doesn't return a defensive copy and I don't know what I might break if I made it do so...
-    public ArrayList<Unit> getCopyOfUnits() {
-        return new ArrayList<>(getHangar().getUnits());
-    }
-
     public ArrayList<Entity> getEntities() {
         ArrayList<Entity> entities = new ArrayList<>();
         for (Unit unit : getUnits()) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -53,7 +53,6 @@ import mekhq.service.IAutosaveService;
 
 import megamek.common.*;
 import megamek.common.enums.Gender;
-import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.generator.RandomUnitGenerator;
 import megamek.client.generator.RandomGenderGenerator;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3619,7 +3619,7 @@ public class Campaign implements Serializable, ITechManager {
     public Money getMaintenanceCosts() {
         if (campaignOptions.payForMaintain()) {
             return getHangar().getUnitsStream()
-                .filter(u -> u.requiresMaintenance() && null != u.getTech())
+                .filter(u -> u.requiresMaintenance() && (null != u.getTech()))
                 .map(Unit::getMaintenanceCost)
                 .reduce(Money.zero(), (a, b) -> a.plus(b));
         }
@@ -7172,49 +7172,49 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     public int getTotalMechBays() {
-        return (int)Math.round(getHangar().getUnitsStream()
+        return (int) Math.round(getHangar().getUnitsStream()
             .mapToDouble(Unit::getMechCapacity)
             .sum());
     }
 
     public int getTotalASFBays() {
-        return (int)Math.round(getHangar().getUnitsStream()
+        return (int) Math.round(getHangar().getUnitsStream()
             .mapToDouble(Unit::getASFCapacity)
             .sum());
     }
 
     public int getTotalSmallCraftBays() {
-        return (int)Math.round(getHangar().getUnitsStream()
+        return (int) Math.round(getHangar().getUnitsStream()
             .mapToDouble(Unit::getSmallCraftCapacity)
             .sum());
     }
 
     public int getTotalBattleArmorBays() {
-        return (int)Math.round(getHangar().getUnitsStream()
+        return (int) Math.round(getHangar().getUnitsStream()
             .mapToDouble(Unit::getBattleArmorCapacity)
             .sum());
     }
 
     public int getTotalInfantryBays() {
-        return (int)Math.round(getHangar().getUnitsStream()
+        return (int) Math.round(getHangar().getUnitsStream()
             .mapToDouble(Unit::getInfantryCapacity)
             .sum());
     }
 
     public int getTotalHeavyVehicleBays() {
-        return (int)Math.round(getHangar().getUnitsStream()
+        return (int) Math.round(getHangar().getUnitsStream()
             .mapToDouble(Unit::getHeavyVehicleCapacity)
             .sum());
     }
 
     public int getTotalLightVehicleBays() {
-        return (int)Math.round(getHangar().getUnitsStream()
+        return (int) Math.round(getHangar().getUnitsStream()
             .mapToDouble(Unit::getLightVehicleCapacity)
             .sum());
     }
 
     public int getTotalProtomechBays() {
-        return (int)Math.round(getHangar().getUnitsStream()
+        return (int) Math.round(getHangar().getUnitsStream()
             .mapToDouble(Unit::getProtomechCapacity)
             .sum());
     }
@@ -8101,7 +8101,7 @@ public class Campaign implements Serializable, ITechManager {
                                     // TODO : Fix this so we aren't using a hack that just assumes IS2
                                     p.setOriginalUnitTech(Person.TECH_IS2);
                                 }
-                                if (null != p.getUnitId() && null != getHangar().getUnit(p.getUnitId())
+                                if ((null != p.getUnitId()) && (null != getHangar().getUnit(p.getUnitId()))
                                         && ms.getName().equals(getHangar().getUnit(p.getUnitId()).getEntity().getShortNameRaw())) {
                                     p.setOriginalUnitId(p.getUnitId());
                                 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -666,7 +666,7 @@ public class Campaign implements Serializable, ITechManager {
                 : calculatePartTransitTime(Compute.d6(2) - 2);
 
         getFinances().debit(cost, Transaction.C_UNIT, "Purchased " + en.getShortName(), getLocalDate());
-        addUnit(en, true, transitDays);
+        addNewUnit(en, true, transitDays);
         if (!getCampaignOptions().getInstantUnitMarketDelivery()) {
             addReport("<font color='green'>Unit will be delivered in " + transitDays + " days.</font>");
         }
@@ -967,11 +967,7 @@ public class Campaign implements Serializable, ITechManager {
      * @param u A {@link Unit} to import into the campaign.
      */
     public void importUnit(Unit u) {
-        addUnit(u);
-    }
-
-    private void addUnit(Unit u) {
-        MekHQ.getLogger().info(this, "Adding unit: (" + u.getId() + "):" + u);
+        MekHQ.getLogger().debug("Importing unit: (" + u.getId() + "): " + u.getName());
 
         getHangar().addUnit(u);
 
@@ -980,7 +976,7 @@ public class Campaign implements Serializable, ITechManager {
         //If this is a ship, add it to the list of potential transports
         //Jumpships and space stations are intentionally ignored at present, because this functionality is being
         //used to auto-load ground units into bays, and doing this for large craft that can't transit is pointless.
-        if (u.getEntity() != null && (u.getEntity() instanceof Dropship || u.getEntity() instanceof Warship)) {
+        if ((u.getEntity() instanceof Dropship) || (u.getEntity() instanceof Warship)) {
             addTransportShip(u.getId());
         }
 
@@ -988,6 +984,7 @@ public class Campaign implements Serializable, ITechManager {
         if (Entity.NONE == u.getEntity().getId()) {
             u.getEntity().setId(game.getNextEntityId());
         }
+
         game.addEntity(u.getEntity().getId(), u.getEntity());
     }
 
@@ -997,7 +994,8 @@ public class Campaign implements Serializable, ITechManager {
      * @param id - The unique ID of the ship we want to add to this Set
      */
     public void addTransportShip(UUID id) {
-        MekHQ.getLogger().info(this, "Adding DropShip/WarShip: " + id);
+        MekHQ.getLogger().debug("Adding DropShip/WarShip: " + id);
+
         transportShips.add(id);
     }
 
@@ -1007,7 +1005,8 @@ public class Campaign implements Serializable, ITechManager {
      * @param id - The unique ID of the ship we want to remove from this Set
      */
     public void removeTransportShip(UUID id) {
-        MekHQ.getLogger().info(this, "Removing DropShip/WarShip: " + id);
+        MekHQ.getLogger().debug("Removing DropShip/WarShip: " + id);
+
         transportShips.remove(id);
     }
 
@@ -1053,11 +1052,11 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     /**
-     * Add a unit to the campaign. This is only for new units
+     * Add a new unit to the campaign.
      *
      * @param en An <code>Entity</code> object that the new unit will be wrapped around
      */
-    public Unit addUnit(Entity en, boolean allowNewPilots, int days) {
+    public Unit addNewUnit(Entity en, boolean allowNewPilots, int days) {
         Unit unit = new Unit(en, this);
         getHangar().addUnit(unit);
 
@@ -1073,7 +1072,7 @@ public class Campaign implements Serializable, ITechManager {
         //If this is a ship, add it to the list of potential transports
         //Jumpships and space stations are intentionally ignored at present, because this functionality is being
         //used to auto-load ground units into bays, and doing this for large craft that can't transit is pointless.
-        if (unit.getEntity() != null && (unit.getEntity() instanceof Dropship || unit.getEntity() instanceof Warship)) {
+        if ((unit.getEntity() instanceof Dropship) || (unit.getEntity() instanceof Warship)) {
             addTransportShip(id);
         }
 
@@ -4307,13 +4306,13 @@ public class Campaign implements Serializable, ITechManager {
         if (campaignOptions.payForUnits()) {
             if (finances.debit(cost, Transaction.C_UNIT,
                     "Purchased " + en.getShortName(), getLocalDate())) {
-                addUnit(en, false, days);
+                addNewUnit(en, false, days);
                 return true;
             } else {
                 return false;
             }
         } else {
-            addUnit(en, false, days);
+            addNewUnit(en, false, days);
             return true;
         }
     }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1113,51 +1113,6 @@ public class Campaign implements Serializable, ITechManager {
         return getHangar().getUnits();
     }
 
-    public List<Unit> getUnits(boolean weightSorted) {
-        return getUnits(false, weightSorted, false);
-    }
-
-    /**
-     * This returns a list of the current units, sorted alphabetically and potentially by other methods
-     * @param weightSorted      True if the unit list is sorted by weight descending, otherwise false
-     * @param weightClassSorted True if the unit list is sorted by weight class in format heaviest to lightest, otherwise false
-     * @param unitTypeSorted    True if the unit list is sorted by the unit type
-     * @return a copy of the units in the campaign with the applicable sort format
-     */
-    public List<Unit> getUnits(boolean weightClassSorted, boolean weightSorted,
-                               boolean unitTypeSorted) {
-        List<Unit> units = getCopyOfUnits();
-
-        // Natural order sorting the units alphabetically is the default for getSortedUnits
-        units.sort(Comparator.comparing(Unit::getName, new NaturalOrderComparator()));
-
-        if (weightClassSorted || weightSorted || unitTypeSorted) {
-            // We need to determine these by both the weight sorted and weight class sorted values,
-            // as to properly sort by weight class and weight we should do both at the same time
-            if (weightSorted && weightClassSorted) {
-                units.sort((lhs, rhs) -> {
-                    int weightClass1 = lhs.getEntity().getWeightClass();
-                    int weightClass2 = rhs.getEntity().getWeightClass();
-                    if (weightClass1 == weightClass2) {
-                        return Double.compare(rhs.getEntity().getWeight(), lhs.getEntity().getWeight());
-                    } else {
-                        return weightClass2 - weightClass1;
-                    }
-                });
-            } else if (weightClassSorted) {
-                units.sort(Comparator.comparingInt(o -> o.getEntity().getWeightClass()));
-            } else if (weightSorted) {
-                // Sorted in descending order of weights
-                units.sort(Comparator.comparingDouble(o -> o.getEntity().getWeight()));
-            }
-
-            if (unitTypeSorted) {
-                units.sort(Comparator.comparingInt(e -> e.getEntity().getUnitType()));
-            }
-        }
-        return units;
-    }
-
     // Since getUnits doesn't return a defensive copy and I don't know what I might break if I made it do so...
     public ArrayList<Unit> getCopyOfUnits() {
         return new ArrayList<>(getHangar().getUnits());

--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -104,7 +104,7 @@ public class CampaignSummary {
         aeroCount = 0;
         infantryCount = 0;
         int squadCount = 0;
-        for (Unit u : campaign.getUnits()) {
+        for (Unit u : campaign.getHangar().getUnits()) {
             Entity e = u.getEntity();
             if (u.isUnmanned() || u.isSalvage() || u.isMothballed() || u.isMothballing() || !u.isPresent() || (null == e)) {
                 continue;

--- a/MekHQ/src/mekhq/campaign/Hangar.java
+++ b/MekHQ/src/mekhq/campaign/Hangar.java
@@ -55,13 +55,11 @@ public class Hangar {
             return;
         }
 
-        UUID id = unit.getId();
-        if (id == null) {
-            id = UUID.randomUUID();
-            unit.setId(id);
+        if (unit.getId() == null) {
+            unit.setId(UUID.randomUUID());
         }
 
-        units.put(id, unit);
+        units.put(unit.getId(), unit);
     }
 
     /**
@@ -155,12 +153,12 @@ public class Hangar {
     }
 
 	public void writeToXml(PrintWriter pw1, int indent, String tag) {
-        pw1.println(MekHqXmlUtil.indentStr(indent) + "<" + tag + ">");
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, tag);
 
         forEachUnit(unit -> {
             unit.writeToXml(pw1, indent + 1);
         });
 
-        pw1.println(MekHqXmlUtil.indentStr(indent) + "</" + tag + ">");
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, tag);
 	}
 }

--- a/MekHQ/src/mekhq/campaign/Hangar.java
+++ b/MekHQ/src/mekhq/campaign/Hangar.java
@@ -28,10 +28,12 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import mekhq.MekHqXmlUtil;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.unit.Unit;
 
 /**
@@ -86,6 +88,26 @@ public class Hangar {
      */
     public Stream<Unit> getUnitsStream() {
         return units.values().stream();
+    }
+
+    /**
+     * Calculates the total costs for the units in the hangar.
+     * @param getCosts A function which returns a cost for a unit.
+     * @return The total costs for the units.
+     */
+    public Money getUnitCosts(Function<Unit, Money> getCosts) {
+        return getUnitsStream().map(getCosts).reduce(Money.zero(), Money::plus);
+    }
+
+    /**
+     * Calculates the total costs for the units matching a predicate
+     * in the hangar.
+     * @param predicate A function to use to select a unit.
+     * @param getCosts A function which returns a cost for a selected unit.
+     * @return The total costs for the units selected by the predicate.
+     */
+    public Money getUnitCosts(Predicate<Unit> predicate, Function<Unit, Money> getCosts) {
+        return getUnitsStream().filter(predicate).map(getCosts).reduce(Money.zero(), Money::plus);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Hangar.java
+++ b/MekHQ/src/mekhq/campaign/Hangar.java
@@ -1,0 +1,144 @@
+/*
+ * Hangar.java
+ *
+ * Copyright (c) 2020 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign;
+
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.unit.Unit;
+
+/**
+ * Represents a hangar which contains zero or more units.
+ */
+public class Hangar {
+    private Map<UUID, Unit> units = new LinkedHashMap<>();
+
+    /**
+     * Adds a unit to the hangar.
+     *
+     * If the unit does not have an ID, one is
+     * assigned to it.
+     *
+     * @param unit The unit to add to the hangar.
+     */
+    public void addUnit(Unit unit) {
+        if (unit == null) {
+            return;
+        }
+
+        UUID id = unit.getId();
+        if (id == null) {
+            id = UUID.randomUUID();
+            unit.setId(id);
+        }
+
+        units.put(id, unit);
+    }
+
+    /**
+     * Gets a unit by a given ID.
+     * @param id The unique identifier of a unit.
+     * @return The unit matching the unique identifier,
+     *         otherwise null if that unit does not exist.
+     */
+    public Unit getUnit(UUID id) {
+        return units.get(id);
+    }
+
+    /**
+     * Gets a collection of units in the hangar.
+     * @return A collection of units in the hangar.
+     */
+    public Collection<Unit> getUnits() {
+        return units.values();
+    }
+
+    /**
+     * Gets a Stream of units in the hangar.
+     * @return A Stream of units in the hangar.
+     */
+    public Stream<Unit> getUnitsStream() {
+        return units.values().stream();
+    }
+
+    /**
+     * Executes a function for each unit in the hangar.
+     * @param consumer A function to apply to each unit.
+     */
+    public void forEachUnit(Consumer<Unit> consumer) {
+        units.forEach((id, unit) -> consumer.accept(unit));
+    }
+
+    /**
+     * Executes a function for each unit in the hangar.
+     * @param consumer A function to apply to each ID-unit pair.
+     */
+    public void forEachUnit(BiConsumer<UUID, Unit> consumer) {
+        units.forEach(consumer);
+    }
+
+    /**
+     * Searches for a specific unit using the given predicate.
+     * @param predicate A function to use to select a given unit.
+     * @return The first unit found which matches the predicate,
+     *         otherwise null if no unit was found.
+     */
+    public Unit findUnit(Predicate<Unit> predicate) {
+        if (predicate == null) {
+            return null;
+        }
+
+        for (Unit unit : units.values()) {
+            if (predicate.test(unit)) {
+                return unit;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Removes a unit from the hangar.
+     * @param id The unit ID.
+     * @return true if the unit was removed, otherwise false.
+     */
+    public boolean removeUnit(UUID id) {
+        return null != units.remove(id);
+    }
+
+	public void writeToXml(PrintWriter pw1, int indent, String tag) {
+        pw1.println(MekHqXmlUtil.indentStr(indent) + "<" + tag + ">");
+
+        forEachUnit(unit -> {
+            unit.writeToXml(pw1, indent + 1);
+        });
+
+        pw1.println(MekHqXmlUtil.indentStr(indent) + "</" + tag + ">");
+	}
+}

--- a/MekHQ/src/mekhq/campaign/MercRosterAccess.java
+++ b/MekHQ/src/mekhq/campaign/MercRosterAccess.java
@@ -557,7 +557,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
 
         progressNote = "Uploading equipment data";
         determineProgress();
-        for (Unit u : campaign.getUnits()) {
+        for (Unit u : campaign.getHangar().getUnits()) {
             try {
                 preparedStatement = connect.prepareStatement("UPDATE " + table + ".equipment SET type=?, name=?, subtype=?, crew=?, weight=?, regnumber=?, notes=? WHERE uuid=?");
                 preparedStatement.setInt(1, u.getEntity().getUnitType() + 1);
@@ -654,7 +654,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
     }
 
     private int getLengthOfTask() {
-        return 2 + campaign.getRanks().getAllRanks().size() + SkillType.skillList.length + Person.T_NUM * 2 + UnitType.SIZE + campaign.getPersonnel().size() * 4 + campaign.getUnits().size() + campaign.getAllForces().size() * 2;
+        return 2 + campaign.getRanks().getAllRanks().size() + SkillType.skillList.length + Person.T_NUM * 2 + UnitType.SIZE + campaign.getPersonnel().size() * 4 + campaign.getHangar().getUnits().size() + campaign.getAllForces().size() * 2;
     }
 
     public void determineProgress() {

--- a/MekHQ/src/mekhq/campaign/finances/FinancialReport.java
+++ b/MekHQ/src/mekhq/campaign/finances/FinancialReport.java
@@ -153,7 +153,7 @@ public class FinancialReport {
         r.loans = campaign.getFinances().getLoanBalance();
         r.assets = campaign.getFinances().getTotalAssetValue();
 
-        for (Unit u : campaign.getUnits()) {
+        campaign.getHangar().forEachUnit(u -> {
             Money value = u.getSellValue();
             if (u.getEntity() instanceof Mech) {
                 r.mech = r.mech.plus(value);
@@ -171,7 +171,7 @@ public class FinancialReport {
             } else if (u.getEntity() instanceof Protomech) {
                 r.proto = r.proto.plus(value);
             }
-        }
+        });
 
         r.spareParts = r.spareParts.plus(
             campaign.streamSpareParts()

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -706,7 +706,7 @@ public class AtBContract extends Contract implements Serializable {
             }
 
             if (null != en) {
-                c.addUnit(en, false, 0);
+                c.addNewUnit(en, false, 0);
             } else {
                 c.addReport("<html><font color='red'>Could not load unit</font></html>");
             }

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -599,13 +599,9 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
                                 .multipliedBy(straightSupport)
                                 .dividedBy(100);
         } else {
-            Money maintCosts = Money.zero();
-            for (Unit u : c.getUnits()) {
-                if (u.getEntity() instanceof Infantry && !(u.getEntity() instanceof BattleArmor)) {
-                    continue;
-                }
-                maintCosts = maintCosts.plus(u.getWeeklyMaintenanceCost());
-            }
+            Money maintCosts = c.getHangar().getUnitCosts(
+                u -> !(u.getEntity() instanceof Infantry) || (u.getEntity() instanceof BattleArmor),
+                Unit::getWeeklyMaintenanceCost);
             maintCosts = maintCosts.multipliedBy(4);
             supportAmount = maintCosts
                                 .multipliedBy(getLength())

--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -142,7 +142,7 @@ public class Loot implements MekHqXmlSerializable {
                     "Reward for " + getName() + " during " + s.getName(), campaign.getLocalDate());
         }
         for(Entity e : units) {
-            campaign.addUnit(e, false, 0);
+            campaign.addNewUnit(e, false, 0);
         }
         for(Part p : parts) {
             campaign.addPart(p, 0);

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -107,9 +107,6 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         setTotalSkillLevels(BigDecimal.ZERO);
 
         for (Unit u : getCampaign().getHangar().getUnits()) {
-            if (null == u) {
-                continue;
-            }
             if (u.isMothballed()) {
                 continue;
             }

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -106,8 +106,7 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         // Reset counts
         setTotalSkillLevels(BigDecimal.ZERO);
 
-        List<Unit> unitList = getCampaign().getCopyOfUnits();
-        for (Unit u : unitList) {
+        for (Unit u : getCampaign().getHangar().getUnits()) {
             if (null == u) {
                 continue;
             }
@@ -248,8 +247,7 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         // Count total units for transport
         getTotalCombatUnits();
 
-        List<Unit> unitList = getCampaign().getCopyOfUnits();
-        for (Unit u : unitList) {
+        for (Unit u : getCampaign().getHangar().getUnits()) {
             if (u == null) {
                 continue;
             }
@@ -665,17 +663,18 @@ public class CampaignOpsReputation extends AbstractUnitRating {
     }
 
     private int calcLargeCraftSupportValue() {
-        boolean crewShortage = false;
-        for (Unit u : getCampaign().getCopyOfUnits()) {
+        Unit unit = getCampaign().getHangar().findUnit(u -> {
             if (u.getEntity() instanceof SmallCraft || u.getEntity() instanceof Jumpship) {
                 if (u.getActiveCrew().size() < u.getFullCrewSize()) {
-                    crewShortage = true;
-                    break;
+                    return true;
                 }
             }
-        }
+            return false;
+        });
 
-        return crewShortage ? -5 : 0;
+        // if we found a unit we have a crew shortage
+        // on at least one vessel in our fleet
+        return (unit != null) ? -5 : 0;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -89,24 +89,25 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         setCountClan(0);
         setCountIS2(0);
 
-        for (Unit u : getCampaign().getCopyOfUnits()) {
-            if ((null == u) || !u.isPresent()) {
+        for (Unit u : getCampaign().getHangar().getUnits()) {
+            if (!u.isPresent()) {
                 continue;
             }
-            MekHQ.getLogger().debug(this, "Processing unit " + u.getName());
+
+            MekHQ.getLogger().debug("Processing unit " + u.getName());
             if (u.isMothballed()) {
-                MekHQ.getLogger().debug(this, "Unit " + u.getName() + " is mothballed. Skipping.");
+                MekHQ.getLogger().debug("Unit " + u.getName() + " is mothballed. Skipping.");
                 continue;
             }
 
             updateUnitCounts(u);
             BigDecimal value = getUnitValue(u);
-            MekHQ.getLogger().debug(this, "Unit " + u.getName() + " -- Value = " + value.toPlainString());
+            MekHQ.getLogger().debug("Unit " + u.getName() + " -- Value = " + value.toPlainString());
             setNumberUnits(getNumberUnits().add(value));
 
             Person p = u.getCommander();
             if (null != p) {
-                MekHQ.getLogger().debug(this, "Unit " + u.getName()
+                MekHQ.getLogger().debug("Unit " + u.getName()
                         + " -- Adding commander (" + p.getFullTitle() + "" + ") to commander list.");
                 getCommanderList().add(p);
             }

--- a/MekHQ/src/mekhq/campaign/report/HangarReport.java
+++ b/MekHQ/src/mekhq/campaign/report/HangarReport.java
@@ -983,7 +983,7 @@ public class HangarReport extends Report {
 
         //region UnitList Processing
         // Gather data and load it into the tree
-        List<Unit> unitList = new ArrayList<>(getCampaign().getUnits());
+        List<Unit> unitList = new ArrayList<>(getCampaign().getHangar().getUnits());
         unitList.sort(Comparator.comparing(Unit::getName, new NaturalOrderComparator()));
         for (Unit u : unitList) {
             Entity e = u.getEntity();

--- a/MekHQ/src/mekhq/campaign/unit/HangarSorter.java
+++ b/MekHQ/src/mekhq/campaign/unit/HangarSorter.java
@@ -1,0 +1,121 @@
+/*
+ * HangarSorter.java
+ *
+ * Copyright (c) 2020 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.unit;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import megamek.common.util.sorter.NaturalOrderComparator;
+import mekhq.campaign.Hangar;
+
+/**
+ * Creates sorted views of a hangar.
+ */
+public class HangarSorter {
+    private final boolean weightClassSorted;
+    private final boolean weightSorted;
+    private final boolean unitTypeSorted;
+
+    /**
+     * Creates a new instance of the HangarSorter class.
+     *
+     * @param weightClassSorted True if the unit list is sorted by weight class in format heaviest to lightest, otherwise false
+     * @param weightSorted      True if the unit list is sorted by weight descending, otherwise false
+     * @param unitTypeSorted    True if the unit list is sorted by the unit type
+     */
+    public HangarSorter(boolean weightClassSorted, boolean weightSorted,
+        boolean unitTypeSorted) {
+        this.weightClassSorted = weightClassSorted;
+        this.weightSorted = weightSorted;
+        this.unitTypeSorted = unitTypeSorted;
+    }
+
+    /**
+     * @return A new HangarSorter that sorts units by their default order.
+     */
+    public static HangarSorter defaultSorting() {
+        return new HangarSorter(true, true, true);
+    }
+
+    /**
+     * @return A new HangarSorter that sorts units by their weight, descending.
+     */
+    public static HangarSorter weightSorted() {
+        return new HangarSorter(false, true, false);
+    }
+
+    /**
+     * Gets a sorted list of units from the given hangar.
+     * @param hangar The hangar to retrieve units from in sorted order.
+     * @return A sorted list of units.
+     */
+    public List<Unit> getUnits(Hangar hangar) {
+        return sort(hangar.getUnitsStream()).collect(Collectors.toList());
+    }
+
+    /**
+     * Executes a consumer function on each unit in the hangar in sorted order.
+     * @param hangar The hangar to retrieve units from in sorted order.
+     * @param consumer A function to apply to each unit.
+     */
+    public void forEachUnit(Hangar hangar, Consumer<Unit> consumer) {
+        sort(hangar.getUnitsStream()).forEach(consumer);
+    }
+
+    /**
+     * This sorts a stream of units, sorted alphabetically and potentially by other methods
+     * @return a stream with the applicable sort format
+     */
+    private Stream<Unit> sort(Stream<Unit> units) {
+        Stream<Unit> stream = units.sorted(Comparator.comparing(Unit::getName, new NaturalOrderComparator()));
+
+        if (weightClassSorted || weightSorted || unitTypeSorted) {
+            // We need to determine these by both the weight sorted and weight class sorted values,
+            // as to properly sort by weight class and weight we should do both at the same time
+            if (weightSorted && weightClassSorted) {
+                stream = stream.sorted((lhs, rhs) -> {
+                    int weightClass1 = lhs.getEntity().getWeightClass();
+                    int weightClass2 = rhs.getEntity().getWeightClass();
+                    if (weightClass1 == weightClass2) {
+                        return Double.compare(rhs.getEntity().getWeight(), lhs.getEntity().getWeight());
+                    } else {
+                        return weightClass2 - weightClass1;
+                    }
+                });
+            } else if (weightClassSorted) {
+                stream = stream.sorted(Comparator.comparingInt(o -> o.getEntity().getWeightClass()));
+            } else if (weightSorted) {
+                // Sorted in descending order of weights
+                stream = stream.sorted(Comparator.comparingDouble(o -> o.getEntity().getWeight()));
+            }
+
+            if (unitTypeSorted) {
+                stream = stream.sorted(Comparator.comparingInt(e -> e.getEntity().getUnitType()));
+            }
+        }
+
+        return stream;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1592,16 +1592,14 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     public void unloadTransportShip() {
         clearTransportedUnits();
         initializeBaySpace();
+
         // And now reset the Transported values for all the units we just booted
-        for (Unit u : campaign.getUnits()) {
-            if (u.hasTransportShipId()) {
-                for (UUID id : u.getTransportShipId().keySet()) {
-                    if (id.equals(getId())) {
-                        u.getTransportShipId().clear();
-                    }
-                }
+        UUID id = getId();
+        campaign.getHangar().forEachUnit(u -> {
+            if (u.hasTransportShipId() && u.getTransportShipId().containsKey(id)) {
+                u.getTransportShipId().clear();
             }
-        }
+        });
     }
 
     public double getUnitCostMultiplier() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1933,7 +1933,7 @@ public class CampaignGUI extends JPanel {
 
             // Add the units from the file.
             for (Entity entity : parser.getEntities()) {
-                getCampaign().addUnit(entity, allowNewPilots, 0);
+                getCampaign().addNewUnit(entity, allowNewPilots, 0);
             }
 
             // TODO : re-add any ejected pilots

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1166,7 +1166,7 @@ public class CampaignGUI extends JPanel {
         }
         Vector<Unit> notMaintained = new Vector<>();
         int totalAstechMinutesNeeded = 0;
-        for (Unit u : getCampaign().getUnits()) {
+        for (Unit u : getCampaign().getHangar().getUnits()) {
             if (u.isUnmaintained()) {
                 notMaintained.add(u);
             } else if (u.isPresent() && (u.getEngineer() == null)) {

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -470,7 +470,7 @@ public final class HangarTab extends CampaignGuiTab {
                 selectedUUID = u.getId();
             }
         }
-        unitModel.setData(getCampaign().getCopyOfUnits());
+        unitModel.setData(new ArrayList<>(getCampaign().getHangar().getUnits()));
         // try to put the focus back on same person if they are still available
         for (int row = 0; row < unitTable.getRowCount(); row++) {
             Unit u = unitModel.getUnit(unitTable.convertRowIndexToModel(row));

--- a/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
+++ b/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
@@ -668,7 +668,7 @@ public class PlanetarySystemMapPanel extends JPanel {
     private Unit getBestDropship() {
         Unit bestUnit = null;
         double bestWeight = 0.0;
-        for (Unit u : campaign.getUnits()) {
+        for (Unit u : campaign.getHangar().getUnits()) {
             if (u.getEntity() instanceof Dropship && u.getEntity().getWeight() > bestWeight) {
                 bestUnit = u;
                 bestWeight = u.getEntity().getWeight();
@@ -685,7 +685,7 @@ public class PlanetarySystemMapPanel extends JPanel {
     private Unit getBestJumpship() {
         Unit bestUnit = null;
         double bestWeight = 0.0;
-        for (Unit u : campaign.getUnits()) {
+        for (Unit u : campaign.getHangar().getUnits()) {
             if (u.getEntity() instanceof Jumpship && u.getEntity().getWeight() > bestWeight) {
                 bestUnit = u;
                 bestWeight = u.getEntity().getWeight();

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -48,6 +48,7 @@ import mekhq.campaign.finances.Transaction;
 import mekhq.campaign.personnel.*;
 import mekhq.campaign.personnel.enums.*;
 import mekhq.campaign.personnel.generator.SingleSpecialAbilityGenerator;
+import mekhq.campaign.unit.HangarSorter;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.*;
@@ -1403,7 +1404,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 int weightClass = -1;
 
                 if (oneSelected && person.getStatus().isActive() && person.getPrisonerStatus().isFree()) {
-                    for (Unit unit : gui.getCampaign().getUnits(true, true, true)) {
+                    for (Unit unit : HangarSorter.defaultSorting().getUnits(gui.getCampaign().getHangar())) {
                         if (!unit.isAvailable()) {
                             continue;
                         } else if (unit.getEntity().getUnitType() != unitType) {
@@ -1559,7 +1560,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         }
                     }
                 } else if (StaticChecks.areAllActive(selected) && StaticChecks.areAllEligible(selected)) {
-                    for (Unit unit : gui.getCampaign().getUnits( true, true, true)) {
+                    for (Unit unit : HangarSorter.defaultSorting().getUnits(gui.getCampaign().getHangar())) {
                         if (!unit.isAvailable()) {
                             continue;
                         } else if (unit.getEntity().getUnitType() != unitType) {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -53,6 +53,7 @@ import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.unit.HangarSorter;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.CamoChoiceDialog;
@@ -827,41 +828,42 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                     // Or Gun Emplacements!
                     // TODO: Or Robotic Systems!
                     JMenu unsorted = new JMenu("Unsorted");
-                    for (Unit u : gui.getCampaign().getUnits(true)) {
+
+                    HangarSorter.weightSorted().forEachUnit(gui.getCampaign().getHangar(), u -> {
                         String type = UnitType.getTypeName(u.getEntity().getUnitType());
                         String className = u.getEntity().getWeightClassName();
                         if (null != u.getCommander()) {
                             Person p = u.getCommander();
                             if (p.getStatus().isActive() && (u.getForceId() < 1) && u.isPresent()) {
-                                menuItem = new JMenuItem(p.getFullTitle() + ", " + u.getName());
-                                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(u.isAvailable());
+                                JMenuItem menuItem0 = new JMenuItem(p.getFullTitle() + ", " + u.getName());
+                                menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
+                                menuItem0.addActionListener(this);
+                                menuItem0.setEnabled(u.isAvailable());
                                 if (null != weightClassForUnitType.get(type + "_" + className)) {
-                                    weightClassForUnitType.get(type + "_" + className).add(menuItem);
+                                    weightClassForUnitType.get(type + "_" + className).add(menuItem0);
                                     weightClassForUnitType.get(type + "_" + className).setEnabled(true);
                                 } else {
-                                    unsorted.add(menuItem);
+                                    unsorted.add(menuItem0);
                                 }
                                 unitTypeMenus.get(type).setEnabled(true);
                             }
                         }
                         if (u.getEntity() instanceof GunEmplacement) {
                             if (u.getForceId() < 1 && u.isPresent()) {
-                                menuItem = new JMenuItem("AutoTurret, " + u.getName());
-                                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(u.isAvailable());
+                                JMenuItem menuItem0 = new JMenuItem("AutoTurret, " + u.getName());
+                                menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
+                                menuItem0.addActionListener(this);
+                                menuItem0.setEnabled(u.isAvailable());
                                 if (null != weightClassForUnitType.get(type + "_" + className)) {
-                                    weightClassForUnitType.get(type + "_" + className).add(menuItem);
+                                    weightClassForUnitType.get(type + "_" + className).add(menuItem0);
                                     weightClassForUnitType.get(type + "_" + className).setEnabled(true);
                                 } else {
-                                    unsorted.add(menuItem);
+                                    unsorted.add(menuItem0);
                                 }
                                 unitTypeMenus.get(type).setEnabled(true);
                             }
                         }
-                    }
+                    });
 
                     for (int i = 0; i < UnitType.SIZE; i++)
                     {

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -293,9 +293,7 @@ public class CampaignExportWizard extends JDialog {
     private void setupUnitList() {
         unitList = new JList<>();
         DefaultListModel<Unit> unitListModel = new DefaultListModel<>();
-        for (Unit unit : sourceCampaign.getUnits()) {
-            unitListModel.addElement(unit);
-        }
+        sourceCampaign.getHangar().forEachUnit(unitListModel::addElement);
         unitList.setModel(unitListModel);
         unitList.addListSelectionListener(e -> {
             lblStatus.setText(getUnitSelectionStatus());
@@ -556,9 +554,7 @@ public class CampaignExportWizard extends JDialog {
             }
         }
 
-        for (Unit unit : destinationCampaign.getUnits()) {
-            unit.resetEngineer();
-        }
+        destinationCampaign.getHangar().forEachUnit(Unit::resetEngineer);
 
         // there's just no way to overwrite parts
         // so we simply add them to the destination

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -678,9 +678,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             }
         });
         choiceOriginalUnit.addItem(null);
-        for (Unit unit : campaign.getUnits()) {
-            choiceOriginalUnit.addItem(unit);
-        }
+        campaign.getHangar().forEachUnit(choiceOriginalUnit::addItem);
         if (null == person.getOriginalUnitId() || null == campaign.getUnit(person.getOriginalUnitId())) {
             choiceOriginalUnit.setSelectedItem(null);
         } else {

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -843,7 +843,7 @@ public class GMToolsDialog extends JDialog {
             try {
                 e = new MechFileParser(getLastRolledUnit().getSourceFile(),
                         getLastRolledUnit().getEntryName()).getEntity();
-                Unit u = getGUI().getCampaign().addUnit(e, false, 0);
+                Unit u = getGUI().getCampaign().addNewUnit(e, false, 0);
                 if ((getPerson() != null) && (getPerson().getUnitId() == null)) {
                     u.addPilotOrSoldier(getPerson());
                     getPerson().setOriginalUnit(u);

--- a/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
@@ -127,7 +127,7 @@ public class MekHQUnitSelectorDialog extends AbstractUnitSelectorDialog {
     protected void select(boolean isGM) {
         if (getSelectedEntity() != null) {
             if (isGM) {
-                campaign.addUnit(selectedUnit.getEntity(), false, 0);
+                campaign.addNewUnit(selectedUnit.getEntity(), false, 0);
             } else {
                 campaign.getShoppingList().addShoppingItem(selectedUnit, 1, campaign);
             }

--- a/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
@@ -137,7 +137,7 @@ public class PayCollateralDialog extends JDialog {
             gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
             gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
             gridBagConstraints.weightx = 1.0;
-            if(j == units.size()) {
+            if (j == units.size()) {
                 gridBagConstraints.weighty = 1.0;
             }
             gridBagConstraints.insets = new java.awt.Insets(5, 5, 0, 0);

--- a/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
@@ -1,20 +1,20 @@
 /*
  * PayCollateralDialog.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -56,23 +56,23 @@ import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
 
 /**
- * A dialog to decide how you want to pay off collateral when you 
+ * A dialog to decide how you want to pay off collateral when you
  * default on a loan
  * @author  Taharqa
  */
 public class PayCollateralDialog extends JDialog {
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 6995319032267472795L;
-    
+
     @SuppressWarnings("unused") // FIXME
 	private Frame frame;
     private Campaign campaign;
     private boolean cancelled;
     private boolean paid;
     private Loan loan;
-    
+
     private Map<JCheckBox, UUID> unitBoxes;
     private ArrayList<JCheckBox> assetBoxes;
     private Map<JSlider, Integer> partSliders;
@@ -80,7 +80,7 @@ public class PayCollateralDialog extends JDialog {
     private JButton btnPay;
     private JButton btnDontPay;
     private JButton btnCancel;
-    
+
     public PayCollateralDialog(java.awt.Frame parent, boolean modal, Campaign c, Loan l) {
         super(parent, modal);
         this.frame = parent;
@@ -97,15 +97,15 @@ public class PayCollateralDialog extends JDialog {
 
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PayCollateralDialog", new EncodeControl()); //$NON-NLS-1$
         java.awt.GridBagConstraints gridBagConstraints;
-        
+
         JTabbedPane panMain = new JTabbedPane();
         JPanel panInfo = new JPanel(new GridLayout(1,0));
         JPanel panBtn = new JPanel(new GridLayout(0,3));
-        
+
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setTitle(resourceMap.getString("Form.title"));
         getContentPane().setLayout(new BorderLayout());
-        
+
         barAmount = new JProgressBar(0, 100);
         barAmount.setValue(0);
         barAmount.setStringPainted(true);
@@ -117,14 +117,14 @@ public class PayCollateralDialog extends JDialog {
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 0.0;
         panInfo.add(barAmount, gridBagConstraints);
-        
+
         unitBoxes = new LinkedHashMap<>();
         JCheckBox box;
         int i = 0;
         int j = 0;
         JPanel pnlUnits = new JPanel(new GridBagLayout());
-        Collection<Unit> units = campaign.getUnits();
-        for(Unit u : units) {
+        Collection<Unit> units = campaign.getHangar().getUnits();
+        for (Unit u : units) {
             j++;
             box = new JCheckBox(u.getName() + " (" + u.getSellValue().toAmountAndSymbolString() + ")");
             box.setSelected(false);
@@ -137,7 +137,7 @@ public class PayCollateralDialog extends JDialog {
             gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
             gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
             gridBagConstraints.weightx = 1.0;
-            if(j == (units.size())) {
+            if(j == units.size()) {
                 gridBagConstraints.weighty = 1.0;
             }
             gridBagConstraints.insets = new java.awt.Insets(5, 5, 0, 0);
@@ -148,7 +148,7 @@ public class PayCollateralDialog extends JDialog {
         scrUnits.setViewportView(pnlUnits);
         scrUnits.setMinimumSize(new java.awt.Dimension(400, 300));
         scrUnits.setPreferredSize(new java.awt.Dimension(400, 300));
-                
+
         partSliders = new LinkedHashMap<>();
         JPanel pnlParts = new JPanel(new GridBagLayout());
         i = 0;
@@ -161,7 +161,7 @@ public class PayCollateralDialog extends JDialog {
             if(p instanceof AmmoStorage) {
                 quantity = ((AmmoStorage)p).getQuantity();
             }
-            partSlider = new JSlider(JSlider.HORIZONTAL, 0, quantity, 0);           
+            partSlider = new JSlider(JSlider.HORIZONTAL, 0, quantity, 0);
             //TODO: deal with armors
             partSlider.setMajorTickSpacing(1);
             if(quantity < 11) {
@@ -189,19 +189,19 @@ public class PayCollateralDialog extends JDialog {
             gridBagConstraints.weightx = 1.0;
             pnlParts.add(new JLabel("<html>" + p.getName() + "<br>" + p.getDetails()  + ", "+ p.getCurrentValue().toAmountAndSymbolString() + "</html>"), gridBagConstraints);
             i++;
-        }    
+        }
         JScrollPane scrParts = new JScrollPane();
         scrParts.setViewportView(pnlParts);
         scrParts.setMinimumSize(new java.awt.Dimension(400, 300));
         scrParts.setPreferredSize(new java.awt.Dimension(400, 300));
-        
+
         //TODO: use cash reserves
-        
+
         btnPay = new JButton(resourceMap.getString("btnPay.text")); // NOI18N
         btnPay.addActionListener(evt -> payCollateral());
         btnPay.setEnabled(false);
         panBtn.add(btnPay);
-        
+
         btnDontPay = new JButton(resourceMap.getString("btnDontPay.text")); // NOI18N
         btnDontPay.addActionListener(evt -> dontPayCollateral());
         panBtn.add(btnDontPay);
@@ -240,9 +240,9 @@ public class PayCollateralDialog extends JDialog {
         JScrollPane scrAssets = new JScrollPane(pnlAssets);
         scrAssets.setMinimumSize(new java.awt.Dimension(400, 300));
         scrAssets.setPreferredSize(new java.awt.Dimension(400, 300));
-        
+
         updateAmount();
-        
+
         panMain.add("Units", scrUnits);
         panMain.add("Parts", scrParts);
         panMain.add("Assets", scrAssets);
@@ -262,23 +262,23 @@ public class PayCollateralDialog extends JDialog {
     public boolean wasCancelled() {
         return cancelled;
     }
-    
+
     public boolean wasPaid() {
         return paid;
     }
-    
+
     public void payCollateral() {
         //TODO: summary and are you sure dialog
         paid = true;
         setVisible(false);
     }
-    
+
     public void dontPayCollateral() {
         //TODO: are you sure dialog
         paid = false;
         setVisible(false);
     }
-    
+
     private void updateAmount() {
         Money amount = Money.zero();
         for (Map.Entry<JCheckBox, UUID> m : unitBoxes.entrySet()) {
@@ -317,7 +317,7 @@ public class PayCollateralDialog extends JDialog {
         barAmount.setValue(percent);
         barAmount.setString(amount.toAmountString() + "/" + loan.getCollateralAmount().toAmountString());
     }
-    
+
     public ArrayList<UUID> getUnits() {
         ArrayList<UUID> uid = new ArrayList<>();
         for (Map.Entry<JCheckBox, UUID> u : unitBoxes.entrySet()) {
@@ -327,7 +327,7 @@ public class PayCollateralDialog extends JDialog {
         }
         return uid;
     }
-    
+
     public ArrayList<int[]> getParts() {
         ArrayList<int[]> parts = new ArrayList<>();
         for (Map.Entry<JSlider, Integer> m : partSliders.entrySet()) {
@@ -339,7 +339,7 @@ public class PayCollateralDialog extends JDialog {
         }
         return parts;
     }
-    
+
     public ArrayList<Asset> getRemainingAssets() {
         ArrayList<Asset> newAssets = new ArrayList<>();
         for(int i = 0; i < assetBoxes.size(); i++) {
@@ -350,5 +350,5 @@ public class PayCollateralDialog extends JDialog {
         }
         return newAssets;
     }
-    
+
 }

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -63,9 +63,9 @@ public class PersonnelMarketDialog extends JDialog {
     //region Variable Declarations
     private static final long serialVersionUID = 707579637170575313L;
 
-	private PersonnelTableModel personnelModel;
-	private Campaign campaign;
-	private CampaignGUI hqView;
+    private PersonnelTableModel personnelModel;
+    private Campaign campaign;
+    private CampaignGUI hqView;
     private PersonnelMarket personnelMarket;
     Person selectedPerson = null;
     @SuppressWarnings("unused")
@@ -313,38 +313,38 @@ public class PersonnelMarketDialog extends JDialog {
     }
 
     public Person getPerson() {
-	    return selectedPerson;
-	}
+        return selectedPerson;
+    }
 
-	private void hirePerson(ActionEvent evt) {
-	    if (null != selectedPerson) {
-	    	if (campaign.getFunds().isLessThan((campaign.getCampaignOptions().payForRecruitment()
+    private void hirePerson(ActionEvent evt) {
+        if (null != selectedPerson) {
+            if (campaign.getFunds().isLessThan((campaign.getCampaignOptions().payForRecruitment()
                             ? selectedPerson.getSalary().multipliedBy(2)
                             : Money.zero()).plus(unitCost))) {
-				 campaign.addReport("<font color='red'><b>Insufficient funds. Transaction cancelled</b>.</font>");
-	    	} else {
-	    		/* Adding person to campaign changes pid; grab the old one to
-	    		 * use as a key to any attached entity
-	    		 */
-	    		UUID pid = selectedPerson.getId();
-	    		if (campaign.recruitPerson(selectedPerson)) {
-	    			Entity en = personnelMarket.getAttachedEntity(pid);
-	    			if (null != en) {
-	    				addUnit(en, true);
-	    				personnelMarket.removeAttachedEntity(pid);
-	    			}
-	    			personnelMarket.removePerson(selectedPerson);
-	    			personnelModel.setData(personnelMarket.getPersonnel());
-	    		}
-	    	}
-	    	refreshPersonView();
-	    }
-	}
+                 campaign.addReport("<font color='red'><b>Insufficient funds. Transaction cancelled</b>.</font>");
+            } else {
+                /* Adding person to campaign changes pid; grab the old one to
+                 * use as a key to any attached entity
+                 */
+                UUID pid = selectedPerson.getId();
+                if (campaign.recruitPerson(selectedPerson)) {
+                    Entity en = personnelMarket.getAttachedEntity(pid);
+                    if (null != en) {
+                        addUnit(en, true);
+                        personnelMarket.removeAttachedEntity(pid);
+                    }
+                    personnelMarket.removePerson(selectedPerson);
+                    personnelModel.setData(personnelMarket.getPersonnel());
+                }
+            }
+            refreshPersonView();
+        }
+    }
 
-	private void addPerson() {
-		if (selectedPerson != null) {
-			Entity en = personnelMarket.getAttachedEntity(selectedPerson);
-			UUID pid = selectedPerson.getId();
+    private void addPerson() {
+        if (selectedPerson != null) {
+            Entity en = personnelMarket.getAttachedEntity(selectedPerson);
+            UUID pid = selectedPerson.getId();
 
             if (campaign.recruitPerson(selectedPerson, true)) {
                 addUnit(en, false);
@@ -353,50 +353,50 @@ public class PersonnelMarketDialog extends JDialog {
                 personnelMarket.removeAttachedEntity(pid);
             }
             refreshPersonView();
-		}
-	}
+        }
+    }
 
-	private void addUnit(Entity en, boolean pay) {
-		if (null == en) {
-			return;
-		}
-		if (pay && !campaign.getFinances().debit(unitCost, Transaction.C_UNIT,
-				"Purchased " + en.getShortName(),
-				campaign.getLocalDate())) {
-			return;
-		}
-		Unit unit = campaign.addNewUnit(en, false, 0);
+    private void addUnit(Entity en, boolean pay) {
+        if (null == en) {
+            return;
+        }
+        if (pay && !campaign.getFinances().debit(unitCost, Transaction.C_UNIT,
+                "Purchased " + en.getShortName(),
+                campaign.getLocalDate())) {
+            return;
+        }
+        Unit unit = campaign.addNewUnit(en, false, 0);
         if (unit == null) {
             // No such unit matching the entity.
             return;
         }
 
-		if (unit.usesSoloPilot()) {
-			unit.addPilotOrSoldier(selectedPerson);
-			selectedPerson.setOriginalUnit(unit);
-		} else if (unit.usesSoldiers()) {
-			unit.addPilotOrSoldier(selectedPerson);
-		} else if (selectedPerson.canDrive(en)) {
-			unit.addDriver(selectedPerson);
-		} else if (selectedPerson.canGun(en)) {
-			unit.addGunner(selectedPerson);
-		} else if (selectedPerson.getPrimaryRole() == Person.T_NAVIGATOR) {
-			unit.setNavigator(selectedPerson);
-		} else {
-			unit.addVesselCrew(selectedPerson);
-		}
+        if (unit.usesSoloPilot()) {
+            unit.addPilotOrSoldier(selectedPerson);
+            selectedPerson.setOriginalUnit(unit);
+        } else if (unit.usesSoldiers()) {
+            unit.addPilotOrSoldier(selectedPerson);
+        } else if (selectedPerson.canDrive(en)) {
+            unit.addDriver(selectedPerson);
+        } else if (selectedPerson.canGun(en)) {
+            unit.addGunner(selectedPerson);
+        } else if (selectedPerson.getPrimaryRole() == Person.T_NAVIGATOR) {
+            unit.setNavigator(selectedPerson);
+        } else {
+            unit.addVesselCrew(selectedPerson);
+        }
 
-		campaign.hirePersonnelFor(unit.getId(), !pay);
-	}
+        campaign.hirePersonnelFor(unit.getId(), !pay);
+    }
 
-	private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {
-	    selectedPerson = null;
-    	personnelMarket.setPaidRecruitment(radioPaidRecruitment.isSelected());
-    	if (radioPaidRecruitment.isSelected()) {
-    		personnelMarket.setPaidRecruitType(comboRecruitType.getSelectedIndex() + 1);
-    	}
-	    setVisible(false);
-	}
+    private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {
+        selectedPerson = null;
+        personnelMarket.setPaidRecruitment(radioPaidRecruitment.isSelected());
+        if (radioPaidRecruitment.isSelected()) {
+            personnelMarket.setPaidRecruitType(comboRecruitType.getSelectedIndex() + 1);
+        }
+        setVisible(false);
+    }
 
     private void filterPersonnel() {
         PersonnelFilter nGroup = (comboPersonType.getSelectedItem() != null)
@@ -419,55 +419,55 @@ public class PersonnelMarketDialog extends JDialog {
             return;
         }
         selectedPerson = personnelModel.getPerson(tablePersonnel.convertRowIndexToModel(view));
-    	Entity en =  personnelMarket.getAttachedEntity(selectedPerson);
-    	if (null == en) {
-    		unitCost = Money.zero();
-    	} else {
-    		if (!campaign.getCampaignOptions().getUseShareSystem() &&
-    				(en instanceof megamek.common.Mech ||
-    						en instanceof megamek.common.Tank ||
-    						en instanceof megamek.common.Aero)) {
-    			unitCost = Money.of(en.getCost(false)).dividedBy(2.0);
-    		} else {
-    			unitCost = Money.zero();
-    		}
-    	}
+        Entity en =  personnelMarket.getAttachedEntity(selectedPerson);
+        if (null == en) {
+            unitCost = Money.zero();
+        } else {
+            if (!campaign.getCampaignOptions().getUseShareSystem() &&
+                    (en instanceof megamek.common.Mech ||
+                            en instanceof megamek.common.Tank ||
+                            en instanceof megamek.common.Aero)) {
+                unitCost = Money.of(en.getCost(false)).dividedBy(2.0);
+            } else {
+                unitCost = Money.zero();
+            }
+        }
         refreshPersonView();
     }
 
      void refreshPersonView() {
-    	 lblUnitCost.setText("");
+         lblUnitCost.setText("");
 
-    	 int row = tablePersonnel.getSelectedRow();
+         int row = tablePersonnel.getSelectedRow();
 
-    	 if (row < 0) {
+         if (row < 0) {
              scrollPersonnelView.setViewportView(null);
              return;
          }
 
          Entity en = personnelMarket.getAttachedEntity(selectedPerson);
          String unitText = "";
-    	 if (unitCost.isPositive()) {
-    		 unitText = "Unit cost: " + unitCost.toAmountAndSymbolString();
-    	 }
+         if (unitCost.isPositive()) {
+             unitText = "Unit cost: " + unitCost.toAmountAndSymbolString();
+         }
 
-		 if (null != en) {
-			 if (StringUtil.isNullOrEmpty(unitText)) {
-				 unitText = "Unit: ";
-			 } else {
-				 unitText += " - ";
-			 }
+         if (null != en) {
+             if (StringUtil.isNullOrEmpty(unitText)) {
+                 unitText = "Unit: ";
+             } else {
+                 unitText += " - ";
+             }
 
-			 unitText += en.getDisplayName();
-		 }
+             unitText += en.getDisplayName();
+         }
 
-    	 lblUnitCost.setText(unitText);
+         lblUnitCost.setText(unitText);
 
          if (null != en) {
              JTabbedPane tabUnit = new JTabbedPane();
              String name = "Commander";
              if (Compute.getFullCrewSize(en) == 1) {
-            	 name = "Pilot";
+                 name = "Pilot";
              }
              tabUnit.add(name, new PersonViewPanel(selectedPerson, campaign, hqView));
              MechViewPanel mvp = new MechViewPanel();
@@ -475,21 +475,21 @@ public class PersonnelMarketDialog extends JDialog {
              tabUnit.add("Unit", mvp);
              scrollPersonnelView.setViewportView(tabUnit);
          } else {
-        	 scrollPersonnelView.setViewportView(new PersonViewPanel(selectedPerson, campaign, hqView));
+             scrollPersonnelView.setViewportView(new PersonViewPanel(selectedPerson, campaign, hqView));
          }
- 		//This odd code is to make sure that the scrollbar stays at the top
- 		//I cant just call it here, because it ends up getting reset somewhere later
- 		javax.swing.SwingUtilities.invokeLater(() -> scrollPersonnelView.getVerticalScrollBar().setValue(0));
+         //This odd code is to make sure that the scrollbar stays at the top
+         //I cant just call it here, because it ends up getting reset somewhere later
+         javax.swing.SwingUtilities.invokeLater(() -> scrollPersonnelView.getVerticalScrollBar().setValue(0));
     }
 
-	@Override
+    @Override
     public void setVisible(boolean visible) {
         filterPersonnel();
         //changePersonnelView();
         super.setVisible(visible);
     }
 
-	public TableCellRenderer getRenderer() {
+    public TableCellRenderer getRenderer() {
         //if(choicePersonView.getSelectedIndex() == CampaignGUI.PV_GRAPHIC) {
             //return personnelModel.new VisualRenderer(hqView.getCamos(), portraits, hqView.getMechTiles());
        // }

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -365,14 +365,7 @@ public class PersonnelMarketDialog extends JDialog {
 				campaign.getLocalDate())) {
 			return;
 		}
-		campaign.addNewUnit(en, false, 0);
-		Unit unit = null;
-		for (Unit u : campaign.getUnits()) {
-			if (u.getEntity() == en) {
-				unit = u;
-				break;
-			}
-        }
+		Unit unit = campaign.addNewUnit(en, false, 0);
         if (unit == null) {
             // No such unit matching the entity.
             return;

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -365,7 +365,7 @@ public class PersonnelMarketDialog extends JDialog {
 				campaign.getLocalDate())) {
 			return;
 		}
-		campaign.addUnit(en, false, 0);
+		campaign.addNewUnit(en, false, 0);
 		Unit unit = null;
 		for (Unit u : campaign.getUnits()) {
 			if (u.getEntity() == en) {

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -505,9 +505,9 @@ public class RetirementDefectionDialog extends JDialog {
         List<UUID> unassignedMechs = new ArrayList<>();
         List<UUID> unassignedASF = new ArrayList<>();
         ArrayList<UUID> availableUnits = new ArrayList<>();
-        for (Unit u : hqView.getCampaign().getUnits()) {
+        hqView.getCampaign().getHangar().forEachUnit(u -> {
             if (!u.isAvailable() && !u.isMothballing() && !u.isMothballed()) {
-                continue;
+                return;
             }
             availableUnits.add(u.getId());
             if (UnitType.MEK == u.getEntity().getUnitType()) {
@@ -520,7 +520,8 @@ public class RetirementDefectionDialog extends JDialog {
                     unassignedASF.add(u.getId());
                 }
             }
-        }
+        });
+
         /* Defectors who steal a unit will take either the one they were
          * piloting or one of the unassigned units (50/50, unless there
          * is only one choice)

--- a/MekHQ/src/mekhq/gui/dialog/UnitMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnitMarketDialog.java
@@ -338,7 +338,7 @@ public class UnitMarketDialog extends JDialog {
                 campaign.getFinances().debit(cost, Transaction.C_UNIT,
                         "Purchased " + selectedEntity.getShortName(),
                         campaign.getLocalDate());
-                campaign.addUnit(selectedEntity, false, transitDays);
+                campaign.addNewUnit(selectedEntity, false, transitDays);
                 if (!campaign.getCampaignOptions().getInstantUnitMarketDelivery()) {
                     campaign.addReport("<font color='green'>Unit will be delivered in " + transitDays + " days.</font>");
                 }
@@ -353,7 +353,7 @@ public class UnitMarketDialog extends JDialog {
 
     private void addUnit() {
         if (null != selectedEntity) {
-            campaign.addUnit(selectedEntity, false, 0);
+            campaign.addNewUnit(selectedEntity, false, 0);
             UnitMarket.MarketOffer selected = ((UnitMarketTableModel) tableUnits.getModel())
                     .getOffer(tableUnits.convertRowIndexToModel(tableUnits.getSelectedRow()));
             unitMarket.removeOffer(selected);

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -303,7 +303,7 @@ public class UnitTableModel extends DataTableModel {
     }
 
     public void refreshData() {
-        setData(getCampaign().getCopyOfUnits());
+        setData(new ArrayList<>(getCampaign().getHangar().getUnits()));
     }
 
     public TableCellRenderer getRenderer(boolean graphic, IconPackage icons) {

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -37,6 +37,7 @@ import megamek.common.MechBay;
 import megamek.common.Tank;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Hangar;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.personnel.Person;
@@ -52,6 +53,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Vector;
@@ -71,6 +73,7 @@ public class CampaignOpsReputationTest {
 
     private Campaign mockCampaign;
     private CampaignOptions mockCampaignOptions;
+    private Hangar mockHangar;
     private List<Unit> unitList;
     private List<Person> personnelList;
     private List<Person> activePersonnelList;
@@ -208,6 +211,8 @@ public class CampaignOpsReputationTest {
         Faction mockFaction = mock(Faction.class);
         when(mockFaction.is(any())).thenReturn(true);
         when(mockCampaign.getFaction()).thenReturn(mockFaction);
+        mockHangar = mock(Hangar.class);
+        when(mockCampaign.getHangar()).thenReturn(mockHangar);
 
         mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaignOptions.getManualUnitRatingModifier()).thenReturn(0);
@@ -282,7 +287,7 @@ public class CampaignOpsReputationTest {
         mockFinances = mock(Finances.class);
         when(mockFinances.isInDebt()).thenReturn(false);
 
-        doReturn(unitList).when(mockCampaign).getCopyOfUnits();
+        when(mockHangar.getUnits()).thenReturn(unitList);
         doReturn(personnelList).when(mockCampaign).getPersonnel();
         doReturn(activePersonnelList).when(mockCampaign).getActivePersonnel();
         doReturn(astechs).when(mockCampaign).getAstechPool();
@@ -363,7 +368,7 @@ public class CampaignOpsReputationTest {
     }
 
     private void buildFreshCampaign() {
-        doReturn(new ArrayList<Unit>(0)).when(mockCampaign).getCopyOfUnits();
+        when(mockHangar.getUnits()).thenReturn(Collections.emptyList());
         doReturn(new ArrayList<Person>(0)).when(mockCampaign).getPersonnel();
         doReturn(new ArrayList<Person>(0)).when(mockCampaign).getActivePersonnel();
         doReturn(new ArrayList<Person>(0)).when(mockCampaign).getAdmins();

--- a/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
@@ -34,6 +34,7 @@ import megamek.common.Tank;
 import megamek.common.TechConstants;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Hangar;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Skill;
 import mekhq.campaign.personnel.SkillType;
@@ -55,6 +56,7 @@ import static org.junit.Assert.*;
  */
 public class FieldManualMercRevDragoonsRatingTest {
     private Campaign mockCampaign;
+    private Hangar mockHangar;
 
     private List<Person> mockPersonnelList;
     private List<Person> mockActivePersonnelList;
@@ -72,6 +74,8 @@ public class FieldManualMercRevDragoonsRatingTest {
     @Before
     public void setUp() {
         mockCampaign = mock(Campaign.class);
+        mockHangar = mock(Hangar.class);
+        when(mockCampaign.getHangar()).thenReturn(mockHangar);
 
         mockPersonnelList = new ArrayList<>();
         mockActivePersonnelList = new ArrayList<>();
@@ -307,7 +311,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         unitList.add(mockLightning2);
         unitList.add(mockUnion);
         unitList.add(mockInvader);
-        doReturn(unitList).when(mockCampaign).getCopyOfUnits();
+        when(mockHangar.getUnits()).thenReturn(unitList);
 
         spyRating.initValues();
     }

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTestUtilities.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTestUtilities.java
@@ -36,7 +36,7 @@ public final class UnitTestUtilities {
 
     public static Unit addAndGetUnit(Campaign campaign, Entity entity) {
         campaign.addNewUnit(entity, false, 0);
-        for (Unit unit : campaign.getUnits()) {
+        for (Unit unit : campaign.getHangar().getUnits()) {
             return unit;
         }
 

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTestUtilities.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTestUtilities.java
@@ -35,7 +35,7 @@ import java.io.InputStream;
 public final class UnitTestUtilities {
 
     public static Unit addAndGetUnit(Campaign campaign, Entity entity) {
-        campaign.addUnit(entity, false, 0);        
+        campaign.addNewUnit(entity, false, 0);
         for (Unit unit : campaign.getUnits()) {
             return unit;
         }


### PR DESCRIPTION
This PR is part of a project of mine to reduce the cognitive burden of Campaign.java and move it into smaller, easier to understand classes. The first step I took was to move the "accounting" functions of Units into a logical Hangar class. This _could_ mean a foray into tracking multiple units on multiple places...but let's not go there just yet.

This also significantly reduces the memory burden of certain areas and on larger campaigns certain actions will be faster, as there won't be giant copies of the unit list made.

**Note: this is a draft while I do some more testing, but functionally this was a lift-n-shift.**