### PR TITLE
Improve performance of searching for spare parts

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -27,6 +27,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -4198,6 +4199,20 @@ public class Campaign implements Serializable, ITechManager {
             }
         }
         return spares;
+    }
+
+    /**
+     * Executes a method for each spare part in the campaign.
+     *
+     * @param consumer The method to apply to each spare part
+     *                 in the campaign.
+     */
+    public void forEachSparePart(Consumer<Part> consumer) {
+        for (Part part : getParts()) {
+            if (part.isSpare()) {
+                consumer.accept(part);
+            }
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -649,11 +649,11 @@ public class CampaignXmlParser {
 
         //unload any ammo bins in the warehouse
         List<AmmoBin> binsToUnload = new ArrayList<>();
-        for (Part prt : retVal.getSpareParts()) {
+        retVal.forEachSparePart(prt -> {
             if (prt instanceof AmmoBin && !prt.isReservedForRefit() && ((AmmoBin) prt).getShotsNeeded() == 0) {
                 binsToUnload.add((AmmoBin) prt);
             }
-        }
+        });
         for (AmmoBin bin : binsToUnload) {
             bin.unload();
         }

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -324,21 +324,19 @@ public class MissingBattleArmorSuit extends MissingPart {
                         int currentPartQuantity = 0;
                         for (Part p : bestPart.getChildParts()) {
                             if (p instanceof BaArmor) {
-                                bestPartArmor = ((BaArmor)p).getAmount();
+                                bestPartArmor = ((BaArmor) p).getAmount();
                             } else {
                                 bestPartQuantity++;
                             }
                         }
                         for (Part p : part.getChildParts()) {
                             if (p instanceof BaArmor) {
-                                currentPartArmor = ((BaArmor)p).getAmount();
+                                currentPartArmor = ((BaArmor) p).getAmount();
                             } else {
                                 currentPartQuantity++;
                             }
                         }
-                        if (currentPartQuantity > bestPartQuantity) {
-                            return part;
-                        } else if (currentPartArmor > bestPartArmor) {
+                        if ((currentPartQuantity > bestPartQuantity) || (currentPartArmor > bestPartArmor)) {
                             return part;
                         }
                     }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1257,20 +1257,18 @@ public class Refit extends Part implements IAcquisitionWork {
     }
 
     public Armor getExistingArmorSupplies() {
-        Armor existingArmorSupplies = null;
         if (null == newArmorSupplies) {
             return null;
         }
-        for (Part part : oldUnit.getCampaign().getSpareParts()) {
+        return (Armor) oldUnit.getCampaign().findSparePart(part -> {
             if (part instanceof Armor && ((Armor) part).getType() == newArmorSupplies.getType()
                     && part.isClanTechBase() == newArmorSupplies.isClanTechBase()
                     && !part.isReservedForRefit()
                     && part.isPresent()) {
-                existingArmorSupplies = (Armor) part;
-                break;
+                return true;
             }
-        }
-        return existingArmorSupplies;
+            return false;
+        });
     }
 
     private void updateRefitClass(int rClass) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -552,6 +552,8 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         AmmoType aType;
         AmmoType curType = (AmmoType)as.getType();
         int converted = 0;
+
+        // TODO: make this less intensive.
         for(Part part : campaign.getSpareParts()) {
             if(!part.isPresent()) {
                 continue;

--- a/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
@@ -57,7 +57,7 @@ public class BombsDialog extends JDialog implements ActionListener {
     private BombChoicePanel bombPanel;
     private IBomber bomber;
     private Campaign campaign;
-    
+
     private int[] bombChoices;
     private int[] bombCatalog = new int[BombType.B_NUM];
     private int[] availBombs = new int[BombType.B_NUM];
@@ -71,7 +71,7 @@ public class BombsDialog extends JDialog implements ActionListener {
         this.bomber = iBomber;
         this.campaign = campaign;
         bombChoices = bomber.getBombChoices();
-        
+
         initGUI();
         validate();
         pack();
@@ -82,19 +82,20 @@ public class BombsDialog extends JDialog implements ActionListener {
     private void initGUI() {
         //Using bombCatalog to store the part ID's of the bombs so don't have to keep full spare list in memory
         //and for ease of access later
-        List<Part> spareParts = campaign.getSpareParts();
-        for(Part spare : spareParts) {
-            if(spare instanceof AmmoStorage && ((EquipmentPart)spare).getType() instanceof BombType && spare.isPresent()) {
+        campaign.forEachSparePart(spare -> {
+            if ((spare instanceof AmmoStorage)
+                    && (((EquipmentPart)spare).getType() instanceof BombType)
+                    && spare.isPresent()) {
                 int bombType = (BombType.getBombTypeFromInternalName(((AmmoStorage)spare).getType().getInternalName()));
                 bombCatalog[bombType] = spare.getId();
                 availBombs[bombType] = ((AmmoStorage)spare).getShots();
             }
-        }
-        
+        });
+
         for (int type = 0; type < BombType.B_NUM; type++) {
             typeMax[type] = availBombs[type] + bombChoices[type];
         }
-        
+
         bombPanel = new BombChoicePanel(bomber, campaign.getGameOptions().booleanOption("at2_nukes"),
                 true, typeMax);
 
@@ -134,7 +135,7 @@ public class BombsDialog extends JDialog implements ActionListener {
         if (okayButton.equals(e.getSource())) {
             bombPanel.applyChoice();
             int[] newLoadout = bombPanel.getChoice();
-            
+
             //Get difference between starting bomb load and new bomb load
             for (int type = 0; type < BombType.B_NUM; type++) {
                 if(bombChoices[type] != newLoadout[type]) {
@@ -143,7 +144,7 @@ public class BombsDialog extends JDialog implements ActionListener {
                     newLoadout[type] = 0;
                 }
             }
-            
+
             for (int type = 0; type < BombType.B_NUM; type++) {
                 if (newLoadout[type] != 0) {
                     //IF there are bombs of this TYPE in the warehouse
@@ -161,7 +162,7 @@ public class BombsDialog extends JDialog implements ActionListener {
                     }
                 }
             }
-            
+
             setVisible(false);
         } else if (cancelButton.equals(e.getSource())) {
             setVisible(false);

--- a/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
@@ -243,12 +243,12 @@ public class MassRepairSalvageDialog extends JDialog {
         if (refreshCompleteList) {
             completePartsList = new ArrayList<>();
 
-            for (Part part : campaignGUI.getCampaign().getSpareParts()) {
+            campaignGUI.getCampaign().forEachSparePart(part -> {
                 if (!part.isBeingWorkedOn() && part.needsFixing() && !(part instanceof AmmoBin)
                         && (part.getSkillMin() <= SkillType.EXP_ELITE)) {
                     completePartsList.add(part);
                 }
-            }
+            });
         }
 
         filteredPartsList = new ArrayList<>();


### PR DESCRIPTION
In large campaigns the number of spare parts is typically overwhelming (I've seen it as high as 100k). In many areas we go ahead and make a huge copy of the array, plus the iteration costs. This PR adds forEachSparePart to improve cases where we're just walking the collection. This PR also switches to streamSpareParts where appropriate. In both cases the number of allocations and iterations is markedly reduced.