### PR TITLE
442: Enable/Disable MRMS Repair and Salvage Portions

### DIFF
--- a/MekHQ/resources/mekhq/resources/MassRepair.properties
+++ b/MekHQ/resources/mekhq/resources/MassRepair.properties
@@ -1,3 +1,16 @@
+#Generic
+Salvage=Salvage
+Repair=Repair
+
+#MassRepairService
+##Campaign Reports
+MRMS.StartWarehouse.report=Beginning mass warehouse repair.
+MRMS.NoAvailableTechs.report=No available techs to repairs parts.
+MRMS.CompleteDisabled.report=Mass Repair/Salvage complete. The service is disabled.
+MRMS.CompleteTypeDisabled.report=Mass Repair/Salvage complete. The service is disabled for %s.
+MRMS.CompleteNoUnits.report=Mass Repair/Salvage complete. There were no units worked on.
+
+##MassRepairSalvageDialog
 MassRepairMassSalvage.title=Mass Repair/Salvage
 MassRepair.title=Mass Repair
 
@@ -27,6 +40,10 @@ btnHideParts.Show.text=Show Parts List
 btnHideParts.Show.toolTipText=Show list of parts
 
 OptionsPanel.title=Options
+useRepairBox.text=Use Repair
+useRepairBox.toolTipText=Enables the repair functionality of mass repair/salvage
+useSalvageBox.text=Use Salvage
+useSalvageBox.toolTipText=Enables the salvage functionality of mass repair/salvage
 useExtraTimeBox.text=Use 'Extra Time' to reach min BTH for repairs/salvage
 useExtraTimeBox.toolTipText=When performing mass repair/salvage, apply 'Extra Time' to lower BTH to specified Min BTH
 useRushJobBox.text=Use 'Rush Job' to reach max BTH for repairs/salvage
@@ -75,6 +92,8 @@ btnSaveAsDefault.text=Save Options as Default
 btnClose.text=Done
 
 #Error Messages
+MRMSDisabled.errorTitle=Mass Repair/Salvage Disabled
+MRMSDisabled.error=Mass Repair/Salvage is currently disabled. Enable Use Repair or Use Salvage to run.
 NoEnabledRepairOptions.errorTitle=No Repair Options Enabled
 NoEnabledRepairOptions.error=No repair options are currently enabled. Please activate at least one type of item to repair.
 NoSelectedUnit.errorTitle=No Unit Selected

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -96,6 +96,8 @@ public class CampaignOptions implements Serializable {
     public static final String[] REPAIR_SYSTEM_NAMES = {"Strat Ops", "Warchest Custom", "Generic Spare Parts"}; // FIXME: This needs to be localized
 
     //Mass Repair/Salvage Options
+    private boolean massRepairUseRepair;
+    private boolean massRepairUseSalvage;
     private boolean massRepairUseExtraTime;
     private boolean massRepairUseRushJob;
     private boolean massRepairAllowCarryover;
@@ -406,6 +408,8 @@ public class CampaignOptions implements Serializable {
         repairSystem = REPAIR_SYSTEM_STRATOPS;
 
         //Mass Repair/Salvage Options
+        massRepairUseRepair = true;
+        massRepairUseSalvage = true;
         massRepairUseExtraTime = true;
         massRepairUseRushJob = true;
         massRepairAllowCarryover = true;
@@ -2946,6 +2950,22 @@ public class CampaignOptions implements Serializable {
     }
 
     //region Mass Repair/ Mass Salvage
+    public boolean massRepairUseRepair() {
+        return massRepairUseRepair;
+    }
+
+    public void setMassRepairUseRepair(boolean massRepairUseRepair) {
+        this.massRepairUseRepair = massRepairUseRepair;
+    }
+
+    public boolean massRepairUseSalvage() {
+        return massRepairUseSalvage;
+    }
+
+    public void setMassRepairUseSalvage(boolean massRepairUseSalvage) {
+        this.massRepairUseSalvage = massRepairUseSalvage;
+    }
+
     public boolean massRepairUseExtraTime() {
         return massRepairUseExtraTime;
     }
@@ -3321,38 +3341,40 @@ public class CampaignOptions implements Serializable {
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "opforLocalUnitChance", opforLocalUnitChance);
 
         //Mass Repair/Salvage Options
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairUseExtraTime", massRepairUseExtraTime);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairUseRushJob", massRepairUseRushJob);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairAllowCarryover", massRepairAllowCarryover);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairOptimizeToCompleteToday", massRepairOptimizeToCompleteToday);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairScrapImpossible", massRepairScrapImpossible);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairUseAssignedTechsFirst", massRepairUseAssignedTechsFirst);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "massRepairReplacePod", massRepairReplacePod);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, ++indent, "massRepairUseRepair", massRepairUseRepair());
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "massRepairUseSalvage", massRepairUseSalvage());
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "massRepairUseExtraTime", massRepairUseExtraTime);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "massRepairUseRushJob", massRepairUseRushJob);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "massRepairAllowCarryover", massRepairAllowCarryover);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "massRepairOptimizeToCompleteToday", massRepairOptimizeToCompleteToday);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "massRepairScrapImpossible", massRepairScrapImpossible);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "massRepairUseAssignedTechsFirst", massRepairUseAssignedTechsFirst);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "massRepairReplacePod", massRepairReplacePod);
 
-        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent + 1, "massRepairOptions");
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent++, "massRepairOptions");
         for (MassRepairOption massRepairOption : massRepairOptions) {
-            massRepairOption.writeToXML(pw1, indent + 2);
+            massRepairOption.writeToXML(pw1, indent);
         }
-        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent + 1, "massRepairOptions");
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, --indent, "massRepairOptions");
 
-        pw1.println(MekHqXmlUtil.indentStr(indent + 1)
+        pw1.println(MekHqXmlUtil.indentStr(indent)
                 + "<planetTechAcquisitionBonus>"
                 + StringUtils.join(planetTechAcquisitionBonus, ',')
                 + "</planetTechAcquisitionBonus>");
-        pw1.println(MekHqXmlUtil.indentStr(indent + 1)
+        pw1.println(MekHqXmlUtil.indentStr(indent)
                 + "<planetIndustryAcquisitionBonus>"
                 + StringUtils.join(planetIndustryAcquisitionBonus, ',')
                 + "</planetIndustryAcquisitionBonus>");
-        pw1.println(MekHqXmlUtil.indentStr(indent + 1)
+        pw1.println(MekHqXmlUtil.indentStr(indent)
                 + "<planetOutputAcquisitionBonus>"
                 + StringUtils.join(planetOutputAcquisitionBonus, ',')
                 + "</planetOutputAcquisitionBonus>");
 
-        pw1.println(MekHqXmlUtil.indentStr(indent + 1)
+        pw1.println(MekHqXmlUtil.indentStr(indent)
                     + "<salaryTypeBase>"
                     + Utilities.printMoneyArray(salaryTypeBase)
                     + "</salaryTypeBase>");
-        pw1.println(MekHqXmlUtil.indentStr(indent + 1)
+        pw1.println(MekHqXmlUtil.indentStr(indent)
                     + "<salaryXpMultiplier>"
                     + StringUtils.join(salaryXpMultiplier, ',')
                     + "</salaryXpMultiplier>");
@@ -3367,20 +3389,20 @@ public class CampaignOptions implements Serializable {
             }
         }
 
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "usePortraitForType", csv.toString());
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "usePortraitForType", csv.toString());
 
         //region AtB Options
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "useAtBUnitMarket", useAtBUnitMarket);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "rats", StringUtils.join(rats, ','));
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "useAtBUnitMarket", useAtBUnitMarket);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "rats", StringUtils.join(rats, ','));
         if (staticRATs) {
-            pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<staticRATs/>");
+            pw1.println(MekHqXmlUtil.indentStr(indent) + "<staticRATs/>");
         }
 
         if (ignoreRatEra) {
-            pw1.println(MekHqXmlUtil.indentStr(indent + 1) + "<ignoreRatEra/>");
+            pw1.println(MekHqXmlUtil.indentStr(indent) + "<ignoreRatEra/>");
         }
         //endregion AtB Options
-        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "campaignOptions");
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, --indent, "campaignOptions");
     }
 
     public static CampaignOptions generateCampaignOptionsFromXml(Node wn) {
@@ -3949,6 +3971,10 @@ public class CampaignOptions implements Serializable {
                 retVal.staticRATs = true;
             } else if (wn2.getNodeName().equalsIgnoreCase("ignoreRatEra")) {
                 retVal.ignoreRatEra = true;
+            } else if (wn2.getNodeName().equalsIgnoreCase("massRepairUseRepair")) {
+                retVal.setMassRepairUseRepair(Boolean.parseBoolean(wn2.getTextContent().trim()));
+            } else if (wn2.getNodeName().equalsIgnoreCase("massRepairUseSalvage")) {
+                retVal.setMassRepairUseSalvage(Boolean.parseBoolean(wn2.getTextContent().trim()));
             } else if (wn2.getNodeName().equalsIgnoreCase("massRepairUseExtraTime")) {
                 retVal.massRepairUseExtraTime = Boolean.parseBoolean(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("massRepairUseRushJob")) {

--- a/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
@@ -125,6 +125,7 @@ public class MassRepairSalvageDialog extends JDialog {
         campaignOptions = campaignGUI.getCampaign().getCampaignOptions();
 
         initComponents();
+        refreshOptions();
 
         if (getMode().isUnits()) {
             filterUnits(new MassRepairConfiguredOptions(this));
@@ -432,7 +433,6 @@ public class MassRepairSalvageDialog extends JDialog {
         useRepairBox = new JCheckBox(resources.getString("useRepairBox.text"));
         useRepairBox.setToolTipText(resources.getString("useRepairBox.toolTipText"));
         useRepairBox.setName("useRepairBox");
-        useRepairBox.setSelected(campaignOptions.massRepairUseRepair());
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = gridRowIdx++;
@@ -444,7 +444,6 @@ public class MassRepairSalvageDialog extends JDialog {
         useSalvageBox = new JCheckBox(resources.getString("useSalvageBox.text"));
         useSalvageBox.setToolTipText(resources.getString("useSalvageBox.toolTipText"));
         useSalvageBox.setName("useSalvageBox");
-        useSalvageBox.setSelected(campaignOptions.massRepairUseSalvage());
         gridBagConstraints.gridy = gridRowIdx++;
         gridBagConstraints.fill = GridBagConstraints.NONE;
         pnlOptions.add(useSalvageBox, gridBagConstraints);
@@ -452,21 +451,18 @@ public class MassRepairSalvageDialog extends JDialog {
         useExtraTimeBox = new JCheckBox(resources.getString("useExtraTimeBox.text"));
         useExtraTimeBox.setToolTipText(resources.getString("useExtraTimeBox.toolTipText"));
         useExtraTimeBox.setName("massRepairUseExtraTimeBox");
-        useExtraTimeBox.setSelected(campaignOptions.massRepairUseExtraTime());
         gridBagConstraints.gridy = gridRowIdx++;
         pnlOptions.add(useExtraTimeBox, gridBagConstraints);
 
         useRushJobBox = new JCheckBox(resources.getString("useRushJobBox.text"));
         useRushJobBox.setToolTipText(resources.getString("useRushJobBox.toolTipText"));
         useRushJobBox.setName("massRepairUseRushJobBox");
-        useRushJobBox.setSelected(campaignOptions.massRepairUseRushJob());
         gridBagConstraints.gridy = gridRowIdx++;
         pnlOptions.add(useRushJobBox, gridBagConstraints);
 
         allowCarryoverBox = new JCheckBox(resources.getString("allowCarryoverBox.text"));
         allowCarryoverBox.setToolTipText(resources.getString("allowCarryoverBox.toolTipText"));
         allowCarryoverBox.setName("massRepairAllowCarryoverBox");
-        allowCarryoverBox.setSelected(campaignOptions.massRepairAllowCarryover());
         allowCarryoverBox.addActionListener(e -> optimizeToCompleteTodayBox.setEnabled(allowCarryoverBox.isSelected()));
         gridBagConstraints.gridy = gridRowIdx++;
         pnlOptions.add(allowCarryoverBox, gridBagConstraints);
@@ -474,8 +470,6 @@ public class MassRepairSalvageDialog extends JDialog {
         optimizeToCompleteTodayBox = new JCheckBox(resources.getString("optimizeToCompleteTodayBox.text"));
         optimizeToCompleteTodayBox.setToolTipText(resources.getString("optimizeToCompleteTodayBox.toolTipText"));
         optimizeToCompleteTodayBox.setName("massRepairOptimizeToCompleteTodayBox");
-        optimizeToCompleteTodayBox.setSelected(campaignOptions.massRepairOptimizeToCompleteToday());
-        optimizeToCompleteTodayBox.setEnabled(campaignOptions.massRepairAllowCarryover());
         gridBagConstraints.gridy = gridRowIdx++;
         pnlOptions.add(optimizeToCompleteTodayBox, gridBagConstraints);
 
@@ -483,21 +477,18 @@ public class MassRepairSalvageDialog extends JDialog {
             useAssignedTechsFirstBox = new JCheckBox(resources.getString("useAssignedTechsFirstBox.text"));
             useAssignedTechsFirstBox.setToolTipText(resources.getString("useAssignedTechsFirstBox.toolTipText"));
             useAssignedTechsFirstBox.setName("massRepairUseAssignedTechsFirstBox");
-            useAssignedTechsFirstBox.setSelected(campaignOptions.massRepairUseAssignedTechsFirst());
             gridBagConstraints.gridy = gridRowIdx++;
             pnlOptions.add(useAssignedTechsFirstBox, gridBagConstraints);
 
             scrapImpossibleBox = new JCheckBox(resources.getString("scrapImpossibleBox.text"));
             scrapImpossibleBox.setToolTipText(resources.getString("scrapImpossibleBox.toolTipText"));
             scrapImpossibleBox.setName("massRepairScrapImpossibleBox");
-            scrapImpossibleBox.setSelected(campaignOptions.massRepairScrapImpossible());
             gridBagConstraints.gridy = gridRowIdx++;
             pnlOptions.add(scrapImpossibleBox, gridBagConstraints);
 
             replacePodPartsBox = new JCheckBox(resources.getString("replacePodPartsBox.text"));
             replacePodPartsBox.setToolTipText(resources.getString("replacePodPartsBox.toolTipText"));
             replacePodPartsBox.setName("replacePodParts");
-            replacePodPartsBox.setSelected(campaignOptions.massRepairReplacePod());
             gridBagConstraints.gridy = gridRowIdx++;
             pnlOptions.add(replacePodPartsBox, gridBagConstraints);
         }
@@ -1009,6 +1000,22 @@ public class MassRepairSalvageDialog extends JDialog {
     }
 
     //region Campaign Options
+    private void refreshOptions() {
+        getUseRepairBox().setSelected(campaignOptions.massRepairUseRepair());
+        getUseSalvageBox().setSelected(campaignOptions.massRepairUseSalvage());
+        getUseExtraTimeBox().setSelected(campaignOptions.massRepairUseExtraTime());
+        getUseRushJobBox().setSelected(campaignOptions.massRepairUseRushJob());
+        getAllowCarryoverBox().setSelected(campaignOptions.massRepairAllowCarryover());
+        getOptimizeToCompleteTodayBox().setSelected(campaignOptions.massRepairOptimizeToCompleteToday());
+        getOptimizeToCompleteTodayBox().setEnabled(campaignOptions.massRepairAllowCarryover());
+
+        if (!getMode().isWarehouse()) {
+            getScrapImpossibleBox().setSelected(campaignOptions.massRepairScrapImpossible());
+            getUseAssignedTechsFirstBox().setSelected(campaignOptions.massRepairUseAssignedTechsFirst());
+            getReplacePodPartsBox().setSelected(campaignOptions.massRepairReplacePod());
+        }
+    }
+
     private void updateOptions() {
         campaignOptions.setMassRepairUseRepair(getUseRepairBox().isSelected());
         campaignOptions.setMassRepairUseSalvage(getUseSalvageBox().isSelected());

--- a/MekHQ/src/mekhq/service/MassRepairConfiguredOptions.java
+++ b/MekHQ/src/mekhq/service/MassRepairConfiguredOptions.java
@@ -28,6 +28,8 @@ import java.util.List;
 
 public class MassRepairConfiguredOptions {
     //region Variable Declarations
+    private boolean useRepair;
+    private boolean useSalvage;
     private boolean useExtraTime;
     private boolean useRushJob;
     private boolean allowCarryover;
@@ -51,6 +53,8 @@ public class MassRepairConfiguredOptions {
 
     //region Initialization
     public void setup(CampaignOptions options) {
+        setUseRepair(options.massRepairUseRepair());
+        setUseSalvage(options.massRepairUseSalvage());
         setUseExtraTime(options.massRepairUseExtraTime());
         setUseRushJob(options.massRepairUseRushJob());
         setAllowCarryover(options.massRepairAllowCarryover());
@@ -68,6 +72,8 @@ public class MassRepairConfiguredOptions {
     }
 
     public void setup(MassRepairSalvageDialog dlg) {
+        setUseRepair(dlg.getUseRepairBox().isSelected());
+        setUseSalvage(dlg.getUseSalvageBox().isSelected());
         setUseExtraTime(dlg.getUseExtraTimeBox().isSelected());
         setUseRushJob(dlg.getUseRushJobBox().isSelected());
         setAllowCarryover(dlg.getAllowCarryoverBox().isSelected());
@@ -109,6 +115,26 @@ public class MassRepairConfiguredOptions {
     //endregion Initialization
 
     //region Getters/Setters
+    public boolean isEnabled() {
+        return useRepair() || useSalvage();
+    }
+
+    public boolean useRepair() {
+        return useRepair;
+    }
+
+    public void setUseRepair(boolean useRepair) {
+        this.useRepair = useRepair;
+    }
+
+    public boolean useSalvage() {
+        return useSalvage;
+    }
+
+    public void setUseSalvage(boolean useSalvage) {
+        this.useSalvage = useSalvage;
+    }
+
     public boolean isUseExtraTime() {
         return useExtraTime;
     }

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -160,7 +160,6 @@ public class MassRepairService {
             case UNFIXABLE_LIMB:
                 msg += " No actions were performed because there is at least one unfixable limb and configured settings do not allow location repairs.";
                 break;
-            case DISABLED:
             case NO_ACTIONS:
             default:
                 break;

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -59,7 +59,7 @@ public class MassRepairService {
     }
 
     public static boolean isValidMRMSUnit(Unit unit, MassRepairConfiguredOptions configuredOptions) {
-        if (unit.isSelfCrewed() || (!unit.isSalvage() && configuredOptions.useRepair())
+        if (unit.isSelfCrewed() || (!unit.isSalvage() && !configuredOptions.useRepair())
                 || (unit.isSalvage() && !configuredOptions.useSalvage())) {
             return false;
         }
@@ -127,7 +127,7 @@ public class MassRepairService {
             String msg = resources.getString("MRMS.CompleteDisabled.report");
             campaign.addReport(msg);
             return msg;
-        } else if ((!unit.isSalvage() && configuredOptions.useRepair())
+        } else if ((!unit.isSalvage() && !configuredOptions.useRepair())
                 || (unit.isSalvage() && !configuredOptions.useSalvage())) {
             String msg = MessageFormat.format(resources.getString("MRMS.CompleteTypeDisabled.report"),
                     unit.isSalvage() ? resources.getString("Salvage") : resources.getString("Repair"));
@@ -1338,10 +1338,6 @@ public class MassRepairService {
         private MassRepairPartSet partSet = new MassRepairPartSet();
         private STATUS status;
         private boolean salvaging;
-
-        public MassRepairUnitAction() {
-
-        }
 
         public MassRepairUnitAction(Unit unit, boolean salvaging, STATUS status) {
             this.unit = unit;

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -1331,7 +1331,7 @@ public class MassRepairService {
 
     public static class MassRepairUnitAction {
         public enum STATUS {
-            NO_ACTIONS, ACTIONS_PERFORMED, NO_TECHS, UNFIXABLE_LIMB, NO_PARTS, ALL_PARTS_IN_PROCESS, DISABLED
+            NO_ACTIONS, ACTIONS_PERFORMED, NO_TECHS, UNFIXABLE_LIMB, NO_PARTS, ALL_PARTS_IN_PROCESS
         }
 
         private Unit unit;

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -19,17 +19,20 @@
 package mekhq.service;
 
 import java.io.Serializable;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import megamek.common.Aero;
 import megamek.common.BattleArmor;
 import megamek.common.Mech;
 import megamek.common.Tank;
 import megamek.common.TargetRoll;
+import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -49,12 +52,15 @@ import mekhq.campaign.work.WorkTime;
 import mekhq.gui.sorter.UnitStatusSorter;
 
 public class MassRepairService {
+    private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MassRepair", new EncodeControl());
+
     private MassRepairService() {
 
     }
 
-    public static boolean isValidMRMSUnit(Unit unit) {
-        if (unit.isSelfCrewed()) {
+    public static boolean isValidMRMSUnit(Unit unit, MassRepairConfiguredOptions configuredOptions) {
+        if (unit.isSelfCrewed() || (!unit.isSalvage() && configuredOptions.useRepair())
+                || (unit.isSalvage() && !configuredOptions.useSalvage())) {
             return false;
         }
 
@@ -65,14 +71,18 @@ public class MassRepairService {
     public static MassRepairPartSet performWarehouseMassRepair(List<IPartWork> selectedParts,
                                                                MassRepairConfiguredOptions configuredOptions,
                                                                Campaign campaign) {
-        campaign.addReport("Beginning mass warehouse repair.");
+        if (!configuredOptions.useRepair()) { // Warehouse only uses repair
+            campaign.addReport(resources.getString("MRMS.CompleteDisabled.report"));
+            return new MassRepairPartSet();
+        }
+        campaign.addReport(resources.getString("MRMS.StartWarehouse.report"));
 
         List<Person> techs = campaign.getTechs(true);
 
         MassRepairPartSet partSet = new MassRepairPartSet();
 
         if (techs.isEmpty()) {
-            campaign.addReport("No available techs to repairs parts.");
+            campaign.addReport(resources.getString("MRMS.NoAvailableTechs.report"));
         } else {
             Map<Integer, MassRepairOption> mroByTypeMap = new HashMap<>();
 
@@ -113,11 +123,23 @@ public class MassRepairService {
 
     public static String performSingleUnitMassRepairOrSalvage(Campaign campaign, Unit unit) {
         MassRepairConfiguredOptions configuredOptions = new MassRepairConfiguredOptions(campaign);
+        if (!configuredOptions.isEnabled()) {
+            String msg = resources.getString("MRMS.CompleteDisabled.report");
+            campaign.addReport(msg);
+            return msg;
+        } else if ((!unit.isSalvage() && configuredOptions.useRepair())
+                || (unit.isSalvage() && !configuredOptions.useSalvage())) {
+            String msg = MessageFormat.format(resources.getString("MRMS.CompleteTypeDisabled.report"),
+                    unit.isSalvage() ? resources.getString("Salvage") : resources.getString("Repair"));
+            campaign.addReport(msg);
+            return msg;
+        }
+
         List<MassRepairOption> activeMROList = configuredOptions.getActiveMassRepairOptions();
         MassRepairUnitAction unitAction = performUnitMassRepairOrSalvage(campaign, unit,
                 unit.isSalvage(), activeMROList, configuredOptions);
 
-        String actionDescriptor = unit.isSalvage() ? "Salvage" : "Repair";
+        String actionDescriptor = unit.isSalvage() ? resources.getString("Salvage") : resources.getString("Repair");
         String msg = String.format("<font color='green'>Mass %s complete on %s.</font>", actionDescriptor,
                 unit.getName());
 
@@ -138,6 +160,7 @@ public class MassRepairService {
             case UNFIXABLE_LIMB:
                 msg += " No actions were performed because there is at least one unfixable limb and configured settings do not allow location repairs.";
                 break;
+            case DISABLED:
             case NO_ACTIONS:
             default:
                 break;
@@ -166,11 +189,16 @@ public class MassRepairService {
     }
 
     public static void massRepairSalvageAllUnits(Campaign campaign) {
-        MassRepairConfiguredOptions massRepairConfiguredOptions = new MassRepairConfiguredOptions(campaign);
+        MassRepairConfiguredOptions configuredOptions = new MassRepairConfiguredOptions(campaign);
+        if (!configuredOptions.isEnabled()) {
+            campaign.addReport(resources.getString("MRMS.CompleteDisabled.report"));
+            return;
+        }
+
         List<Unit> units = new ArrayList<>();
 
         for (Unit unit : campaign.getServiceableUnits()) {
-            if (!isValidMRMSUnit(unit)) {
+            if (!isValidMRMSUnit(unit, configuredOptions)) {
                 continue;
             }
 
@@ -191,11 +219,16 @@ public class MassRepairService {
             return 1;
         });
 
-        massRepairSalvageUnits(campaign, units, massRepairConfiguredOptions);
+        massRepairSalvageUnits(campaign, units, configuredOptions);
     }
 
     public static void massRepairSalvageUnits(Campaign campaign, List<Unit> units,
                                               MassRepairConfiguredOptions configuredOptions) {
+        // This shouldn't happen but is being added preventatively
+        if (!configuredOptions.isEnabled()) {
+            campaign.addReport(resources.getString("MRMS.CompleteDisabled.report"));
+            return;
+        }
         Map<MassRepairUnitAction.STATUS, List<MassRepairUnitAction>> unitActionsByStatus = new HashMap<>();
         List<MassRepairOption> activeMROs = configuredOptions.getActiveMassRepairOptions();
 
@@ -209,7 +242,7 @@ public class MassRepairService {
         }
 
         if (unitActionsByStatus.isEmpty()) {
-            campaign.addReport("Mass Repair/Salvage complete. There were no units worked on.");
+            campaign.addReport(resources.getString("MRMS.CompleteNoUnits.report"));
         } else {
             int totalCount = 0;
             int actionsPerformed = 0;
@@ -332,7 +365,7 @@ public class MassRepairService {
         campaign.addReport(sbMsg.toString());
     }
 
-    public static MassRepairUnitAction performUnitMassRepairOrSalvage(Campaign campaign, Unit unit,
+    private static MassRepairUnitAction performUnitMassRepairOrSalvage(Campaign campaign, Unit unit,
                                                                       boolean isSalvage,
                                                                       List<MassRepairOption> mroList,
                                                                       MassRepairConfiguredOptions configuredOptions) {
@@ -1179,10 +1212,6 @@ public class MassRepairService {
         private int maxTechSkill;
         private int configuredBTHMin;
 
-        public MassRepairPartAction() {
-
-        }
-
         public MassRepairPartAction(IPartWork partWork) {
             this.partWork = partWork;
         }
@@ -1266,7 +1295,7 @@ public class MassRepairService {
         private Map<MassRepairPartAction.STATUS, List<MassRepairPartAction>> partActionsByStatus = new HashMap<>();
 
         public void addPartAction(MassRepairPartAction partAction) {
-            if (null == partAction) {
+            if (partAction == null) {
                 return;
             }
 
@@ -1302,7 +1331,7 @@ public class MassRepairService {
 
     public static class MassRepairUnitAction {
         public enum STATUS {
-            NO_ACTIONS, ACTIONS_PERFORMED, NO_TECHS, UNFIXABLE_LIMB, NO_PARTS, ALL_PARTS_IN_PROCESS
+            NO_ACTIONS, ACTIONS_PERFORMED, NO_TECHS, UNFIXABLE_LIMB, NO_PARTS, ALL_PARTS_IN_PROCESS, DISABLED
         }
 
         private Unit unit;


### PR DESCRIPTION
This fixes #442 and implements the basis of a refresh system.

As part of this I discovered we use type in two ways for MassRepairOptions, for two arrays that do not align. That will be my next fix.