### PR TITLE
UnitRatingMethod: Add Disabled Case

### DIFF
--- a/MekHQ/resources/mekhq/resources/Rating.properties
+++ b/MekHQ/resources/mekhq/resources/Rating.properties
@@ -4,6 +4,6 @@
 
 ## Enums
 # UnitRatingMethod Enum
-UnitRatingMethod.NONE.text=None
+UnitRatingMethod.NONE.text=Disabled
 UnitRatingMethod.CAMPAIGN_OPS.text=Campaign Ops
 UnitRatingMethod.FLD_MAN_MERCS_REV.text=FM: Mercenaries (rev)

--- a/MekHQ/resources/mekhq/resources/Rating.properties
+++ b/MekHQ/resources/mekhq/resources/Rating.properties
@@ -1,0 +1,9 @@
+# This is used to store any Rating Resources
+
+## General Rating Resources
+
+## Enums
+# UnitRatingMethod Enum
+UnitRatingMethod.NONE.text=None
+UnitRatingMethod.CAMPAIGN_OPS.text=Campaign Ops
+UnitRatingMethod.FLD_MAN_MERCS_REV.text=FM: Mercenaries (rev)

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1431,7 +1431,7 @@ public class Campaign implements Serializable, ITechManager {
                 }
             }
             // Higher rated units are more likely to have Bloodnamed
-            if (getCampaignOptions().useDragoonRating()) {
+            if (getCampaignOptions().getUnitRatingMethod().isEnabled()) {
                 IUnitRating rating = getUnitRating();
                 bloodnameTarget += IUnitRating.DRAGOON_C - (getCampaignOptions().getUnitRatingMethod().equals(
                         mekhq.campaign.rating.UnitRatingMethod.FLD_MAN_MERCS_REV)
@@ -6050,24 +6050,20 @@ public class Campaign implements Serializable, ITechManager {
      * the user here.
      */
     public int getUnitRatingMod() {
-        if (!getCampaignOptions().useDragoonRating()) {
+        if (!getCampaignOptions().getUnitRatingMethod().isEnabled()) {
             return IUnitRating.DRAGOON_C;
         }
         IUnitRating rating = getUnitRating();
-        return getCampaignOptions().getUnitRatingMethod()
-                .equals(mekhq.campaign.rating.UnitRatingMethod.FLD_MAN_MERCS_REV) ? rating.getUnitRatingAsInteger()
-                        : rating.getModifier();
+        return getCampaignOptions().getUnitRatingMethod().isFMMR() ? rating.getUnitRatingAsInteger()
+                : rating.getModifier();
     }
 
     /**
      * This is a better method for pairing AtB with IOpts with regards to Prisoner Capture
      */
     public int getUnitRatingAsInteger() {
-        if (getCampaignOptions().useDragoonRating()) {
-            return getUnitRating().getUnitRatingAsInteger();
-        } else {
-            return IUnitRating.DRAGOON_C;
-        }
+        return getCampaignOptions().getUnitRatingMethod().isEnabled()
+                ? getUnitRating().getUnitRatingAsInteger() : IUnitRating.DRAGOON_C;
     }
 
     public RandomSkillPreferences getRandomSkillPreferences() {

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -109,7 +109,6 @@ public class CampaignOptions implements Serializable {
     //endregion Unlisted Variables
 
     //region General Tab
-    private boolean useUnitRating;
     private UnitRatingMethod unitRatingMethod;
     private int manualUnitRatingModifier;
     //endregion General Tab
@@ -425,7 +424,6 @@ public class CampaignOptions implements Serializable {
         //endregion Unlisted Variables
 
         //region General Tab
-        useUnitRating = true;
         unitRatingMethod = UnitRatingMethod.CAMPAIGN_OPS;
         manualUnitRatingModifier = 0;
         //endregion General Tab
@@ -1915,14 +1913,6 @@ public class CampaignOptions implements Serializable {
         this.resetToFirstTech = resetToFirstTech;
     }
 
-    public boolean useDragoonRating() {
-        return useUnitRating;
-    }
-
-    public void setDragoonRating(boolean b) {
-        this.useUnitRating = b;
-    }
-
     public int getRepairSystem() {
         return repairSystem;
     }
@@ -3101,7 +3091,6 @@ public class CampaignOptions implements Serializable {
 
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "useFactionForNames", useOriginFactionForNames);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "repairSystem", repairSystem);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "useUnitRating", useUnitRating);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "unitRatingMethod", unitRatingMethod.name());
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "useEraMods", useEraMods);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "assignedTechFirst", assignedTechFirst);
@@ -3607,9 +3596,11 @@ public class CampaignOptions implements Serializable {
                 retVal.factionIntroDate = Boolean.parseBoolean(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("techLevel")) {
                 retVal.techLevel = Integer.parseInt(wn2.getTextContent().trim());
-            } else if (wn2.getNodeName().equalsIgnoreCase("useUnitRating")
-                    || wn2.getNodeName().equalsIgnoreCase("useDragoonRating")) {
-                retVal.useUnitRating = Boolean.parseBoolean(wn2.getTextContent().trim());
+            } else if (wn2.getNodeName().equalsIgnoreCase("useUnitRating") // Legacy
+                    || wn2.getNodeName().equalsIgnoreCase("useDragoonRating")) { // Legacy
+                if (!Boolean.parseBoolean(wn2.getTextContent())) {
+                    retVal.setUnitRatingMethod(UnitRatingMethod.NONE);
+                }
             } else if (wn2.getNodeName().equalsIgnoreCase("unitRatingMethod")
                     || wn2.getNodeName().equalsIgnoreCase("dragoonsRatingMethod")) {
                 retVal.setUnitRatingMethod(UnitRatingMethod.parseFromString(wn2.getTextContent().trim()));

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -353,20 +353,16 @@ public class AtBContract extends Contract implements Serializable {
         int unitRatingMod = campaign.getUnitRatingMod();
         double multiplier = 1.0;
         // IntOps reputation factor then Dragoons rating
-        if (campaign.getCampaignOptions().useDragoonRating()
-            && campaign.getCampaignOptions().getUnitRatingMethod().equals(mekhq.campaign.rating.UnitRatingMethod.CAMPAIGN_OPS)) {
+        if (campaign.getCampaignOptions().getUnitRatingMethod().isCampaignOperations()) {
             multiplier *= (unitRatingMod * 0.2) + 0.5;
         } else {
             if (unitRatingMod >= IUnitRating.DRAGOON_A) {
                 multiplier *= 2.0;
-            }
-            if (unitRatingMod == IUnitRating.DRAGOON_B) {
+            } else if (unitRatingMod == IUnitRating.DRAGOON_B) {
                 multiplier *= 1.5;
-            }
-            if (unitRatingMod == IUnitRating.DRAGOON_D) {
+            } else if (unitRatingMod == IUnitRating.DRAGOON_D) {
                 multiplier *= 0.8;
-            }
-            if (unitRatingMod == IUnitRating.DRAGOON_F) {
+            } else if (unitRatingMod == IUnitRating.DRAGOON_F) {
                 multiplier *= 0.5;
             }
         }

--- a/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
+++ b/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
@@ -48,16 +48,16 @@ public enum UnitRatingMethod {
     //endregion Constructors
 
     //region Boolean Comparison Methods
+    public boolean isEnabled() {
+        return this != NONE;
+    }
+
     public boolean isCampaignOperations() {
         return this == CAMPAIGN_OPS;
     }
 
     public boolean isFMMR() {
         return this == FLD_MAN_MERCS_REV;
-    }
-
-    public boolean isEnabled() {
-        return isCampaignOperations() || isFMMR();
     }
     //endregion Boolean Comparison Methods
 

--- a/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
+++ b/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
@@ -20,26 +20,48 @@
  */
 package mekhq.campaign.rating;
 
+import megamek.common.util.EncodeControl;
+
+import java.util.ResourceBundle;
+
 /**
  * @author Deric Page (deric (dot) page (at) usa.net)
- * @version %Id%
  * @since 9/24/2013
  */
 public enum UnitRatingMethod {
-    CAMPAIGN_OPS("Campaign Ops"),
-    FLD_MAN_MERCS_REV("FM: Mercenaries (rev)");
+    //region Enum Declarations
+    NONE("UnitRatingMethod.NONE.text"),
+    CAMPAIGN_OPS("UnitRatingMethod.CAMPAIGN_OPS.text"),
+    FLD_MAN_MERCS_REV("UnitRatingMethod.FLD_MAN_MERCS_REV.text");
+    //endregion Enum Declarations
 
-    private final String description;
+    //region Variable Declarations
+    private final String name;
+    private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Rating",
+            new EncodeControl());
+    //endregion Variable Declarations
 
-    UnitRatingMethod(String description) {
-        this.description = description;
+    //region Constructors
+    UnitRatingMethod(String name) {
+        this.name = resources.getString(name);
+    }
+    //endregion Constructors
+
+    //region Boolean Comparison Methods
+    public boolean isCampaignOperations() {
+        return this == CAMPAIGN_OPS;
     }
 
-    @Override
-    public String toString() {
-        return description;
+    public boolean isFMMR() {
+        return this == FLD_MAN_MERCS_REV;
     }
 
+    public boolean isEnabled() {
+        return isCampaignOperations() || isFMMR();
+    }
+    //endregion Boolean Comparison Methods
+
+    //region File IO
     public static UnitRatingMethod parseFromString(String text) {
         try {
             return valueOf(text);
@@ -56,5 +78,11 @@ public enum UnitRatingMethod {
             default:
                 return FLD_MAN_MERCS_REV;
         }
+    }
+    //endregion File IO
+
+    @Override
+    public String toString() {
+        return name;
     }
 }

--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -53,6 +53,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
 
     // basic info panel
     private JPanel panInfo;
+    private JLabel lblRatingHead;
     private JLabel lblRating;
     private JLabel lblExperience;
     private JLabel lblPersonnel;
@@ -78,6 +79,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
 
     // available reports
     private JPanel panReports;
+    private JButton btnUnitRating;
 
     //icon panel
     private JPanel panIcon;
@@ -162,20 +164,20 @@ public final class CommandCenterTab extends CampaignGuiTab {
         int y = 0;
 
         /* Unit Rating */
+        lblRatingHead = new JLabel(resourceMap.getString("lblRating.text"));
+        lblRatingHead.setVisible(getCampaign().getCampaignOptions().getUnitRatingMethod().isEnabled());
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = y++;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new Insets(5, 5, 1, 5);
+        panInfo.add(lblRatingHead, gridBagConstraints);
         lblRating = new JLabel(getCampaign().getUnitRatingText());
-        if (getCampaign().getCampaignOptions().useDragoonRating()) {
-            JLabel lblRatingHead = new JLabel(resourceMap.getString("lblRating.text"));
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 0;
-            gridBagConstraints.gridy = y++;
-            gridBagConstraints.fill = GridBagConstraints.NONE;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            gridBagConstraints.insets = new Insets(5, 5, 1, 5);
-            panInfo.add(lblRatingHead, gridBagConstraints);
-            gridBagConstraints.gridx = 1;
-            gridBagConstraints.weightx = 1.0;
-            panInfo.add(lblRating, gridBagConstraints);
-        }
+        lblRating.setVisible(getCampaign().getCampaignOptions().getUnitRatingMethod().isEnabled());
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.weightx = 1.0;
+        panInfo.add(lblRating, gridBagConstraints);
         JLabel lblExperienceHead = new JLabel(resourceMap.getString("lblExperience.text"));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -430,7 +432,8 @@ public final class CommandCenterTab extends CampaignGuiTab {
         btnCargoCapacity.addActionListener(evt -> getCampaignGui().showReport(new CargoReport(getCampaign())));
         panReports.add(btnCargoCapacity);
 
-        JButton btnUnitRating = new JButton(resourceMap.getString("btnUnitRating.text"));
+        btnUnitRating = new JButton(resourceMap.getString("btnUnitRating.text"));
+        btnUnitRating.setVisible(getCampaign().getCampaignOptions().getUnitRatingMethod().isEnabled());
         btnUnitRating.addActionListener(evt -> getCampaignGui().showReport(new RatingReport(getCampaign())));
         panReports.add(btnUnitRating);
 
@@ -599,6 +602,9 @@ public final class CommandCenterTab extends CampaignGuiTab {
 
     @Subscribe
     public void handle(OptionsChangedEvent evt) {
+        lblRatingHead.setVisible(evt.getOptions().getUnitRatingMethod().isEnabled());
+        lblRating.setVisible(evt.getOptions().getUnitRatingMethod().isEnabled());
+        btnUnitRating.setVisible(evt.getOptions().getUnitRatingMethod().isEnabled());
         basicInfoScheduler.schedule();
         procurementListScheduler.schedule();
         setIcon();
@@ -624,5 +630,4 @@ public final class CommandCenterTab extends CampaignGuiTab {
     public void handle(AssetEvent ev) {
         basicInfoScheduler.schedule();
     }
-
 }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -145,8 +145,7 @@ public class CampaignOptionsDialog extends JDialog {
     private JPanel panGeneral;
     private JTextField txtName;
     private JComboBox<String> comboFaction;
-    SortedComboBoxModel<String> factionModel;
-    private JCheckBox useUnitRatingCheckBox;
+    private SortedComboBoxModel<String> factionModel;
     private JComboBox<UnitRatingMethod> unitRatingMethodCombo;
     private JSpinner manualUnitRatingModifier;
     private JButton btnDate;
@@ -658,31 +657,22 @@ public class CampaignOptionsDialog extends JDialog {
 
         JPanel unitRatingPanel = new JPanel(new GridBagLayout());
 
-        useUnitRatingCheckBox = new JCheckBox(resourceMap.getString("useUnitRatingCheckBox.text"));
-        useUnitRatingCheckBox.setName("useUnitRatingCheckBox");
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        unitRatingPanel.add(useUnitRatingCheckBox);
-
         JLabel unitRatingMethodLabel = new JLabel(resourceMap.getString("unitRatingMethodLabel.text"));
         unitRatingMethodLabel.setName("unitRatingMethodLabel");
-        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridx = 0;
         unitRatingPanel.add(unitRatingMethodLabel, gridBagConstraints);
 
         unitRatingMethodCombo = new JComboBox<>(UnitRatingMethod.values());
         unitRatingMethodCombo.setName("unitRatingMethodCombo");
-        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridx = 1;
         unitRatingPanel.add(unitRatingMethodCombo, gridBagConstraints);
 
         JLabel manualUnitRatingModifierLabel = new JLabel(resourceMap.getString("manualUnitRatingModifierLabel.text"));
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridx = 2;
         unitRatingPanel.add(manualUnitRatingModifierLabel, gridBagConstraints);
 
         manualUnitRatingModifier = new JSpinner(new SpinnerNumberModel(0, -100, 100, 1));
-        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridx = 3;
         unitRatingPanel.add(manualUnitRatingModifier, gridBagConstraints);
 
         gridBagConstraints = new GridBagConstraints();
@@ -4370,7 +4360,6 @@ public class CampaignOptionsDialog extends JDialog {
         }
 
         //region General Tab
-        useUnitRatingCheckBox.setSelected(options.useDragoonRating());
         unitRatingMethodCombo.setSelectedItem(options.getUnitRatingMethod());
         manualUnitRatingModifier.setValue(options.getManualUnitRatingModifier());
         //endregion General Tab
@@ -4902,7 +4891,6 @@ public class CampaignOptionsDialog extends JDialog {
         }
         options.setDamagedPartsValue((Double) spnDamagedPartsValue.getModel().getValue());
         options.setCanceledOrderReimbursement((Double) spnOrderRefund.getModel().getValue());
-        options.setDragoonRating(useUnitRatingCheckBox.isSelected());
         options.setUnitRatingMethod((UnitRatingMethod) unitRatingMethodCombo.getSelectedItem());
         options.setManualUnitRatingModifier((Integer) manualUnitRatingModifier.getValue());
         options.setUseOriginFactionForNames(chkUseOriginFactionForNames.isSelected());


### PR DESCRIPTION
This merges the useUnitRating into the UnitRatingMethod enum as a disabled case. The idea to do so was brought up based on the confusing method name of useDragoonsRating in a previous PR of mine.

I also fixed the command center hide/refresh for unit rating upon campaign options change.