### PR TITLE
Do not reference units by ID if an object reference will do

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -966,6 +966,8 @@ public class Campaign implements Serializable, ITechManager {
      * @param u A {@link Unit} to import into the campaign.
      */
     public void importUnit(Unit u) {
+        Objects.requireNonNull(u);
+
         MekHQ.getLogger().debug("Importing unit: (" + u.getId() + "): " + u.getName());
 
         getHangar().addUnit(u);
@@ -995,7 +997,7 @@ public class Campaign implements Serializable, ITechManager {
     public void addTransportShip(Unit unit) {
         MekHQ.getLogger().debug("Adding DropShip/WarShip: " + unit.getId());
 
-        transportShips.add(unit);
+        transportShips.add(Objects.requireNonNull(unit));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -990,7 +990,7 @@ public class Campaign implements Serializable, ITechManager {
     /**
      * Adds an entry to the list of transit-capable transport ships. We'll use this
      * to look for empty bays that ground units can be assigned to
-     * @param id - The unique ID of the ship we want to add to this Set
+     * @param unit - The ship we want to add to this Set
      */
     public void addTransportShip(Unit unit) {
         MekHQ.getLogger().debug("Adding DropShip/WarShip: " + unit.getId());
@@ -1001,7 +1001,7 @@ public class Campaign implements Serializable, ITechManager {
     /**
      * Deletes an entry from the list of transit-capable transport ships. This gets updated when
      * the ship is removed from the campaign for one reason or another
-     * @param id - The unique ID of the ship we want to remove from this Set
+     * @param unit - The ship we want to remove from this Set
      */
     public void removeTransportShip(Unit unit) {
         MekHQ.getLogger().debug("Removing DropShip/WarShip: " + unit.getId());

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -368,8 +368,9 @@ public class CampaignXmlParser {
         // Process parts...
         List<Part> removeParts = new ArrayList<>();
         for (Part prt : retVal.getParts()) {
-            Unit u = retVal.getUnit(prt.getUnitId());
-            prt.setUnit(u);
+            prt.fixReferences(retVal);
+
+            Unit u = prt.getUnit();
             if (null != u) {
                 // get rid of any equipmentparts without locations or mounteds
                 if (prt instanceof EquipmentPart) {
@@ -481,10 +482,6 @@ public class CampaignXmlParser {
         }
         for (Part prt : removeParts) {
             retVal.removePart(prt);
-        }
-
-        for (Part prt : retVal.getParts()) {
-            prt.fixReferences(retVal);
         }
 
         MekHQ.getLogger().info(String.format("[Campaign Load] Parts processed in %dms",
@@ -663,9 +660,9 @@ public class CampaignXmlParser {
         //is not refitting or is gone then unreserve
         for (Part part : retVal.getParts()) {
             if (part.isReservedForRefit()) {
-                Unit u = retVal.getUnit(part.getRefitId());
-                if (null == u || !u.isRefitting()) {
-                    part.setRefitId(null);
+                Unit u = part.getRefitUnit();
+                if ((null == u) || !u.isRefitting()) {
+                    part.setRefitUnit(null);
                 }
             }
         }
@@ -1479,12 +1476,12 @@ public class CampaignXmlParser {
                 p = null;
             }
 
-            if ((null != p) && (p.getUnitId() != null)
+            if ((null != p) && (p.getUnit() != null)
                     && ((version.getMinorVersion() < 43)
                             || ((version.getMinorVersion() == 43) && (version.getSnapshot() < 5)))
                     && ((p instanceof AmmoBin) || (p instanceof MissingAmmoBin))) {
-                Unit u = retVal.getUnit(p.getUnitId());
-                if ((null != u) && (u.getEntity().usesWeaponBays())) {
+                Unit u = p.getUnit();
+                if (u.getEntity().usesWeaponBays()) {
                     Mounted ammo;
                     if (p instanceof EquipmentPart) {
                         ammo = u.getEntity().getEquipment(((EquipmentPart) p).getEquipmentNum());
@@ -1517,7 +1514,7 @@ public class CampaignXmlParser {
 
         retVal.importParts(parts);
 
-        MekHQ.getLogger().info(CampaignXmlParser.class, "Load Part Nodes Complete!");
+        MekHQ.getLogger().info("Load Part Nodes Complete!");
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryUtil.java
@@ -105,7 +105,7 @@ public final class InjuryUtil {
 
     /** Generate combat injuries spread through the whole body */
     public static Collection<Injury> genInjuries(Campaign c, Person p, int hits) {
-        final Unit u = c.getUnit(p.getUnitId());
+        final Unit u = p.getUnit();
         final Entity en = (null != u) ? u.getEntity() : null;
         final boolean mwasf = ((en instanceof Mech) || (en instanceof Aero));
         final int critMod = mwasf ? 0 : 2;
@@ -327,14 +327,14 @@ public final class InjuryUtil {
                             }
                             i.setWorkedOn(true);
                             MedicalLogger.successfullyTreated(doc, p, c.getLocalDate(), i);
-                            Unit u = c.getUnit(p.getUnitId());
+                            Unit u = p.getUnit();
                             if (null != u) {
                                 u.resetPilotAndEntity();
                             }
                         }));
                 }
                 i.setWorkedOn(true);
-                Unit u = c.getUnit(p.getUnitId());
+                Unit u = p.getUnit();
                 if (null != u) {
                     u.resetPilotAndEntity();
                 }

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -228,8 +228,8 @@ public class Armor extends Part implements IAcquisitionWork {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof Armor
-                && Objects.equals(getRefitId(), part.getRefitId())
+        return (part instanceof Armor)
+                && (getRefitUnit() == part.getRefitUnit())
                 && isSameType((Armor)part);
     }
 
@@ -577,9 +577,9 @@ public class Armor extends Part implements IAcquisitionWork {
 
     public void changeAmountAvailable(int amount) {
         Armor a = (Armor)campaign.findSparePart(part -> {
-            return part instanceof Armor
+            return (part instanceof Armor)
                 && part.isPresent()
-                && Objects.equals(getRefitId(), part.getRefitId())
+                && (getRefitUnit() == part.getRefitUnit())
                 && isSameType((Armor)part);
         });
 

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -229,7 +229,7 @@ public class Armor extends Part implements IAcquisitionWork {
     @Override
     public boolean isSamePartType(Part part) {
         return (part instanceof Armor)
-                && (getRefitUnit() == part.getRefitUnit())
+                && Objects.equals(getRefitUnit(), part.getRefitUnit())
                 && isSameType((Armor)part);
     }
 
@@ -579,7 +579,7 @@ public class Armor extends Part implements IAcquisitionWork {
         Armor a = (Armor)campaign.findSparePart(part -> {
             return (part instanceof Armor)
                 && part.isPresent()
-                && (getRefitUnit() == part.getRefitUnit())
+                && Objects.equals(getRefitUnit(), part.getRefitUnit())
                 && isSameType((Armor)part);
         });
 

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -21,6 +21,8 @@
 
 package mekhq.campaign.parts;
 
+import java.util.Objects;
+
 import megamek.common.EquipmentType;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -128,7 +130,7 @@ public class BaArmor extends Armor implements IAcquisitionWork {
     public boolean isSamePartType(Part part) {
         return (part instanceof BaArmor)
                 && (isClanTechBase() == part.isClanTechBase())
-                && (getRefitUnit() == part.getRefitUnit())
+                && Objects.equals(getRefitUnit(), part.getRefitUnit())
                 && (((BaArmor) part).getType() == getType());
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -129,7 +129,7 @@ public class BaArmor extends Armor implements IAcquisitionWork {
         return (part instanceof BaArmor)
                 && (isClanTechBase() == part.isClanTechBase())
                 && (getRefitUnit() == part.getRefitUnit())
-                && (((BaArmor)part).getType() == getType());
+                && (((BaArmor) part).getType() == getType());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -1,27 +1,25 @@
 /*
  * BaArmor.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq.campaign.parts;
-
-import java.util.Objects;
 
 import megamek.common.EquipmentType;
 import mekhq.campaign.Campaign;
@@ -34,42 +32,42 @@ import mekhq.campaign.work.IAcquisitionWork;
  */
 public class BaArmor extends Armor implements IAcquisitionWork {
     private static final long serialVersionUID = 5275226057484468868L;
-    
+
     public static boolean canBeClan(int type) {
-        return type == EquipmentType.T_ARMOR_BA_STANDARD || type == EquipmentType.T_ARMOR_BA_STEALTH_BASIC 
+        return type == EquipmentType.T_ARMOR_BA_STANDARD || type == EquipmentType.T_ARMOR_BA_STEALTH_BASIC
                 || type == EquipmentType.T_ARMOR_BA_STEALTH_IMP || type == EquipmentType.T_ARMOR_BA_STEALTH
-                || type == EquipmentType.T_ARMOR_BA_FIRE_RESIST; 
+                || type == EquipmentType.T_ARMOR_BA_FIRE_RESIST;
     }
-    
+
     public static boolean canBeIs(int type) {
         return type != EquipmentType.T_ARMOR_BA_FIRE_RESIST;
     }
-    
+
 
     public static double getPointsPerTon(int t, boolean isClan) {
         return 1.0/EquipmentType.getBaArmorWeightPerPoint(t, isClan);
     }
-    
+
     public BaArmor() {
         this(0, 0, 0, -1, false, null);
     }
-    
+
     public BaArmor(int tonnage, int points, int type, int loc, boolean clan, Campaign c) {
         // Amount is used for armor quantity, not tonnage
         super(tonnage, type, points, loc, false, clan, c);
     }
-    
+
     public BaArmor clone() {
         BaArmor clone = new BaArmor(0, amount, type, location, clan, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     @Override
     public double getTonnage() {
         return EquipmentType.getBaArmorWeightPerPoint(type, clan) * amount;
     }
-    
+
     public Money getPointCost() {
         switch(type) {
         case EquipmentType.T_ARMOR_BA_STANDARD_ADVANCED:
@@ -90,50 +88,50 @@ public class BaArmor extends Armor implements IAcquisitionWork {
             return Money.of(10000);
         }
     }
-    
+
     private double getPointsPerTon() {
         return getPointsPerTon(type, clan);
     }
-    
+
     @Override
     public int getType() {
         return type;
     }
-    
+
     @Override
     public Money getCurrentValue() {
         return getPointCost().multipliedBy(amount);
     }
-    
+
     @Override
     public double getTonnageNeeded() {
         return amountNeeded / getPointsPerTon();
     }
-    
+
     @Override
     public Money getValueNeeded() {
         return adjustCostsForCampaignOptions(getPointCost().multipliedBy(amountNeeded));
     }
-    
+
     @Override
     public Money getStickerPrice() {
         //always in 5-ton increments
         return getPointCost().multipliedBy(5).multipliedBy(getPointsPerTon());
     }
-    
+
     @Override
     public Money getBuyCost() {
         return getStickerPrice();
     }
-    
+
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof BaArmor
-                && isClanTechBase() == part.isClanTechBase()
-                && Objects.equals(getRefitId(), part.getRefitId())
-                && ((BaArmor)part).getType() == getType();
+        return (part instanceof BaArmor)
+                && (isClanTechBase() == part.isClanTechBase())
+                && (getRefitUnit() == part.getRefitUnit())
+                && (((BaArmor)part).getType() == getType());
     }
-    
+
     @Override
     public boolean isSameStatus(Part part) {
         return !hasParentPart() && !part.hasParentPart() && this.getDaysToArrival() == part.getDaysToArrival();

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1253,7 +1253,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     /**
      * Sets the unit which has reserved this part for a refit.
-     * @param unitId The unit reserving this part for a refit.
+     * @param unit The unit reserving this part for a refit.
      */
     public void setRefitUnit(@Nullable Unit unit) {
         refitUnit = unit;

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -169,7 +169,6 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     //null is valid. It indicates parts that are not attached to units.
     protected Unit unit;
-    protected UUID unitId;
 
     protected int quality;
 
@@ -181,7 +180,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     protected int shorthandedMod;
 
     /** This tracks the unit which resorved the part for a refit */
-    private UUID refitId;
+    private Unit refitUnit;
     /** The unique identifier of the tech who is reserving this part for overnight work */
     private Person reservedBy;
     //temporarily mark the part used by current refit planning
@@ -235,10 +234,8 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         this.skillMin = SkillType.EXP_GREEN;
         this.mode = WorkTime.NORMAL;
         this.timeSpent = 0;
-        this.unitId = null;
         this.workingOvertime = false;
         this.shorthandedMod = 0;
-        this.refitId = null;
         this.usedForRefitPlanning = false;
         this.daysToArrival = 0;
         this.campaign = c;
@@ -296,10 +293,6 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public int getId() {
         return id;
-    }
-
-    public UUID getUnitId() {
-        return unitId;
     }
 
     public void setCampaign(Campaign c) {
@@ -405,17 +398,14 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         this.omniPodded = omniPod;
     }
 
-    public Unit getUnit() {
+    public @Nullable Unit getUnit() {
         return unit;
     }
 
-    public void setUnit(Unit u) {
-        this.unit = u;
+    public void setUnit(@Nullable Unit u) {
+        unit = u;
         if (null != unit) {
-            unitId = unit.getId();
             unitTonnage = (int) unit.getEntity().getWeight();
-        } else {
-            unitId = null;
         }
     }
 
@@ -656,10 +646,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             .append(skillMin)
             .append("</skillMin>")
             .append(NL);
-        if (null != unitId) {
+        if (null != unit) {
             builder.append(level1)
                 .append("<unitId>")
-                .append(unitId)
+                .append(unit.getId())
                 .append("</unitId>")
                 .append(NL);
         }
@@ -677,10 +667,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                 .append("</shorthandedMod>")
                 .append(NL);
         }
-        if (refitId != null) {
+        if (refitUnit != null) {
             builder.append(level1)
                 .append("<refitId>")
-                .append(refitId)
+                .append(refitUnit.getId())
                 .append("</refitId>")
                 .append(NL);
         }
@@ -823,13 +813,13 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("unitId")) {
                     if (!wn2.getTextContent().equals("null")) {
-                        retVal.unitId = UUID.fromString(wn2.getTextContent());
+                        retVal.unit = new PartUnitRef(UUID.fromString(wn2.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("shorthandedMod")) {
                     retVal.shorthandedMod = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("refitId")) {
                     if (!wn2.getTextContent().equals("null")) {
-                        retVal.refitId = UUID.fromString(wn2.getTextContent());
+                        retVal.refitUnit = new PartUnitRef(UUID.fromString(wn2.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("daysToArrival")) {
                     retVal.daysToArrival = Integer.parseInt(wn2.getTextContent());
@@ -857,7 +847,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             }
 
             // Refit protection of unit id
-            if (retVal.unitId != null && retVal.refitId != null) {
+            if (retVal.unit != null && retVal.refitUnit != null) {
                 retVal.setUnit(null);
             }
         } catch (Exception ex) {
@@ -1263,23 +1253,22 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     /**
      * Sets the unit which has reserved this part for a refit.
-     * @param unitId The unique identifier of the unit.
+     * @param unitId The unit reserving this part for a refit.
      */
-    public void setRefitId(UUID unitId) {
-        refitId = unitId;
+    public void setRefitUnit(@Nullable Unit unit) {
+        refitUnit = unit;
     }
 
     /**
-     * Gets the unique identifier of the unit which reserved
-     * this part for a refit.
-     * @return The unique identifier of the unit reserving this part.
+     * Gets the unit which reserved this part for a refit.
+     * @return The unit reserving this part.
      */
-    public UUID getRefitId() {
-        return refitId;
+    public @Nullable Unit getRefitUnit() {
+        return refitUnit;
     }
 
     public boolean isReservedForRefit() {
-        return refitId != null;
+        return refitUnit != null;
     }
 
     public boolean isReservedForReplacement() {
@@ -1367,9 +1356,9 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 
     public boolean isSpare() {
-        return (unitId == null)
+        return (unit == null)
             && (parentPart == null)
-            && (refitId == null)
+            && (refitUnit == null)
             && (reservedBy == null);
     }
 
@@ -1848,6 +1837,26 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                         getId(), getName(), id));
             }
         }
+
+        if (unit instanceof PartUnitRef) {
+            UUID id = unit.getId();
+            unit = campaign.getUnit(id);
+            if (unit == null) {
+                MekHQ.getLogger().error(
+                    String.format("Part %d ('%s') references missing unit %s",
+                        getId(), getName(), id));
+            }
+        }
+
+        if (refitUnit instanceof PartUnitRef) {
+            UUID id = refitUnit.getId();
+            refitUnit = campaign.getUnit(id);
+            if (refitUnit == null) {
+                MekHQ.getLogger().error(
+                    String.format("Part %d ('%s') references missing refit unit %s",
+                        getId(), getName(), id));
+            }
+        }
     }
 
     public static class PartRef extends Part {
@@ -1944,6 +1953,13 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
         private PartPersonRef(UUID id) {
             super(id);
+        }
+    }
+
+    public static class PartUnitRef extends Unit {
+
+        private PartUnitRef(UUID id) {
+            setId(id);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
@@ -21,8 +21,6 @@
 
 package mekhq.campaign.parts;
 
-import java.util.Objects;
-
 import megamek.common.EquipmentType;
 import megamek.common.Protomech;
 import megamek.common.TechAdvancement;
@@ -90,7 +88,7 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
         return part instanceof ProtomekArmor
                 && getType() == ((ProtomekArmor) part).getType()
                 && isClanTechBase() == part.isClanTechBase()
-                && Objects.equals(getRefitId(), part.getRefitId());
+                && (getRefitUnit() == part.getRefitUnit());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
@@ -21,6 +21,8 @@
 
 package mekhq.campaign.parts;
 
+import java.util.Objects;
+
 import megamek.common.EquipmentType;
 import megamek.common.Protomech;
 import megamek.common.TechAdvancement;
@@ -88,7 +90,7 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
         return part instanceof ProtomekArmor
                 && getType() == ((ProtomekArmor) part).getType()
                 && isClanTechBase() == part.isClanTechBase()
-                && (getRefitUnit() == part.getRefitUnit());
+                && Objects.equals(getRefitUnit(), part.getRefitUnit());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1322,7 +1322,7 @@ public class Refit extends Part implements IAcquisitionWork {
         toRemove.add(this);
         if (getRefitUnit() != null) {
             for (IAcquisitionWork part : campaign.getShoppingList().getPartList()) {
-                if ((part instanceof Part) && (((Part) part).getRefitUnit() == getRefitUnit())) {
+                if ((part instanceof Part) && Objects.equals(getRefitUnit(), ((Part) part).getRefitUnit())) {
                     toRemove.add(part);
                 }
             }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -829,7 +829,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 newArmorSupplies = new Armor(0, atype, 0, 0, false, aclan, oldUnit.getCampaign());
             }
             newArmorSupplies.setAmountNeeded(armorNeeded);
-            newArmorSupplies.setRefitId(oldUnit.getId());
+            newArmorSupplies.setRefitUnit(oldUnit);
             //check existing supplies before determining cost
             Armor existingArmorSupplies = getExistingArmorSupplies();
             double tonnageNeeded = newArmorSupplies.getTonnageNeeded();
@@ -1039,7 +1039,7 @@ public class Refit extends Part implements IAcquisitionWork {
         for (Iterator<Part> iter = shoppingList.iterator(); iter.hasNext(); ) {
             final Part part = iter.next();
             if (part instanceof AmmoBin) {
-                part.setRefitId(oldUnit.getId());
+                part.setRefitUnit(oldUnit);
                 part.setUnit(null);
                 campaign.addPart(part, 0);
                 newUnitParts.add(part);
@@ -1078,7 +1078,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 // ...and add that to our list of new unit parts
                 int tons = (int) Math.ceil((double) needed / atype.getShots());
                 AmmoStorage ammo = new AmmoStorage(tons, atype, atype.getShots() * tons, campaign);
-                ammo.setRefitId(oldUnit.getId());
+                ammo.setRefitUnit(oldUnit);
                 campaign.addPart(ammo, 0);
                 newUnitParts.add(ammo);
             }
@@ -1095,7 +1095,7 @@ public class Refit extends Part implements IAcquisitionWork {
                     //armor by location to the shopping list but instead changing it all via
                     //the newArmorSupplies object, but commented out for completeness
                     //oldUnit.getCampaign().addPart(part, 0);
-                    //part.setRefitId(oldUnit.getId());
+                    //part.setRefitUnit(oldUnit);
                     //newUnitParts.add(part.getId());
                 }
                 else if (part instanceof AmmoBin) {
@@ -1104,7 +1104,7 @@ public class Refit extends Part implements IAcquisitionWork {
                     //ammo bins are free - bleh
                     AmmoBin bin = (AmmoBin) part;
                     bin.setShotsNeeded(bin.getFullShots());
-                    part.setRefitId(oldUnit.getId());
+                    part.setRefitUnit(oldUnit);
                     oldUnit.getCampaign().addPart(part, 0);
                     newUnitParts.add(part);
                     if (bin.needsFixing()) {
@@ -1163,11 +1163,11 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (newPart.getQuantity() > 1) {
                     newPart.decrementQuantity();
                     newPart = newPart.clone();
-                    newPart.setRefitId(oldUnit.getId());
+                    newPart.setRefitUnit(oldUnit);
                     oldUnit.getCampaign().addPart(newPart, 0);
                     newNewUnitParts.add(newPart);
                 } else {
-                    newPart.setRefitId(oldUnit.getId());
+                    newPart.setRefitUnit(oldUnit);
                     newNewUnitParts.add(newPart);
                 }
             } else {
@@ -1208,12 +1208,12 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (null != replacement) {
                     if (replacement.getQuantity() > 1) {
                         Part actualReplacement = replacement.clone();
-                        actualReplacement.setRefitId(oldUnit.getId());
+                        actualReplacement.setRefitUnit(oldUnit);
                         oldUnit.getCampaign().addPart(actualReplacement, 0);
                         newUnitParts.add(actualReplacement);
                         replacement.decrementQuantity();
                     } else {
-                        replacement.setRefitId(oldUnit.getId());
+                        replacement.setRefitUnit(oldUnit);
                         newUnitParts.add(replacement);
                     }
                 } else {
@@ -1291,11 +1291,11 @@ public class Refit extends Part implements IAcquisitionWork {
         }
 
         for (Part part : newUnitParts) {
-            part.setRefitId(null);
+            part.setRefitUnit(null);
 
             // If the part was not part of the old unit we need to consolidate it with others of its type
             // in the warehouse. Ammo Bins just get unloaded and removed; no reason to keep them around.
-            if (part.getUnitId() == null) {
+            if (part.getUnit() == null) {
                 if (part instanceof AmmoBin) {
                     ((AmmoBin) part).unload();
                     oldUnit.getCampaign().removePart(part);
@@ -1310,7 +1310,7 @@ public class Refit extends Part implements IAcquisitionWork {
         }
 
         if (null != newArmorSupplies) {
-            newArmorSupplies.setRefitId(null);
+            newArmorSupplies.setRefitUnit(null);
             newArmorSupplies.setUnit(oldUnit);
             oldUnit.getCampaign().removePart(newArmorSupplies);
             newArmorSupplies.changeAmountAvailable(newArmorSupplies.getAmount());
@@ -1320,9 +1320,11 @@ public class Refit extends Part implements IAcquisitionWork {
         // are in transit are left as is.
         List<IAcquisitionWork> toRemove = new ArrayList<>();
         toRemove.add(this);
-        for (IAcquisitionWork part : campaign.getShoppingList().getPartList()) {
-            if ((part instanceof Part) && Objects.equals(((Part) part).getRefitId(), this.getRefitId())) {
-                toRemove.add(part);
+        if (getRefitUnit() != null) {
+            for (IAcquisitionWork part : campaign.getShoppingList().getPartList()) {
+                if ((part instanceof Part) && (((Part) part).getRefitUnit() == getRefitUnit())) {
+                    toRemove.add(part);
+                }
             }
         }
         for (IAcquisitionWork work : toRemove) {
@@ -1470,7 +1472,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 continue;
             }
             part.setUnit(oldUnit);
-            part.setRefitId(null);
+            part.setRefitUnit(null);
             newParts.add(part);
             if (part instanceof Armor) {
                 //get amounts correct for armor
@@ -1960,7 +1962,7 @@ public class Refit extends Part implements IAcquisitionWork {
 
     public static Refit generateInstanceFromXML(Node wn, Unit u, Version version) {
         Refit retVal = new Refit();
-        retVal.oldUnit = u;
+        retVal.oldUnit = Objects.requireNonNull(u);
 
         NodeList nl = wn.getChildNodes();
 
@@ -2029,7 +2031,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(Refit.class, ex);
+            MekHQ.getLogger().error(ex);
         }
 
         return retVal;
@@ -2146,7 +2148,7 @@ public class Refit extends Part implements IAcquisitionWork {
     public void addRefitKitParts(int transitDays) {
         for (Part part : shoppingList) {
             if (part instanceof AmmoBin) {
-                part.setRefitId(oldUnit.getId());
+                part.setRefitUnit(oldUnit);
                 oldUnit.getCampaign().addPart(part, 0);
                 newUnitParts.add(part);
                 AmmoBin bin = (AmmoBin) part;
@@ -2158,12 +2160,12 @@ public class Refit extends Part implements IAcquisitionWork {
                 }
             } else if (part instanceof MissingPart) {
                 Part newPart = (Part)((IAcquisitionWork) part).getNewEquipment();
-                newPart.setRefitId(oldUnit.getId());
+                newPart.setRefitUnit(oldUnit);
                 oldUnit.getCampaign().addPart(newPart, transitDays);
                 newUnitParts.add(newPart);
             } else if (part instanceof AmmoStorage) {
                 part.setUnit(null);
-                part.setRefitId(oldUnit.getId());
+                part.setRefitUnit(oldUnit);
                 campaign.addPart(part, transitDays);
             }
         }
@@ -2574,14 +2576,16 @@ public class Refit extends Part implements IAcquisitionWork {
 
     @Override
     public void fixReferences(Campaign campaign) {
+        super.fixReferences(campaign);
+
         if (newArmorSupplies instanceof RefitArmorRef) {
             Part realPart = campaign.getPart(newArmorSupplies.getId());
             if (realPart instanceof Armor) {
                 newArmorSupplies = (Armor) realPart;
             } else {
                 MekHQ.getLogger().error(
-                    String.format("Refit %s (Unit: %s) references missing armor supplies %d",
-                        getRefitId(), getUnitId(), newArmorSupplies.getId()));
+                    String.format("Refit on Unit %s references missing armor supplies %d",
+                        getUnit().getId(), newArmorSupplies.getId()));
                 newArmorSupplies = null;
             }
         }
@@ -2594,8 +2598,8 @@ public class Refit extends Part implements IAcquisitionWork {
                     oldUnitParts.set(ii, realPart);
                 } else if (part.getId() > 0) {
                     MekHQ.getLogger().error(
-                        String.format("Refit %s (Unit: %s) references missing old unit part %d",
-                            getRefitId(), getUnitId(), part.getId()));
+                        String.format("Refit on Unit %s references missing old unit part %d",
+                            getUnit().getId(), part.getId()));
                     oldUnitParts.remove(ii);
                 }
             }
@@ -2609,8 +2613,8 @@ public class Refit extends Part implements IAcquisitionWork {
                     newUnitParts.set(ii, realPart);
                 } else if (part.getId() > 0) {
                     MekHQ.getLogger().error(
-                        String.format("Refit %s (Unit: %s) references missing new unit part %d",
-                            getRefitId(), getUnitId(), part.getId()));
+                        String.format("Refit on Unit %s references missing new unit part %d",
+                            getUnit().getId(), part.getId()));
                     newUnitParts.remove(ii);
                 }
             }
@@ -2627,8 +2631,8 @@ public class Refit extends Part implements IAcquisitionWork {
                     realParts.add(realPart);
                 } else {
                     MekHQ.getLogger().error(
-                        String.format("Refit %s (Unit: %s) references missing large craft ammo bin %d",
-                            getRefitId(), getUnitId(), part.getId()));
+                        String.format("Refit on Unit %s references missing large craft ammo bin %d",
+                            getUnit().getId(), part.getId()));
                 }
             }
         }
@@ -2640,8 +2644,8 @@ public class Refit extends Part implements IAcquisitionWork {
             assignedTech = campaign.getPerson(id);
             if (assignedTech == null) {
                 MekHQ.getLogger().error(
-                    String.format("Refit %s (Unit: %s) references missing tech %s",
-                        getRefitId(), getUnitId(), id));
+                    String.format("Refit on Unit %s references missing tech %s",
+                        getUnit().getId(), id));
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -144,7 +144,7 @@ public class SVArmor extends Armor {
         SVArmor a = (SVArmor)campaign.findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent()
-                && (getRefitUnit() == part.getRefitUnit());
+                && Objects.equals(getRefitUnit(), part.getRefitUnit());
         });
 
         if (null != a) {

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -144,7 +144,7 @@ public class SVArmor extends Armor {
         SVArmor a = (SVArmor)campaign.findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent()
-                && Objects.equals(getRefitId(), part.getRefitId());
+                && (getRefitUnit() == part.getRefitUnit());
         });
 
         if (null != a) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3262,11 +3262,11 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return false;
     }
 
-    public Unit getUnit() {
+    public @Nullable Unit getUnit() {
         return unit;
     }
 
-    public void setUnit(Unit unit) {
+    public void setUnit(@Nullable Unit unit) {
         this.unit = unit;
     }
 
@@ -3275,6 +3275,8 @@ public class Person implements Serializable, MekHqXmlSerializable {
     }
 
     public void addTechUnit(Unit unit) {
+        Objects.requireNonNull(unit);
+
         if (!techUnits.contains(unit)) {
             techUnits.add(unit);
         }
@@ -3285,7 +3287,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     }
 
     public List<Unit> getTechUnits() {
-        return techUnits;
+        return Collections.unmodifiableList(techUnits);
     }
 
     public int getMinutesLeft() {
@@ -3697,7 +3699,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
     }
 
     public void addInjury(Injury i) {
-        injuries.add(i);
+        injuries.add(Objects.requireNonNull(i));
         if (null != getUnit()) {
             getUnit().resetPilotAndEntity();
         }

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -134,8 +134,8 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
                 }
                 if (p.getPrimaryRole() >= Person.T_MECH_TECH) {
                     support++;
-                } else if ((null == p.getUnitId()) ||
-                        ((null != campaign.getUnit(p.getUnitId())) && campaign.getUnit(p.getUnitId()).isCommander(p))) {
+                } else if ((null == p.getUnit()) ||
+                        ((null != p.getUnit()) && p.getUnit().isCommander(p))) {
                     /* The AtB rules do not state that crews count as a
                      * single person for leadership purposes, but to do otherwise
                      * would tax all but the most exceptional commanders of
@@ -172,8 +172,8 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
                 continue;
             }
             /* Infantry units retire or defect by platoon */
-            if (null != p.getUnitId() && null != campaign.getUnit(p.getUnitId()) && campaign.getUnit(p.getUnitId()).usesSoldiers() &&
-                    !campaign.getUnit(p.getUnitId()).isCommander(p)) {
+            if ((null != p.getUnit()) && p.getUnit().usesSoldiers()
+                    && !p.getUnit().isCommander(p)) {
                 continue;
             }
             TargetRoll target = new TargetRoll(5, "Target");
@@ -494,7 +494,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
                 stolenUnit = true;
             } else {
                 if (p.getProfession() == Ranks.RPROF_INF) {
-                    if (p.getUnitId() != null) {
+                    if (p.getUnit() != null) {
                         payoutAmount = Money.of(50000);
                     }
                 } else {
@@ -725,7 +725,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(RetirementDefectionTracker.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(ex);
         }
 
         if (retVal != null) {

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ROMDesignation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ROMDesignation.java
@@ -99,7 +99,7 @@ public enum ROMDesignation {
             case Person.T_SPACE_GUNNER:
             case Person.T_SPACE_PILOT:
             case Person.T_NAVIGATOR:
-                Unit u = campaign.getUnit(person.getUnitId());
+                Unit u = person.getUnit();
                 if (u != null) {
                     Entity en = u.getEntity();
                     if (en instanceof Dropship) {

--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -85,7 +85,7 @@ public class MothballInfo implements MekHqXmlSerializable {
         }
 
         for (Person driver : drivers) {
-            if (driver.getStatus().isActive() && driver.getUnit() == null) {
+            if (driver.getStatus().isActive() && (driver.getUnit() == null)) {
                 unit.addDriver(driver);
             }
         }
@@ -100,16 +100,16 @@ public class MothballInfo implements MekHqXmlSerializable {
         }
 
         for (Person crew : vesselCrew) {
-            if (crew.getStatus().isActive() && crew.getUnit() == null) {
+            if (crew.getStatus().isActive() && (crew.getUnit() == null)) {
                 unit.addVesselCrew(crew);
             }
         }
 
-        if (techOfficer != null && techOfficer.getStatus().isActive() && techOfficer.getUnit() == null) {
+        if ((techOfficer != null) && (techOfficer.getStatus().isActive()) && (techOfficer.getUnit() == null)) {
             unit.setTechOfficer(techOfficer);
         }
 
-        if (navigator != null && navigator.getStatus().isActive() && navigator.getUnit() == null) {
+        if ((navigator != null) && (navigator.getStatus().isActive()) && (navigator.getUnit() == null)) {
             unit.setNavigator(navigator);
         }
 

--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -85,7 +85,7 @@ public class MothballInfo implements MekHqXmlSerializable {
         }
 
         for (Person driver : drivers) {
-            if (driver.getStatus().isActive() && (driver.getUnitId() == null)) {
+            if (driver.getStatus().isActive() && driver.getUnit() == null) {
                 unit.addDriver(driver);
             }
         }
@@ -94,22 +94,22 @@ public class MothballInfo implements MekHqXmlSerializable {
             // add the gunner if they exist, aren't dead/retired/etc and aren't already assigned to some
             // other unit. Caveat: single-person units have the same driver and gunner.
             if (gunner.getStatus().isActive() &&
-                    ((gunner.getUnitId() == null) || (gunner.getUnitId() == unit.getId()))) {
+                    ((gunner.getUnit() == null) || (gunner.getUnit() == unit))) {
                 unit.addGunner(gunner);
             }
         }
 
         for (Person crew : vesselCrew) {
-            if (crew.getStatus().isActive() && (crew.getUnitId() == null)) {
+            if (crew.getStatus().isActive() && crew.getUnit() == null) {
                 unit.addVesselCrew(crew);
             }
         }
 
-        if (techOfficer != null && techOfficer.getStatus().isActive() && techOfficer.getUnitId() == null) {
+        if (techOfficer != null && techOfficer.getStatus().isActive() && techOfficer.getUnit() == null) {
             unit.setTechOfficer(techOfficer);
         }
 
-        if (navigator != null && navigator.getStatus().isActive() && navigator.getUnitId() == null) {
+        if (navigator != null && navigator.getStatus().isActive() && navigator.getUnit() == null) {
             unit.setNavigator(navigator);
         }
 

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3940,7 +3940,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     engineer.addSkill(SkillType.S_TECH_VESSEL, sumSkill / nCrew, sumBonus / nCrew);
                     engineer.setEdgeUsed(sumEdgeUsed);
                     engineer.setCurrentEdge((sumEdge - sumEdgeUsed) / nCrew);
-                    engineer.setUnitId(this.getId());
+                    engineer.setUnit(this);
                 } else {
                     engineer = null;
                 }
@@ -4082,7 +4082,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
         ensurePersonIsRegistered(p);
         drivers.add(p);
-        p.setUnitId(getId());
+        p.setUnit(this);
         resetPilotAndEntity();
         if (useTransfers) {
             ServiceLogger.reassignedTo(p, getCampaign().getLocalDate(), getName());
@@ -4101,7 +4101,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
         ensurePersonIsRegistered(p);
         gunners.add(p);
-        p.setUnitId(getId());
+        p.setUnit(this);
         resetPilotAndEntity();
         if (useTransfers) {
             ServiceLogger.reassignedTo(p, getCampaign().getLocalDate(), getName());
@@ -4120,7 +4120,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
         ensurePersonIsRegistered(p);
         vesselCrew.add(p);
-        p.setUnitId(getId());
+        p.setUnit(this);
         resetPilotAndEntity();
         if (useTransfers) {
             ServiceLogger.reassignedTo(p, getCampaign().getLocalDate(), getName());
@@ -4139,7 +4139,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
         ensurePersonIsRegistered(p);
         navigator = p;
-        p.setUnitId(getId());
+        p.setUnit(this);
         resetPilotAndEntity();
         if (useTransfers) {
             ServiceLogger.reassignedTo(p, getCampaign().getLocalDate(), getName());
@@ -4162,7 +4162,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
         ensurePersonIsRegistered(p);
         techOfficer = p;
-        p.setUnitId(getId());
+        p.setUnit(this);
         resetPilotAndEntity();
         if (useTransfers) {
             ServiceLogger.reassignedTo(p, getCampaign().getLocalDate(), getName());
@@ -4180,7 +4180,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         }
         ensurePersonIsRegistered(p);
         tech = p;
-        p.addTechUnitID(getId());
+        p.addTechUnit(this);
         ServiceLogger.assignedTo(p, getCampaign().getLocalDate(), getName());
         MekHQ.triggerEvent(new PersonTechAssignmentEvent(p, this));
     }
@@ -4188,7 +4188,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     public void removeTech() {
         if (tech != null) {
             Person originalTech = tech;
-            tech.removeTechUnitId(getId());
+            tech.removeTechUnit(this);
             tech = null;
             MekHQ.triggerEvent(new PersonTechAssignmentEvent(originalTech, null));
         }
@@ -4215,7 +4215,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         if (entity.getCrew().getCrewType().getPilotPos() == entity.getCrew().getCrewType().getGunnerPos()) {
             gunners.add(p);
         }
-        p.setUnitId(getId());
+        p.setUnit(this);
         resetPilotAndEntity();
         if (useTransfers) {
             ServiceLogger.reassignedTo(p, getCampaign().getLocalDate(), getName());
@@ -4232,7 +4232,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         if (p.equals(tech)) {
             removeTech();
         } else {
-            p.setUnitId(null);
+            p.setUnit(null);
             drivers.remove(p);
             gunners.remove(p);
             vesselCrew.remove(p);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4627,12 +4627,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             return false;
         }
         final Unit other = (Unit) obj;
-        return Objects.equals(id, other.id) && Objects.equals(getName(), other.getName());
+        return Objects.equals(id, other.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, getName());
+        return Objects.hash(id);
     }
 
     public Person getEngineer() {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2004,8 +2004,8 @@ public class CampaignGUI extends JPanel {
                     // Clear some values we no longer should have set in case this
                     // has transferred campaigns or things in the campaign have
                     // changed...
-                    p.setUnitId(null);
-                    p.clearTechUnitIDs();
+                    p.setUnit(null);
+                    p.clearTechUnits();
                 }
             }
 

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -728,7 +728,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
                     }
                     // check whether the engineer is assigned to the correct
                     // unit
-                    return unit.getId().equals(tech.getUnitId());
+                    return unit == tech.getUnit();
                 } else if ((tech.getPrimaryRole() == Person.T_SPACE_CREW) && (unit != null) && !unit.isSelfCrewed()) {
                     return false;
                 } else if (!tech.isRightTechTypeFor(part) && !btnShowAllTechs.isSelected()) {

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -728,7 +728,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
                     }
                     // check whether the engineer is assigned to the correct
                     // unit
-                    return unit == tech.getUnit();
+                    return unit.equals(tech.getUnit());
                 } else if ((tech.getPrimaryRole() == Person.T_SPACE_CREW) && (unit != null) && !unit.isSelfCrewed()) {
                     return false;
                 } else if (!tech.isRightTechTypeFor(part) && !btnShowAllTechs.isSelected()) {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -220,7 +220,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         person.setManeiDominiClass(mdClass);
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(this, "Failed to assign Manei Domini Class", e);
+                    MekHQ.getLogger().error("Failed to assign Manei Domini Class", e);
                 }
                 break;
             }
@@ -231,7 +231,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         person.setPrimaryDesignator(romDesignation);
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(this, "Failed to assign ROM designator", e);
+                    MekHQ.getLogger().error("Failed to assign ROM designator", e);
                 }
                 break;
             }
@@ -242,7 +242,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         person.setSecondaryDesignator(romDesignation);
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(this, "Failed to assign ROM secondary designator", e);
+                    MekHQ.getLogger().error("Failed to assign ROM secondary designator", e);
                 }
                 break;
             }
@@ -269,21 +269,18 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
             }
             case CMD_REMOVE_UNIT: {
                 for (Person person : people) {
-                    Unit u = gui.getCampaign().getUnit(person.getUnitId());
+                    Unit u = person.getUnit();
                     if (null != u) {
                         u.remove(person, true);
                         u.resetEngineer();
                         u.runDiagnostic(false);
                     }
                     // check for tech unit assignments
-                    if (!person.getTechUnitIDs().isEmpty()) {
-                        for (UUID id : new ArrayList<>(person.getTechUnitIDs())) {
-                            u = gui.getCampaign().getUnit(id);
-                            if (null != u) {
-                                u.remove(person, true);
-                                u.resetEngineer();
-                                u.runDiagnostic(false);
-                            }
+                    if (!person.getTechUnits().isEmpty()) {
+                        for (Unit unitWeTech : new ArrayList<>(person.getTechUnits())) {
+                            unitWeTech.remove(person, true);
+                            unitWeTech.resetEngineer();
+                            unitWeTech.runDiagnostic(false);
                         }
                         /*
                          * Incase there's still some assignments for this tech,
@@ -292,7 +289,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                          * but to a null unit and it will never go away
                          * otherwise.
                          */
-                        person.clearTechUnitIDs();
+                        person.clearTechUnits();
                     }
                 }
                 break;
@@ -300,7 +297,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
             case CMD_ADD_PILOT: {
                 UUID selected = UUID.fromString(data[1]);
                 Unit u = gui.getCampaign().getUnit(selected);
-                Unit oldUnit = gui.getCampaign().getUnit(selectedPerson.getUnitId());
+                Unit oldUnit = selectedPerson.getUnit();
                 boolean useTransfers = false;
                 boolean transferLog = !gui.getCampaign().getCampaignOptions().useTransfers();
                 if (null != oldUnit) {
@@ -320,7 +317,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 if (null != u) {
                     for (Person p : people) {
                         if (u.canTakeMoreGunners()) {
-                            Unit oldUnit = gui.getCampaign().getUnit(p.getUnitId());
+                            Unit oldUnit = p.getUnit();
                             boolean useTransfers = false;
                             boolean transferLog = !gui.getCampaign().getCampaignOptions().useTransfers();
                             if (null != oldUnit) {
@@ -339,7 +336,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
             case CMD_ADD_DRIVER: {
                 UUID selected = UUID.fromString(data[1]);
                 Unit u = gui.getCampaign().getUnit(selected);
-                Unit oldUnit = gui.getCampaign().getUnit(selectedPerson.getUnitId());
+                Unit oldUnit = selectedPerson.getUnit();
                 boolean useTransfers = false;
                 boolean transferLog = !gui.getCampaign().getCampaignOptions().useTransfers();
                 if (null != oldUnit) {
@@ -359,7 +356,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 if (null != u) {
                     for (Person p : people) {
                         if (u.canTakeMoreDrivers()) {
-                            Unit oldUnit = gui.getCampaign().getUnit(p.getUnitId());
+                            Unit oldUnit = p.getUnit();
                             boolean useTransfers = false;
                             boolean transferLog = !gui.getCampaign().getCampaignOptions().useTransfers();
                             if (null != oldUnit) {
@@ -380,7 +377,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 if (null != u) {
                     for (Person p : people) {
                         if (u.canTakeMoreGunners()) {
-                            Unit oldUnit = gui.getCampaign().getUnit(p.getUnitId());
+                            Unit oldUnit = p.getUnit();
                             boolean useTransfers = false;
                             boolean transferLog = !gui.getCampaign().getCampaignOptions().useTransfers();
                             if (null != oldUnit) {
@@ -402,7 +399,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 if (null != u) {
                     for (Person p : people) {
                         if (u.canTakeMoreVesselCrew()) {
-                            Unit oldUnit = gui.getCampaign().getUnit(p.getUnitId());
+                            Unit oldUnit = p.getUnit();
                             boolean useTransfers = false;
                             boolean transferLog = !gui.getCampaign().getCampaignOptions().useTransfers();
                             if (null != oldUnit) {
@@ -424,7 +421,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 if (null != u) {
                     for (Person p : people) {
                         if (u.canTakeNavigator()) {
-                            Unit oldUnit = gui.getCampaign().getUnit(p.getUnitId());
+                            Unit oldUnit = p.getUnit();
                             boolean useTransfers = false;
                             boolean transferLog = !gui.getCampaign().getCampaignOptions().useTransfers();
                             if (null != oldUnit) {
@@ -446,7 +443,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 if (null != u) {
                     for (Person p : people) {
                         if (u.canTakeTechOfficer()) {
-                            Unit oldUnit = gui.getCampaign().getUnit(p.getUnitId());
+                            Unit oldUnit = p.getUnit();
                             boolean useTransfers = false;
                             boolean transferLog = !gui.getCampaign().getCampaignOptions().useTransfers();
                             if (null != oldUnit) {
@@ -520,7 +517,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                     gui.getCampaign().getLocalDate());
                         }
                     } catch (Exception e) {
-                        MekHQ.getLogger().error(this, "Could not remove award.", e);
+                        MekHQ.getLogger().error("Could not remove award.", e);
                     }
                 }
                 break;
@@ -637,7 +634,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         }
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(this, "Unknown PrisonerStatus Option. No changes will be made.", e);
+                    MekHQ.getLogger().error("Unknown PrisonerStatus Option. No changes will be made.", e);
                 }
                 break;
             }
@@ -893,7 +890,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
             }
             case CMD_ADD_KILL: {
                 AddOrEditKillEntryDialog nkd;
-                Unit unit = gui.getCampaign().getUnit(selectedPerson.getUnitId());
+                Unit unit = selectedPerson.getUnit();
                 if (people.length > 1) {
                     nkd = new AddOrEditKillEntryDialog(gui.getFrame(), true, null,
                             (unit != null) ? unit.getName() : resourceMap.getString("bareHands.text"),
@@ -1045,7 +1042,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
             case CMD_CLEAR_INJURIES: {
                 for (Person person : people) {
                     person.clearInjuries();
-                    Unit u = gui.getCampaign().getUnit(person.getUnitId());
+                    Unit u = person.getUnit();
                     if (null != u) {
                         u.resetPilotAndEntity();
                     }
@@ -1064,7 +1061,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 if (toRemove != null) {
                     selectedPerson.removeInjury(toRemove);
                 }
-                Unit u = gui.getCampaign().getUnit(selectedPerson.getUnitId());
+                Unit u = selectedPerson.getUnit();
                 if (null != u) {
                     u.resetPilotAndEntity();
                 }
@@ -1491,7 +1488,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         } else if (unit.usesSoldiers()) {
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 soldierEntityWeightMenu.add(cbMenuItem);
@@ -1499,7 +1496,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         } else {
                             if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_DRIVER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 if (unit.getEntity() instanceof Aero || unit.getEntity() instanceof Mech) {
@@ -1510,7 +1507,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 gunnerEntityWeightMenu.add(cbMenuItem);
@@ -1519,14 +1516,14 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                     && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
                                     || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_CREW, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 crewEntityWeightMenu.add(cbMenuItem);
                             }
                             if (unit.canTakeNavigator() && person.hasSkill(SkillType.S_NAV)) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_NAVIGATOR, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 navEntityWeightMenu.add(cbMenuItem);
@@ -1536,14 +1533,14 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                 if (unit.getEntity() instanceof Tank) {
                                     if (person.canDrive(unit.getEntity()) || person.canGun(unit.getEntity())) {
                                         cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                        cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                        cbMenuItem.setSelected(unit == person.getUnit());
                                         cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH_OFFICER, unit.getId().toString()));
                                         cbMenuItem.addActionListener(this);
                                         consoleCmdrEntityWeightMenu.add(cbMenuItem);
                                     }
                                 } else if (person.canDrive(unit.getEntity()) && person.canGun(unit.getEntity())) {
                                     cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                    cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                    cbMenuItem.setSelected(unit == person.getUnit());
                                     cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH_OFFICER, unit.getId().toString()));
                                     cbMenuItem.addActionListener(this);
                                     techOfficerEntityWeightMenu.add(cbMenuItem);
@@ -1554,7 +1551,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                 && (person.getMaintenanceTimeUsing() + unit.getMaintenanceTime() <= 480)) {
                             cbMenuItem = new JCheckBoxMenuItem(String.format(resourceMap.getString("maintenanceTimeDesc.format"), //$NON-NLS-1$
                                     unit.getName(), unit.getMaintenanceTime()));
-                            cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                            cbMenuItem.setSelected(unit == person.getUnit());
                             cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH, unit.getId().toString()));
                             cbMenuItem.addActionListener(this);
                             techEntityWeightMenu.add(cbMenuItem);
@@ -1624,7 +1621,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 soldierEntityWeightMenu.add(cbMenuItem);
@@ -1635,7 +1632,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 soldierEntityWeightMenu.add(cbMenuItem);
@@ -1646,7 +1643,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 gunnerEntityWeightMenu.add(cbMenuItem);
@@ -1657,7 +1654,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 gunnerEntityWeightMenu.add(cbMenuItem);
@@ -1670,7 +1667,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                     && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
                                     || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_CREW, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 crewEntityWeightMenu.add(cbMenuItem);
@@ -1681,7 +1678,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_VESSEL_PILOT, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 pilotEntityWeightMenu.add(cbMenuItem);
@@ -1692,7 +1689,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeNavigator() && person.hasSkill(SkillType.S_NAV)) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.getId().equals(person.getUnitId()));
+                                cbMenuItem.setSelected(unit == person.getUnit());
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_NAVIGATOR, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 navEntityWeightMenu.add(cbMenuItem);
@@ -1740,8 +1737,8 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 cbMenuItem.addActionListener(this);
                 menu.add(cbMenuItem);
 
-                if ((menu.getItemCount() > 1) || (gui.getCampaign().getUnit(person.getUnitId()) != null)
-                        || (person.getTechUnitIDs().size() > 0)) {
+                if ((menu.getItemCount() > 1) || (person.getUnit() != null)
+                        || !person.getTechUnits().isEmpty()) {
                     JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
                 }
             }
@@ -1926,7 +1923,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         }
                         boolean available = (cost >= 0) && (person.getXP() >= cost);
                         if (spa.getName().equals(OptionsConstants.GUNNERY_WEAPON_SPECIALIST)) {
-                            Unit u = gui.getCampaign().getUnit(person.getUnitId());
+                            Unit u = person.getUnit();
                             if (null != u) {
                                 JMenu specialistMenu = new JMenu(resourceMap.getString("weaponSpecialist.text"));
                                 TreeSet<String> uniqueWeapons = new TreeSet<>();

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1488,7 +1488,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         } else if (unit.usesSoldiers()) {
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 soldierEntityWeightMenu.add(cbMenuItem);
@@ -1496,7 +1496,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         } else {
                             if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_DRIVER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 if (unit.getEntity() instanceof Aero || unit.getEntity() instanceof Mech) {
@@ -1507,7 +1507,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 gunnerEntityWeightMenu.add(cbMenuItem);
@@ -1516,14 +1516,14 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                     && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
                                     || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_CREW, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 crewEntityWeightMenu.add(cbMenuItem);
                             }
                             if (unit.canTakeNavigator() && person.hasSkill(SkillType.S_NAV)) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_NAVIGATOR, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 navEntityWeightMenu.add(cbMenuItem);
@@ -1533,14 +1533,14 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                 if (unit.getEntity() instanceof Tank) {
                                     if (person.canDrive(unit.getEntity()) || person.canGun(unit.getEntity())) {
                                         cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                        cbMenuItem.setSelected(unit == person.getUnit());
+                                        cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                         cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH_OFFICER, unit.getId().toString()));
                                         cbMenuItem.addActionListener(this);
                                         consoleCmdrEntityWeightMenu.add(cbMenuItem);
                                     }
                                 } else if (person.canDrive(unit.getEntity()) && person.canGun(unit.getEntity())) {
                                     cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                    cbMenuItem.setSelected(unit == person.getUnit());
+                                    cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                     cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH_OFFICER, unit.getId().toString()));
                                     cbMenuItem.addActionListener(this);
                                     techOfficerEntityWeightMenu.add(cbMenuItem);
@@ -1551,7 +1551,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                 && (person.getMaintenanceTimeUsing() + unit.getMaintenanceTime() <= 480)) {
                             cbMenuItem = new JCheckBoxMenuItem(String.format(resourceMap.getString("maintenanceTimeDesc.format"), //$NON-NLS-1$
                                     unit.getName(), unit.getMaintenanceTime()));
-                            cbMenuItem.setSelected(unit == person.getUnit());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
                             cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH, unit.getId().toString()));
                             cbMenuItem.addActionListener(this);
                             techEntityWeightMenu.add(cbMenuItem);
@@ -1621,7 +1621,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 soldierEntityWeightMenu.add(cbMenuItem);
@@ -1632,7 +1632,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 soldierEntityWeightMenu.add(cbMenuItem);
@@ -1643,7 +1643,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 gunnerEntityWeightMenu.add(cbMenuItem);
@@ -1654,7 +1654,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 gunnerEntityWeightMenu.add(cbMenuItem);
@@ -1667,7 +1667,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                                     && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
                                     || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_CREW, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 crewEntityWeightMenu.add(cbMenuItem);
@@ -1678,7 +1678,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_VESSEL_PILOT, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 pilotEntityWeightMenu.add(cbMenuItem);
@@ -1689,7 +1689,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                             }
                             if (unit.canTakeNavigator() && person.hasSkill(SkillType.S_NAV)) {
                                 cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit == person.getUnit());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                 cbMenuItem.setActionCommand(makeCommand(CMD_ADD_NAVIGATOR, unit.getId().toString()));
                                 cbMenuItem.addActionListener(this);
                                 navEntityWeightMenu.add(cbMenuItem);

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -239,7 +239,7 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                 if (null != tech) {
                     if (singleForce.getTechID() != null) {
                         Person oldTech = gui.getCampaign().getPerson(singleForce.getTechID());
-                        oldTech.clearTechUnitIDs();
+                        oldTech.clearTechUnits();
                         ServiceLogger.removedFrom(oldTech, gui.getCampaign().getLocalDate(), singleForce.getName());
                     }
                     singleForce.setTechID(tech.getId());
@@ -433,7 +433,7 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
         } else if (command.contains(TOEMouseAdapter.REMOVE_LANCE_TECH)) {
             if (null != singleForce && singleForce.getTechID() != null) {
                 Person oldTech = gui.getCampaign().getPerson(singleForce.getTechID());
-                oldTech.clearTechUnitIDs();
+                oldTech.clearTechUnits();
 
                 ServiceLogger.removedFrom(oldTech, gui.getCampaign().getLocalDate(), singleForce.getName());
 
@@ -1011,12 +1011,12 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                     //Only display the Assign to Ship command if your command has at least 1 valid transport
                     //and if your selection does not include a transport
                     if (!shipInSelection && !gui.getCampaign().getTransportShips().isEmpty()) {
-                        for (UUID id : gui.getCampaign().getTransportShips()) {
-                            Unit ship = gui.getCampaign().getUnit(id);
-                            if (ship == null || ship.isSalvage() || ship.getCommander() == null) {
+                        for (Unit ship : gui.getCampaign().getTransportShips()) {
+                            if (ship.isSalvage() || ship.getCommander() == null) {
                                 continue;
                             }
 
+                            UUID id = ship.getId();
                             if (allUnitsSameType) {
                                 double capacity = ship.getCorrectBayCapacity(singleUnitType, unitWeight);
                                 if (capacity > 0) {
@@ -1365,11 +1365,12 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                         //is in a basic state that can accept units. Capacity gets checked once the action
                         //is submitted.
                         menu = new JMenu("Assign Unit to Transport Ship");
-                        for (UUID id : gui.getCampaign().getTransportShips()) {
-                            Unit ship = gui.getCampaign().getUnit(id);
-                            if (ship == null || ship.isSalvage() || ship.getCommander() == null) {
+                        for (Unit ship : gui.getCampaign().getTransportShips()) {
+                            if (ship.isSalvage() || ship.getCommander() == null) {
                                 continue;
                             }
+
+                            UUID id = ship.getId();
                             if (allUnitsSameType) {
                                 double capacity = ship.getCorrectBayCapacity(singleUnitType, unitWeight);
                                 if (capacity > 0) {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1012,7 +1012,7 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                     //and if your selection does not include a transport
                     if (!shipInSelection && !gui.getCampaign().getTransportShips().isEmpty()) {
                         for (Unit ship : gui.getCampaign().getTransportShips()) {
-                            if (ship.isSalvage() || ship.getCommander() == null) {
+                            if (ship.isSalvage() || (ship.getCommander() == null)) {
                                 continue;
                             }
 
@@ -1366,7 +1366,7 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                         //is submitted.
                         menu = new JMenu("Assign Unit to Transport Ship");
                         for (Unit ship : gui.getCampaign().getTransportShips()) {
-                            if (ship.isSalvage() || ship.getCommander() == null) {
+                            if (ship.isSalvage() || (ship.getCommander() == null)) {
                                 continue;
                             }
 

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -565,10 +565,10 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionLi
             UUID id = gui.selectTech(unit, description, true);
             if (null != id) {
                 tech = gui.getCampaign().getPerson(id);
-                if (tech.getTechUnitIDs().size() > 0) {
+                if (!tech.getTechUnits().isEmpty()) {
                     if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(gui.getFrame(),
                             tech.getFullName() + " will not be able to perform maintenance on "
-                                    + tech.getTechUnitIDs().size() + " assigned units. Proceed?",
+                                    + tech.getTechUnits().size() + " assigned units. Proceed?",
                                     "Unmaintained unit warning",
                                     JOptionPane.YES_NO_OPTION)) {
                         tech = null;

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -414,10 +414,8 @@ public class CampaignExportWizard extends JDialog {
         }
 
         for (Person person : personList.getSelectedValuesList()) {
-            if (person.getUnitId() != null) {
-                Unit unit = sourceCampaign.getUnit(person.getUnitId());
-
-                unitList.setSelectedValue(unit, false);
+            if (person.getUnit() != null) {
+                unitList.setSelectedValue(person.getUnit(), false);
                 selectedIndices.add(unitList.getSelectedIndex());
             }
         }

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -844,7 +844,7 @@ public class GMToolsDialog extends JDialog {
                 e = new MechFileParser(getLastRolledUnit().getSourceFile(),
                         getLastRolledUnit().getEntryName()).getEntity();
                 Unit u = getGUI().getCampaign().addNewUnit(e, false, 0);
-                if ((getPerson() != null) && (getPerson().getUnitId() == null)) {
+                if ((getPerson() != null) && (getPerson().getUnit() == null)) {
                     u.addPilotOrSoldier(getPerson());
                     getPerson().setOriginalUnit(u);
                     setVisible(false);

--- a/MekHQ/src/mekhq/gui/dialog/MassMothballDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassMothballDialog.java
@@ -354,7 +354,7 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
 
             Person person = (Person) value;
 
-            boolean maintainsUnits = person.getTechUnitIDs().size() > 0;
+            boolean maintainsUnits = !person.getTechUnits().isEmpty();
             setText((maintainsUnits ? "(*) " : "") + person.getFullTitle() + " ("
                     + person.getMinutesLeft() + " min)");
 

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -542,9 +542,9 @@ public class RetirementDefectionDialog extends JDialog {
                         && p.equals(hqView.getCampaign().getUnit(rdTracker.getPayout(id).getStolenUnitId()).getCommander())) {
                     continue;
                 }
-                if ((hqView.getCampaign().getPerson(id).getUnitId() != null)
+                if ((p.getUnit() != null)
                         && ((Compute.d6() < 4) || !unassignedAvailable)) {
-                    unitAssignments.put(id, p.getUnitId());
+                    unitAssignments.put(id, p.getUnit().getId());
                 } else if (unassignedAvailable) {
                     if (p.getPrimaryRole() == Person.T_MECHWARRIOR) {
                         int roll = Compute.randomInt(unassignedMechs.size());
@@ -584,9 +584,9 @@ public class RetirementDefectionDialog extends JDialog {
             /* For infantry, the unit commander makes a retirement roll on behalf of the
              * entire unit. Unassigned infantry can retire individually.
              */
-            if ((p.getUnitId() != null)
+            if ((p.getUnit() != null)
                     && ((p.getPrimaryRole() == Person.T_INFANTRY) || (p.getPrimaryRole() == Person.T_BA))) {
-                unitAssignments.put(id, p.getUnitId());
+                unitAssignments.put(id, p.getUnit().getId());
             }
             ((UnitAssignmentTableModel) unitAssignmentTable.getModel()).setData(availableUnits);
         }

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -24,7 +24,6 @@ import java.awt.Toolkit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
-import java.util.UUID;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -303,13 +302,10 @@ public class PersonnelTableModel extends DataTableModel {
             case COL_NIMP:
                 return p.getAbilityListAsString(PilotOptions.MD_ADVANTAGES);
             case COL_ASSIGN: {
-                if ((p.getTechUnitIDs().size() > 1) && !loadAssignmentFromMarket) {
+                if ((p.getTechUnits().size() > 1) && !loadAssignmentFromMarket) {
                     StringBuilder toReturn = new StringBuilder("<html>");
-                    for (UUID id : p.getTechUnitIDs()) {
-                        Unit u = getCampaign().getUnit(id);
-                        if (u != null) {
-                            toReturn.append(u.getName()).append("<br>");
-                        }
+                    for (Unit u : p.getTechUnits()) {
+                        toReturn.append(u.getName()).append("<br>");
                     }
                     toReturn.append("</html>");
                     return toReturn.toString();
@@ -367,17 +363,10 @@ public class PersonnelTableModel extends DataTableModel {
                 } else {
                     // If we're grouping by unit, determine the number of persons under
                     // their command.
-                    UUID unitId = p.getUnitId();
+                    Unit u = p.getUnit();
 
                     // If the personnel does not have a unit, return their name
-                    if (unitId == null) {
-                        return toReturn;
-                    }
-
-                    // Get the actual unit
-                    Unit u = getCampaign().getUnit(unitId);
                     if (u == null) {
-                        // This should not happen, but if it does, just return their name
                         return toReturn;
                     }
 
@@ -583,7 +572,7 @@ public class PersonnelTableModel extends DataTableModel {
                     Entity en = personnelMarket.getAttachedEntity(p);
                     return ((en != null) ? en.getDisplayName() : "-");
                 } else {
-                    Unit u = getCampaign().getUnit(p.getUnitId());
+                    Unit u = p.getUnit();
                     if (u != null) {
                         String name = u.getName();
                         if (u.getEntity() instanceof Tank) {
@@ -608,14 +597,14 @@ public class PersonnelTableModel extends DataTableModel {
                     }
 
                     //check for tech
-                    if (!p.getTechUnitIDs().isEmpty()) {
-                        if (p.getTechUnitIDs().size() == 1) {
-                            u = getCampaign().getUnit(p.getTechUnitIDs().get(0));
+                    if (!p.getTechUnits().isEmpty()) {
+                        if (p.getTechUnits().size() == 1) {
+                            u = p.getTechUnits().get(0);
                             if (u != null) {
                                 return u.getName() + " (" + p.getMaintenanceTimeUsing() + "m)";
                             }
                         } else {
-                            return "" + p.getTechUnitIDs().size() + " units (" + p.getMaintenanceTimeUsing() + "m)";
+                            return "" + p.getTechUnits().size() + " units (" + p.getMaintenanceTimeUsing() + "m)";
                         }
                     }
                 }
@@ -624,8 +613,8 @@ public class PersonnelTableModel extends DataTableModel {
             case COL_XP:
                 return Integer.toString(p.getXP());
             case COL_DEPLOY:
-                Unit u = getCampaign().getUnit(p.getUnitId());
-                if ((u != null) && u.isDeployed()) {
+                Unit u = p.getUnit();
+                if ((null != u) && u.isDeployed()) {
                     return getCampaign().getScenario(u.getScenarioId()).getName();
                 }
                 break;
@@ -667,14 +656,10 @@ public class PersonnelTableModel extends DataTableModel {
             Campaign c = getCampaign();
             List<Person> commanders = new ArrayList<>();
             for (Person p : c.getPersonnel()) {
-                if (p.getUnitId() != null) {
-                    UUID unitId = p.getUnitId();
-                    Unit u = c.getUnit(unitId);
-                    if ((u != null) && !p.equals(u.getCommander())) {
-                        // this person is NOT the commander of their unit,
-                        // skip them.
-                        continue;
-                    }
+                if ((p.getUnit() != null) && !p.equals(p.getUnit().getCommander())) {
+                    // this person is NOT the commander of their unit,
+                    // skip them.
+                    continue;
                 }
 
                 // 1. If they don't have a unit, add them.
@@ -756,9 +741,9 @@ public class PersonnelTableModel extends DataTableModel {
                         Entity en = personnelMarket.getAttachedEntity(p);
                         setText((en != null) ? en.getDisplayName() : "-");
                     } else {
-                        Unit u = getCampaign().getUnit(p.getUnitId());
-                        if ((u == null) && !p.getTechUnitIDs().isEmpty()) {
-                            u = getCampaign().getUnit(p.getTechUnitIDs().get(0));
+                        Unit u = p.getUnit();
+                        if ((u == null) && !p.getTechUnits().isEmpty()) {
+                            u = p.getTechUnits().get(0);
                         }
 
                         if (u != null) {

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -168,7 +168,7 @@ public class RetirementTableModel extends AbstractTableModel {
         try {
             retVal = getValueAt(0, col).getClass();
         } catch (NullPointerException e) {
-            MekHQ.getLogger().error(RetirementTableModel.class, "getColumnClass", e);
+            MekHQ.getLogger().error(e);
         }
         return retVal;
     }
@@ -185,7 +185,7 @@ public class RetirementTableModel extends AbstractTableModel {
             case COL_PERSON:
                 return p.makeHTMLRank();
             case COL_ASSIGN:
-                Unit u = campaign.getUnit(p.getUnitId());
+                Unit u = p.getUnit();
                 if (null != u) {
                     String name = u.getName();
                     if (u.getEntity() instanceof Tank) {
@@ -209,14 +209,14 @@ public class RetirementTableModel extends AbstractTableModel {
                     return name;
                 }
                 //check for tech
-                if (!p.getTechUnitIDs().isEmpty()) {
-                    if (p.getTechUnitIDs().size() == 1) {
-                        u = campaign.getUnit(p.getTechUnitIDs().get(0));
+                if (!p.getTechUnits().isEmpty()) {
+                    if (p.getTechUnits().size() == 1) {
+                        u = p.getTechUnits().get(0);
                         if (null != u) {
                             return u.getName() + " (" + p.getMaintenanceTimeUsing() + "m)";
                         }
                     } else {
-                        return "" + p.getTechUnitIDs().size() + " units (" + p.getMaintenanceTimeUsing() + "m)";
+                        return "" + p.getTechUnits().size() + " units (" + p.getMaintenanceTimeUsing() + "m)";
                     }
                 }
                 return "-";
@@ -424,9 +424,9 @@ public class RetirementTableModel extends AbstractTableModel {
                 setText(p.getFullDesc());
             }
             if (actualCol == COL_ASSIGN) {
-                Unit u = campaign.getUnit(p.getUnitId());
-                if (!p.getTechUnitIDs().isEmpty()) {
-                    u = campaign.getUnit(p.getTechUnitIDs().get(0));
+                Unit u = p.getUnit();
+                if (!p.getTechUnits().isEmpty()) {
+                    u = p.getTechUnits().get(0);
                 }
                 if (null != u) {
                     String desc = "<b>" + u.getName() + "</b><br>";

--- a/MekHQ/src/mekhq/gui/model/TechTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TechTableModel.java
@@ -88,7 +88,7 @@ public class TechTableModel extends DataTableModel {
     public String getTechDesc(Person tech, boolean overtimeAllowed, IPartWork part) {
         StringBuilder toReturn = new StringBuilder(128);
         toReturn.append("<html><font size='2'");
-        if (null != part && null != part.getUnit() && tech.getTechUnitIDs().contains(part.getUnit().getId())) {
+        if ((null != part) && (null != part.getUnit()) && tech.getTechUnits().contains(part.getUnit())) {
             toReturn.append(" color='green'><b>@");
         }
         else {

--- a/MekHQ/src/mekhq/gui/sorter/TechSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/TechSorter.java
@@ -12,11 +12,11 @@ import mekhq.campaign.work.IPartWork;
      */
     public class TechSorter implements Comparator<Person> {
     	private IPartWork partWork;
-    	
+
     	public TechSorter() {
     		this(null);
     	}
-    	
+
     	public TechSorter(IPartWork p) {
     		partWork = p;
     	}
@@ -24,20 +24,20 @@ import mekhq.campaign.work.IPartWork;
         @Override
         public int compare(Person p0, Person p1) {
         	if (partWork != null && partWork.getUnit() != null) {
-        		if (p0.getTechUnitIDs().contains(partWork.getUnit().getId())) {
+        		if (p0.getTechUnits().contains(partWork.getUnit())) {
         			return -1;
         		}
-        		if (p1.getTechUnitIDs().contains(partWork.getUnit().getId())) {
+        		if (p1.getTechUnits().contains(partWork.getUnit())) {
         			return 1;
         		}
         	}
             return ((Comparable<Integer>)p0.getBestTechLevel()).compareTo(p1.getBestTechLevel());
         }
-        
+
         public void setPart(IPartWork p) {
         	partWork = p;
         }
-        
+
         public void clearPart() {
         	partWork = null;
         }

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -19,7 +19,6 @@
 package mekhq.gui.utilities;
 
 import java.util.StringJoiner;
-import java.util.UUID;
 import java.util.Vector;
 
 import megamek.common.Entity;
@@ -726,14 +725,15 @@ public class StaticChecks {
     }
 
     public static boolean allHaveSameUnit(Person[] people) {
-        UUID unitId = people[0].getUnitId();
-        for (Person person : people) {
-            if ((unitId == null && person.getUnitId() == null)
-                    || (person.getUnitId() != null && person.getUnitId()
-                            .equals(unitId))) {
-                continue;
-            }
+        if ((people == null) || (people.length == 0)) {
             return false;
+        }
+
+        Unit unit = people[0].getUnit();
+        for (Person person : people) {
+            if (unit != person.getUnit()) {
+                return false;
+            }
         }
         return true;
     }

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.utilities;
 
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.Vector;
 
@@ -731,7 +732,7 @@ public class StaticChecks {
 
         Unit unit = people[0].getUnit();
         for (Person person : people) {
-            if (unit != person.getUnit()) {
+            if (!Objects.equals(unit, person.getUnit())) {
                 return false;
             }
         }

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -780,8 +780,8 @@ public class MassRepairService {
                     assigned = force.getTechID().toString().equals(tech.getId().toString());
                 }
 
-                if (!assigned && (tech.getTechUnitIDs() != null) && !tech.getTechUnitIDs().isEmpty()) {
-                    assigned = tech.getTechUnitIDs().contains(unit.getId());
+                if (!assigned && !tech.getTechUnits().isEmpty()) {
+                    assigned = tech.getTechUnits().contains(unit);
                 }
             }
 

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -22,15 +22,20 @@ package mekhq.campaign;
 
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.campaign.unit.Unit;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import megamek.common.Dropship;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.mockito.Mockito.doReturn;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Deric Page (dericdotpageatgmaildotcom)
@@ -113,5 +118,40 @@ public class CampaignTest {
         expected.add(mockTechActive);
         expected.add(mockTechNoTime);
         Assert.assertEquals(expected, testCampaign.getTechs(false, testId, false, false));
+    }
+
+    @Test
+    public void testTransportShips() {
+        Campaign campaign = spy(new Campaign());
+
+        // New campaigns have no transports
+        assertTrue(campaign.getTransportShips().isEmpty());
+
+        // Create a mock transport
+        Dropship mockTransport = mock(Dropship.class);
+        UUID mockId = UUID.randomUUID();
+        Unit mockUnit = mock(Unit.class);
+        when(mockUnit.getId()).thenReturn(mockId);
+        when(mockUnit.getEntity()).thenReturn(mockTransport);
+
+        // Add our mock transport
+        campaign.addTransportShip(mockUnit);
+
+        // Ensure our mock transport exists
+        assertEquals(1, campaign.getTransportShips().size());
+        assertTrue(campaign.getTransportShips().contains(mockUnit));
+
+        // Add our mock transport a second time
+        campaign.addTransportShip(mockUnit);
+
+        // Ensure our mock transport exists only once
+        assertEquals(1, campaign.getTransportShips().size());
+        assertTrue(campaign.getTransportShips().contains(mockUnit));
+
+        // Remove the mock transport
+        campaign.removeTransportShip(mockUnit);
+
+        // Ensure it was removed
+        assertTrue(campaign.getTransportShips().isEmpty());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
@@ -37,9 +37,9 @@ public class PartTest {
     public void sparePart() {
         Part part = new MekSensor();
 
-        assertNull(part.getUnitId());
+        assertNull(part.getUnit());
         assertNull(part.getParentPart());
-        assertNull(part.getRefitId());
+        assertNull(part.getRefitUnit());
         assertFalse(part.isReservedForReplacement());
         assertTrue(part.isSpare());
     }
@@ -56,21 +56,24 @@ public class PartTest {
         Part part = new MekSensor();
         part.setUnit(mockUnit);
 
-        assertNotNull(part.getUnitId());
+        assertNotNull(part.getUnit());
         assertNull(part.getParentPart());
-        assertNull(part.getRefitId());
+        assertNull(part.getRefitUnit());
         assertFalse(part.isReservedForReplacement());
         assertFalse(part.isSpare());
     }
 
     @Test
     public void isReservedForRefitNotSpare() {
-        Part part = new MekSensor();
-        part.setRefitId(UUID.randomUUID());
+        Unit mockUnit = mock(Unit.class);
+        when(mockUnit.getId()).thenReturn(UUID.randomUUID());
 
-        assertNull(part.getUnitId());
+        Part part = new MekSensor();
+        part.setRefitUnit(mockUnit);
+
+        assertNull(part.getUnit());
         assertNull(part.getParentPart());
-        assertNotNull(part.getRefitId());
+        assertNotNull(part.getRefitUnit());
         assertFalse(part.isReservedForReplacement());
         assertFalse(part.isSpare());
     }
@@ -82,9 +85,9 @@ public class PartTest {
         Part part = new MekSensor();
         part.setParentPart(parent);
 
-        assertNull(part.getUnitId());
+        assertNull(part.getUnit());
         assertNotNull(part.getParentPart());
-        assertNull(part.getRefitId());
+        assertNull(part.getRefitUnit());
         assertFalse(part.isReservedForReplacement());
         assertFalse(part.isSpare());
     }
@@ -97,9 +100,9 @@ public class PartTest {
         Part part = new MekSensor();
         part.setReserveId(mockTech);
 
-        assertNull(part.getUnitId());
+        assertNull(part.getUnit());
         assertNull(part.getParentPart());
-        assertNull(part.getRefitId());
+        assertNull(part.getRefitUnit());
         assertTrue(part.isReservedForReplacement());
         assertFalse(part.isSpare());
     }

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -8,6 +8,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import megamek.common.Entity;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.personnel.enums.PrisonerStatus;
 import mekhq.campaign.unit.Unit;
 
 import java.time.LocalDate;
@@ -250,6 +253,110 @@ public class PersonTest {
 
         // Ensure the unit had its status reset to reflect crew damage
         verify(unit0, Mockito.times(1)).resetPilotAndEntity();
+    }
+
+    @Test
+    public void testPrisonerRemovedFromUnit() {
+        initPerson();
+
+        CampaignOptions mockCampaignOpts = Mockito.mock(CampaignOptions.class);
+
+        Campaign mockCampaign = Mockito.mock(Campaign.class);
+        Mockito.when(mockCampaign.getLocalDate()).thenReturn(LocalDate.now());
+        Mockito.when(mockCampaign.getName()).thenReturn("Campaign");
+        Mockito.when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOpts);
+
+        Mockito.when(mockPerson.getCampaign()).thenReturn(mockCampaign);
+
+        // Add a unit to the person
+        UUID id0 = UUID.randomUUID();
+        Unit unit0 = Mockito.mock(Unit.class);
+        Mockito.when(unit0.getId()).thenReturn(id0);
+
+        mockPerson.setUnit(unit0);
+
+        mockPerson.setPrisonerStatus(PrisonerStatus.PRISONER, true);
+
+        // Ensure the unit removes the person
+        verify(unit0, Mockito.times(1)).remove(Mockito.eq(mockPerson), Mockito.anyBoolean());
+    }
+
+    @Test
+    public void testPrisonerDefectorRemovedFromUnit() {
+        initPerson();
+
+        CampaignOptions mockCampaignOpts = Mockito.mock(CampaignOptions.class);
+
+        Campaign mockCampaign = Mockito.mock(Campaign.class);
+        Mockito.when(mockCampaign.getLocalDate()).thenReturn(LocalDate.now());
+        Mockito.when(mockCampaign.getName()).thenReturn("Campaign");
+        Mockito.when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOpts);
+
+        Mockito.when(mockPerson.getCampaign()).thenReturn(mockCampaign);
+
+        // Add a unit to the person
+        UUID id0 = UUID.randomUUID();
+        Unit unit0 = Mockito.mock(Unit.class);
+        Mockito.when(unit0.getId()).thenReturn(id0);
+
+        mockPerson.setUnit(unit0);
+
+        mockPerson.setPrisonerStatus(PrisonerStatus.PRISONER_DEFECTOR, true);
+
+        // Ensure the unit removes the person
+        verify(unit0, Mockito.times(1)).remove(Mockito.eq(mockPerson), Mockito.anyBoolean());
+    }
+
+    @Test
+    public void testBondsmanRemovedFromUnit() {
+        initPerson();
+
+        CampaignOptions mockCampaignOpts = Mockito.mock(CampaignOptions.class);
+
+        Campaign mockCampaign = Mockito.mock(Campaign.class);
+        Mockito.when(mockCampaign.getLocalDate()).thenReturn(LocalDate.now());
+        Mockito.when(mockCampaign.getName()).thenReturn("Campaign");
+        Mockito.when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOpts);
+
+        Mockito.when(mockPerson.getCampaign()).thenReturn(mockCampaign);
+
+        // Add a unit to the person
+        UUID id0 = UUID.randomUUID();
+        Unit unit0 = Mockito.mock(Unit.class);
+        Mockito.when(unit0.getId()).thenReturn(id0);
+
+        mockPerson.setUnit(unit0);
+
+        mockPerson.setPrisonerStatus(PrisonerStatus.BONDSMAN, true);
+
+        // Ensure the unit removes the person
+        verify(unit0, Mockito.times(1)).remove(Mockito.eq(mockPerson), Mockito.anyBoolean());
+    }
+
+    @Test
+    public void testFreeNotRemovedFromUnit() {
+        initPerson();
+
+        CampaignOptions mockCampaignOpts = Mockito.mock(CampaignOptions.class);
+
+        Campaign mockCampaign = Mockito.mock(Campaign.class);
+        Mockito.when(mockCampaign.getLocalDate()).thenReturn(LocalDate.now());
+        Mockito.when(mockCampaign.getName()).thenReturn("Campaign");
+        Mockito.when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOpts);
+
+        Mockito.when(mockPerson.getCampaign()).thenReturn(mockCampaign);
+
+        // Add a unit to the person
+        UUID id0 = UUID.randomUUID();
+        Unit unit0 = Mockito.mock(Unit.class);
+        Mockito.when(unit0.getId()).thenReturn(id0);
+
+        mockPerson.setUnit(unit0);
+
+        mockPerson.setPrisonerStatus(PrisonerStatus.FREE, true);
+
+        // Ensure the unit DOES NOT remove the person
+        verify(unit0, Mockito.times(0)).remove(Mockito.eq(mockPerson), Mockito.anyBoolean());
     }
 
     private void initPerson(){

--- a/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/PersonTest.java
@@ -2,6 +2,7 @@ package mekhq.campaign.personnel;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -161,6 +162,94 @@ public class PersonTest {
             assertEquals(clanWeightClass, mockPerson.getOriginalUnitWeight());
             assertEquals(clanId, mockPerson.getOriginalUnitId());
         }
+    }
+
+    @Test
+    public void testTechUnits() {
+        initPerson();
+
+        UUID id0 = UUID.randomUUID();
+        Unit unit0 = Mockito.mock(Unit.class);
+        Mockito.when(unit0.getId()).thenReturn(id0);
+
+        UUID id1 = UUID.randomUUID();
+        Unit unit1 = Mockito.mock(Unit.class);
+        Mockito.when(unit1.getId()).thenReturn(id1);
+
+        // Add a tech unit
+        mockPerson.addTechUnit(unit0);
+        assertNotNull(mockPerson.getTechUnits());
+        assertFalse(mockPerson.getTechUnits().isEmpty());
+        assertTrue(mockPerson.getTechUnits().contains(unit0));
+
+        // Add a second unit
+        mockPerson.addTechUnit(unit1);
+        assertEquals(2, mockPerson.getTechUnits().size());
+        assertTrue(mockPerson.getTechUnits().contains(unit1));
+
+        // Adding the same unit twice does not add it again!
+        mockPerson.addTechUnit(unit1);
+        assertEquals(2, mockPerson.getTechUnits().size());
+        assertTrue(mockPerson.getTechUnits().contains(unit1));
+
+        // Remove the first unit
+        mockPerson.removeTechUnit(unit0);
+        assertEquals(1, mockPerson.getTechUnits().size());
+        assertFalse(mockPerson.getTechUnits().contains(unit0));
+        assertTrue(mockPerson.getTechUnits().contains(unit1));
+
+        // Ensure we can clear the units
+        mockPerson.clearTechUnits();
+        assertNotNull(mockPerson.getTechUnits());
+        assertTrue(mockPerson.getTechUnits().isEmpty());
+    }
+
+    @Test
+    public void testIsDeployed() {
+        initPerson();
+
+        // No unit? We're not deployed
+        assertFalse(mockPerson.isDeployed());
+
+        UUID id0 = UUID.randomUUID();
+        Unit unit0 = Mockito.mock(Unit.class);
+        Mockito.when(unit0.getId()).thenReturn(id0);
+        Mockito.when(unit0.getScenarioId()).thenReturn(-1);
+
+        mockPerson.setUnit(unit0);
+        assertEquals(unit0, mockPerson.getUnit());
+
+        // If the unit is not deployed, the person is not delpoyed
+        assertFalse(mockPerson.isDeployed());
+
+        // Deploy the unit
+        Mockito.when(unit0.getScenarioId()).thenReturn(1);
+
+        // The person should now be deployed
+        assertTrue(mockPerson.isDeployed());
+    }
+
+    @Test
+    public void testAddInjuriesResetsUnitStatus() {
+        initPerson();
+
+        // Add an injury without a unit
+        Injury injury0 = Mockito.mock(Injury.class);
+        mockPerson.addInjury(injury0);
+
+        // Add a unit to the person
+        UUID id0 = UUID.randomUUID();
+        Unit unit0 = Mockito.mock(Unit.class);
+        Mockito.when(unit0.getId()).thenReturn(id0);
+
+        mockPerson.setUnit(unit0);
+
+        // Add an injury with a unit
+        Injury injury1 = Mockito.mock(Injury.class);
+        mockPerson.addInjury(injury1);
+
+        // Ensure the unit had its status reset to reflect crew damage
+        verify(unit0, Mockito.times(1)).resetPilotAndEntity();
     }
 
     private void initPerson(){

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitPersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitPersonTest.java
@@ -55,7 +55,7 @@ public class UnitPersonTest {
         unit.setTech(mockTech);
 
         // Ensure we were added to the unit
-        verify(mockTech, times(1)).addTechUnitID(eq(unitId));
+        verify(mockTech, times(1)).addTechUnit(eq(unit));
 
         // Ensure when getting the tech that it is the same tech
         assertEquals(mockTech, unit.getTech());
@@ -81,7 +81,7 @@ public class UnitPersonTest {
         unit.setTech(mockTech);
 
         // Ensure we were added to the unit
-        verify(mockTech, times(1)).addTechUnitID(eq(unitId));
+        verify(mockTech, times(1)).addTechUnit(eq(unit));
 
         // Add an engineer to the unit
         Person mockEngineer = mock(Person.class);
@@ -127,13 +127,13 @@ public class UnitPersonTest {
         unit.setTech(mockTech);
 
         // Ensure we were added to the unit
-        verify(mockTech, times(1)).addTechUnitID(eq(unitId));
+        verify(mockTech, times(1)).addTechUnit(eq(unit));
 
         // Remove the tech
         unit.removeTech();
 
         // Ensure we were removed from the unit
-        verify(mockTech, times(1)).removeTechUnitId(eq(unitId));
+        verify(mockTech, times(1)).removeTechUnit(eq(unit));
     }
 
     @Test
@@ -190,7 +190,7 @@ public class UnitPersonTest {
         unit.completeActivation();
 
         // Ensure we were removed from the unit after activation
-        verify(mockTech, times(1)).removeTechUnitId(eq(unitId));
+        verify(mockTech, times(1)).removeTechUnit(eq(unit));
     }
 
     @Test
@@ -239,7 +239,7 @@ public class UnitPersonTest {
         unit.addDriver(mockDriver);
 
         // Ensure we were added to the unit
-        verify(mockDriver, times(1)).setUnitId(eq(unitId));
+        verify(mockDriver, times(1)).setUnit(eq(unit));
         verify(unit, times(1)).resetPilotAndEntity();
 
         // Ensure when getting the driver that it is the same driver
@@ -263,7 +263,7 @@ public class UnitPersonTest {
         unit.remove(mockDriver, false);
 
         // Make sure we are removed from the person
-        verify(mockDriver, times(1)).setUnitId(eq(null));
+        verify(mockDriver, times(1)).setUnit(eq(null));
         verify(unit, times(2)).resetPilotAndEntity();
 
         // Make sure we were removed from the unit
@@ -297,7 +297,7 @@ public class UnitPersonTest {
         unit.addGunner(mockGunner);
 
         // Ensure we were added to the unit
-        verify(mockGunner, times(1)).setUnitId(eq(unitId));
+        verify(mockGunner, times(1)).setUnit(eq(unit));
         verify(unit, times(1)).resetPilotAndEntity();
 
         // Ensure when getting the gunner that it is the same gunner
@@ -321,7 +321,7 @@ public class UnitPersonTest {
         unit.remove(mockGunner, false);
 
         // Make sure we are removed from the person
-        verify(mockGunner, times(1)).setUnitId(eq(null));
+        verify(mockGunner, times(1)).setUnit(eq(null));
         verify(unit, times(2)).resetPilotAndEntity();
 
         // Make sure we were removed from the unit
@@ -352,7 +352,7 @@ public class UnitPersonTest {
         unit.addVesselCrew(mockVesselCrew);
 
         // Ensure we were added to the unit
-        verify(mockVesselCrew, times(1)).setUnitId(eq(unitId));
+        verify(mockVesselCrew, times(1)).setUnit(eq(unit));
         verify(unit, times(1)).resetPilotAndEntity();
 
         // Ensure when getting the vessel crew that it is the same vessel crew
@@ -369,7 +369,7 @@ public class UnitPersonTest {
         unit.remove(mockVesselCrew, false);
 
         // Make sure we are removed from the person
-        verify(mockVesselCrew, times(1)).setUnitId(eq(null));
+        verify(mockVesselCrew, times(1)).setUnit(eq(null));
         verify(unit, times(2)).resetPilotAndEntity();
 
         // Make sure we were removed from the unit
@@ -402,7 +402,7 @@ public class UnitPersonTest {
         unit.setTechOfficer(mockTechOfficer);
 
         // Ensure we were added to the unit
-        verify(mockTechOfficer, times(1)).setUnitId(eq(unitId));
+        verify(mockTechOfficer, times(1)).setUnit(eq(unit));
         verify(unit, times(1)).resetPilotAndEntity();
 
         // Ensure when getting the tech officer that it is the same tech officer
@@ -425,7 +425,7 @@ public class UnitPersonTest {
         unit.remove(mockTechOfficer, false);
 
         // Make sure we are removed from the person
-        verify(mockTechOfficer, times(1)).setUnitId(eq(null));
+        verify(mockTechOfficer, times(1)).setUnit(eq(null));
         verify(unit, times(2)).resetPilotAndEntity();
 
         // Make sure we were removed from the unit
@@ -459,7 +459,7 @@ public class UnitPersonTest {
         unit.setNavigator(mockNavigator);
 
         // Ensure we were added to the unit
-        verify(mockNavigator, times(1)).setUnitId(eq(unitId));
+        verify(mockNavigator, times(1)).setUnit(eq(unit));
         verify(unit, times(1)).resetPilotAndEntity();
 
         // Make sure we're part of the crew!
@@ -482,7 +482,7 @@ public class UnitPersonTest {
         unit.remove(mockNavigator, false);
 
         // Make sure we are removed from the person
-        verify(mockNavigator, times(1)).setUnitId(eq(null));
+        verify(mockNavigator, times(1)).setUnit(eq(null));
         verify(unit, times(2)).resetPilotAndEntity();
 
         // Make sure we were removed from the unit


### PR DESCRIPTION
This is a follow-on to #2137 to keep things manageable. Basically, this furthers the goal of using object references to refer to objects (one of the selling points of OOP).

I'm still fleshing out unit tests for areas that are testable, but this comes with tests for units+persons.