### PR TITLE
2159: Personnel Filter Style for All Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUIEnums.properties
+++ b/MekHQ/resources/mekhq/resources/GUIEnums.properties
@@ -55,6 +55,14 @@ PersonnelFilter.MIA=Missing in Action Personnel
 PersonnelFilter.KIA=Rolls of Honor
 PersonnelFilter.DEAD=Cemetery
 
+# PersonnelFilterStyle Enum
+PersonnelFilterStyle.STANDARD.text=Standard
+PersonnelFilterStyle.STANDARD.toolTipText=This is the standard filter style for MekHQ, which groups less commonly used but related personnel roles into a single filter (e.g. Doctors and Medics are grouped as Medical Staff)
+PersonnelFilterStyle.INDIVIDUAL_ROLE.text=Individual Role
+PersonnelFilterStyle.INDIVIDUAL_ROLE.toolTipText=This filter style provides filters that allow one to filter personnel by each individual role, without the filter groupings as seen previously.
+PersonnelFilterStyle.ALL.text=All
+PersonnelFilterStyle.ALL.toolTipText=This filter style provides all of the standard AND individual role filters.
+
 # PersonnelTabView Enum
 PersonnelTabView.GRAPHIC=Graphic
 PersonnelTabView.GENERAL=General

--- a/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
@@ -16,7 +16,8 @@ optionCommandCenterMRMS.text=Command Center Mass Repair/Mass Salvage Button
 optionCommandCenterMRMS.toolTipText=This adds a button to launch the Mass Repair/Mass Salvage Dialog and a second to run it using current settings to the Command Center Tab
 
 labelPersonnelDisplay.text=Personnel Tab Display Options
-optionPersonnelIndividualRoleFilters.text=Use Individual Role Personnel Filters
+optionPersonnelFilterStyle.text=Personnel Filter Style
+optionPersonnelFilterStyle.toolTipText=This is the style for which Personnel Filters will be displayed
 optionPersonnelFilterOnPrimaryRole.text=Filter Personnel Based On Primary Role
 
 labelSavedInfo.text=Autosave options

--- a/MekHQ/src/mekhq/MekHQOptions.java
+++ b/MekHQ/src/mekhq/MekHQOptions.java
@@ -18,6 +18,8 @@
  */
 package mekhq;
 
+import mekhq.gui.enums.PersonnelFilterStyle;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.prefs.Preferences;
@@ -81,12 +83,13 @@ public final class MekHQOptions {
     //endregion Command Center Display
 
     //region Personnel Tab Display Options
-    public boolean getPersonnelIndividualRoleFilters() {
-        return userPreferences.node(MekHqConstants.DISPLAY_NODE).getBoolean(MekHqConstants.PERSONNEL_INDIVIDUAL_ROLE_FILTERS, false);
+    public PersonnelFilterStyle getPersonnelFilterStyle() {
+        return PersonnelFilterStyle.valueOf(userPreferences.node(MekHqConstants.DISPLAY_NODE)
+                .get(MekHqConstants.PERSONNEL_FILTER_STYLE, "STANDARD"));
     }
 
-    public void setPersonnelIndividualRoleFilters(boolean value) {
-        userPreferences.node(MekHqConstants.DISPLAY_NODE).putBoolean(MekHqConstants.PERSONNEL_INDIVIDUAL_ROLE_FILTERS, value);
+    public void setPersonnelFilterStyle(PersonnelFilterStyle value) {
+        userPreferences.node(MekHqConstants.DISPLAY_NODE).put(MekHqConstants.PERSONNEL_FILTER_STYLE, value.name());
     }
 
     public boolean getPersonnelFilterOnPrimaryRole() {

--- a/MekHQ/src/mekhq/MekHqConstants.java
+++ b/MekHQ/src/mekhq/MekHqConstants.java
@@ -35,7 +35,7 @@ public final class MekHqConstants {
     //endregion Command Center
 
     //region Personnel Tab Display Options
-    public static final String PERSONNEL_INDIVIDUAL_ROLE_FILTERS = "personnelIndividualRoleFilters";
+    public static final String PERSONNEL_FILTER_STYLE = "personnelFilterStyle";
     public static final String PERSONNEL_FILTER_ON_PRIMARY_ROLE = "personnelFilterOnPrimaryRole";
     //endregion Personnel Tab Display Options
     //endregion Display

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -20,7 +20,6 @@ package mekhq.gui;
 
 import java.awt.*;
 import java.awt.event.MouseEvent;
-import java.util.List;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 import java.util.UUID;
@@ -248,12 +247,10 @@ public final class PersonnelTab extends CampaignGuiTab {
     private DefaultComboBoxModel<PersonnelFilter> createPersonGroupModel() {
         DefaultComboBoxModel<PersonnelFilter> personGroupModel = new DefaultComboBoxModel<>();
 
-        List<PersonnelFilter> personnelFilters = MekHQ.getMekHQOptions().getPersonnelIndividualRoleFilters()
-                ? PersonnelFilter.getIndividualRolesExpandedPersonnelFilters()
-                : PersonnelFilter.getExpandedPersonnelFilters();
-        for (PersonnelFilter filter : personnelFilters) {
+        for (PersonnelFilter filter : MekHQ.getMekHQOptions().getPersonnelFilterStyle().getFilters(false)) {
             personGroupModel.addElement(filter);
         }
+
         return personGroupModel;
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
@@ -22,12 +22,14 @@ package mekhq.gui.dialog;
 
 import mekhq.MekHQ;
 import mekhq.campaign.event.MekHQOptionsChangedEvent;
+import mekhq.gui.enums.PersonnelFilterStyle;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 public class MekHqOptionsDialog extends BaseDialog {
@@ -45,7 +47,7 @@ public class MekHqOptionsDialog extends BaseDialog {
     //endregion Command Center Display
 
     //region Personnel Tab Display Options
-    private JCheckBox optionPersonnelIndividualRoleFilters;
+    private JComboBox<PersonnelFilterStyle> optionPersonnelFilterStyle;
     private JCheckBox optionPersonnelFilterOnPrimaryRole;
     //endregion Personnel Tab Display Options
     //endregion Display
@@ -124,7 +126,25 @@ public class MekHqOptionsDialog extends BaseDialog {
         //region Personnel Tab Display Options
         JLabel labelPersonnelDisplay = new JLabel(resources.getString("labelPersonnelDisplay.text"));
 
-        optionPersonnelIndividualRoleFilters = new JCheckBox(resources.getString("optionPersonnelIndividualRoleFilters.text"));
+        JLabel labelPersonnelFilterStyle = new JLabel(resources.getString("optionPersonnelFilterStyle.text"));
+        labelPersonnelFilterStyle.setToolTipText(resources.getString("optionPersonnelFilterStyle.toolTipText"));
+
+        optionPersonnelFilterStyle = new JComboBox<>(PersonnelFilterStyle.values());
+        optionPersonnelFilterStyle.setRenderer(new DefaultListCellRenderer() {
+            private static final long serialVersionUID = -543354619818226314L;
+
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                                                          boolean isSelected, boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (isSelected && (index > -1)) {
+                    list.setToolTipText((list.getSelectedValue() instanceof PersonnelFilterStyle)
+                            ? ((PersonnelFilterStyle) list.getSelectedValue()).getToolTipText() : "");
+                }
+
+                return this;
+            }
+        });
 
         optionPersonnelFilterOnPrimaryRole = new JCheckBox(resources.getString("optionPersonnelFilterOnPrimaryRole.text"));
         //endregion Personnel Tab Display Options
@@ -218,7 +238,9 @@ public class MekHqOptionsDialog extends BaseDialog {
                     .addComponent(optionCommandCenterUseUnitMarket)
                     .addComponent(optionCommandCenterMRMS)
                     .addComponent(labelPersonnelDisplay)
-                    .addComponent(optionPersonnelIndividualRoleFilters)
+                    .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                            .addComponent(labelPersonnelFilterStyle)
+                            .addComponent(optionPersonnelFilterStyle, GroupLayout.Alignment.TRAILING))
                     .addComponent(optionPersonnelFilterOnPrimaryRole)
                     .addComponent(labelSavedInfo)
                     .addComponent(optionNoSave)
@@ -258,7 +280,9 @@ public class MekHqOptionsDialog extends BaseDialog {
                     .addComponent(optionCommandCenterUseUnitMarket)
                     .addComponent(optionCommandCenterMRMS)
                     .addComponent(labelPersonnelDisplay)
-                    .addComponent(optionPersonnelIndividualRoleFilters)
+                    .addGroup(layout.createSequentialGroup()
+                            .addComponent(labelPersonnelFilterStyle)
+                            .addComponent(optionPersonnelFilterStyle))
                     .addComponent(optionPersonnelFilterOnPrimaryRole)
                     .addComponent(labelSavedInfo)
                     .addComponent(optionNoSave)
@@ -296,7 +320,7 @@ public class MekHqOptionsDialog extends BaseDialog {
         MekHQ.getMekHQOptions().setHistoricalDailyLog(optionHistoricalDailyLog.isSelected());
         MekHQ.getMekHQOptions().setCommandCenterUseUnitMarket(optionCommandCenterUseUnitMarket.isSelected());
         MekHQ.getMekHQOptions().setCommandCenterMRMS(optionCommandCenterMRMS.isSelected());
-        MekHQ.getMekHQOptions().setPersonnelIndividualRoleFilters(optionPersonnelIndividualRoleFilters.isSelected());
+        MekHQ.getMekHQOptions().setPersonnelFilterStyle((PersonnelFilterStyle) Objects.requireNonNull(optionPersonnelFilterStyle.getSelectedItem()));
         MekHQ.getMekHQOptions().setPersonnelFilterOnPrimaryRole(optionPersonnelFilterOnPrimaryRole.isSelected());
 
         MekHQ.getMekHQOptions().setNoAutosaveValue(optionNoSave.isSelected());
@@ -324,7 +348,7 @@ public class MekHqOptionsDialog extends BaseDialog {
         optionHistoricalDailyLog.setSelected(MekHQ.getMekHQOptions().getHistoricalDailyLog());
         optionCommandCenterUseUnitMarket.setSelected(MekHQ.getMekHQOptions().getCommandCenterUseUnitMarket());
         optionCommandCenterMRMS.setSelected(MekHQ.getMekHQOptions().getCommandCenterMRMS());
-        optionPersonnelIndividualRoleFilters.setSelected(MekHQ.getMekHQOptions().getPersonnelIndividualRoleFilters());
+        optionPersonnelFilterStyle.setSelectedItem(MekHQ.getMekHQOptions().getPersonnelFilterStyle());
         optionPersonnelFilterOnPrimaryRole.setSelected(MekHQ.getMekHQOptions().getPersonnelFilterOnPrimaryRole());
 
         optionNoSave.setSelected(MekHQ.getMekHQOptions().getNoAutosaveValue());

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -140,7 +140,7 @@ public class PersonnelMarketDialog extends JDialog {
         panelFilterBtns.add(lblPersonChoice, gridBagConstraints);
 
         DefaultComboBoxModel<PersonnelFilter> personTypeModel = new DefaultComboBoxModel<>();
-        for (PersonnelFilter filter : PersonnelFilter.getStandardPersonnelFilters()) {
+        for (PersonnelFilter filter : MekHQ.getMekHQOptions().getPersonnelFilterStyle().getFilters(true)) {
             personTypeModel.addElement(filter);
         }
         comboPersonType.setSelectedItem(0);

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -196,7 +196,7 @@ public class RetirementDefectionDialog extends JDialog {
             JPanel panOverview = new JPanel(new BorderLayout());
 
             cbGroupOverview = new JComboBox<>();
-            for (PersonnelFilter filter : PersonnelFilter.getStandardPersonnelFilters()) {
+            for (PersonnelFilter filter : MekHQ.getMekHQOptions().getPersonnelFilterStyle().getFilters(true)) {
                 cbGroupOverview.addItem(filter);
             }
             JPanel panTop = new JPanel();
@@ -300,7 +300,7 @@ public class RetirementDefectionDialog extends JDialog {
         JPanel panRetirees = new JPanel(new BorderLayout());
 
         cbGroupResults = new JComboBox<>();
-        for (PersonnelFilter filter : PersonnelFilter.getStandardPersonnelFilters()) {
+        for (PersonnelFilter filter : MekHQ.getMekHQOptions().getPersonnelFilterStyle().getFilters(true)) {
             cbGroupResults.addItem(filter);
         }
         JPanel panTop = new JPanel();

--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -23,90 +23,105 @@ import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ResourceBundle;
 
 public enum PersonnelFilter {
     //region Personnel Filters
     //region Standard Personnel Filters
-    ALL("PersonnelFilter.ALL", true, true, true),
-    ACTIVE("PersonnelFilter.ACTIVE", true, true, true),
-    COMBAT("PersonnelFilter.COMBAT", true, true, true),
-    SUPPORT("PersonnelFilter.SUPPORT", true, true, true),
-    MECHWARRIOR("PersonnelFilter.MECHWARRIOR", true, true, true),
-    VEHICLE_CREWMEMBER("PersonnelFilter.VEHICLE_CREWMEMBER", true, true, false),
-    GROUND_VEHICLE_DRIVER("PersonnelFilter.GROUND_VEHICLE_DRIVER", false, false, true),
-    NAVAL_VEHICLE_DRIVER("PersonnelFilter.NAVAL_VEHICLE_DRIVER", false, false, true),
-    VEHICLE_GUNNER("PersonnelFilter.VEHICLE_GUNNER", false, false, true),
-    VEHICLE_CREW("PersonnelFilter.VEHICLE_CREW", false, false, true),
-    VTOL_PILOT("PersonnelFilter.VTOL_PILOT", false, false, true),
-    AEROSPACE_PILOT("PersonnelFilter.AEROSPACE_PILOT", true, true, true),
-    CONVENTIONAL_AIRCRAFT_PILOT("PersonnelFilter.CONVENTIONAL_AIRCRAFT_PILOT", true, true,true),
-    PROTOMECH_PILOT("PersonnelFilter.PROTOMECH_PILOT", true, true, true),
-    BATTLE_ARMOUR("PersonnelFilter.BATTLE_ARMOUR", true, true, true),
-    SOLDIER("PersonnelFilter.SOLDIER", true, true, true),
-    VESSEL_CREWMEMBER("PersonnelFilter.VESSEL_CREWMEMBER", true, true, false),
-    VESSEL_PILOT("PersonnelFilter.VESSEL_PILOT", false, false, true),
-    VESSEL_CREW("PersonnelFilter.VESSEL_CREW", false, false, true),
-    VESSEL_GUNNER("PersonnelFilter.VESSEL_GUNNER", false, false, true),
-    VESSEL_NAVIGATOR("PersonnelFilter.VESSEL_NAVIGATOR", false, false, true),
-    TECH("PersonnelFilter.TECH", true, true, false),
-    MECH_TECH("PersonnelFilter.MECH_TECH", false, false, true),
-    MECHANIC("PersonnelFilter.MECHANIC", false, false, true),
-    AERO_TECH("PersonnelFilter.AERO_TECH", false, false, true),
-    BA_TECH("PersonnelFilter.BA_TECH", false, false, true),
-    ASTECH("PersonnelFilter.ASTECH", false, false, true),
-    MEDICAL("PersonnelFilter.MEDICAL", true, true, false),
-    DOCTOR("PersonnelFilter.DOCTOR", false, false, true),
-    MEDIC("PersonnelFilter.MEDIC",  false, false, true),
-    ADMINISTRATOR("PersonnelFilter.ADMINISTRATOR", true, true, false),
-    ADMINISTRATOR_COMMAND("PersonnelFilter.ADMINISTRATOR_COMMAND", false, false, true),
-    ADMINISTRATOR_LOGISTICS("PersonnelFilter.ADMINISTRATOR_LOGISTICS", false, false, true),
-    ADMINISTRATOR_TRANSPORT("PersonnelFilter.ADMINISTRATOR_TRANSPORT", false, false, true),
-    ADMINISTRATOR_HR("PersonnelFilter.ADMINISTRATOR_HR", false, false, true),
+    ALL("PersonnelFilter.ALL"),
+    ACTIVE("PersonnelFilter.ACTIVE"),
+    COMBAT("PersonnelFilter.COMBAT"),
+    SUPPORT("PersonnelFilter.SUPPORT"),
+    MECHWARRIOR("PersonnelFilter.MECHWARRIOR"),
+    VEHICLE_CREWMEMBER("PersonnelFilter.VEHICLE_CREWMEMBER", true, false),
+    GROUND_VEHICLE_DRIVER("PersonnelFilter.GROUND_VEHICLE_DRIVER", false, true),
+    NAVAL_VEHICLE_DRIVER("PersonnelFilter.NAVAL_VEHICLE_DRIVER", false, true),
+    VEHICLE_GUNNER("PersonnelFilter.VEHICLE_GUNNER", false, true),
+    VEHICLE_CREW("PersonnelFilter.VEHICLE_CREW", false, true),
+    VTOL_PILOT("PersonnelFilter.VTOL_PILOT", false, true),
+    AEROSPACE_PILOT("PersonnelFilter.AEROSPACE_PILOT"),
+    CONVENTIONAL_AIRCRAFT_PILOT("PersonnelFilter.CONVENTIONAL_AIRCRAFT_PILOT"),
+    PROTOMECH_PILOT("PersonnelFilter.PROTOMECH_PILOT"),
+    BATTLE_ARMOUR("PersonnelFilter.BATTLE_ARMOUR"),
+    SOLDIER("PersonnelFilter.SOLDIER"),
+    VESSEL_CREWMEMBER("PersonnelFilter.VESSEL_CREWMEMBER", true, false),
+    VESSEL_PILOT("PersonnelFilter.VESSEL_PILOT", false, true),
+    VESSEL_CREW("PersonnelFilter.VESSEL_CREW", false, true),
+    VESSEL_GUNNER("PersonnelFilter.VESSEL_GUNNER", false, true),
+    VESSEL_NAVIGATOR("PersonnelFilter.VESSEL_NAVIGATOR", false, true),
+    TECH("PersonnelFilter.TECH", true, false),
+    MECH_TECH("PersonnelFilter.MECH_TECH", false, true),
+    MECHANIC("PersonnelFilter.MECHANIC", false, true),
+    AERO_TECH("PersonnelFilter.AERO_TECH", false, true),
+    BA_TECH("PersonnelFilter.BA_TECH", false, true),
+    ASTECH("PersonnelFilter.ASTECH", false, true),
+    MEDICAL("PersonnelFilter.MEDICAL", true, false),
+    DOCTOR("PersonnelFilter.DOCTOR", false, true),
+    MEDIC("PersonnelFilter.MEDIC",  false, true),
+    ADMINISTRATOR("PersonnelFilter.ADMINISTRATOR", true, false),
+    ADMINISTRATOR_COMMAND("PersonnelFilter.ADMINISTRATOR_COMMAND", false, true),
+    ADMINISTRATOR_LOGISTICS("PersonnelFilter.ADMINISTRATOR_LOGISTICS", false, true),
+    ADMINISTRATOR_TRANSPORT("PersonnelFilter.ADMINISTRATOR_TRANSPORT", false, true),
+    ADMINISTRATOR_HR("PersonnelFilter.ADMINISTRATOR_HR", false, true),
     //endregion Standard Personnel Filters
 
     //region Expanded Personnel Tab Filters
-    DEPENDENT("PersonnelFilter.DEPENDENT", false, true, true),
-    FOUNDER("PersonnelFilter.FOUNDER", false, true, true),
-    PRISONER("PersonnelFilter.PRISONER", false, true, true),
-    INACTIVE("PersonnelFilter.INACTIVE", false, true, true),
-    RETIRED("PersonnelFilter.RETIRED", false, true, true),
-    MIA("PersonnelFilter.MIA", false, true, true),
-    KIA("PersonnelFilter.KIA", false, true, true),
-    DEAD("PersonnelFilter.DEAD", false, true, true);
+    DEPENDENT("PersonnelFilter.DEPENDENT", false, false),
+    FOUNDER("PersonnelFilter.FOUNDER", false, false),
+    PRISONER("PersonnelFilter.PRISONER", false, false),
+    INACTIVE("PersonnelFilter.INACTIVE", false, false),
+    RETIRED("PersonnelFilter.RETIRED", false, false),
+    MIA("PersonnelFilter.MIA", false, false),
+    KIA("PersonnelFilter.KIA", false, false),
+    DEAD("PersonnelFilter.DEAD", false, false);
     //endregion Expanded Personnel Tab Filters
     //endregion Personnel Filters
 
+    //region Variable Declarations
     private final String name;
+    private final boolean baseline;
     private final boolean standard;
-    private final boolean expanded;
-    private final boolean individualRolesExpanded;
+    private final boolean individualRole;
 
-    PersonnelFilter(String name, boolean standard, boolean expanded, boolean individualRolesExpanded) {
-        this.name = ResourceBundle.getBundle("mekhq.resources.GUIEnums", new EncodeControl())
-                .getString(name);
+    private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUIEnums", new EncodeControl());
+    //endregion Variable Declarations
+
+    //region Constructors
+    PersonnelFilter(String name) {
+        this(name, true, true, true);
+    }
+
+    PersonnelFilter(String name, boolean standard, boolean individualRole) {
+        this(name, false, standard, individualRole);
+    }
+    PersonnelFilter(String name, boolean baseline, boolean standard, boolean individualRole) {
+        this.name = resources.getString(name);
+        this.baseline = baseline;
         this.standard = standard;
-        this.expanded = expanded;
-        this.individualRolesExpanded = individualRolesExpanded;
+        this.individualRole = individualRole;
+    }
+    //endregion Constructors
+
+    //region Getters
+    public boolean isBaseline() {
+        return baseline;
     }
 
     public boolean isStandard() {
         return standard;
     }
 
-    public boolean isExpanded() {
-        return expanded;
+    public boolean isIndividualRole() {
+        return individualRole;
     }
-
-    public boolean isIndividualRolesExpanded() {
-        return individualRolesExpanded;
-    }
+    //endregion Getters
 
     public static List<PersonnelFilter> getStandardPersonnelFilters() {
         List<PersonnelFilter> standardFilters = new ArrayList<>();
         for (PersonnelFilter filter : values()) {
-            if (filter.isStandard()) {
+            if (filter.isBaseline() || filter.isStandard()) {
                 standardFilters.add(filter);
             }
         }
@@ -116,21 +131,45 @@ public enum PersonnelFilter {
     public static List<PersonnelFilter> getExpandedPersonnelFilters() {
         List<PersonnelFilter> expandedFilters = new ArrayList<>();
         for (PersonnelFilter filter : values()) {
-            if (filter.isExpanded()) {
+            if (filter.isBaseline() || !filter.isIndividualRole()) {
                 expandedFilters.add(filter);
             }
         }
         return expandedFilters;
     }
 
+    public static List<PersonnelFilter> getIndividualRolesStandardPersonnelFilters() {
+        List<PersonnelFilter> individualRolesStandardFilters = new ArrayList<>();
+        for (PersonnelFilter filter : values()) {
+            if (filter.isBaseline() || filter.isIndividualRole()) {
+                individualRolesStandardFilters.add(filter);
+            }
+        }
+        return individualRolesStandardFilters;
+    }
+
     public static List<PersonnelFilter> getIndividualRolesExpandedPersonnelFilters() {
         List<PersonnelFilter> individualRolesExpandedFilters = new ArrayList<>();
         for (PersonnelFilter filter : values()) {
-            if (filter.isIndividualRolesExpanded()) {
+            if (filter.isBaseline() || !filter.isStandard() || filter.isIndividualRole()) {
                 individualRolesExpandedFilters.add(filter);
             }
         }
         return individualRolesExpandedFilters;
+    }
+
+    public static List<PersonnelFilter> getAllStandardFilters() {
+        List<PersonnelFilter> allStandardFilters = new ArrayList<>();
+        for (PersonnelFilter filter : values()) {
+            if (filter.isBaseline() || filter.isStandard() || filter.isIndividualRole()) {
+                allStandardFilters.add(filter);
+            }
+        }
+        return allStandardFilters;
+    }
+
+    public static List<PersonnelFilter> getAllIndividualRoleFilters() {
+        return new ArrayList<>(Arrays.asList(values()));
     }
 
     public boolean getFilteredInformation(Person person) {

--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilterStyle.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilterStyle.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.enums;
+
+import megamek.common.util.EncodeControl;
+
+import java.util.List;
+import java.util.ResourceBundle;
+
+public enum PersonnelFilterStyle {
+    //region Enum Declarations
+    STANDARD("PersonnelFilterStyle.STANDARD.text", "PersonnelFilterStyle.STANDARD.toolTipText"),
+    INDIVIDUAL_ROLE("PersonnelFilterStyle.INDIVIDUAL_ROLE.text", "PersonnelFilterStyle.INDIVIDUAL_ROLE.toolTipText"),
+    ALL("PersonnelFilterStyle.ALL.text", "PersonnelFilterStyle.ALL.toolTipText");
+    //endregion Enum Declarations
+
+    //region Variable Declarations
+    private final String name;
+    private final String toolTipText;
+
+    private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUIEnums", new EncodeControl());
+    //endregion Variable Declarations
+
+    //region Constructors
+    PersonnelFilterStyle(String name, String toolTipText) {
+        this.name = resources.getString(name);
+        this.toolTipText = resources.getString(toolTipText);
+    }
+    //endregion Constructors
+
+    public List<PersonnelFilter> getFilters(boolean standard) {
+        switch (this) {
+            case INDIVIDUAL_ROLE:
+                return standard ? PersonnelFilter.getIndividualRolesStandardPersonnelFilters()
+                        : PersonnelFilter.getIndividualRolesExpandedPersonnelFilters();
+            case ALL:
+                return standard ? PersonnelFilter.getAllStandardFilters()
+                        : PersonnelFilter.getAllIndividualRoleFilters();
+            default:
+            case STANDARD:
+                return standard ? PersonnelFilter.getStandardPersonnelFilters()
+                        : PersonnelFilter.getExpandedPersonnelFilters();
+        }
+    }
+
+    public String getToolTipText() {
+        return toolTipText;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}


### PR DESCRIPTION
This fixes #2159 part 3 by implementing a PersonnelFilterStyle enum that has standard, individual role, and all options. I also added a bugfix for the filters being used ignoring the individual role option. Now, all pull from the selected PersonnelFilterStyle.