### PR TITLE
Add Warehouse to store and manage parts

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3714,11 +3714,6 @@ public class Campaign implements Serializable, ITechManager {
 
     public void removePart(Part part) {
         parts.removePart(part);
-
-        //remove child parts as well
-        for (Part childPart : part.getChildParts()) {
-            removePart(childPart);
-        }
     }
 
     public void removeKill(Kill k) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -27,9 +27,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import javax.swing.JOptionPane;
 
@@ -4059,56 +4056,6 @@ public class Campaign implements Serializable, ITechManager {
 
     public void setIconFileName(String s) {
         this.iconFileName = s;
-    }
-
-    public ArrayList<Part> getSpareParts() {
-        ArrayList<Part> spares = new ArrayList<>();
-        for (Part part : getParts()) {
-            if (part.isSpare()) {
-                spares.add(part);
-            }
-        }
-        return spares;
-    }
-
-    /**
-     * Executes a method for each spare part in the campaign.
-     *
-     * @param consumer The method to apply to each spare part
-     *                 in the campaign.
-     */
-    public void forEachSparePart(Consumer<Part> consumer) {
-        for (Part part : getParts()) {
-            if (part.isSpare()) {
-                consumer.accept(part);
-            }
-        }
-    }
-
-    /**
-     * Finds the first spare part matching a predicate.
-     *
-     * @param predicate The predicate to use when searching
-     *                  for a suitable spare part.
-     * @return A matching spare {@link Part} or {@code null}
-     *         if no suitable match was found.
-     */
-    @Nullable
-    public Part findSparePart(Predicate<Part> predicate) {
-        for (Part part : parts.getParts()) {
-            if (part.isSpare() && predicate.test(part)) {
-                return part;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Streams the spare parts in the campaign.
-     * @return A stream of spare parts in the campaign.
-     */
-    public Stream<Part> streamSpareParts() {
-        return parts.getParts().stream().filter(Part::isSpare);
     }
 
     public void addFunds(Money quantity) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -81,7 +81,6 @@ import mekhq.campaign.event.NewDayEvent;
 import mekhq.campaign.event.OrganizationChangedEvent;
 import mekhq.campaign.event.OvertimeModeEvent;
 import mekhq.campaign.event.PartArrivedEvent;
-import mekhq.campaign.event.PartChangedEvent;
 import mekhq.campaign.event.PartNewEvent;
 import mekhq.campaign.event.PartRemovedEvent;
 import mekhq.campaign.event.PartWorkEvent;
@@ -175,7 +174,7 @@ public class Campaign implements Serializable, ITechManager {
     private Hangar units = new Hangar();
     private Set<Unit> transportShips = new HashSet<>();
     private Map<UUID, Person> personnel = new LinkedHashMap<>();
-    private TreeMap<Integer, Part> parts = new TreeMap<>();
+    private Warehouse parts = new Warehouse();
     private TreeMap<Integer, Force> forceIds = new TreeMap<>();
     private TreeMap<Integer, Mission> missions = new TreeMap<>();
     private TreeMap<Integer, Scenario> scenarios = new TreeMap<>();
@@ -1598,37 +1597,14 @@ public class Campaign implements Serializable, ITechManager {
             p.setId(-1);
             return;
         }
-        if ((null == p.getUnit()) && !p.hasParentPart()
-                && !p.isReservedForRefit() && !p.isReservedForReplacement()) {
-            Part spare = checkForExistingSparePart(p);
-            if (null != spare) {
-                if (p instanceof Armor) {
-                    if (spare instanceof Armor) {
-                        ((Armor) spare).setAmount(((Armor) spare).getAmount()
-                                + ((Armor) p).getAmount());
-                        MekHQ.triggerEvent(new PartChangedEvent(spare));
-                        p.setId(-1);
-                        return;
-                    }
-                } else if (p instanceof AmmoStorage) {
-                    if (spare instanceof AmmoStorage) {
-                        ((AmmoStorage) spare).changeShots(((AmmoStorage) p)
-                                .getShots());
-                        MekHQ.triggerEvent(new PartChangedEvent(spare));
-                        p.setId(-1);
-                        return;
-                    }
-                } else {
-                    spare.incrementQuantity();
-                    MekHQ.triggerEvent(new PartChangedEvent(spare));
-                    p.setId(-1);
-                    return;
-                }
-            }
+
+        // Add the part to our warehouse and merge it with any existing part if possible
+        p = parts.addPart(p, true);
+        if (id == p.getId()) {
+            // We have a new part!
+            lastPartId = id;
+            MekHQ.triggerEvent(new PartNewEvent(p));
         }
-        parts.put(id, p);
-        lastPartId = id;
-        MekHQ.triggerEvent(new PartNewEvent(p));
     }
 
     /**
@@ -1644,7 +1620,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         p.setDaysToArrival(0);
         addReport(p.getArrivalReport());
-        Part spare = p.isReservedForRefit() ? null : checkForExistingSparePart(p);
+        Part spare = p.isReservedForRefit() ? null : getWarehouse().checkForExistingSparePart(p);
         if (null != spare) {
             int quantity = p.getQuantity();
             if (p instanceof Armor) {
@@ -1704,15 +1680,23 @@ public class Campaign implements Serializable, ITechManager {
         // which may occur if a replacement ID is assigned
         lastPartId = Math.max(lastPartId, p.getId());
 
-        parts.put(p.getId(), p);
+        parts.addPart(p, false);
         MekHQ.triggerEvent(new PartNewEvent(p));
     }
 
     /**
-     * @return an <code>ArrayList</code> of SupportTeams in the campaign
+     * Gets the Warehouse which stores parts.
      */
+    public Warehouse getWarehouse() {
+        return parts;
+    }
+
+    /**
+     * @return A collection of parts in the Warehouse.
+     */
+    @Deprecated
     public Collection<Part> getParts() {
-        return parts.values();
+        return parts.getParts();
     }
 
     private int getQuantity(Part p) {
@@ -1763,12 +1747,12 @@ public class Campaign implements Serializable, ITechManager {
         piu.setStoreCount(0);
         piu.setTransferCount(0);
         piu.setPlannedCount(0);
-        for (Part p : getParts()) {
+        getWarehouse().forEachPart(p -> {
             PartInUse newPiu = getPartInUse(p);
             if (piu.equals(newPiu)) {
                 updatePartInUseData(piu, p);
             }
-        }
+        });
         for (IAcquisitionWork maybePart : shoppingList.getPartList()) {
             PartInUse newPiu = getPartInUse((Part) maybePart);
             if (piu.equals(newPiu)) {
@@ -1782,18 +1766,18 @@ public class Campaign implements Serializable, ITechManager {
     public Set<PartInUse> getPartsInUse() {
         // java.util.Set doesn't supply a get(Object) method, so we have to use a java.util.Map
         Map<PartInUse, PartInUse> inUse = new HashMap<>();
-        for (Part p : getParts()) {
+        getWarehouse().forEachPart(p -> {
             PartInUse piu = getPartInUse(p);
             if (null == piu) {
-                continue;
+                return;
             }
-            if ( inUse.containsKey(piu) ) {
+            if (inUse.containsKey(piu)) {
                 piu = inUse.get(piu);
             } else {
                 inUse.put(piu, piu);
             }
             updatePartInUseData(piu, p);
-        }
+        });
         for (IAcquisitionWork maybePart : shoppingList.getPartList()) {
             if (!(maybePart instanceof Part)) {
                 continue;
@@ -1815,8 +1799,9 @@ public class Campaign implements Serializable, ITechManager {
         return inUse.keySet();
     }
 
+    @Deprecated
     public Part getPart(int id) {
-        return parts.get(id);
+        return parts.getPart(id);
     }
 
     public Force getForce(int id) {
@@ -3399,7 +3384,7 @@ public class Campaign implements Serializable, ITechManager {
             // check to see if this part can now be combined with other
             // spare parts
             if (part.isSpare()) {
-                Part spare = checkForExistingSparePart(part);
+                Part spare = getWarehouse().checkForExistingSparePart(part);
                 if (null != spare) {
                     spare.incrementQuantity();
                     removePart(part);
@@ -3744,7 +3729,7 @@ public class Campaign implements Serializable, ITechManager {
             // if this is a test unit, then we won't remove the part because its not there
             return;
         }
-        parts.remove(part.getId());
+        parts.removePart(part);
         //remove child parts as well
         for (Part childPart : part.getChildParts()) {
             removePart(childPart);
@@ -4131,7 +4116,7 @@ public class Campaign implements Serializable, ITechManager {
      */
     @Nullable
     public Part findSparePart(Predicate<Part> predicate) {
-        for (Part part : parts.values()) {
+        for (Part part : parts.getParts()) {
             if (part.isSpare() && predicate.test(part)) {
                 return part;
             }
@@ -4144,7 +4129,7 @@ public class Campaign implements Serializable, ITechManager {
      * @return A stream of spare parts in the campaign.
      */
     public Stream<Part> streamSpareParts() {
-        return parts.values().stream().filter(Part::isSpare);
+        return parts.getParts().stream().filter(Part::isSpare);
     }
 
     public void addFunds(Money quantity) {
@@ -4436,7 +4421,7 @@ public class Campaign implements Serializable, ITechManager {
         MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, "specialAbilities");
         rskillPrefs.writeToXml(pw1, indent);
         // parts is the biggest so it goes last
-        writeMapToXml(pw1, indent, "parts", parts); // Parts
+        parts.writeToXml(pw1, indent, "parts"); // Parts
 
         writeGameOptions(pw1);
 
@@ -6224,18 +6209,6 @@ public class Campaign implements Serializable, ITechManager {
         // TODO: still a lot of stuff to do here, but oh well
         entity.setOwner(player);
         entity.setGame(game);
-    }
-
-    public Part checkForExistingSparePart(Part part) {
-        for (Part spare : parts.values()) {
-            if (!spare.isSpare() || spare.getId() == part.getId()) {
-                continue;
-            }
-            if (part.isSamePartTypeAndStatus(spare)) {
-                return spare;
-            }
-        }
-        return null;
     }
 
     public void refreshNetworks() {

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -140,6 +140,9 @@ public class Warehouse {
             MekHQ.triggerEvent(new PartRemovedEvent(part));
         }
 
+        // Clear the part's ID
+        part.setId(-1);
+
         // Remove child parts as well
         for (Part childPart : part.getChildParts()) {
             removePart(childPart);
@@ -173,7 +176,10 @@ public class Warehouse {
                         return spare;
                     }
                 } else {
-                    spare.incrementQuantity();
+                    // Add more spare parts
+                    for (int count = 0; count < part.getQuantity(); ++count) {
+                        spare.incrementQuantity();
+                    }
                     return spare;
                 }
             }

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -160,7 +160,7 @@ public class Warehouse {
         Objects.requireNonNull(part);
 
         if ((null == part.getUnit()) && !part.hasParentPart()
-                && !part.isReservedForRefit() && !part.isReservedForReplacement()) {
+                && !part.isReservedForReplacement()) {
             Part spare = checkForExistingSparePart(part);
             if (null != spare) {
                 if (part instanceof Armor) {

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign;
+
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+import megamek.common.annotations.Nullable;
+import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.event.PartChangedEvent;
+import mekhq.campaign.parts.AmmoStorage;
+import mekhq.campaign.parts.Armor;
+import mekhq.campaign.parts.Part;
+
+public class Warehouse {
+    private final TreeMap<Integer, Part> parts = new TreeMap<>();
+
+    /**
+     * Adds a part to the warehouse.
+     * @param part The part to add to the warehouse.
+     * @return The part added to the warehouse.
+     */
+    public Part addPart(Part part) {
+        return addPart(part, false);
+    }
+
+    /**
+     * Adds a part to the warehouse, optionally merging it with
+     * any existing spare part.
+     * @param part The part to add to the warehouse.
+     * @param mergeWithExisting If true and the part is spare, it may
+     *                          be merged with an existing spare part.
+     * @return The part itself or the spare part it was merged with.
+     */
+    public Part addPart(Part part, boolean mergeWithExisting) {
+        Objects.requireNonNull(part);
+
+        if (mergeWithExisting) {
+            part = mergePartWithExisting(part);
+        }
+
+        parts.put(part.getId(), part);
+
+        return part;
+    }
+
+    /**
+     * Gets a collection of parts within the warehouse.
+     */
+    public Collection<Part> getParts() {
+        return parts.values();
+    }
+
+    /**
+     * Gets a part from the warehouse by its ID.
+     * @param id The unique ID of the part.
+     * @return The part with the given ID, or null if no matching part exists.
+     */
+    public @Nullable Part getPart(int id) {
+        return parts.get(id);
+    }
+
+    /**
+     * Executes a function for each part in the warehouse.
+     * @param consumer A function to apply to each part.
+     */
+    public void forEachPart(Consumer<Part> consumer) {
+        for (Part part : parts.values()) {
+            consumer.accept(part);
+        }
+    }
+
+    /**
+     * Removes a part from the warehouse.
+     * @param part The part to remove.
+     * @return A value indicating whether or not the part was removed.
+     */
+	public boolean removePart(Part part) {
+        return (parts.remove(part.getId()) != null);
+	}
+
+    /**
+     * Merges a part with an existing part, if possible.
+     * @param part The part to try and merge with an existing part.
+     * @return The part itself, or the spare part the part was merged with.
+     */
+    private Part mergePartWithExisting(Part part) {
+        Objects.requireNonNull(part);
+
+        if ((null == part.getUnit()) && !part.hasParentPart()
+                && !part.isReservedForRefit() && !part.isReservedForReplacement()) {
+            Part spare = checkForExistingSparePart(part);
+            if (null != spare) {
+                if (part instanceof Armor) {
+                    if (spare instanceof Armor) {
+                        ((Armor) spare).setAmount(((Armor) spare).getAmount()
+                                + ((Armor) part).getAmount());
+                        MekHQ.triggerEvent(new PartChangedEvent(spare));
+                        part.setId(-1);
+                        return spare;
+                    }
+                } else if (part instanceof AmmoStorage) {
+                    if (spare instanceof AmmoStorage) {
+                        ((AmmoStorage) spare).changeShots(((AmmoStorage) part)
+                                .getShots());
+                        MekHQ.triggerEvent(new PartChangedEvent(spare));
+                        part.setId(-1);
+                        return spare;
+                    }
+                } else {
+                    spare.incrementQuantity();
+                    MekHQ.triggerEvent(new PartChangedEvent(spare));
+                    part.setId(-1);
+                    return spare;
+                }
+            }
+        }
+
+        return part;
+    }
+
+    /**
+     * Checks for an existing spare part.
+     * @param part The part to search for in the warehouse.
+     * @return The matching spare part or null if none were found.
+     */
+    public @Nullable Part checkForExistingSparePart(Part part) {
+        for (Part spare : parts.values()) {
+            if (!spare.isSpare() || spare.getId() == part.getId()) {
+                continue;
+            }
+            if (part.isSamePartTypeAndStatus(spare)) {
+                return spare;
+            }
+        }
+        return null;
+    }
+
+	public void writeToXml(PrintWriter pw1, int indent, String tag) {
+        MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, tag);
+
+        forEachPart(part -> {
+            part.writeToXml(pw1, indent + 1);
+        });
+
+        MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, tag);
+	}
+}

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -136,7 +136,9 @@ public class Warehouse {
 
         boolean didRemove = (parts.remove(part.getId()) != null);
 
-        MekHQ.triggerEvent(new PartRemovedEvent(part));
+        if (didRemove) {
+            MekHQ.triggerEvent(new PartRemovedEvent(part));
+        }
 
         return didRemove;
 	}

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq.campaign;
@@ -83,7 +83,7 @@ public class Warehouse {
                 return mergedPart;
             }
 
-            // ...we did not merge parts, so fall through to the
+            // ... we did not merge parts, so fall through to the
             // normal addPart logic.
         }
 

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -131,7 +131,7 @@ public class Warehouse {
      * @param part The part to remove.
      * @return A value indicating whether or not the part was removed.
      */
-	public boolean removePart(Part part) {
+    public boolean removePart(Part part) {
         Objects.requireNonNull(part);
 
         boolean didRemove = (parts.remove(part.getId()) != null);
@@ -146,7 +146,7 @@ public class Warehouse {
         }
 
         return didRemove;
-	}
+    }
 
     /**
      * Merges a part with an existing part, if possible.
@@ -199,7 +199,7 @@ public class Warehouse {
         return null;
     }
 
-	public void writeToXml(PrintWriter pw1, int indent, String tag) {
+    public void writeToXml(PrintWriter pw1, int indent, String tag) {
         MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent, tag);
 
         forEachPart(part -> {
@@ -207,5 +207,5 @@ public class Warehouse {
         });
 
         MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, indent, tag);
-	}
+    }
 }

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -140,6 +140,11 @@ public class Warehouse {
             MekHQ.triggerEvent(new PartRemovedEvent(part));
         }
 
+        // Remove child parts as well
+        for (Part childPart : part.getChildParts()) {
+            removePart(childPart);
+        }
+
         return didRemove;
 	}
 

--- a/MekHQ/src/mekhq/campaign/finances/Accountant.java
+++ b/MekHQ/src/mekhq/campaign/finances/Accountant.java
@@ -198,7 +198,7 @@ public class Accountant {
 
     public Money getTotalEquipmentValue() {
         Money unitsSellValue = getHangar().getUnitCosts(Unit::getSellValue);
-        return getCampaign().streamSpareParts().map(Part::getActualValue)
+        return getCampaign().getWarehouse().streamSpareParts().map(Part::getActualValue)
             .reduce(unitsSellValue, Money::plus);
     }
 

--- a/MekHQ/src/mekhq/campaign/finances/FinancialReport.java
+++ b/MekHQ/src/mekhq/campaign/finances/FinancialReport.java
@@ -174,7 +174,7 @@ public class FinancialReport {
         });
 
         r.spareParts = r.spareParts.plus(
-            campaign.streamSpareParts()
+            campaign.getWarehouse().streamSpareParts()
                 .map(x -> x.getActualValue().multipliedBy(x.getQuantity()))
                 .collect(Collectors.toList()));
 

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -642,7 +642,7 @@ public class CampaignXmlParser {
 
         //unload any ammo bins in the warehouse
         List<AmmoBin> binsToUnload = new ArrayList<>();
-        retVal.forEachSparePart(prt -> {
+        retVal.getWarehouse().forEachSparePart(prt -> {
             if (prt instanceof AmmoBin && !prt.isReservedForRefit() && ((AmmoBin) prt).getShotsNeeded() == 0) {
                 binsToUnload.add((AmmoBin) prt);
             }

--- a/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroHeatSink.java
@@ -1,20 +1,20 @@
 /*
  * AeroHeatSink.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,18 +45,18 @@ public class AeroHeatSink extends Part {
     private static final long serialVersionUID = -717866644605314883L;
 
     private int type;
-    
+
     static final TechAdvancement TA_SINGLE = EquipmentType.get("Heat Sink").getTechAdvancement();
     static final TechAdvancement TA_IS_DOUBLE = EquipmentType.get("ISDoubleHeatSink").getTechAdvancement();
     static final TechAdvancement TA_CLAN_DOUBLE = EquipmentType.get("CLDoubleHeatSink").getTechAdvancement();
-    
+
     //To differentiate Clan double heatsinks, which aren't defined in Aero
     public static final int CLAN_HEAT_DOUBLE = 2;
-    
+
     public AeroHeatSink() {
         this(0, Aero.HEAT_SINGLE, false, null);
     }
-    
+
     public AeroHeatSink(int tonnage, int type, boolean omniPodded, Campaign c) {
         super(tonnage, omniPodded, c);
         this.name = "Aero Heat Sink";
@@ -68,14 +68,14 @@ public class AeroHeatSink extends Part {
             this.name = "Aero Double Heat Sink";
         }
     }
-    
+
     @Override
     public AeroHeatSink clone() {
         AeroHeatSink clone = new AeroHeatSink(getUnitTonnage(), type, omniPodded, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-        
+
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         int priorHits = hits;
@@ -96,15 +96,15 @@ public class AeroHeatSink extends Part {
             } else {
                 hits = 0;
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
         }
     }
-    
-    @Override 
+
+    @Override
     public int getBaseTime() {
         if (isOmniPodded()) {
             return 10;
@@ -112,7 +112,7 @@ public class AeroHeatSink extends Part {
         //New SO errata 6-2019
         return 20;
     }
-    
+
     @Override
     public int getDifficulty() {
         if(isSalvaging()) {
@@ -147,7 +147,7 @@ public class AeroHeatSink extends Part {
             if(hits == 0) {
                 ((Aero)unit.getEntity()).setHeatSinks(((Aero)unit.getEntity()).getHeatSinks()-1);
             }
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {
@@ -220,7 +220,7 @@ public class AeroHeatSink extends Part {
     public int getType() {
         return type;
     }
-    
+
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
@@ -234,10 +234,10 @@ public class AeroHeatSink extends Part {
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
         NodeList nl = wn.getChildNodes();
-        
+
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            
+
             if (wn2.getNodeName().equalsIgnoreCase("type")) {
                 type = Integer.parseInt(wn2.getTextContent());
                 if(type == CLAN_HEAT_DOUBLE) {
@@ -245,11 +245,11 @@ public class AeroHeatSink extends Part {
                 }
                 if(type == Aero.HEAT_DOUBLE) {
                     this.name = "Aero Double Heat Sink";
-                } 
-            } 
+                }
+            }
         }
     }
-    
+
     @Override
     public boolean isRightTechType(String skillType) {
         return skillType.equals(SkillType.S_TECH_AERO);
@@ -270,7 +270,7 @@ public class AeroHeatSink extends Part {
         }
         return Entity.LOC_NONE;
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         if (type == Aero.HEAT_SINGLE) {

--- a/MekHQ/src/mekhq/campaign/parts/AeroLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroLifeSupport.java
@@ -1,20 +1,20 @@
 /*
  * AeroLifeSupport.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -60,7 +60,7 @@ public class AeroLifeSupport extends Part {
     public AeroLifeSupport() {
         this(0, Money.zero(), false, null);
     }
-    
+
     public AeroLifeSupport(int tonnage, Money cost, boolean f, Campaign c) {
         super(tonnage, c);
         this.cost = cost;
@@ -70,13 +70,13 @@ public class AeroLifeSupport extends Part {
             this.name = "Spacecraft Life Support";
         }
     }
-    
+
     public AeroLifeSupport clone() {
         AeroLifeSupport clone = new AeroLifeSupport(getUnitTonnage(), cost, fighter, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-        
+
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         int priorHits = hits;
@@ -162,7 +162,7 @@ public class AeroLifeSupport extends Part {
     public void remove(boolean salvage) {
         if(null != unit && unit.getEntity() instanceof Aero) {
             ((Aero)unit.getEntity()).setLifeSupport(false);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {
@@ -270,7 +270,7 @@ public class AeroLifeSupport extends Part {
         }
         return Entity.LOC_NONE;
     }
-    
+
     @Override
     public int getMassRepairOptionType() {
         return Part.REPAIR_PART_TYPE.ELECTRONICS;

--- a/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
@@ -166,7 +166,7 @@ public class AeroSensor extends Part {
     public void remove(boolean salvage) {
         if(null != unit && unit.getEntity() instanceof Aero) {
             ((Aero)unit.getEntity()).setSensorHits(3);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -298,7 +298,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
     public void changeAmountAvailable(int amount, final AmmoType curType) {
-        AmmoStorage a = (AmmoStorage) campaign.findSparePart(part -> {
+        AmmoStorage a = (AmmoStorage) campaign.getWarehouse().findSparePart(part -> {
             return IsRightAmmo(part, curType);
         });
 

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -565,7 +565,7 @@ public class Armor extends Part implements IAcquisitionWork {
     }
 
     public int getAmountAvailable() {
-        Armor a = (Armor)campaign.findSparePart(part -> {
+        Armor a = (Armor)campaign.getWarehouse().findSparePart(part -> {
             return part instanceof Armor
                 && part.isPresent()
                 && !part.isReservedForRefit()
@@ -576,7 +576,7 @@ public class Armor extends Part implements IAcquisitionWork {
     }
 
     public void changeAmountAvailable(int amount) {
-        Armor a = (Armor)campaign.findSparePart(part -> {
+        Armor a = (Armor)campaign.getWarehouse().findSparePart(part -> {
             return (part instanceof Armor)
                 && part.isPresent()
                 && Objects.equals(getRefitUnit(), part.getRefitUnit())

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -565,7 +565,7 @@ public class Armor extends Part implements IAcquisitionWork {
     }
 
     public int getAmountAvailable() {
-        Armor a = (Armor)campaign.getWarehouse().findSparePart(part -> {
+        Armor a = (Armor) campaign.getWarehouse().findSparePart(part -> {
             return part instanceof Armor
                 && part.isPresent()
                 && !part.isReservedForRefit()
@@ -576,7 +576,7 @@ public class Armor extends Part implements IAcquisitionWork {
     }
 
     public void changeAmountAvailable(int amount) {
-        Armor a = (Armor)campaign.getWarehouse().findSparePart(part -> {
+        Armor a = (Armor) campaign.getWarehouse().findSparePart(part -> {
             return (part instanceof Armor)
                 && part.isPresent()
                 && Objects.equals(getRefitUnit(), part.getRefitUnit())

--- a/MekHQ/src/mekhq/campaign/parts/Avionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/Avionics.java
@@ -1,20 +1,20 @@
 /*
  * Avionics.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -46,32 +46,32 @@ import mekhq.campaign.personnel.SkillType;
 public class Avionics extends Part {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -717866644605314883L;
 
 	public Avionics() {
     	this(0, null);
     }
-    
+
     public Avionics(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "Avionics";
     }
-    
+
     public Avionics clone() {
     	Avionics clone = new Avionics(0, campaign);
         clone.copyBaseData(this);
     	return clone;
     }
-        
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		int priorHits = hits;
 		if(null != unit
 		        && (unit.getEntity().getEntityType() & (Entity.ETYPE_AERO | Entity.ETYPE_LAND_AIR_MECH)) != 0) {
 			hits = ((IAero)unit.getEntity()).getAvionicsHits();
-			if(checkForDestruction 
+			if(checkForDestruction
 					&& hits > priorHits
 					&& (hits < 3 && !campaign.getCampaignOptions().useAeroSystemHits())
 					&& Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
@@ -81,8 +81,8 @@ public class Avionics extends Part {
 			}
 		}
 	}
-	
-	@Override 
+
+	@Override
 	public int getBaseTime() {
 	    int time = 0;
 		if (campaign.getCampaignOptions().useAeroSystemHits()) {
@@ -101,7 +101,7 @@ public class Avionics extends Part {
 		    }
 		    if (hits == 1) {
 		        time *= 1;
-		    } 
+		    }
 		    if (hits == 2) {
 		        time *= 2;
 		    }
@@ -114,7 +114,7 @@ public class Avionics extends Part {
 		}
 		return time;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 	    if (campaign.getCampaignOptions().useAeroSystemHits()) {
@@ -124,7 +124,7 @@ public class Avionics extends Part {
             }
             if (hits == 1) {
                 return 0;
-            } 
+            }
             if (hits == 2) {
                 return 1;
             }
@@ -171,7 +171,7 @@ public class Avionics extends Part {
 		    } else if (unit.getEntity() instanceof LandAirMech) {
 		        unit.damageSystem(CriticalSlot.TYPE_SYSTEM, LandAirMech.LAM_AVIONICS, 3);
 		    }
-			Part spare = campaign.checkForExistingSparePart(this);
+			Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
 			if(!salvage) {
 				campaign.removePart(this);
 			} else if(null != spare) {
@@ -234,7 +234,7 @@ public class Avionics extends Part {
 	protected void loadFieldsFromXmlNode(Node wn) {
 		//nothing to load
 	}
-	
+
 	@Override
 	public boolean isRightTechType(String skillType) {
 	    if (unit != null && unit.getEntity() instanceof LandAirMech) {
@@ -258,10 +258,10 @@ public class Avionics extends Part {
         }
         return Entity.LOC_NONE;
     }
-    
+
 	@Override
 	public TechAdvancement getTechAdvancement() {
 	    return TA_GENERIC;
 	}
-	
+
 }

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -153,7 +153,7 @@ public class BaArmor extends Armor implements IAcquisitionWork {
     }
 
     public int getAmountAvailable() {
-        BaArmor a = (BaArmor)campaign.getWarehouse().findSparePart(part -> {
+        BaArmor a = (BaArmor) campaign.getWarehouse().findSparePart(part -> {
             return part instanceof BaArmor
                 && part.isPresent()
                 && !part.isReservedForRefit()
@@ -166,7 +166,7 @@ public class BaArmor extends Armor implements IAcquisitionWork {
 
     @Override
     public void changeAmountAvailable(int amount) {
-        BaArmor a = (BaArmor)campaign.getWarehouse().findSparePart(part -> {
+        BaArmor a = (BaArmor) campaign.getWarehouse().findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent();
         });

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -153,7 +153,7 @@ public class BaArmor extends Armor implements IAcquisitionWork {
     }
 
     public int getAmountAvailable() {
-        BaArmor a = (BaArmor)campaign.findSparePart(part -> {
+        BaArmor a = (BaArmor)campaign.getWarehouse().findSparePart(part -> {
             return part instanceof BaArmor
                 && part.isPresent()
                 && !part.isReservedForRefit()
@@ -166,7 +166,7 @@ public class BaArmor extends Armor implements IAcquisitionWork {
 
     @Override
     public void changeAmountAvailable(int amount) {
-        BaArmor a = (BaArmor)campaign.findSparePart(part -> {
+        BaArmor a = (BaArmor)campaign.getWarehouse().findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent();
         });

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -469,7 +469,7 @@ public class BattleArmorSuit extends Part {
         for(Part p : trooperParts) {
             p.remove(salvage);
         }
-        Part spare = campaign.checkForExistingSparePart(this);
+        Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
         if(!salvage) {
             campaign.removePart(this);
         } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/BayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BayDoor.java
@@ -89,7 +89,7 @@ public class BayDoor extends Part {
     @Override
     public void remove(boolean salvage) {
         if (null != parentPart) {
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
             } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/CombatInformationCenter.java
+++ b/MekHQ/src/mekhq/campaign/parts/CombatInformationCenter.java
@@ -1,20 +1,20 @@
 /*
  * CombatInformationCenter.java
- * 
+ *
  * Copyright (C) 2019, MegaMek team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -43,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class CombatInformationCenter extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 7069129053879581753L;
 
@@ -58,7 +58,7 @@ public class CombatInformationCenter extends Part {
         this.cost = cost;
         this.name = "Combat Information Center";
     }
-    
+
     public CombatInformationCenter clone() {
         CombatInformationCenter clone = new CombatInformationCenter(0, cost, campaign);
         clone.copyBaseData(this);
@@ -70,8 +70,8 @@ public class CombatInformationCenter extends Part {
         int priorHits = hits;
         if(null != unit && unit.getEntity() instanceof Aero) {
             hits = ((Aero)unit.getEntity()).getCICHits();
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && (hits < 3 && !campaign.getCampaignOptions().useAeroSystemHits())
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
@@ -81,7 +81,7 @@ public class CombatInformationCenter extends Part {
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time = 0;
         if (campaign.getCampaignOptions().useAeroSystemHits()) {
@@ -109,7 +109,7 @@ public class CombatInformationCenter extends Part {
             //Test of proposed errata for repair time and difficulty
             if (hits == 1) {
                 return 1;
-            } 
+            }
             if (hits == 2) {
                 return 2;
             }
@@ -139,7 +139,7 @@ public class CombatInformationCenter extends Part {
     public void remove(boolean salvage) {
         if(null != unit && unit.getEntity() instanceof Aero) {
             ((Aero)unit.getEntity()).setCICHits(3);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {
@@ -217,12 +217,12 @@ public class CombatInformationCenter extends Part {
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
         NodeList nl = wn.getChildNodes();
-        
+
         for (int x=0; x<nl.getLength(); x++) {
-            Node wn2 = nl.item(x);        
+            Node wn2 = nl.item(x);
             if (wn2.getNodeName().equalsIgnoreCase("cost")) {
                 cost = Money.fromXmlString(wn2.getTextContent().trim());
-            } 
+            }
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/Cubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/Cubicle.java
@@ -84,7 +84,7 @@ public class Cubicle extends Part {
     @Override
     public void remove(boolean salvage) {
         if (null != parentPart) {
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
             } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
+++ b/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
@@ -1,20 +1,20 @@
 /*
  * DropshipDockingCollar.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -43,10 +43,10 @@ import mekhq.campaign.personnel.SkillType;
 public class DropshipDockingCollar extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -717866644605314883L;
-    
+
     static final TechAdvancement TA_BOOM = new TechAdvancement(TECH_BASE_ALL)
             .setAdvancement(2458, 2470, 2500).setPrototypeFactions(F_TH)
             .setProductionFactions(F_TH).setTechRating(RATING_C)
@@ -57,13 +57,13 @@ public class DropshipDockingCollar extends Part {
             .setProductionFactions(F_TH).setTechRating(RATING_B)
             .setAvailability(RATING_C, RATING_X, RATING_X, RATING_X)
             .setStaticTechLevel(SimpleTechLevel.ADVANCED);
-    
+
     private int collarType = Dropship.COLLAR_STANDARD;
-    
+
     public DropshipDockingCollar() {
         this(0, null, Dropship.COLLAR_STANDARD);
     }
-    
+
     public DropshipDockingCollar(int tonnage, Campaign c, int collarType) {
         super(tonnage, c);
         this.collarType = collarType;
@@ -74,42 +74,42 @@ public class DropshipDockingCollar extends Part {
             name += " (Prototype)";
         }
     }
-    
+
     public DropshipDockingCollar clone() {
         DropshipDockingCollar clone = new DropshipDockingCollar(getUnitTonnage(), campaign, collarType);
         clone.copyBaseData(this);
         return clone;
     }
-    
+
     public int getCollarType() {
         return collarType;
     }
-        
+
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         int priorHits = hits;
         if(null != unit && unit.getEntity() instanceof Dropship) {
              if(((Dropship)unit.getEntity()).isDockCollarDamaged()) {
                  hits = 1;
-             } else { 
+             } else {
                  hits = 0;
              }
-             if(checkForDestruction 
+             if(checkForDestruction
                      && hits > priorHits
                      && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                  remove(false);
              }
         }
     }
-    
-    @Override 
+
+    @Override
     public int getBaseTime() {
         if(isSalvaging()) {
             return 2880;
         }
         return 120;
     }
-    
+
     @Override
     public int getDifficulty() {
         if(isSalvaging()) {
@@ -137,7 +137,7 @@ public class DropshipDockingCollar extends Part {
     public void remove(boolean salvage) {
         if(null != unit && unit.getEntity() instanceof Dropship) {
             ((Dropship)unit.getEntity()).setDamageDockCollar(true);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {
@@ -176,7 +176,7 @@ public class DropshipDockingCollar extends Part {
             return Money.of(1010000) ;
         }
     }
-    
+
     @Override
     public double getTonnage() {
         return 0;
@@ -187,7 +187,7 @@ public class DropshipDockingCollar extends Part {
         return (part instanceof DropshipDockingCollar)
                 && (collarType == ((DropshipDockingCollar)part).collarType);
     }
-    
+
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
@@ -206,7 +206,7 @@ public class DropshipDockingCollar extends Part {
             }
         }
     }
-    
+
     @Override
     public boolean isRightTechType(String skillType) {
         return skillType.equals(SkillType.S_TECH_VESSEL);
@@ -222,7 +222,7 @@ public class DropshipDockingCollar extends Part {
     public int getLocation() {
         return Entity.LOC_NONE;
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         if (collarType != Dropship.COLLAR_NO_BOOM) {

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -239,7 +239,7 @@ public class EnginePart extends Part {
             if (unit.getEntity() instanceof Protomech) {
                 ((Protomech) unit.getEntity()).setEngineHit(true);
             }
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
             } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/FireControlSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/FireControlSystem.java
@@ -1,20 +1,20 @@
 /*
  * FireControlSystem.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,7 +45,7 @@ import mekhq.campaign.personnel.SkillType;
 public class FireControlSystem extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -717866644605314883L;
 
@@ -72,8 +72,8 @@ public class FireControlSystem extends Part {
         int priorHits = hits;
         if(null != unit && unit.getEntity() instanceof Aero) {
             hits = ((Aero)unit.getEntity()).getFCSHits();
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && (hits < 3 && !campaign.getCampaignOptions().useAeroSystemHits())
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
@@ -83,7 +83,7 @@ public class FireControlSystem extends Part {
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time = 0;
         if (campaign.getCampaignOptions().useAeroSystemHits()) {
@@ -94,7 +94,7 @@ public class FireControlSystem extends Part {
                     time *= 2;
                 }
             } else {
-                time = 60; 
+                time = 60;
             }
             if (isSalvaging()) {
                 time *= 10;
@@ -122,7 +122,7 @@ public class FireControlSystem extends Part {
             }
             if (hits == 1) {
                 return 1;
-            } 
+            }
             if (hits == 2) {
                 return 2;
             }
@@ -138,7 +138,7 @@ public class FireControlSystem extends Part {
         if(null != unit && unit.getEntity() instanceof Aero) {
             ((Aero)unit.getEntity()).setFCSHits(hits);
         }
-        
+
     }
 
     @Override
@@ -153,7 +153,7 @@ public class FireControlSystem extends Part {
     public void remove(boolean salvage) {
         if(null != unit && unit.getEntity() instanceof Aero) {
             ((Aero)unit.getEntity()).setFCSHits(3);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {
@@ -236,12 +236,12 @@ public class FireControlSystem extends Part {
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
         NodeList nl = wn.getChildNodes();
-        
+
         for (int x=0; x<nl.getLength(); x++) {
-            Node wn2 = nl.item(x);        
+            Node wn2 = nl.item(x);
             if (wn2.getNodeName().equalsIgnoreCase("cost")) {
                 cost = Money.fromXmlString(wn2.getTextContent().trim());
-            } 
+            }
         }
     }
 
@@ -255,7 +255,7 @@ public class FireControlSystem extends Part {
     public int getLocation() {
         return Entity.LOC_NONE;
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return TA_GENERIC;

--- a/MekHQ/src/mekhq/campaign/parts/GravDeck.java
+++ b/MekHQ/src/mekhq/campaign/parts/GravDeck.java
@@ -1,19 +1,19 @@
 /*
  * GravDeck.java
- * 
+ *
  * Copyright (c) 2019, MegaMek team
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -42,7 +42,7 @@ import mekhq.campaign.personnel.SkillType;
 public class GravDeck extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -3387290388135852860L;
 
@@ -96,8 +96,8 @@ public class GravDeck extends Part {
         int priorHits = hits;
         if (null != unit && unit.getEntity() instanceof Jumpship) {
             hits = ((Jumpship) unit.getEntity()).getGravDeckDamageFlag(deckNumber);
-            
-            if (checkForDestruction 
+
+            if (checkForDestruction
                     && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
@@ -105,7 +105,7 @@ public class GravDeck extends Part {
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         if(isSalvaging()) {
             return 4800;
@@ -140,8 +140,8 @@ public class GravDeck extends Part {
     public void remove(boolean salvage) {
         if (unit.getEntity() instanceof Jumpship) {
             ((Jumpship) unit.getEntity()).setGravDeckDamageFlag(deckNumber, 1);
-            
-            Part spare = campaign.checkForExistingSparePart(this);
+
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -132,7 +132,7 @@ public class InfantryAmmoStorage extends AmmoStorage {
     }
 
     public void changeAmountAvailable(int amount, final AmmoType curType) {
-        InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.findSparePart(part ->
+        InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.getWarehouse().findSparePart(part ->
                 isRightAmmo(part, curType, weaponType));
 
         if (null != a) {

--- a/MekHQ/src/mekhq/campaign/parts/InfantryArmorPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryArmorPart.java
@@ -142,7 +142,7 @@ public class InfantryArmorPart extends Part {
     @Override
     public void remove(boolean salvage) {
         if(null != unit) {
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/InfantryMotiveType.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryMotiveType.java
@@ -1,20 +1,20 @@
 /*
  * InfantryMotiveType.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -39,18 +39,18 @@ import mekhq.campaign.Campaign;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class InfantryMotiveType extends Part {
-	
+
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -2915821210551422633L;
-	
+
 	private EntityMovementMode mode;
 
 	public InfantryMotiveType() {
     	this(0, null, null);
     }
-	
+
 	public InfantryMotiveType(int tonnage, Campaign c, EntityMovementMode m) {
 		super(tonnage, c);
 		this.mode = m;
@@ -59,7 +59,7 @@ public class InfantryMotiveType extends Part {
 		}
 
 	}
-	
+
 	private void assignName() {
 		switch (mode) {
         case INF_UMU:
@@ -84,22 +84,22 @@ public class InfantryMotiveType extends Part {
         	name = "Unknown Motive Type";
 		}
 	}
-	
+
 	@Override
 	public void updateConditionFromEntity(boolean checkForDestruction) {
 		//nothing to do here
 	}
 
-	@Override 
+	@Override
 	public int getBaseTime() {
 		return 0;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return 0;
 	}
-	
+
 	@Override
 	public void updateConditionFromPart() {
 		//nothing to do here
@@ -108,7 +108,7 @@ public class InfantryMotiveType extends Part {
 	@Override
 	public void remove(boolean salvage) {
 		if(null != unit) {
-			Part spare = campaign.checkForExistingSparePart(this);
+			Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
 			if(!salvage) {
 				campaign.removePart(this);
 			} else if(null != spare) {
@@ -120,7 +120,7 @@ public class InfantryMotiveType extends Part {
 				campaign.removePart(this);
 			}
 			unit.removePart(this);
-		}	
+		}
 		setUnit(null);
 	}
 
@@ -170,7 +170,7 @@ public class InfantryMotiveType extends Part {
 	public TechAdvancement getTechAdvancement() {
 	    return Infantry.getMotiveTechAdvancement(mode);
 	}
-	
+
 	@Override
 	public boolean isSamePartType(Part part) {
 		return part instanceof InfantryMotiveType && mode.equals(((InfantryMotiveType)part).getMovementMode());
@@ -189,13 +189,13 @@ public class InfantryMotiveType extends Part {
 	@Override
 	protected void loadFieldsFromXmlNode(Node wn) {
 		NodeList nl = wn.getChildNodes();
-		
+
 		for (int x=0; x<nl.getLength(); x++) {
-			Node wn2 = nl.item(x);		
+			Node wn2 = nl.item(x);
 			if (wn2.getNodeName().equalsIgnoreCase("mode")) {
 				mode = EntityMovementMode.getMode(wn2.getTextContent());
 				assignName();
-			} 
+			}
 			else if (wn2.getNodeName().equalsIgnoreCase("moveMode")) {
 				mode = EntityMovementMode.getMode(wn2.getTextContent());
 				assignName();
@@ -207,11 +207,11 @@ public class InfantryMotiveType extends Part {
 	public Part clone() {
 		return new InfantryMotiveType(0, campaign, mode);
 	}
-	
+
 	public EntityMovementMode getMovementMode() {
 		return mode;
 	}
-	
+
 	@Override
     public boolean needsMaintenance() {
         return false;

--- a/MekHQ/src/mekhq/campaign/parts/JumpshipDockingCollar.java
+++ b/MekHQ/src/mekhq/campaign/parts/JumpshipDockingCollar.java
@@ -1,19 +1,19 @@
 /*
  * JumpshipDockingCollar.java
- * 
+ *
  * Copyright (c) 2019, MegaMek team
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -43,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class JumpshipDockingCollar extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -7060162354112320241L;
 
@@ -60,7 +60,7 @@ public class JumpshipDockingCollar extends Part {
 
     private int collarType;
     private int collarNumber;
-    
+
     public JumpshipDockingCollar() {
         this(0, 0, null, Jumpship.COLLAR_STANDARD);
     }
@@ -96,10 +96,10 @@ public class JumpshipDockingCollar extends Part {
             DockingCollar collar = unit.getEntity().getCollarById(collarNumber);
             if (collar != null && collar.isDamaged()) {
                 hits = 1;
-            } else { 
+            } else {
                 hits = 0;
             }
-            if (checkForDestruction 
+            if (checkForDestruction
                     && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
@@ -107,7 +107,7 @@ public class JumpshipDockingCollar extends Part {
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         if(isSalvaging()) {
             return 2880;
@@ -151,7 +151,7 @@ public class JumpshipDockingCollar extends Part {
             if (collar != null) {
                 collar.setDamaged(true);
             }
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/KFDriveController.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFDriveController.java
@@ -154,7 +154,7 @@ public class KFDriveController extends Part {
                 js.setKFDriveControllerHit(true);
                 //You can transport a drive controller
                 //See SO p130 for reference
-                Part spare = campaign.checkForExistingSparePart(this);
+                Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
                 if(!salvage) {
                     campaign.removePart(this);
                 } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/KFFieldInitiator.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFFieldInitiator.java
@@ -156,7 +156,7 @@ public class KFFieldInitiator extends Part {
                 js.setKFFieldInitiatorHit(true);
                 //You can transport a field initiator
                 //See SO p130 for reference
-                Part spare = campaign.checkForExistingSparePart(this);
+                Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
                 if(!salvage) {
                     campaign.removePart(this);
                 } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/KFHeliumTank.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFHeliumTank.java
@@ -157,7 +157,7 @@ public class KFHeliumTank extends Part {
                 js.setKFHeliumTankHit(true);
                 //You can transport a helium tank
                 //See SO p130 for reference
-                Part spare = campaign.checkForExistingSparePart(this);
+                Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
                 if(!salvage) {
                     campaign.removePart(this);
                 } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/KfBoom.java
+++ b/MekHQ/src/mekhq/campaign/parts/KfBoom.java
@@ -1,20 +1,20 @@
 /*
  * KFBoom.java
- * 
+ *
  * Copyright (c) 2019 MegaMek Team
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -43,7 +43,7 @@ import mekhq.campaign.personnel.SkillType;
 public class KfBoom extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -3211076278442082220L;
 
@@ -59,7 +59,7 @@ public class KfBoom extends Part {
             .setStaticTechLevel(SimpleTechLevel.ADVANCED);
 
     private int boomType = Dropship.BOOM_STANDARD;
-    
+
     public KfBoom() {
         this(0, null, Dropship.BOOM_STANDARD);
     }
@@ -89,10 +89,10 @@ public class KfBoom extends Part {
         if(null != unit && unit.getEntity() instanceof Dropship) {
              if(((Dropship)unit.getEntity()).isKFBoomDamaged()) {
                  hits = 1;
-             } else { 
+             } else {
                  hits = 0;
              }
-             if(checkForDestruction 
+             if(checkForDestruction
                      && hits > priorHits
                      && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                  remove(false);
@@ -100,7 +100,7 @@ public class KfBoom extends Part {
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         if(isSalvaging()) {
             return 3600;
@@ -135,7 +135,7 @@ public class KfBoom extends Part {
     public void remove(boolean salvage) {
         if(null != unit && unit.getEntity() instanceof Dropship) {
             ((Dropship)unit.getEntity()).setDamageKFBoom(true);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/LandingGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/LandingGear.java
@@ -1,20 +1,20 @@
 /*
  * LandingGear.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,7 +44,7 @@ import mekhq.campaign.personnel.SkillType;
 public class LandingGear extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -717866644605314883L;
 
@@ -76,15 +76,15 @@ public class LandingGear extends Part {
             } else if (unit.getEntity() instanceof LandAirMech) {
                 hits = unit.getHitCriticals(CriticalSlot.TYPE_SYSTEM, LandAirMech.LAM_LANDING_GEAR);
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
             }
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time;
         if (campaign.getCampaignOptions().useAeroSystemHits()) {
@@ -146,7 +146,7 @@ public class LandingGear extends Part {
             } else if (unit.getEntity() instanceof LandAirMech) {
                 unit.damageSystem(CriticalSlot.TYPE_SYSTEM, LandAirMech.LAM_LANDING_GEAR, 3);
             }
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/MekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekActuator.java
@@ -192,7 +192,7 @@ public class MekActuator extends Part {
     public void remove(boolean salvage) {
         if (null != unit) {
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, type, location);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
             } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
@@ -1,20 +1,20 @@
 /*
  * MekCockpit.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -157,7 +157,7 @@ public class MekCockpit extends Part {
     public void remove(boolean salvage) {
         if (null != unit) {
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_COCKPIT);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
             } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/MekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekGyro.java
@@ -163,7 +163,7 @@ public class MekGyro extends Part {
     public void remove(boolean salvage) {
         if (null != unit) {
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_GYRO, Mech.LOC_CT);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
             } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLifeSupport.java
@@ -1,20 +1,20 @@
 /*
  * MekLifeSupport.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,24 +44,24 @@ public class MekLifeSupport extends Part {
 	public MekLifeSupport() {
 		this(0, null);
 	}
-	
+
 	public MekLifeSupport(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "Mech Life Support System";
     }
-	
+
 	public MekLifeSupport clone() {
 		MekLifeSupport clone = new MekLifeSupport(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
 		return clone;
 	}
-	
+
 	@Override
 	public double getTonnage() {
 		//TODO: what should this tonnage be?
 		return 0;
 	}
-	
+
 	@Override
 	public Money getStickerPrice() {
 		return Money.of(50000);
@@ -101,7 +101,7 @@ public class MekLifeSupport extends Part {
 	public void remove(boolean salvage) {
 		if(null != unit) {
 			unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_LIFE_SUPPORT);
-			Part spare = campaign.checkForExistingSparePart(this);
+			Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
 			if(!salvage) {
 				campaign.removePart(this);
 			} else if(null != spare) {
@@ -124,8 +124,8 @@ public class MekLifeSupport extends Part {
 			Entity entity = unit.getEntity();
 			for (int i = 0; i < entity.locations(); i++) {
 				if (entity.getNumberOfCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_LIFE_SUPPORT, i) > 0) {
-					if (!unit.isSystemMissing(Mech.SYSTEM_LIFE_SUPPORT, i)) {					
-						hits = entity.getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_LIFE_SUPPORT, i);	
+					if (!unit.isSystemMissing(Mech.SYSTEM_LIFE_SUPPORT, i)) {
+						hits = entity.getDamagedCriticals(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_LIFE_SUPPORT, i);
 						break;
 					} else {
 						remove(false);
@@ -133,15 +133,15 @@ public class MekLifeSupport extends Part {
 					}
 				}
 			}
-			if(checkForDestruction 
+			if(checkForDestruction
 					&& hits > priorHits && hits >= 2
 					&& Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
 				remove(false);
 			}
 		}
 	}
-	
-	@Override 
+
+	@Override
 	public int getBaseTime() {
 		if(isSalvaging()) {
 			return 180;
@@ -151,7 +151,7 @@ public class MekLifeSupport extends Part {
 		}
 		return 60;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		if(isSalvaging()) {
@@ -167,7 +167,7 @@ public class MekLifeSupport extends Part {
 	public boolean needsFixing() {
 		return hits > 0;
 	}
-	
+
 	@Override
 	public void updateConditionFromPart() {
 		if(null != unit) {
@@ -178,7 +178,7 @@ public class MekLifeSupport extends Part {
 			}
 		}
 	}
-	
+
 	@Override
     public String checkFixable() {
 		if(null == unit) {
@@ -199,7 +199,7 @@ public class MekLifeSupport extends Part {
         }
         return null;
     }
-	
+
 	@Override
 	public boolean isMountedOnDestroyedLocation() {
 		if(null == unit) {
@@ -213,12 +213,12 @@ public class MekLifeSupport extends Part {
 		 }
 		return false;
 	}
-	
+
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
         return false;
     }
-	
+
 	@Override
 	public boolean isRightTechType(String skillType) {
 		return skillType.equals(SkillType.S_TECH_MECH);
@@ -242,7 +242,7 @@ public class MekLifeSupport extends Part {
 		}
 		return Entity.LOC_NONE;
 	}
-	
+
 	@Override
 	public TechAdvancement getTechAdvancement() {
 	    return TA_GENERIC;
@@ -261,9 +261,9 @@ public class MekLifeSupport extends Part {
 		 } else if (unit.getEntity().getLocationFromAbbr(loc) == Mech.LOC_HEAD) {
              return true;
          }
-		 return false;	
+		 return false;
     }
-	
+
 	@Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ELECTRONICS;

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -342,7 +342,7 @@ public class MekLocation extends Part {
 			unit.getEntity().setInternal(IArmorState.ARMOR_DESTROYED, loc);
 			unit.getEntity().setLocationBlownOff(loc, false);
 			unit.getEntity().setLocationStatus(loc, ILocationExposureStatus.NORMAL, true);
-			Part spare = campaign.checkForExistingSparePart(this);
+			Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
 			if(!salvage) {
 				campaign.removePart(this);
 			} else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -109,7 +109,7 @@ public class MekSensor extends Part {
     public void remove(boolean salvage) {
         if (null != unit) {
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_SENSORS);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
             } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -311,7 +311,7 @@ public class MissingBattleArmorSuit extends MissingPart {
             return getReplacementPart();
         }
         // don't just return with the first part if it is damaged
-        return campaign.streamSpareParts()
+        return campaign.getWarehouse().streamSpareParts()
             .filter(MissingPart::isAvailableAsReplacement)
             .reduce(null, (bestPart, part) -> {
                 if (isAcceptableReplacement(part, refit)) {

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -164,7 +164,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
         }
 
         // don't just return with the first part if it is damaged
-        return campaign.streamSpareParts()
+        return campaign.getWarehouse().streamSpareParts()
             .filter(MissingPart::isAvailableAsReplacement)
             .reduce(null, (bestPart, part) -> {
                 if (isAcceptableReplacement(part, refit)) {

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -406,12 +406,12 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
         if ((null != replacement) && (null != getTech())) {
             if (replacement.getQuantity() > 1) {
                 Part actualReplacement = replacement.clone();
-                actualReplacement.setReserveId(getTech());
+                actualReplacement.setReservedBy(getTech());
                 campaign.addPart(actualReplacement, 0);
                 setReplacementPart(actualReplacement);
                 replacement.decrementQuantity();
             } else {
-                replacement.setReserveId(getTech());
+                replacement.setReservedBy(getTech());
                 setReplacementPart(replacement);
             }
         }
@@ -422,7 +422,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
         Part replacement = findReplacement(false);
         if (hasReplacementPart() && (null != replacement)) {
             setReplacementPart(null);
-            replacement.setReserveId(null);
+            replacement.setReservedBy(null);
             if (replacement.isSpare()) {
                 Part spare = campaign.getWarehouse().checkForExistingSparePart(replacement);
                 if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -424,7 +424,7 @@ public abstract class MissingPart extends Part implements Serializable, MekHqXml
             setReplacementPart(null);
             replacement.setReserveId(null);
             if (replacement.isSpare()) {
-                Part spare = campaign.checkForExistingSparePart(replacement);
+                Part spare = campaign.getWarehouse().checkForExistingSparePart(replacement);
                 if (null != spare) {
                     spare.incrementQuantity();
                     campaign.removePart(replacement);

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -226,7 +226,7 @@ public class OmniPod extends Part {
     @Override
     public void fix() {
         Part newPart = partType.clone();
-        Part oldPart = campaign.checkForExistingSparePart(newPart.clone());
+        Part oldPart = campaign.getWarehouse().checkForExistingSparePart(newPart.clone());
         if (null != oldPart) {
             newPart.setOmniPodded(true);
             campaign.addPart(newPart, 0);

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1083,7 +1083,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
      * performing overnight.
      * @param tech The team member.
      */
-    public void setReserveId(@Nullable Person tech) {
+    public void setReservedBy(@Nullable Person tech) {
         this.reservedBy = tech;
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
@@ -143,7 +143,7 @@ public class ProtomekArmActuator extends Part {
         if(null != unit) {
             int h = Math.max(1, hits);
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_ARMCRIT, location, h);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
@@ -123,7 +123,7 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
     }
 
     public int getAmountAvailable() {
-        ProtomekArmor a = (ProtomekArmor)campaign.findSparePart(part -> {
+        ProtomekArmor a = (ProtomekArmor)campaign.getWarehouse().findSparePart(part -> {
             return part instanceof ProtomekArmor
                 && part.isPresent()
                 && !part.isReservedForRefit()
@@ -135,7 +135,7 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
     }
 
     public void changeAmountAvailable(int amount) {
-        ProtomekArmor a = (ProtomekArmor)campaign.findSparePart(part -> {
+        ProtomekArmor a = (ProtomekArmor)campaign.getWarehouse().findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent();
         });

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
@@ -123,7 +123,7 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
     }
 
     public int getAmountAvailable() {
-        ProtomekArmor a = (ProtomekArmor)campaign.getWarehouse().findSparePart(part -> {
+        ProtomekArmor a = (ProtomekArmor) campaign.getWarehouse().findSparePart(part -> {
             return part instanceof ProtomekArmor
                 && part.isPresent()
                 && !part.isReservedForRefit()
@@ -135,7 +135,7 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
     }
 
     public void changeAmountAvailable(int amount) {
-        ProtomekArmor a = (ProtomekArmor)campaign.getWarehouse().findSparePart(part -> {
+        ProtomekArmor a = (ProtomekArmor) campaign.getWarehouse().findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent();
         });

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekJumpJet.java
@@ -135,7 +135,7 @@ public class ProtomekJumpJet extends Part {
                 h = 2;
             }
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_TORSOCRIT, Protomech.LOC_TORSO, h);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLegActuator.java
@@ -109,7 +109,7 @@ public class ProtomekLegActuator extends Part {
         if(null != unit) {
             int h = Math.max(2, hits);
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_LEGCRIT, Protomech.LOC_LEG, h);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
@@ -293,7 +293,7 @@ public class ProtomekLocation extends Part {
         if(null != unit) {
             unit.getEntity().setInternal(IArmorState.ARMOR_DESTROYED, loc);
             unit.getEntity().setLocationBlownOff(loc, false);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekSensor.java
@@ -109,7 +109,7 @@ public class ProtomekSensor extends Part {
         if(null != unit) {
             int h = Math.max(1, hits);
             unit.destroySystem(CriticalSlot.TYPE_SYSTEM, Protomech.SYSTEM_HEADCRIT, Protomech.LOC_HEAD, h);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/QuadVeeGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/QuadVeeGear.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package mekhq.campaign.parts;
 
@@ -17,17 +17,17 @@ import mekhq.campaign.Campaign;
 
 /**
  * Conversion gear for QuadVees
- * 
+ *
  * @author Neoancient
  *
  */
 public class QuadVeeGear extends Part {
-    
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -382649905317675957L;
-    
+
     static final TechAdvancement TECH_ADVANCEMENT = new TechAdvancement(TECH_BASE_CLAN)
             .setTechRating(RATING_F)
             .setAvailability(RATING_X, RATING_X, RATING_X, RATING_F)
@@ -40,18 +40,18 @@ public class QuadVeeGear extends Part {
     public QuadVeeGear() {
         this(0, null);
     }
-    
+
     public QuadVeeGear(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "Conversion Gear";
     }
-    
+
     public QuadVeeGear clone() {
         QuadVeeGear clone = new QuadVeeGear(0, campaign);
         clone.copyBaseData(this);
         return clone;
     }
-        
+
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         if(null != unit) {
@@ -59,7 +59,7 @@ public class QuadVeeGear extends Part {
                         QuadVee.SYSTEM_CONVERSION_GEAR);
         }
     }
-    
+
     @Override
     public int getBaseTime() {
         // Using value for 'Mech "weapons and other equipment"
@@ -110,7 +110,7 @@ public class QuadVeeGear extends Part {
     public void remove(boolean salvage) {
         if(null != unit) {
             unit.damageSystem(CriticalSlot.TYPE_SYSTEM, QuadVee.SYSTEM_CONVERSION_GEAR, 4);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {
@@ -183,7 +183,7 @@ public class QuadVeeGear extends Part {
     public TechAdvancement getTechAdvancement() {
         return TECH_ADVANCEMENT;
     }
-    
+
     @Override
     public boolean isSamePartType(Part part) {
         return part instanceof QuadVeeGear && part.unitTonnage == unitTonnage;

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1260,7 +1260,7 @@ public class Refit extends Part implements IAcquisitionWork {
         if (null == newArmorSupplies) {
             return null;
         }
-        return (Armor) oldUnit.getCampaign().findSparePart(part -> {
+        return (Armor) oldUnit.getCampaign().getWarehouse().findSparePart(part -> {
             if (part instanceof Armor && ((Armor) part).getType() == newArmorSupplies.getType()
                     && part.isClanTechBase() == newArmorSupplies.isClanTechBase()
                     && !part.isReservedForRefit()

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1300,7 +1300,7 @@ public class Refit extends Part implements IAcquisitionWork {
                     ((AmmoBin) part).unload();
                     oldUnit.getCampaign().removePart(part);
                 } else {
-                    Part spare = oldUnit.getCampaign().checkForExistingSparePart(part);
+                    Part spare = oldUnit.getCampaign().getWarehouse().checkForExistingSparePart(part);
                     if (null != spare) {
                         spare.incrementQuantity();
                         oldUnit.getCampaign().removePart(part);
@@ -1395,7 +1395,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (part instanceof AmmoBin) {
                     ((AmmoBin) part).unload();
                 }
-                Part spare = oldUnit.getCampaign().checkForExistingSparePart(part);
+                Part spare = oldUnit.getCampaign().getWarehouse().checkForExistingSparePart(part);
                 if (spare != null) {
                     spare.incrementQuantity();
                     oldUnit.getCampaign().removePart(part);

--- a/MekHQ/src/mekhq/campaign/parts/Rotor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Rotor.java
@@ -1,20 +1,20 @@
 /*
  * Rotor.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,13 +44,13 @@ public class Rotor extends TankLocation {
     public Rotor() {
         this(0, null);
     }
-    
+
     public Rotor(int tonnage, Campaign c) {
         super(VTOL.LOC_ROTOR, tonnage, c);
         this.name = "Rotor";
         this.damage = 0;
     }
-    
+
     public Rotor clone() {
         Rotor clone = new Rotor(getUnitTonnage(), campaign);
         clone.copyBaseData(this);
@@ -59,10 +59,10 @@ public class Rotor extends TankLocation {
         clone.breached = this.breached;
         return clone;
     }
- 
+
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof Rotor 
+        return part instanceof Rotor
                 && getLoc() == ((Rotor)part).getLoc()
                 && getUnitTonnage() == ((Rotor)part).getUnitTonnage()
                 && this.getDamage() == ((Rotor)part).getDamage()
@@ -92,7 +92,7 @@ public class Rotor extends TankLocation {
     public void remove(boolean salvage) {
         if(null != unit && unit.getEntity() instanceof VTOL) {
             unit.getEntity().setInternal(IArmorState.ARMOR_DESTROYED, VTOL.LOC_ROTOR);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -131,7 +131,7 @@ public class SVArmor extends Armor {
     }
 
     public int getAmountAvailable() {
-        SVArmor a = (SVArmor)campaign.getWarehouse().findSparePart(part -> {
+        SVArmor a = (SVArmor) campaign.getWarehouse().findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent()
                 && !part.isReservedForRefit();
@@ -141,7 +141,7 @@ public class SVArmor extends Armor {
     }
 
     public void changeAmountAvailable(int amount) {
-        SVArmor a = (SVArmor)campaign.getWarehouse().findSparePart(part -> {
+        SVArmor a = (SVArmor) campaign.getWarehouse().findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent()
                 && Objects.equals(getRefitUnit(), part.getRefitUnit());

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -131,7 +131,7 @@ public class SVArmor extends Armor {
     }
 
     public int getAmountAvailable() {
-        SVArmor a = (SVArmor)campaign.findSparePart(part -> {
+        SVArmor a = (SVArmor)campaign.getWarehouse().findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent()
                 && !part.isReservedForRefit();
@@ -141,7 +141,7 @@ public class SVArmor extends Armor {
     }
 
     public void changeAmountAvailable(int amount) {
-        SVArmor a = (SVArmor)campaign.findSparePart(part -> {
+        SVArmor a = (SVArmor)campaign.getWarehouse().findSparePart(part -> {
             return isSamePartType(part)
                 && part.isPresent()
                 && Objects.equals(getRefitUnit(), part.getRefitUnit());

--- a/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
@@ -203,7 +203,7 @@ public class SVEnginePart extends Part {
             } else if (unit.getEntity() instanceof Aero) {
                 ((Aero) unit.getEntity()).setEngineHits(((Aero) unit.getEntity()).getMaxEngineHits());
             }
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/SpacecraftCoolingSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/SpacecraftCoolingSystem.java
@@ -154,7 +154,7 @@ public class SpacecraftCoolingSystem extends Part {
         if (unit != null && unit.getEntity() instanceof Aero) {
             //Spare part is usually 'this', but we're looking for spare heatsinks here...
             Part spareHeatSink = new AeroHeatSink(0, sinkType, false, campaign);
-            Part spare = campaign.checkForExistingSparePart(spareHeatSink);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(spareHeatSink);
            if (null != spare) {
                 spare.setQuantity(spare.getQuantity() - Math.min(sinksNeeded, 50));
                 ((Aero)unit.getEntity()).setHeatSinks(((Aero)unit.getEntity()).getHeatSinks() + Math.min(sinksNeeded, 50));
@@ -192,7 +192,7 @@ public class SpacecraftCoolingSystem extends Part {
         if (unit != null && unit.getEntity() instanceof Aero) {
             //Spare part is usually 'this', but we're looking for spare heatsinks here...
             Part spareHeatSink = new AeroHeatSink(0, sinkType, false, campaign);
-            Part spare = campaign.checkForExistingSparePart(spareHeatSink);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(spareHeatSink);
             //How many sinks are we trying to remove? It'll be between 0 and 50.
             int sinkBatch = Math.max(0, Math.min((currentSinks - engineSinks), 50));
             if(!salvage) {
@@ -223,7 +223,7 @@ public class SpacecraftCoolingSystem extends Part {
             return "All remaining heat sinks are built-in and cannot be salvaged.";
         }
         Part spareHeatSink = new AeroHeatSink(0, sinkType, false, campaign);
-        Part spare = campaign.checkForExistingSparePart(spareHeatSink);
+        Part spare = campaign.getWarehouse().checkForExistingSparePart(spareHeatSink);
         if (!isSalvaging()) {
             if (spare == null) {
                 return "No compatible heat sinks in warehouse!";

--- a/MekHQ/src/mekhq/campaign/parts/SpacecraftEngine.java
+++ b/MekHQ/src/mekhq/campaign/parts/SpacecraftEngine.java
@@ -1,20 +1,20 @@
 /*
  * SpacecraftEngine.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -43,7 +43,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.SkillType;
 
 /**
- * 
+ *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class SpacecraftEngine extends Part {
@@ -100,18 +100,18 @@ public class SpacecraftEngine extends Part {
         }
     }
 
-    @Override 
+    @Override
     public Money getStickerPrice() {
         //Add engine cost from SO p158 for advanced aerospace
         //Drive Unit + Engine + Engine Control Unit
         if (unit != null) {
             if(unit.getEntity() instanceof Warship) {
-                return Money.of((500 * unit.getEntity().getOriginalWalkMP() * (unit.getEntity().getWeight() / 100)) 
+                return Money.of((500 * unit.getEntity().getOriginalWalkMP() * (unit.getEntity().getWeight() / 100))
                         + (engineTonnage * 1000)
                         + 1000);
             } else if(unit.getEntity() instanceof Jumpship) {
                 // If we're a space station or jumpship, need the station keeping thrust, which is always 0.2
-                return Money.of((500 * 0.2 * (unit.getEntity().getWeight() / 100)) 
+                return Money.of((500 * 0.2 * (unit.getEntity().getWeight() / 100))
                             + (engineTonnage * 1000)
                             + 1000);
             }
@@ -164,7 +164,7 @@ public class SpacecraftEngine extends Part {
                 engineTonnage = Double.parseDouble(wn2.getTextContent());
             } else if (wn2.getNodeName().equalsIgnoreCase("clan")) {
                 clan = wn2.getTextContent().equalsIgnoreCase("true");
-            } 
+            }
         }
     }
 
@@ -190,7 +190,7 @@ public class SpacecraftEngine extends Part {
             if(unit.getEntity() instanceof Aero) {
                 ((Aero)unit.getEntity()).setEngineHits(((Aero)unit.getEntity()).getMaxEngineHits());
             }
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {
@@ -226,7 +226,7 @@ public class SpacecraftEngine extends Part {
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time = 0;
         //Per errata, small craft now use fighter engine times but still have the
@@ -246,7 +246,7 @@ public class SpacecraftEngine extends Part {
         }
         if (campaign.getCampaignOptions().useAeroSystemHits()) {
             //Test of proposed errata for repair times
-            time = 300; 
+            time = 300;
             //Light Damage
             if (hits > 0 && hits < 3) {
                 time *= (1 * hits);

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -190,7 +190,7 @@ public class TankLocation extends Part {
     public void remove(boolean salvage) {
         if(null != unit) {
             unit.getEntity().setInternal(IArmorState.ARMOR_DESTROYED, loc);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/Thrusters.java
+++ b/MekHQ/src/mekhq/campaign/parts/Thrusters.java
@@ -1,20 +1,20 @@
 /*
  * Thrusters.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,7 +44,7 @@ import mekhq.campaign.personnel.SkillType;
 public class Thrusters extends Part {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -336290094932539638L;
     private boolean isLeftThrusters;
@@ -78,8 +78,8 @@ public class Thrusters extends Part {
             } else {
                 hits = ((Aero)unit.getEntity()).getRightThrustHits();
             }
-            if(checkForDestruction 
-                    && hits > priorHits 
+            if(checkForDestruction
+                    && hits > priorHits
                     && (hits < 4 && !campaign.getCampaignOptions().useAeroSystemHits())
                     && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                 remove(false);
@@ -89,7 +89,7 @@ public class Thrusters extends Part {
         }
     }
 
-    @Override 
+    @Override
     public int getBaseTime() {
         int time = 0;
         if (campaign.getCampaignOptions().useAeroSystemHits()) {
@@ -101,7 +101,7 @@ public class Thrusters extends Part {
             }
             if (hits == 1) {
                 time *= 1;
-            } 
+            }
             if (hits == 2) {
                 time *= 2;
             }
@@ -127,7 +127,7 @@ public class Thrusters extends Part {
             }
             if (hits == 1) {
                 return -1;
-            } 
+            }
             if (hits == 2) {
                 return 0;
             }
@@ -172,7 +172,7 @@ public class Thrusters extends Part {
             } else {
                 ((Aero)unit.getEntity()).setRightThrustHits(4);
             }
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {
@@ -200,8 +200,8 @@ public class Thrusters extends Part {
 
     @Override
     public boolean needsFixing() {
-        if(null != getUnit() && null != getUnit().getEntity() && 
-                (getUnit().getEntity() instanceof Aero 
+        if(null != getUnit() && null != getUnit().getEntity() &&
+                (getUnit().getEntity() instanceof Aero
                         && !(getUnit().getEntity() instanceof SmallCraft
                                 || getUnit().getEntity() instanceof Jumpship))) {
             return false;
@@ -211,9 +211,9 @@ public class Thrusters extends Part {
 
     @Override
     public boolean isSalvaging() {
-        if(null != getUnit() && null != getUnit().getEntity() && 
-                (getUnit().getEntity() instanceof Aero 
-                        && !(getUnit().getEntity() instanceof SmallCraft 
+        if(null != getUnit() && null != getUnit().getEntity() &&
+                (getUnit().getEntity() instanceof Aero
+                        && !(getUnit().getEntity() instanceof SmallCraft
                                 || getUnit().getEntity() instanceof Jumpship))) {
             return false;
         }

--- a/MekHQ/src/mekhq/campaign/parts/Turret.java
+++ b/MekHQ/src/mekhq/campaign/parts/Turret.java
@@ -135,7 +135,7 @@ public class Turret extends TankLocation {
     public void remove(boolean salvage) {
         if(null != unit) {
             unit.getEntity().setInternal(IArmorState.ARMOR_DESTROYED, loc);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/VeeSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeSensor.java
@@ -1,20 +1,20 @@
 /*
  * VeeSensor.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -43,7 +43,7 @@ public class VeeSensor extends Part {
 	public VeeSensor() {
 		this(0, null);
 	}
-	
+
 	public VeeSensor(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "Vehicle Sensors";
@@ -54,7 +54,7 @@ public class VeeSensor extends Part {
         clone.copyBaseData(this);
 		return clone;
 	}
-	
+
     @Override
     public boolean isSamePartType(Part part) {
         return part instanceof VeeSensor;
@@ -88,7 +88,7 @@ public class VeeSensor extends Part {
 	public void remove(boolean salvage) {
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			((Tank)unit.getEntity()).setSensorHits(4);
-			Part spare = campaign.checkForExistingSparePart(this);
+			Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
 			if(!salvage) {
 				campaign.removePart(this);
 			} else if(null != spare) {
@@ -109,22 +109,22 @@ public class VeeSensor extends Part {
 		if(null != unit && unit.getEntity() instanceof Tank) {
 			int priorHits = hits;
 			hits = ((Tank)unit.getEntity()).getSensorHits();
-			if(checkForDestruction 
-					&& hits > priorHits 
+			if(checkForDestruction
+					&& hits > priorHits
 					&& Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
 				remove(false);
 			}
 		}
 	}
-	
-	@Override 
+
+	@Override
 	public int getBaseTime() {
 		if(isSalvaging()) {
 			return 260;
 		}
 		return 75;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return 0;
@@ -158,7 +158,7 @@ public class VeeSensor extends Part {
 		// TODO Auto-generated method stub
 		return Money.zero();
 	}
-	
+
 	@Override
 	public boolean isRightTechType(String skillType) {
 		return skillType.equals(SkillType.S_TECH_MECHANIC);
@@ -174,12 +174,12 @@ public class VeeSensor extends Part {
 	public int getLocation() {
 		return Entity.LOC_NONE;
 	}
-	
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return TankLocation.TECH_ADVANCEMENT;
     }
-    
+
     @Override
 	public int getMassRepairOptionType() {
     	return Part.REPAIR_PART_TYPE.ELECTRONICS;

--- a/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
@@ -110,7 +110,7 @@ public class VeeStabiliser extends Part {
     public void remove(boolean salvage) {
         if(null != unit && unit.getEntity() instanceof Tank) {
             ((Tank)unit.getEntity()).setStabiliserHit(loc);
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if(!salvage) {
                 campaign.removePart(this);
             } else if(null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -554,7 +554,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         int converted = 0;
 
         // TODO: make this less intensive.
-        for(Part part : campaign.getSpareParts()) {
+        for(Part part : campaign.getWarehouse().getSpareParts()) {
             if(!part.isPresent()) {
                 continue;
             }
@@ -593,7 +593,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     public static void changeAmountAvailable(Campaign campaign, int amount, final AmmoType curType) {
-        AmmoStorage a = (AmmoStorage)campaign.findSparePart(part -> {
+        AmmoStorage a = (AmmoStorage)campaign.getWarehouse().findSparePart(part -> {
             if (!(part instanceof AmmoStorage) || !part.isPresent() || part.isReservedForRefit()) {
                 return false;
             }
@@ -713,10 +713,11 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                             && ammoType.getMunitionType() == ((AmmoType) ((AmmoStorage) part).getType()).getMunitionType();
                 };
             }
-            AmmoStorage a = (AmmoStorage) campaign.findSparePart(predicate);
+            AmmoStorage a = (AmmoStorage) campaign.getWarehouse().findSparePart(predicate);
             return a != null ? a.getShots() : 0;
         } else {
-            return campaign.streamSpareParts()
+            return campaign.getWarehouse()
+                           .streamSpareParts()
                            .filter(part -> part instanceof AmmoStorage && part.isPresent())
                            .mapToInt(part -> {
                                AmmoStorage a = (AmmoStorage)part;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -227,7 +227,7 @@ public class EquipmentPart extends Part {
                 mounted.setRepairable(false);
                 unit.destroySystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
             }
-            Part spare = campaign.checkForExistingSparePart(this);
+            Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {
                 campaign.removePart(this);
             } else if (null != spare) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -215,7 +215,7 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public void changeAmountAvailable(int amount, final AmmoType curType) {
-        InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.findSparePart(part ->
+        InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.getWarehouse().findSparePart(part ->
             InfantryAmmoStorage.isRightAmmo(part, (AmmoType) getType(), getWeaponType()));
 
         if (a != null) {
@@ -235,7 +235,7 @@ public class InfantryAmmoBin extends AmmoBin {
 
     public int getAmountAvailable() {
         final AmmoType thisType = (AmmoType) getType();
-        return campaign.streamSpareParts()
+        return campaign.getWarehouse().streamSpareParts()
             .filter(part -> part instanceof InfantryAmmoStorage && part.isPresent()
                     && InfantryAmmoStorage.isRightAmmo(part, thisType, weaponType))
             .mapToInt(part -> ((InfantryAmmoStorage) part).getShots())

--- a/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
+++ b/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
@@ -100,7 +100,7 @@ public class CargoStatistics {
         int hv = stats.getNumberOfUnitsByType(Entity.ETYPE_TANK, false);
         int protos = stats.getNumberOfUnitsByType(Entity.ETYPE_PROTOMECH);
 
-        cargoTonnage += getCampaign().streamSpareParts().filter(p -> inTransit || p.isPresent())
+        cargoTonnage += getCampaign().getWarehouse().streamSpareParts().filter(p -> inTransit || p.isPresent())
                             .mapToDouble(p -> p.getQuantity() * p.getTonnage())
                             .sum();
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2184,7 +2184,7 @@ public class CampaignGUI extends JPanel {
 
         File partsFile = maybeFile.get();
 
-        MekHQ.getLogger().info(this, "Starting load of parts file from XML...");
+        MekHQ.getLogger().info("Starting load of parts file from XML...");
         // Initialize variables.
         Document xmlDoc;
 
@@ -2196,7 +2196,7 @@ public class CampaignGUI extends JPanel {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(is);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(this, ex);
+            MekHQ.getLogger().error(ex);
             return;
         }
 
@@ -2211,6 +2211,7 @@ public class CampaignGUI extends JPanel {
 
         // we need to iterate through three times, the first time to collect
         // any custom units that might not be written yet
+        List<Part> parts = new ArrayList<>();
         for (int x = 0; x < nl.getLength(); x++) {
             Node wn2 = nl.item(x);
 
@@ -2222,17 +2223,18 @@ public class CampaignGUI extends JPanel {
             if (!wn2.getNodeName().equalsIgnoreCase("part")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error(this, "Unknown node type not loaded in Parts nodes: " + wn2.getNodeName());
+                MekHQ.getLogger().error("Unknown node type not loaded in Parts nodes: " + wn2.getNodeName());
                 continue;
             }
 
             Part p = Part.generateInstanceFromXML(wn2, version);
             if (p != null) {
-                p.setCampaign(getCampaign());
-                getCampaign().addPartWithoutId(p);
+                parts.add(p);
             }
         }
-        MekHQ.getLogger().info(this, "Finished load of parts file");
+
+        getCampaign().importParts(parts);
+        MekHQ.getLogger().info("Finished load of parts file");
     }
 
     protected void loadOptionsFile() {

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -598,7 +598,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     }
 
     public void refreshPartsList() {
-        partsModel.setData(getCampaign().getSpareParts());
+        partsModel.setData(getCampaign().getWarehouse().getSpareParts());
         getCampaign().getShoppingList().removeZeroQuantityFromList(); // To
                                                                       // prevent
                                                                       // zero

--- a/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
@@ -82,7 +82,7 @@ public class BombsDialog extends JDialog implements ActionListener {
     private void initGUI() {
         //Using bombCatalog to store the part ID's of the bombs so don't have to keep full spare list in memory
         //and for ease of access later
-        campaign.forEachSparePart(spare -> {
+        campaign.getWarehouse().forEachSparePart(spare -> {
             if ((spare instanceof AmmoStorage)
                     && (((EquipmentPart)spare).getType() instanceof BombType)
                     && spare.isPresent()) {

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -305,7 +305,7 @@ public class CampaignExportWizard extends JDialog {
     private void setupPartList() {
         partList = new JList<>();
         DefaultListModel<Part> partListModel = new DefaultListModel<>();
-        List<Part> parts = sourceCampaign.getSpareParts();
+        List<Part> parts = sourceCampaign.getWarehouse().getSpareParts();
         parts.sort(Comparator.comparing(Part::getName));
 
         for (Part part : parts) {

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -574,7 +574,7 @@ public class CampaignExportWizard extends JDialog {
                 // it comes back as null if the part we're looking for is there but has the same ID,
                 // which is likely to happen when exporting to a brand new campaign
                 newPart.setId(-1);
-                Part existingPart = destinationCampaign.checkForExistingSparePart(newPart);
+                Part existingPart = destinationCampaign.getWarehouse().checkForExistingSparePart(newPart);
                 if (existingPart == null) {
                     // addpart doesn't allow adding multiple parts, so we update it afterwards
                     destinationCampaign.addPart(newPart, 0);

--- a/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
@@ -245,7 +245,7 @@ public class MassRepairSalvageDialog extends JDialog {
         if (refreshCompleteList) {
             completePartsList = new ArrayList<>();
 
-            campaignGUI.getCampaign().forEachSparePart(part -> {
+            campaignGUI.getCampaign().getWarehouse().forEachSparePart(part -> {
                 if (!part.isBeingWorkedOn() && part.needsFixing() && !(part instanceof AmmoBin)
                         && (part.getSkillMin() <= SkillType.EXP_ELITE)) {
                     completePartsList.add(part);

--- a/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
@@ -29,6 +29,7 @@ import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.UUID;
@@ -154,7 +155,7 @@ public class PayCollateralDialog extends JDialog {
         i = 0;
         j = 0;
         JSlider partSlider;
-        ArrayList<Part> spareParts = campaign.getSpareParts();
+        List<Part> spareParts = campaign.getWarehouse().getSpareParts();
         for(Part p : spareParts) {
             j++;
             int quantity = p.getQuantity();
@@ -290,7 +291,7 @@ public class PayCollateralDialog extends JDialog {
         for (Map.Entry<JSlider, Integer> m : partSliders.entrySet()) {
             int quantity = m.getKey().getValue();
             if(quantity > 0) {
-                amount = amount.plus(campaign.getPart(m.getValue()).getCurrentValue().multipliedBy(quantity));
+                amount = amount.plus(campaign.getWarehouse().getPart(m.getValue()).getCurrentValue().multipliedBy(quantity));
             }
         }
 

--- a/MekHQ/unittests/mekhq/EventSpy.java
+++ b/MekHQ/unittests/mekhq/EventSpy.java
@@ -33,15 +33,13 @@ import mekhq.campaign.event.*;
  * Provides a list of events captured during its lifetime.
  * Use this as part of a try-with-resources block.
  *
- * If you need to listen to a new event, add a handler to this
- * class.
+ * If you need to listen to a new event, add a handler to this class.
  */
 public class EventSpy implements AutoCloseable {
     private final List<MMEvent> events = new ArrayList<>();
 
     /**
-     * Creates a new EventSpy and registers it with
-     * MekHQ's event bus.
+     * Creates a new EventSpy and registers it with MekHQ's event bus.
      */
     public EventSpy() {
         MekHQ.registerHandler(this);
@@ -56,8 +54,7 @@ public class EventSpy implements AutoCloseable {
 
     /**
      * Gets the list of events which occurred.
-     * @return The list of events which occurred, in the order
-     *         received.
+     * @return The list of events which occurred, in the order received.
      */
     public List<MMEvent> getEvents() {
         return Collections.unmodifiableList(events);

--- a/MekHQ/unittests/mekhq/EventSpy.java
+++ b/MekHQ/unittests/mekhq/EventSpy.java
@@ -22,7 +22,9 @@ package mekhq;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
+import megamek.common.annotations.Nullable;
 import megamek.common.event.MMEvent;
 import megamek.common.event.Subscribe;
 import mekhq.campaign.event.*;
@@ -59,6 +61,25 @@ public class EventSpy implements AutoCloseable {
      */
     public List<MMEvent> getEvents() {
         return Collections.unmodifiableList(events);
+    }
+
+    /**
+     * Finds an event of a certain type matching a given predicate.
+     * @param clazz The event class in question.
+     * @param predicate The predicate to apply when searching for an event.
+     * @return The first matching event, otherwise null.
+     */
+    public @Nullable <TEvent extends MMEvent> TEvent findEvent(Class<TEvent> clazz, Predicate<TEvent> predicate) {
+        for (MMEvent e : events) {
+            if (clazz.isInstance(e)) {
+                TEvent instance = clazz.cast(e);
+                if (predicate.test(instance)) {
+                    return instance;
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/MekHQ/unittests/mekhq/EventSpy.java
+++ b/MekHQ/unittests/mekhq/EventSpy.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import megamek.common.event.MMEvent;
+import megamek.common.event.Subscribe;
+import mekhq.campaign.event.*;
+
+/**
+ * Provides a list of events captured during its lifetime.
+ * Use this as part of a try-with-resources block.
+ *
+ * If you need to listen to a new event, add a handler to this
+ * class.
+ */
+public class EventSpy implements AutoCloseable {
+    private final List<MMEvent> events = new ArrayList<>();
+
+    /**
+     * Creates a new EventSpy and registers it with
+     * MekHQ's event bus.
+     */
+    public EventSpy() {
+        MekHQ.registerHandler(this);
+    }
+
+    /**
+     * Deregisters this instance from MekHQ's event bus.
+     */
+    public void close() {
+        MekHQ.unregisterHandler(this);
+    }
+
+    /**
+     * Gets the list of events which occurred.
+     * @return The list of events which occurred, in order
+     *         received.
+     */
+    public List<MMEvent> getEvents() {
+        return Collections.unmodifiableList(events);
+    }
+
+    /**
+     * Records an event.
+     * @param e The event received.
+     */
+    private void record(MMEvent e) {
+        events.add(e);
+    }
+
+    //
+    // CAW: Add new event handlers below as needed for a unit test.
+    //
+
+    @Subscribe
+    public void handle(PartNewEvent e) {
+        record(e);
+    }
+
+    @Subscribe
+    public void handle(PartChangedEvent e) {
+        record(e);
+    }
+
+    @Subscribe
+    public void handle(PartRemovedEvent e) {
+        record(e);
+    }
+}

--- a/MekHQ/unittests/mekhq/EventSpy.java
+++ b/MekHQ/unittests/mekhq/EventSpy.java
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq;
@@ -56,7 +56,7 @@ public class EventSpy implements AutoCloseable {
 
     /**
      * Gets the list of events which occurred.
-     * @return The list of events which occurred, in order
+     * @return The list of events which occurred, in the order
      *         received.
      */
     public List<MMEvent> getEvents() {

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -21,15 +21,25 @@ package mekhq.campaign;
 
 import org.junit.Test;
 
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.EquipmentType;
+import megamek.common.Mech;
 import mekhq.EventSpy;
+import mekhq.campaign.event.PartChangedEvent;
 import mekhq.campaign.event.PartNewEvent;
 import mekhq.campaign.event.PartRemovedEvent;
+import mekhq.campaign.parts.AmmoStorage;
+import mekhq.campaign.parts.Armor;
+import mekhq.campaign.parts.MekLocation;
 import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
+import java.util.UUID;
 
 public class WarehouseTest {
     @Test
@@ -261,6 +271,211 @@ public class WarehouseTest {
         }
     }
 
+    @Test
+    public void testAddSpareRegularPart() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+
+        // Add a spare part to the warehouse
+        Part mockPart = spy(new MekLocation());
+        mockPart.setCampaign(mockCampaign);
+        mockPart.setQuantity(1);
+
+        // Add the part to our warehouse, merging it
+        // with any existing part
+        Part addedPart = warehouse.addPart(mockPart, true);
+
+        // We should only have one of these parts
+        assertEquals(1, warehouse.getParts().size());
+        assertEquals(mockPart, addedPart);
+        assertTrue(addedPart.isSpare());
+        assertEquals(1, addedPart.getQuantity());
+
+        // Make a new part, also spare
+        Part mockSparePart = spy(new MekLocation());
+        mockSparePart.setCampaign(mockCampaign);
+        mockSparePart.setQuantity(2);
+
+        try (EventSpy eventSpy = new EventSpy()) {
+            // Add the spare part to our warehouse, and
+            // ask that it be merged with an existing part
+            addedPart = warehouse.addPart(mockSparePart, true);
+
+            // We should see that the original part was changed
+            assertNotNull(eventSpy.findEvent(PartChangedEvent.class, e -> mockPart == e.getPart()));
+
+            // And we should see that the other part was never added
+            assertNull(eventSpy.findEvent(PartNewEvent.class, e -> mockSparePart == e.getPart()));
+            assertTrue(mockSparePart.getId() <= 0);
+        }
+
+        // We should still only have one instance of the
+        // part, but instead we will now have 3 of them.
+        assertEquals(1, warehouse.getParts().size());
+        assertEquals(mockPart, addedPart);
+        assertTrue(addedPart.isSpare());
+        assertEquals(3, addedPart.getQuantity());
+    }
+
+    @Test
+    public void testReturnSpareRegularPart() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+
+        // Add a spare part to the warehouse
+        Part mockPart = spy(new MekLocation());
+        mockPart.setCampaign(mockCampaign);
+        mockPart.setQuantity(2);
+
+        // Add the part to our warehouse, merging it
+        // with any existing part (there aren't any).
+        Part addedPart = warehouse.addPart(mockPart, true);
+
+        // We should only have one instance of this part
+        assertEquals(1, warehouse.getParts().size());
+        assertEquals(mockPart, addedPart);
+        assertTrue(addedPart.isSpare());
+        assertEquals(2, addedPart.getQuantity());
+
+        // Make a new part that is on a unit
+        Part mockUnitPart = spy(new MekLocation());
+        mockUnitPart.setCampaign(mockCampaign);
+        mockUnitPart.setQuantity(1);
+
+        Unit mockUnit = mock(Unit.class);
+        when(mockUnit.getId()).thenReturn(UUID.randomUUID());
+        Mech mockEntity = mock(Mech.class);
+        when(mockEntity.getWeight()).thenReturn(0.0); // CAW: match the 0 ton MekLocation above.
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        mockUnitPart.setUnit(mockUnit);
+
+        // Add the new part that is part of a unit
+        addedPart = warehouse.addPart(mockUnitPart, true);
+
+        // We should have two parts in the warehouse,
+        // and they should be distinct.
+        assertEquals(2, warehouse.getParts().size());
+        assertEquals(mockUnitPart, addedPart);
+        assertFalse(addedPart.isSpare());
+        assertEquals(2, mockPart.getQuantity());
+        assertEquals(1, addedPart.getQuantity());
+
+        try (EventSpy eventSpy = new EventSpy()) {
+            // Now lets take the new part off of the unit...
+            mockUnitPart.setUnit(null);
+
+            // ...and add it back to the Warehouse.
+            addedPart = warehouse.addPart(mockUnitPart, true);
+
+            // We should see that the existing spare part was changed
+            assertNotNull(eventSpy.findEvent(PartChangedEvent.class, e -> mockPart == e.getPart()));
+
+            // And we should see that the "unit part" was removed
+            // when it was merged with the existing spare part
+            assertNotNull(eventSpy.findEvent(PartRemovedEvent.class, e -> mockUnitPart == e.getPart()));
+            assertTrue(mockUnitPart.getId() <= 0);
+        }
+
+        // We should now only have one instance of the
+        // part, and we will now have 3 of them.
+        assertEquals(1, warehouse.getParts().size());
+        assertEquals(mockPart, addedPart);
+        assertTrue(addedPart.isSpare());
+        assertEquals(3, addedPart.getQuantity());
+    }
+
+    @Test
+    public void testAddSpareArmorPart() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+
+        // Add some spare armor to the warehouse
+        Armor mockArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
+
+        // Add the armor to our warehouse, merging it
+        // with any existing part
+        Part addedArmor = warehouse.addPart(mockArmor, true);
+        assertTrue(addedArmor instanceof Armor);
+
+        // We should only have one of these parts
+        assertEquals(1, warehouse.getParts().size());
+        assertEquals(mockArmor, addedArmor);
+        assertTrue(addedArmor.isSpare());
+
+        // Make some new armor, also spare
+        Armor mockSpareArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 32);
+
+        try (EventSpy eventSpy = new EventSpy()) {
+            // Add the spare armor to our warehouse, and
+            // ask that it be merged with an existing part
+            addedArmor = warehouse.addPart(mockSpareArmor, true);
+            assertTrue(addedArmor instanceof Armor);
+
+            // We should see that the original part was changed
+            assertNotNull(eventSpy.findEvent(PartChangedEvent.class, e -> mockArmor == e.getPart()));
+
+            // And we should see that the other part was never added
+            assertNull(eventSpy.findEvent(PartNewEvent.class, e -> mockSpareArmor == e.getPart()));
+            assertTrue(mockSpareArmor.getId() <= 0);
+        }
+
+        // We should still only have one instance of the
+        // part, but instead we will now have 3 of them.
+        assertEquals(1, warehouse.getParts().size());
+        assertEquals(mockArmor, addedArmor);
+        assertTrue(addedArmor.isSpare());
+
+        // Double check the math from above.
+        assertEquals(3.0, addedArmor.getTonnage(), 0.000001);
+        assertEquals(48, ((Armor) addedArmor).getAmount());
+    }
+
+    @Test
+    public void testAddSpareAmmoStoragePart() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+
+        // Add some spare ammo to the warehouse
+        AmmoStorage mockAmmoStorage = createMockAmmoStorage(mockCampaign, getAmmoType("ISAC5 Ammo"), 20);
+
+        // Add the ammo to our warehouse, merging it
+        // with any existing part (there are none)
+        Part addedAmmo = warehouse.addPart(mockAmmoStorage, true);
+        assertTrue(addedAmmo instanceof AmmoStorage);
+
+        // We should only have one of these parts
+        assertEquals(1, warehouse.getParts().size());
+        assertEquals(mockAmmoStorage, addedAmmo);
+        assertTrue(addedAmmo.isSpare());
+
+        // Make some new ammo, also spare
+        AmmoStorage mockSpareAmmo = createMockAmmoStorage(mockCampaign, getAmmoType("ISAC5 Ammo"), 40);
+
+        try (EventSpy eventSpy = new EventSpy()) {
+            // Add the spare ammo to our warehouse, and
+            // ask that it be merged with an existing part
+            addedAmmo = warehouse.addPart(mockSpareAmmo, true);
+            assertTrue(addedAmmo instanceof AmmoStorage);
+
+            // We should see that the original part was changed
+            assertNotNull(eventSpy.findEvent(PartChangedEvent.class, e -> mockAmmoStorage == e.getPart()));
+
+            // And we should see that the other part was never added
+            assertNull(eventSpy.findEvent(PartNewEvent.class, e -> mockSpareAmmo == e.getPart()));
+            assertTrue(mockSpareAmmo.getId() <= 0);
+        }
+
+        // We should still only have one instance of the
+        // part, but instead we will now have 3 of them.
+        assertEquals(1, warehouse.getParts().size());
+        assertEquals(mockAmmoStorage, addedAmmo);
+        assertTrue(addedAmmo.isSpare());
+
+        // Double check the math from above.
+        assertEquals(3.0, addedAmmo.getTonnage(), 0.000001);
+        assertEquals(60, ((AmmoStorage) addedAmmo).getShots());
+    }
+
     /**
      * Creates a mock part with the given ID.
      * @param id The unique ID of the part.
@@ -271,5 +486,47 @@ public class WarehouseTest {
         when(mockPart.getId()).thenReturn(id);
 
         return mockPart;
+    }
+
+    /**
+     * Creates mock Armor for the campaign.
+     * @param campaign The campaign to assign to the Armor.
+     * @param armorType The type of armor.
+     * @param points The number of points of armor.
+     */
+    private Armor createMockArmor(Campaign campaign, int armorType, int points) {
+        return spy(new Armor(1, armorType, points, Entity.LOC_NONE, false, false, campaign));
+    }
+
+    /**
+     * Creates mock AmmoStorage for the campaign.
+     * @param campaign The campaign to assign to the AmmoStorage.
+     * @param ammoType The type of ammo.
+     * @param shots The number of shots ammo.
+     */
+    private AmmoStorage createMockAmmoStorage(Campaign campaign, AmmoType ammoType, int shots) {
+        return spy(new AmmoStorage(1, ammoType, shots, campaign));
+    }
+
+    /**
+     * Gets an AmmoType by name (performing any initialization required
+     * on the MM side).
+     * @param name The lookup name for the AmmoType.
+     * @return The ammo type for the given name.
+     */
+    private AmmoType getAmmoType(String name) {
+        initializeAmmoTypes();
+
+        return (AmmoType) EquipmentType.get(name);
+    }
+
+    private static boolean initializedAmmoTypes;
+
+    private synchronized static void initializeAmmoTypes() {
+        if (!initializedAmmoTypes) {
+            initializedAmmoTypes = true;
+
+            AmmoType.initializeTypes();
+        }
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import mekhq.EventSpy;
 import mekhq.campaign.event.PartNewEvent;
+import mekhq.campaign.event.PartRemovedEvent;
 import mekhq.campaign.parts.Part;
 
 import static org.junit.Assert.*;
@@ -178,6 +179,42 @@ public class WarehouseTest {
                             .stream()
                             .filter(e -> e instanceof PartNewEvent)
                             .filter(e -> mockPart == ((PartNewEvent) e).getPart())
+                            .count());
+        }
+    }
+
+    @Test
+    public void testWarehouseRemovePart() {
+        Warehouse warehouse = new Warehouse();
+
+        // Create a mock part
+        int mockId = 10;
+        Part mockPart = mock(Part.class);
+        when(mockPart.getId()).thenReturn(mockId);
+
+        try (EventSpy eventSpy = new EventSpy()) {
+            // Ensure we can't remove a part that doesn't exist
+            assertFalse(warehouse.removePart(mockPart));
+
+            // If we didn't remove a part, we should have no event
+            assertTrue(eventSpy.getEvents()
+                    .stream()
+                    .filter(e -> e instanceof PartRemovedEvent)
+                    .findAny()
+                    .isEmpty());
+
+            // Add the mock part to our warehouse
+            warehouse.addPart(mockPart);
+
+            // Ensure we can then remove the part
+            assertTrue(warehouse.removePart(mockPart));
+
+            // There should be an event where we removed the mock part
+            assertEquals(1,
+                    eventSpy.getEvents()
+                            .stream()
+                            .filter(e -> e instanceof PartRemovedEvent)
+                            .filter(e -> mockPart == ((PartRemovedEvent) e).getPart())
                             .count());
         }
     }

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq.campaign;
@@ -157,7 +157,7 @@ public class WarehouseTest {
         // We should have been assigned an ID...
         assertTrue(mockPart1.getId() > 0);
 
-        // ...that is not the same as our previous part
+        // ... that is not the same as our previous part
         assertNotEquals(mockPart0.getId(), mockPart1.getId());
     }
 

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -199,11 +199,11 @@ public class WarehouseTest {
             assertFalse(warehouse.removePart(mockPart));
 
             // If we didn't remove a part, we should have no event
-            assertTrue(eventSpy.getEvents()
+            assertFalse(eventSpy.getEvents()
                     .stream()
                     .filter(e -> e instanceof PartRemovedEvent)
                     .findAny()
-                    .isEmpty());
+                    .isPresent());
 
             // Add the mock part to our warehouse
             warehouse.addPart(mockPart);

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -40,7 +40,9 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class WarehouseTest {
     @Test
@@ -746,6 +748,208 @@ public class WarehouseTest {
 
         // We should have 2 instances of these parts
         assertEquals(2, warehouse.getParts().size());
+    }
+
+    @Test
+    public void testGetSpareParts() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+
+        // Spare
+        Part mockSparePart = spy(new MekLocation());
+        Part addedPart = warehouse.addPart(mockSparePart, true);
+        assertEquals(mockSparePart, addedPart);
+
+        Part mockUnitPart = spy(new MekLocation());
+        mockUnitPart.setUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockUnitPart, true);
+        assertEquals(mockUnitPart, addedPart);
+
+        // Spare (being repaired)
+        Part mockSparePartUnderRepair = spy(new MekLocation());
+        mockSparePartUnderRepair.setTech(createMockTech());
+        addedPart = warehouse.addPart(mockSparePartUnderRepair, true);
+        assertEquals(mockSparePartUnderRepair, addedPart);
+
+        Part mockPartForRefit = spy(new MekLocation());
+        mockPartForRefit.setRefitUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockPartForRefit, true);
+        assertEquals(mockPartForRefit, addedPart);
+
+        Part mockPartForRepairTask = spy(new MekLocation());
+        mockPartForRepairTask.setReservedBy(createMockTech());
+        addedPart = warehouse.addPart(mockPartForRepairTask, true);
+        assertEquals(mockPartForRepairTask, addedPart);
+
+        // Spare
+        Armor mockSpareArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
+        addedPart = warehouse.addPart(mockSpareArmor, true);
+        assertEquals(mockSpareArmor, addedPart);
+
+        Armor mockUnitArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
+        mockUnitArmor.setUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockUnitArmor, true);
+        assertEquals(mockUnitArmor, addedPart);
+
+        // Spare
+        AmmoStorage mockSpareAmmo = createMockAmmoStorage(mockCampaign, getAmmoType(""), 20);
+        addedPart = warehouse.addPart(mockSpareAmmo, true);
+        assertEquals(mockSpareAmmo, addedPart);
+
+        AmmoStorage mockRefitAmmo = createMockAmmoStorage(mockCampaign, getAmmoType(""), 20);
+        mockRefitAmmo.setRefitUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockRefitAmmo, true);
+        assertEquals(mockRefitAmmo, addedPart);
+
+        // Test: getSpareParts
+        List<Part> spareParts = warehouse.getSpareParts();
+        assertEquals(4, spareParts.size());
+        assertTrue(spareParts.contains(mockSparePart));
+        assertTrue(spareParts.contains(mockSparePartUnderRepair));
+        assertTrue(spareParts.contains(mockSpareArmor));
+        assertTrue(spareParts.contains(mockSpareAmmo));
+
+        // Test: streamSpareParts
+        spareParts = warehouse.streamSpareParts().collect(Collectors.toList());
+        assertEquals(4, spareParts.size());
+        assertTrue(spareParts.contains(mockSparePart));
+        assertTrue(spareParts.contains(mockSparePartUnderRepair));
+        assertTrue(spareParts.contains(mockSpareArmor));
+        assertTrue(spareParts.contains(mockSpareAmmo));
+    }
+
+    @Test
+    public void testForEachSpareParts() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+
+        // The warehouse is empty!
+        warehouse.forEachSparePart(spare -> {
+            assertTrue(false);
+        });
+
+        // Spare
+        Part mockSparePart = spy(new MekLocation());
+        Part addedPart = warehouse.addPart(mockSparePart, true);
+        assertEquals(mockSparePart, addedPart);
+
+        Part mockUnitPart = spy(new MekLocation());
+        mockUnitPart.setUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockUnitPart, true);
+        assertEquals(mockUnitPart, addedPart);
+
+        // Spare (being repaired)
+        Part mockSparePartUnderRepair = spy(new MekLocation());
+        mockSparePartUnderRepair.setTech(createMockTech());
+        addedPart = warehouse.addPart(mockSparePartUnderRepair, true);
+        assertEquals(mockSparePartUnderRepair, addedPart);
+
+        Part mockPartForRefit = spy(new MekLocation());
+        mockPartForRefit.setRefitUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockPartForRefit, true);
+        assertEquals(mockPartForRefit, addedPart);
+
+        Part mockPartForRepairTask = spy(new MekLocation());
+        mockPartForRepairTask.setReservedBy(createMockTech());
+        addedPart = warehouse.addPart(mockPartForRepairTask, true);
+        assertEquals(mockPartForRepairTask, addedPart);
+
+        // Spare
+        Armor mockSpareArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
+        addedPart = warehouse.addPart(mockSpareArmor, true);
+        assertEquals(mockSpareArmor, addedPart);
+
+        Armor mockUnitArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
+        mockUnitArmor.setUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockUnitArmor, true);
+        assertEquals(mockUnitArmor, addedPart);
+
+        // Spare
+        AmmoStorage mockSpareAmmo = createMockAmmoStorage(mockCampaign, getAmmoType(""), 20);
+        addedPart = warehouse.addPart(mockSpareAmmo, true);
+        assertEquals(mockSpareAmmo, addedPart);
+
+        AmmoStorage mockRefitAmmo = createMockAmmoStorage(mockCampaign, getAmmoType(""), 20);
+        mockRefitAmmo.setRefitUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockRefitAmmo, true);
+        assertEquals(mockRefitAmmo, addedPart);
+
+        List<Part> spareParts = warehouse.getSpareParts();
+        assertEquals(4, spareParts.size());
+
+        warehouse.forEachSparePart(spare -> {
+            assertTrue(spareParts.contains(spare));
+        });
+    }
+
+    @Test
+    public void testFindSparePart() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+
+        // The warehouse is empty!
+        assertNull(warehouse.findSparePart(spare -> true));
+
+        // Spare
+        Part mockSparePart = spy(new MekLocation());
+        Part addedPart = warehouse.addPart(mockSparePart, true);
+        assertEquals(mockSparePart, warehouse.findSparePart(spare -> spare.getId() == mockSparePart.getId()));
+
+        Part mockUnitPart = spy(new MekLocation());
+        mockUnitPart.setUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockUnitPart, true);
+        assertNull(warehouse.findSparePart(spare -> spare.getId() == mockUnitPart.getId()));
+
+        // Spare (being repaired)
+        Part mockSparePartUnderRepair = spy(new MekLocation());
+        mockSparePartUnderRepair.setTech(createMockTech());
+        addedPart = warehouse.addPart(mockSparePartUnderRepair, true);
+        assertEquals(mockSparePartUnderRepair, addedPart);
+        assertEquals(mockSparePartUnderRepair, warehouse.findSparePart(spare -> spare.getId() == mockSparePartUnderRepair.getId()));
+
+        Part mockPartForRefit = spy(new MekLocation());
+        mockPartForRefit.setRefitUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockPartForRefit, true);
+        assertEquals(mockPartForRefit, addedPart);
+        assertNull(warehouse.findSparePart(spare -> spare.getId() == mockPartForRefit.getId()));
+
+        Part mockPartForRepairTask = spy(new MekLocation());
+        mockPartForRepairTask.setReservedBy(createMockTech());
+        addedPart = warehouse.addPart(mockPartForRepairTask, true);
+        assertEquals(mockPartForRepairTask, addedPart);
+        assertNull(warehouse.findSparePart(spare -> spare.getId() == mockPartForRepairTask.getId()));
+
+        // Spare
+        Armor mockSpareArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
+        addedPart = warehouse.addPart(mockSpareArmor, true);
+        assertEquals(mockSpareArmor, addedPart);
+        assertEquals(mockSpareArmor, warehouse.findSparePart(spare -> spare.getId() == mockSpareArmor.getId()));
+
+        Armor mockUnitArmor = createMockArmor(mockCampaign, EquipmentType.T_ARMOR_STANDARD, 16);
+        mockUnitArmor.setUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockUnitArmor, true);
+        assertEquals(mockUnitArmor, addedPart);
+        assertNull(warehouse.findSparePart(spare -> spare.getId() == mockUnitArmor.getId()));
+
+        // Spare
+        AmmoStorage mockSpareAmmo = createMockAmmoStorage(mockCampaign, getAmmoType(""), 20);
+        addedPart = warehouse.addPart(mockSpareAmmo, true);
+        assertEquals(mockSpareAmmo, addedPart);
+        assertEquals(mockSpareAmmo, warehouse.findSparePart(spare -> spare.getId() == mockSpareAmmo.getId()));
+
+        AmmoStorage mockRefitAmmo = createMockAmmoStorage(mockCampaign, getAmmoType(""), 20);
+        mockRefitAmmo.setRefitUnit(createMockUnit());
+        addedPart = warehouse.addPart(mockRefitAmmo, true);
+        assertEquals(mockRefitAmmo, addedPart);
+        assertNull(warehouse.findSparePart(spare -> spare.getId() == mockRefitAmmo.getId()));
+
+        // Ensure we actually test the predicate, no matter how silly
+        assertNull(warehouse.findSparePart(spare -> false));
+
+        // The warehouse full of spare parts, so find (any) one!
+        Part sparePart = warehouse.findSparePart(spare -> true);
+        assertNotNull(sparePart);
+        assertTrue(sparePart.isSpare());
     }
 
     /**

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2020 - The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign;
+
+import org.junit.Test;
+
+import mekhq.EventSpy;
+import mekhq.campaign.event.PartNewEvent;
+import mekhq.campaign.parts.Part;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class WarehouseTest {
+    @Test
+    public void testWarehouseSimplePartActions() {
+        Warehouse warehouse = new Warehouse();
+
+        // A new warehouse is empty
+        assertTrue(warehouse.getParts().isEmpty());
+
+        // Create a mock part
+        int mockId = 10;
+        Part mockPart = mock(Part.class);
+        when(mockPart.getId()).thenReturn(mockId);
+
+        // Add the mock part to our warehouse
+        warehouse.addPart(mockPart);
+
+        // The part should be returned when we get it by ID
+        assertEquals(mockPart, warehouse.getPart(mockId));
+
+        // forEachPart should have our part
+        warehouse.forEachPart(p -> {
+            // There should only be one part in the warehouse
+            // and it should be our part
+            assertEquals(mockPart, p);
+        });
+
+        // getParts should return the part
+        assertTrue(warehouse.getParts().contains(mockPart));
+
+        // The part should also be removed when we request it
+        assertTrue(warehouse.removePart(mockPart));
+
+        // And the part should no longer be in the warehouse
+        assertNull(warehouse.getPart(mockId));
+
+        // We should not run over any part once removed
+        warehouse.forEachPart(p -> {
+            assertTrue(false);
+        });
+
+        // getParts should no longer contain anything
+        assertTrue(warehouse.getParts().isEmpty());
+    }
+
+    @Test
+    public void testWarehouseAddNewPart() {
+        Warehouse warehouse = new Warehouse();
+
+        // Create a mock part without an ID
+        Part mockPart = mock(Part.class, RETURNS_DEEP_STUBS);
+        when(mockPart.getId()).thenCallRealMethod();
+        doCallRealMethod().when(mockPart).setId(anyInt());
+
+        // Add the mock part to our warehouse
+        warehouse.addPart(mockPart);
+
+        // We should have been assigned an ID
+        assertTrue(mockPart.getId() > 0);
+
+        // The part should be returned when we get it by ID
+        assertEquals(mockPart, warehouse.getPart(mockPart.getId()));
+
+        // forEachPart should have our part
+        warehouse.forEachPart(p -> {
+            // There should only be one part in the warehouse
+            // and it should be our part
+            assertEquals(mockPart, p);
+        });
+
+        // getParts should return the part
+        assertTrue(warehouse.getParts().contains(mockPart));
+
+        // The part should also be removed when we request it
+        assertTrue(warehouse.removePart(mockPart));
+
+        // And the part should no longer be in the warehouse
+        assertNull(warehouse.getPart(mockPart.getId()));
+
+        // We should not run over any part once removed
+        warehouse.forEachPart(p -> {
+            assertTrue(false);
+        });
+
+        // getParts should no longer contain anything
+        assertTrue(warehouse.getParts().isEmpty());
+    }
+
+    @Test
+    public void testWarehouseAddSecondNewPart() {
+        Warehouse warehouse = new Warehouse();
+
+        // Create a mock part without an ID
+        Part mockPart0 = mock(Part.class, RETURNS_DEEP_STUBS);
+        when(mockPart0.getId()).thenCallRealMethod();
+        doCallRealMethod().when(mockPart0).setId(anyInt());
+
+        // Add the mock part to our warehouse
+        warehouse.addPart(mockPart0);
+
+        // We should have been assigned an ID
+        assertTrue(mockPart0.getId() > 0);
+
+        // Create a second mock part without an ID
+        Part mockPart1 = mock(Part.class, RETURNS_DEEP_STUBS);
+        when(mockPart1.getId()).thenCallRealMethod();
+        doCallRealMethod().when(mockPart1).setId(anyInt());
+
+        // Add the mock part to our warehouse
+        warehouse.addPart(mockPart1);
+
+        // We should have been assigned an ID...
+        assertTrue(mockPart1.getId() > 0);
+
+        // ...that is not the same as our previous part
+        assertNotEquals(mockPart0.getId(), mockPart1.getId());
+    }
+
+    @Test
+    public void testWarehouseAddPartEvent() {
+        Warehouse warehouse = new Warehouse();
+
+        // Create a mock part
+        int mockId = 10;
+        Part mockPart = mock(Part.class);
+        when(mockPart.getId()).thenReturn(mockId);
+
+        try (EventSpy eventSpy = new EventSpy()) {
+            // Add the mock part to our warehouse
+            warehouse.addPart(mockPart);
+
+            // This part never existed so there should be
+            // a PartNewEvent fired.
+            assertTrue(eventSpy.getEvents()
+                    .stream()
+                    .filter(e -> e instanceof PartNewEvent)
+                    .filter(e -> mockPart == ((PartNewEvent) e).getPart())
+                    .findAny()
+                    .isPresent());
+
+            // Add the part again, simulating being say removed from a
+            // unit or something
+            warehouse.addPart(mockPart);
+
+            // There should be only ONE event as we did not add
+            // this part to the warehouse
+            assertEquals(1,
+                    eventSpy.getEvents()
+                            .stream()
+                            .filter(e -> e instanceof PartNewEvent)
+                            .filter(e -> mockPart == ((PartNewEvent) e).getPart())
+                            .count());
+        }
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
@@ -98,7 +98,7 @@ public class PartTest {
         when(mockTech.getId()).thenReturn(UUID.randomUUID());
 
         Part part = new MekSensor();
-        part.setReserveId(mockTech);
+        part.setReservedBy(mockTech);
 
         assertNull(part.getUnit());
         assertNull(part.getParentPart());


### PR DESCRIPTION
This takes us down the path of fixing many of the odd part related bugs (in transit ammo, refit oddities with armor supplies missing or aero heat sink worries). This will consolidate the logic for managing spare parts.

Of interest to downstream work, I have an `EventSpy` utility class that we can use during unit testing to ensure we're firing all the correct events during certain actions.

TODO:
- [x] Test merging spare parts