### PR TITLE
Clean up various pieces of part logic and add tests

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4173,7 +4173,7 @@ public class Campaign implements Serializable, ITechManager {
     /**
      * Sell one or more points of armor
      * @param armor The armor to sell.
-     * @param shots The number of points of armor to sell.
+     * @param points The number of points of armor to sell.
      */
     public void sellArmor(Armor armor, int points) {
         Objects.requireNonNull(armor);

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -140,7 +140,7 @@ public class BattleArmorSuit extends Part {
     public double getTonnage() {
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded alternate costs
-        if ((null == unit) && getChildParts().isEmpty()) {
+        if ((null == unit) && !hasChildParts()) {
             return alternateTon;
         }
         double tons = 0;
@@ -219,7 +219,7 @@ public class BattleArmorSuit extends Part {
         }
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded extra costs
-        if ((null == unit) && getChildParts().isEmpty()) {
+        if ((null == unit) && !hasChildParts()) {
             tons += alternateTon;
         }
         for (Part p : getChildParts()) {
@@ -234,7 +234,7 @@ public class BattleArmorSuit extends Part {
     public Money getStickerPrice() {
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded alternate costs
-        if ((null == unit) && getChildParts().isEmpty()) {
+        if ((null == unit) && !hasChildParts()) {
             return alternateCost;
         }
         Money cost = Money.zero();
@@ -526,7 +526,7 @@ public class BattleArmorSuit extends Part {
         } else {
             int nEquip = 0;
             int armor = 0;
-            if (!getChildParts().isEmpty()) {
+            if (!hasChildParts()) {
                 for (Part p : getChildParts()) {
                     if (p instanceof BaArmor) {
                         armor = ((BaArmor)p).getAmount();
@@ -648,7 +648,7 @@ public class BattleArmorSuit extends Part {
 
     @Override
     public void postProcessCampaignAddition() {
-        if (!isReplacement && getChildParts().isEmpty()) {
+        if (!isReplacement && !hasChildParts()) {
             addSubParts();
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -781,7 +781,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         Part retVal = null;
         try {
             // Instantiate the correct child class, and call its parsing function.
-            retVal = (Part) Class.forName(className).newInstance();
+            retVal = (Part) Class.forName(className).getDeclaredConstructor().newInstance();
             retVal.loadFieldsFromXmlNode(wn);
 
             // Okay, now load Part-specific fields!
@@ -1841,7 +1841,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     public void fixReferences(Campaign campaign) {
         if (replacementPart instanceof PartRef) {
             int id = replacementPart.getId();
-            replacementPart = campaign.getPart(id);
+            replacementPart = campaign.getWarehouse().getPart(id);
             if ((replacementPart == null) && (id > 0)) {
                 MekHQ.getLogger().error(
                     String.format("Part %d ('%s') references missing replacement part %d",
@@ -1851,7 +1851,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
         if (parentPart instanceof PartRef) {
             int id = parentPart.getId();
-            parentPart = campaign.getPart(id);
+            parentPart = campaign.getWarehouse().getPart(id);
             if ((parentPart == null) && (id > 0)) {
                 MekHQ.getLogger().error(
                     String.format("Part %d ('%s') references missing parent part %d",
@@ -1862,7 +1862,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         for (int ii = childParts.size() - 1; ii >= 0; --ii) {
             Part childPart = childParts.get(ii);
             if (childPart instanceof PartRef) {
-                Part realPart = campaign.getPart(childPart.getId());
+                Part realPart = campaign.getWarehouse().getPart(childPart.getId());
                 if (realPart != null) {
                     childParts.set(ii, realPart);
                 } else if (childPart.getId() > 0) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1463,32 +1463,67 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     public abstract String getLocationName();
 
-    public void setParentPart(Part part) {
+    /**
+     * Sets the parent part.
+     * @param part The parent part.
+     */
+    public void setParentPart(@Nullable Part part) {
         parentPart = part;
     }
 
-    public Part getParentPart() {
+    /**
+     * Gets the parent part, or null if none exists.
+     */
+    public @Nullable Part getParentPart() {
         return parentPart;
     }
 
+    /**
+     * Gets a value indicating whether or not this part
+     * has a parent part.
+     */
     public boolean hasParentPart() {
         return parentPart != null;
     }
 
-    public ArrayList<Part> getChildParts() {
-        return childParts;
+    /**
+     * Gets a value indicating whether or not this part has child parts.
+     */
+    public boolean hasChildParts() {
+        return !childParts.isEmpty();
     }
 
-    public void addChildPart(Part child) {
-        childParts.add(child);
-        child.setParentPart(this);
+    /**
+     * Gets a list of child parts for this part.
+     */
+    public List<Part> getChildParts() {
+        return Collections.unmodifiableList(childParts);
     }
 
+    /**
+     * Adds a child part to this part.
+     * @param childPart The part to add as a child.
+     */
+    public void addChildPart(Part childPart) {
+        childParts.add(Objects.requireNonNull(childPart));
+        childPart.setParentPart(this);
+    }
+
+    /**
+     * Removes a child part from this part.
+     * @param childPart The child part to remove.
+     */
     public void removeChildPart(Part childPart) {
-        childPart.setParentPart(null);
-        childParts.remove(childPart);
+        Objects.requireNonNull(childPart);
+
+        if (childParts.remove(childPart)) {
+            childPart.setParentPart(null);
+        }
     }
 
+    /**
+     * Removes all child parts from this part.
+     */
     public void removeAllChildParts() {
         for (Part childPart : childParts) {
             childPart.setParentPart(null);

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -243,7 +243,7 @@ public class WarehouseTest {
         warehouse.addPart(mockParentPart);
 
         // Create child parts for the parent part
-        ArrayList<Part> mockChildParts = new ArrayList<>();
+        List<Part> mockChildParts = new ArrayList<>();
         mockChildParts.add(createMockPart(2));
         mockChildParts.add(createMockPart(3));
         when(mockParentPart.getChildParts()).thenReturn(mockChildParts);

--- a/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
@@ -21,14 +21,17 @@
 
 package mekhq.campaign.parts;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import megamek.common.Entity;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 
@@ -105,5 +108,170 @@ public class PartTest {
         assertNull(part.getRefitUnit());
         assertTrue(part.isReservedForReplacement());
         assertFalse(part.isSpare());
+    }
+
+    @Test
+    public void incrementQuantity() {
+        Part part = new MekLocation();
+
+        int quantity = part.getQuantity();
+
+        part.incrementQuantity();
+
+        assertEquals(quantity + 1, part.getQuantity());
+    }
+
+    @Test
+    public void decrementQuantity() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Part part = new MekLocation();
+        part.setCampaign(mockCampaign);
+
+        part.setQuantity(2);
+
+        // Setting the quantity specifically should work.
+        assertEquals(2, part.getQuantity());
+
+        part.decrementQuantity();
+
+        // Quantity should now be 1
+        assertEquals(1, part.getQuantity());
+
+        part.decrementQuantity();
+
+        // Quantity should now be 0...
+        assertEquals(0, part.getQuantity());
+
+        // ...which means we should have removed the part.
+        verify(mockCampaign, times(1)).removePart(eq(part));
+    }
+
+    @Test
+    public void decrementQuantityDoesNotGoNegative() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Part part = new MekLocation();
+        part.setCampaign(mockCampaign);
+
+        part.setQuantity(1);
+
+        part.decrementQuantity();
+
+        // Quantity should now be 0...
+        assertEquals(0, part.getQuantity());
+
+        part.decrementQuantity();
+
+        // Quantity should still be 0...
+        assertEquals(0, part.getQuantity());
+    }
+
+    @Test
+    public void decrementQuantityZeroRemovesChildParts() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Part part = new MekLocation();
+        part.setCampaign(mockCampaign);
+
+        Part childPart0 = mock(Part.class);
+        part.addChildPart(childPart0);
+
+        Part childPart1 = mock(Part.class);
+        part.addChildPart(childPart1);
+
+        part.setQuantity(1);
+
+        // Remove the part by decrementing its quantity to 0.
+        part.decrementQuantity();
+
+        ArgumentCaptor<Part> partCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(mockCampaign, times(3)).removePart(partCaptor.capture());
+
+        List<Part> removedParts = partCaptor.getAllValues();
+        assertTrue(removedParts.contains(childPart0));
+        assertTrue(removedParts.contains(childPart1));
+        assertTrue(removedParts.contains(part));
+    }
+
+    @Test
+    public void setQuantity() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Part part = new MekLocation();
+        part.setCampaign(mockCampaign);
+
+        part.setQuantity(10);
+
+        // Setting the quantity specifically should work.
+        assertEquals(10, part.getQuantity());
+
+        part.setQuantity(0);
+
+        // Quantity should now be 0...
+        assertEquals(0, part.getQuantity());
+
+        // ...which means we should have removed the part.
+        verify(mockCampaign, times(1)).removePart(eq(part));
+    }
+
+    @Test
+    public void setNegativeQuantity() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Part part = new MekLocation();
+        part.setCampaign(mockCampaign);
+
+        part.setQuantity(10);
+
+        // Setting the quantity specifically should work.
+        assertEquals(10, part.getQuantity());
+
+        part.setQuantity(-5);
+
+        // Quantity should be zero, even though we set a negative count.
+        assertEquals(0, part.getQuantity());
+
+        // ...which means we should have removed the part.
+        verify(mockCampaign, times(1)).removePart(eq(part));
+    }
+
+    @Test
+    public void setQuantityZeroRemovesChildParts() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Part part = new MekLocation();
+        part.setCampaign(mockCampaign);
+
+        Part childPart0 = mock(Part.class);
+        part.addChildPart(childPart0);
+
+        Part childPart1 = mock(Part.class);
+        part.addChildPart(childPart1);
+
+        // Remove the part by setting its quantity to 0.
+        part.setQuantity(0);
+
+        ArgumentCaptor<Part> partCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(mockCampaign, times(3)).removePart(partCaptor.capture());
+
+        List<Part> removedParts = partCaptor.getAllValues();
+        assertTrue(removedParts.contains(childPart0));
+        assertTrue(removedParts.contains(childPart1));
+        assertTrue(removedParts.contains(part));
+    }
+
+    @Test
+    public void daysToArrival() {
+        Part part = new MekLocation();
+
+        part.setDaysToArrival(5);
+
+        assertEquals(5, part.getDaysToArrival());
+
+        assertFalse(part.isPresent());
+
+        part.setDaysToArrival(0);
+
+        assertTrue(part.isPresent());
+
+        part.setDaysToArrival(-5);
+
+        assertEquals(0, part.getDaysToArrival());
+        assertTrue(part.isPresent());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
@@ -274,4 +274,66 @@ public class PartTest {
         assertEquals(0, part.getDaysToArrival());
         assertTrue(part.isPresent());
     }
+
+    @Test
+    public void childParts() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Part part = new MekLocation();
+        part.setCampaign(mockCampaign);
+
+        // Parts should start without child parts.
+        assertFalse(part.hasChildParts());
+        assertNotNull(part.getChildParts());
+        assertTrue(part.getChildParts().isEmpty());
+
+        // Add a child part
+        Part childPart0 = mock(Part.class);
+        part.addChildPart(childPart0);
+
+        assertTrue(part.hasChildParts());
+        assertNotNull(part.getChildParts());
+        assertEquals(1, part.getChildParts().size());
+        assertTrue(part.getChildParts().contains(childPart0));
+        verify(childPart0, times(1)).setParentPart(eq(part));
+
+        // Add a second child part
+        Part childPart1 = mock(Part.class);
+        part.addChildPart(childPart1);
+
+        assertTrue(part.hasChildParts());
+        assertNotNull(part.getChildParts());
+        assertEquals(2, part.getChildParts().size());
+        assertTrue(part.getChildParts().contains(childPart0));
+        assertTrue(part.getChildParts().contains(childPart1));
+        verify(childPart1, times(1)).setParentPart(eq(part));
+
+        // Remove a random part not associated with this part
+        Part randomPart = mock(Part.class);
+        part.removeChildPart(randomPart);
+
+        assertTrue(part.hasChildParts());
+        assertNotNull(part.getChildParts());
+        assertEquals(2, part.getChildParts().size());
+        assertTrue(part.getChildParts().contains(childPart0));
+        assertTrue(part.getChildParts().contains(childPart1));
+        verify(randomPart, times(0)).setParentPart(eq(null));
+
+        // Remove one of the actual child parts
+        part.removeChildPart(childPart1);
+
+        assertTrue(part.hasChildParts());
+        assertNotNull(part.getChildParts());
+        assertEquals(1, part.getChildParts().size());
+        assertTrue(part.getChildParts().contains(childPart0));
+        assertFalse(part.getChildParts().contains(childPart1));
+        verify(childPart1, times(1)).setParentPart(eq(null));
+
+        // Now remove al lthe remaining parts
+        part.removeAllChildParts();
+
+        assertFalse(part.hasChildParts());
+        assertNotNull(part.getChildParts());
+        assertTrue(part.getChildParts().isEmpty());
+        verify(childPart0, times(1)).setParentPart(eq(null));
+    }
 }


### PR DESCRIPTION
This cleans up various bits of Part logic that I noticed during my last few PRs. I targeted three areas:

1. Duplicative or erroneous events.
2. Correctness (e.g. removing the non-idempotent Part::checkArrival).
3. Ease of use / style (e.g. renaming arguments or refactoring method internals).

I added tests for most of the changes.