### PR TITLE
Issue #785 SLDF Ranks are Wrong

### DIFF
--- a/MekHQ/data/universe/ranks.xml
+++ b/MekHQ/data/universe/ranks.xml
@@ -109,7 +109,7 @@
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
-			<rankNames>-,-,-,-,-,-</rankNames>
+			<rankNames>Warrant Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- WO1 -->
@@ -164,12 +164,12 @@
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
-			<rankNames>Lieutenant JG,-,-,--MW,-,-</rankNames>
+			<rankNames>-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
-			<rankNames>Lieutenant SG,-,-,--MW,-,-</rankNames>
+			<rankNames>Lieutenant,-,-,--MW,-,-</rankNames>
 			<officer>true</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O3 -->
@@ -4917,6 +4917,265 @@
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O20 -->
+	</rankSystem>
+	<rankSystem>
+		<!-- Second Star League -->
+		<system>19</system>
+		<rank>
+			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E0 "None" -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E1 -->
+		<rank>
+			<rankNames>Recruit,-,-,Spaceman Recruit,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E2 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E3 -->
+		<rank>
+			<rankNames>Private,-,-,Spaceman,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E4 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E5 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E6 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E7 -->
+		<rank>
+			<rankNames>Corporal,-,-,Petty Officer,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E8 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E9 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E10 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E11 -->
+		<rank>
+			<rankNames>Sergeant,-,-,Chief Petty Officer,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E12 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E13 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E14 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E15 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E16 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E17 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E18 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E19 -->
+		<rank>
+			<rankNames>Master Sergeant,-,-,Master Chief PO,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- E20 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO1 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO2 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO3 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO4 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO5 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO6 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO7 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO8 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO9 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>false</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- WO10 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O1 -->
+		<rank>
+			<rankNames>Lieutenant JG,-,-,--MW,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O2 -->
+		<rank>
+			<rankNames>Lieutenant SG,-,-,--MW,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O3 -->
+		<rank>
+			<rankNames>Captain,-,-,Commander,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O4 -->
+		<rank>
+			<rankNames>Major,-,-,Captain,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O5 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O6 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O7 -->
+		<rank>
+			<rankNames>Colonel,-,-,Commodore,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O8 -->
+		<rank>
+			<rankNames>Lieutenant General,-,-,Rear Admiral,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O9 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O10 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O11 -->
+		<rank>
+			<rankNames>Major General,-,-,Vice Admiral,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O12 -->
+		<rank>
+			<rankNames>General,-,-,Admiral,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O13 -->
+		<rank>
+			<rankNames>Commanding General,-,-,Commanding Admiral,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O14 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O15 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O16 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O17 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O18 -->
+		<rank>
+			<rankNames>-,-,-,-,-,-</rankNames>
+			<officer>true</officer>
+			<payMultiplier>1.0</payMultiplier>
+		</rank> <!-- O19 -->
+		<rank>
+			<rankNames>Star Lord,-,-,--MW,-,-</rankNames>
 			<officer>true</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O20 -->

--- a/MekHQ/data/universe/ranks.xml
+++ b/MekHQ/data/universe/ranks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rankSystems>
 	<rankSystem>
-		<!-- Star League -->
+		<!-- Second Star League -->
 		<system>0</system>
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW</rankNames>
@@ -109,7 +109,7 @@
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
-			<rankNames>Warrant Officer,-,-,-,-,-</rankNames>
+			<rankNames>-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- WO1 -->
@@ -164,12 +164,12 @@
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
-			<rankNames>-,-,-,-,-,-</rankNames>
+			<rankNames>Lieutenant JG,-,-,--MW,-,-</rankNames>
 			<officer>true</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
-			<rankNames>Lieutenant,-,-,--MW,-,-</rankNames>
+			<rankNames>Lieutenant SG,-,-,--MW,-,-</rankNames>
 			<officer>true</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O3 -->
@@ -4922,7 +4922,7 @@
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
-		<!-- Second Star League -->
+		<!-- Star League -->
 		<system>19</system>
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW</rankNames>
@@ -5030,7 +5030,7 @@
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
-			<rankNames>-,-,-,-,-,-</rankNames>
+			<rankNames>Warrant Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- WO1 -->
@@ -5085,12 +5085,12 @@
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
-			<rankNames>Lieutenant JG,-,-,--MW,-,-</rankNames>
+			<rankNames>-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
-			<rankNames>Lieutenant SG,-,-,--MW,-,-</rankNames>
+			<rankNames>Lieutenant,-,-,--MW,-,-</rankNames>
 			<officer>true</officer>
 			<payMultiplier>1.0</payMultiplier>
 		</rank> <!-- O3 -->

--- a/MekHQ/data/universe/ranks.xml
+++ b/MekHQ/data/universe/ranks.xml
@@ -4922,7 +4922,7 @@
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
-		<!-- Star League -->
+		<!-- First Star League -->
 		<system>19</system>
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW</rankNames>

--- a/MekHQ/src/mekhq/campaign/personnel/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Ranks.java
@@ -72,7 +72,8 @@ public class Ranks {
     public static final int RS_OA		= 16;
     public static final int RS_FRR		= 17;
     public static final int RS_ARC      = 18;
-    public static final int RS_NUM		= 19;
+    public statis final int RS_SSL  = 19;
+    public static final int RS_NUM		= 20;
 
     public static final int[] translateFactions = { /* 0 */ 0, /* 1 */ 1, /* 2 */ 4, /* 3 */ 5, /* 4 */ 6, /* 5 */ 8, /* 6 */ 9, /* 7 */ 12 };
 
@@ -225,6 +226,8 @@ public class Ranks {
                 return "Free Rasalhague Republic";
             case RS_ARC:
                 return "Aurigan Coalition";
+            case RS_SSL:
+                return "Second Star League";
             default:
                 return "?";
         }

--- a/MekHQ/src/mekhq/campaign/personnel/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Ranks.java
@@ -53,7 +53,7 @@ import mekhq.gui.model.RankTableModel;
  */
 public class Ranks {
     // Rank Faction Codes
-    public static final int RS_SL		= 0;
+    public static final int RS_SSL		= 0;
     public static final int RS_FS		= 1;
     public static final int RS_FC		= 2;
     public static final int RS_LC		= 3;
@@ -72,7 +72,7 @@ public class Ranks {
     public static final int RS_OA		= 16;
     public static final int RS_FRR		= 17;
     public static final int RS_ARC      = 18;
-    public statis final int RS_SSL  = 19;
+    public static final int RS_SL  = 19;
     public static final int RS_NUM		= 20;
 
     public static final int[] translateFactions = { /* 0 */ 0, /* 1 */ 1, /* 2 */ 4, /* 3 */ 5, /* 4 */ 6, /* 5 */ 8, /* 6 */ 9, /* 7 */ 12 };
@@ -190,8 +190,8 @@ public class Ranks {
         switch (system) {
             case RS_CUSTOM:
                 return "Custom";
-            case RS_SL:
-                return "Star League";
+            case RS_SSL:
+                return "Second Star League";
             case RS_FS:
                 return "Federated Suns";
             case RS_FC:
@@ -226,8 +226,8 @@ public class Ranks {
                 return "Free Rasalhague Republic";
             case RS_ARC:
                 return "Aurigan Coalition";
-            case RS_SSL:
-                return "Second Star League";
+            case RS_SL:
+                return "Star League";
             default:
                 return "?";
         }

--- a/MekHQ/src/mekhq/campaign/personnel/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Ranks.java
@@ -53,7 +53,7 @@ import mekhq.gui.model.RankTableModel;
  */
 public class Ranks {
     // Rank Faction Codes
-    public static final int RS_SSL		= 0;
+    public static final int RS_SL		= 0;
     public static final int RS_FS		= 1;
     public static final int RS_FC		= 2;
     public static final int RS_LC		= 3;
@@ -72,7 +72,7 @@ public class Ranks {
     public static final int RS_OA		= 16;
     public static final int RS_FRR		= 17;
     public static final int RS_ARC      = 18;
-    public static final int RS_SL  = 19;
+    public static final int RS_FSL  = 19;
     public static final int RS_NUM		= 20;
 
     public static final int[] translateFactions = { /* 0 */ 0, /* 1 */ 1, /* 2 */ 4, /* 3 */ 5, /* 4 */ 6, /* 5 */ 8, /* 6 */ 9, /* 7 */ 12 };
@@ -190,7 +190,7 @@ public class Ranks {
         switch (system) {
             case RS_CUSTOM:
                 return "Custom";
-            case RS_SSL:
+            case RS_SL:
                 return "Second Star League";
             case RS_FS:
                 return "Federated Suns";
@@ -226,8 +226,8 @@ public class Ranks {
                 return "Free Rasalhague Republic";
             case RS_ARC:
                 return "Aurigan Coalition";
-            case RS_SL:
-                return "Star League";
+            case RS_FSL:
+                return "First Star League";
             default:
                 return "?";
         }


### PR DESCRIPTION
Fixes #785. Adds 2nd Star League rank set, edits default Star League rank set to remove two lieutenants, add warrant, per FM: SLDF