### PR TITLE
564: AbstractIcon: Fixing Basic Info Portrait Scaling

### DIFF
--- a/MekHQ/src/mekhq/gui/BasicInfo.java
+++ b/MekHQ/src/mekhq/gui/BasicInfo.java
@@ -35,7 +35,6 @@ import javax.swing.border.LineBorder;
 import megamek.client.ui.swing.tileset.EntityImage;
 import megamek.client.ui.swing.util.PlayerColors;
 import megamek.common.icons.AbstractIcon;
-import megamek.common.icons.Portrait;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
@@ -158,38 +157,7 @@ public class BasicInfo extends JPanel {
     }
 
     protected void setPortrait(Person p) {
-        String category = p.getPortraitCategory();
-        String filename = p.getPortraitFileName();
-
-        // Return a null if the player has selected no portrait file.
-        if ((null == category) || (null == filename)) {
-            return;
-        }
-
-        if (AbstractIcon.ROOT_CATEGORY.equals(category)) {
-            category = "";
-        }
-
-        if (AbstractIcon.DEFAULT_ICON_FILENAME.equals(filename)) {
-            filename = Portrait.DEFAULT_PORTRAIT_FILENAME;
-        }
-
-        // Try to get the player's portrait file.
-        Image portrait;
-        try {
-            portrait = (Image) MHQStaticDirectoryManager.getPortraits().getItem(category, filename);
-            if (portrait == null) {
-                // the image could not be found so switch to default one
-                portrait = (Image) MHQStaticDirectoryManager.getPortraits().getItem("", Portrait.DEFAULT_PORTRAIT_FILENAME);
-            }
-            // make sure no images are longer than 72 pixels
-            if (null != portrait) {
-                portrait = portrait.getScaledInstance(-1, 58, Image.SCALE_SMOOTH);
-                setImage(portrait);
-            }
-        } catch (Exception e) {
-            MekHQ.getLogger().error(e);
-        }
+        setImage(p.getPortrait().getImage(54));
     }
 
     protected Image getImageFor(Force force) {

--- a/MekHQ/src/mekhq/gui/BasicInfo.java
+++ b/MekHQ/src/mekhq/gui/BasicInfo.java
@@ -22,8 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Image;
 import java.awt.Insets;
-import java.util.LinkedHashMap;
-import java.util.Vector;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -34,7 +32,6 @@ import javax.swing.border.LineBorder;
 
 import megamek.client.ui.swing.tileset.EntityImage;
 import megamek.client.ui.swing.util.PlayerColors;
-import megamek.common.icons.AbstractIcon;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
@@ -161,35 +158,12 @@ public class BasicInfo extends JPanel {
     }
 
     protected Image getImageFor(Force force) {
-        String category = force.getIconCategory();
-        String filename = force.getIconFileName();
-        LinkedHashMap<String, Vector<String>> iconMap = force.getIconMap();
-
-        if (AbstractIcon.ROOT_CATEGORY.equals(category)) {
-            category = "";
-        }
-
-        // Return a null if the player has selected no portrait file.
-        if ((null == category) || (null == filename)
-                || (AbstractIcon.DEFAULT_ICON_FILENAME.equals(filename) && !Force.ROOT_LAYERED.equals(category))) {
-            filename = "empty.png";
-        }
-
-        // Try to get the player's portrait file.
-        Image portrait;
         try {
-            portrait = MHQStaticDirectoryManager.buildForceIcon(category, filename, iconMap);
-            if (null != portrait) {
-                portrait = portrait.getScaledInstance(58, -1, Image.SCALE_SMOOTH);
-            } else {
-                portrait = (Image) MHQStaticDirectoryManager.getForceIcons().getItem("", "empty.png");
-                if (null != portrait) {
-                    portrait = portrait.getScaledInstance(58, -1, Image.SCALE_SMOOTH);
-                }
-            }
-            return portrait;
+            return MHQStaticDirectoryManager.buildForceIcon(force.getIconCategory(),
+                    force.getIconFileName(), force.getIconMap())
+                    .getScaledInstance(54, -1, Image.SCALE_SMOOTH);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            MekHQ.getLogger().error("Failed to build force icon", e);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/gui/model/CrewListModel.java
+++ b/MekHQ/src/mekhq/gui/model/CrewListModel.java
@@ -1,5 +1,20 @@
-/**
+/*
+ * Copyright (c) 2020 - The MegaMek Team. All Rights Reserved.
  *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.gui.model;
 
@@ -114,39 +129,29 @@ public class CrewListModel extends AbstractListModel<Person> {
         }
 
         @Override
-        public Component getListCellRendererComponent(JList<? extends Person> list, Person value, int index,
-                boolean isSelected, boolean cellHasFocus) {
+        public Component getListCellRendererComponent(JList<? extends Person> list, Person value,
+                                                      int index, boolean isSelected, boolean cellHasFocus) {
             Component c = this;
             setOpaque(true);
-            Person p = (Person)getElementAt(index);
-            StringBuilder sb = new StringBuilder("<html><font size='2'><b>")
-                    .append(p.getFullTitle())
-                    .append("</b><br/>")
-                    .append(CrewRole.getCrewRole(p, unit).getDisplayName())
-                    .append(" (");
+            Person p = getElementAt(index);
             String gunSkill = SkillType.getGunnerySkillFor(unit.getEntity());
             String driveSkill = SkillType.getDrivingSkillFor(unit.getEntity());
-            if (p.hasSkill(gunSkill)) {
-                sb.append(p.getSkill(gunSkill).getFinalSkillValue());
-            } else {
-                sb.append("-");
-            }
-            sb.append("/");
-            if (p.hasSkill(driveSkill)) {
-                sb.append(p.getSkill(driveSkill).getFinalSkillValue());
-            } else {
-                sb.append("-");
-            }
-            sb.append(")</font></html>");
-            setHtmlText(sb.toString());
+            String sb = "<html><font size='2'><b>" + p.getFullTitle() + "</b><br/>"
+                    + CrewRole.getCrewRole(p, unit).getDisplayName()
+                    + " ("
+                    + (p.hasSkill(gunSkill) ? p.getSkill(gunSkill).getFinalSkillValue() : "-")
+                    + "/"
+                    + (p.hasSkill(driveSkill) ? p.getSkill(driveSkill).getFinalSkillValue() : "-")
+                    + ")</font></html>";
+            setHtmlText(sb);
             if (isSelected) {
                 highlightBorder();
             } else {
                 unhighlightBorder();
             }
+
             setPortrait(p);
             return c;
         }
     }
-
 }


### PR DESCRIPTION
This fixes #564 by fixing the scaling size, namely changing it to be 54 instead of 58. Further, I swapped Basic Info to use AbstractIcon for portraits and cleaned up the Force icon code in this location as part of the continuing AbstractIcon changes.

The changes to CrewListModel are included in the first commit by accident. They were part of a version that I determined was not ready to be used. However, they do clean up the code and would be otherwise included in the near future, so I'm opening this with them.