### PR TITLE
Switch to AmmoType when more specific type is available

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -1203,7 +1203,7 @@ public class Utilities {
                                 bin.updateConditionFromPart();
                                 // Unload bin before munition change
                                 bin.unload();
-                                bin.changeMunition(m.getType());
+                                bin.changeMunition((AmmoType) m.getType());
                                 found = true;
                                 break;
                             }

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -197,9 +197,9 @@ public class PartsStore implements Serializable {
                         //because presumably this is happening because KgperShot is -1 or 0
                         shots = 20;
                     }
-                    parts.add(new AmmoStorage(0, et, shots, c));
+                    parts.add(new AmmoStorage(0,(AmmoType) et, shots, c));
                 } else {
-                    parts.add(new AmmoStorage(0, et, ((AmmoType)et).getShots(), c));
+                    parts.add(new AmmoStorage(0, (AmmoType) et, ((AmmoType) et).getShots(), c));
                 }
             } else if(et instanceof MiscType && (((MiscType)et).hasFlag(MiscType.F_HEAT_SINK) || ((MiscType)et).hasFlag(MiscType.F_DOUBLE_HEAT_SINK))) {
                 Part p = new HeatSink(0, et, -1, false, c);

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -197,7 +197,7 @@ public class PartsStore implements Serializable {
                         //because presumably this is happening because KgperShot is -1 or 0
                         shots = 20;
                     }
-                    parts.add(new AmmoStorage(0,(AmmoType) et, shots, c));
+                    parts.add(new AmmoStorage(0, (AmmoType) et, shots, c));
                 } else {
                     parts.add(new AmmoStorage(0, (AmmoType) et, ((AmmoType) et).getShots(), c));
                 }

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -29,10 +29,10 @@ import org.w3c.dom.NodeList;
 
 import megamek.common.AmmoType;
 import megamek.common.BombType;
-import megamek.common.EquipmentType;
 import megamek.common.ITechnology;
 import megamek.common.TargetRoll;
 import megamek.common.TechAdvancement;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.equipment.EquipmentPart;
@@ -55,10 +55,12 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     	this(0, null, 0, null);
     }
 
-    public AmmoStorage(int tonnage, AmmoType et, int shots, Campaign c) {
+    public AmmoStorage(int tonnage, @Nullable AmmoType et, int shots, @Nullable Campaign c) {
         super(tonnage, et, -1, 1.0, c);
         this.shots = shots;
-        this.munition = et.getMunitionType();
+        if (et != null) {
+            this.munition = et.getMunitionType();
+        }
     }
 
     public AmmoStorage clone() {

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -55,10 +55,10 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     	this(0, null, 0, null);
     }
 
-    public AmmoStorage(int tonnage, EquipmentType et, int shots, Campaign c) {
+    public AmmoStorage(int tonnage, AmmoType et, int shots, Campaign c) {
         super(tonnage, et, -1, 1.0, c);
         this.shots = shots;
-        this.munition = getType().getMunitionType();
+        this.munition = et.getMunitionType();
     }
 
     public AmmoStorage clone() {

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -19,7 +19,9 @@
 package mekhq.campaign.parts;
 
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.weapons.infantry.InfantryWeapon;
+import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -27,12 +29,15 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.PrintWriter;
+import java.util.Objects;
 
 /**
  * Storage for infantry weapon ammo. The AmmoType is a placeholder and distinguishes between
  * standard and inferno munitions, but does not distinguish the type of weapon.
  */
 public class InfantryAmmoStorage extends AmmoStorage {
+
+    private static final long serialVersionUID = 930316771091252049L;
 
     private InfantryWeapon weaponType;
 
@@ -41,8 +46,8 @@ public class InfantryAmmoStorage extends AmmoStorage {
         this(0, null, 0, null, null);
     }
 
-    public InfantryAmmoStorage(int tonnage, AmmoType et, int shots,
-                               InfantryWeapon weaponType, Campaign c) {
+    public InfantryAmmoStorage(int tonnage, @Nullable AmmoType et, int shots,
+            @Nullable InfantryWeapon weaponType, @Nullable Campaign c) {
         super(tonnage, et, shots, c);
         this.weaponType = weaponType;
     }
@@ -56,6 +61,8 @@ public class InfantryAmmoStorage extends AmmoStorage {
             } else {
                 this.name = weaponType.getShortName() + " Ammo";
             }
+        } else {
+            MekHQ.getLogger().error("InfantryAmmoStorage does not have a weapon type!");
         }
     }
 
@@ -92,8 +99,8 @@ public class InfantryAmmoStorage extends AmmoStorage {
     @Override
     public boolean isSamePartType(Part part) {
         return (part instanceof InfantryAmmoStorage)
-                && (getType() == ((InfantryAmmoStorage) part).getType())
-                && (getWeaponType() == ((InfantryAmmoStorage) part).getWeaponType());
+                && Objects.equals(getType(), ((InfantryAmmoStorage) part).getType())
+                && Objects.equals(getWeaponType(), ((InfantryAmmoStorage) part).getWeaponType());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -41,7 +41,7 @@ public class InfantryAmmoStorage extends AmmoStorage {
         this(0, null, 0, null, null);
     }
 
-    public InfantryAmmoStorage(int tonnage, EquipmentType et, int shots,
+    public InfantryAmmoStorage(int tonnage, AmmoType et, int shots,
                                InfantryWeapon weaponType, Campaign c) {
         super(tonnage, et, shots, c);
         this.weaponType = weaponType;
@@ -151,7 +151,7 @@ public class InfantryAmmoStorage extends AmmoStorage {
     }
 
     public Part getNewPart() {
-        return new InfantryAmmoStorage(1, type, weaponType.getShots(),
+        return new InfantryAmmoStorage(1, getType(), weaponType.getShots(),
                 weaponType, campaign);
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -602,7 +602,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             if (!(part instanceof AmmoStorage) || !part.isPresent() || part.isReservedForRefit()) {
                 return false;
             }
-            AmmoType ammoType = ((AmmoStorage)part).getType();
+            AmmoType ammoType = ((AmmoStorage) part).getType();
             return ammoType.equals(curType)
                 && (curType.getMunitionType() == ammoType.getMunitionType());
         });

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -42,6 +42,7 @@ import megamek.common.Protomech;
 import megamek.common.SmallCraft;
 import megamek.common.TargetRoll;
 import megamek.common.TechAdvancement;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
@@ -77,13 +78,15 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         this(0, null, -1, 0, false, false, null);
     }
 
-    public AmmoBin(int tonnage, AmmoType et, int equipNum, int shots, boolean singleShot,
-            boolean omniPodded, Campaign c) {
+    public AmmoBin(int tonnage, @Nullable AmmoType et, int equipNum, int shots, boolean singleShot,
+            boolean omniPodded, @Nullable Campaign c) {
         super(tonnage, et, equipNum, 1.0, omniPodded, c);
         this.shotsNeeded = shots;
         this.oneShot = singleShot;
         this.checkedToday = false;
-        this.munition = et.getMunitionType();
+        if (et != null) {
+            this.munition = et.getMunitionType();
+        }
         if(null != name) {
             this.name += " Bin";
         }
@@ -341,7 +344,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                     shotsNeeded -= shots;
                 }
                 else {
-                    MekHQ.getLogger().warning(AmmoBin.class, mType.getName() + " is not valid equipment for " + getName() + " to restock ammo on unit " + unit.getName());
+                    MekHQ.getLogger().warning(mType.getName() + " is not valid equipment for " + getName() + " to restock ammo on unit " + unit.getName());
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -24,6 +24,7 @@ package mekhq.campaign.parts.equipment;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import mekhq.campaign.finances.Money;
@@ -76,15 +77,13 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         this(0, null, -1, 0, false, false, null);
     }
 
-    public AmmoBin(int tonnage, EquipmentType et, int equipNum, int shots, boolean singleShot,
+    public AmmoBin(int tonnage, AmmoType et, int equipNum, int shots, boolean singleShot,
             boolean omniPodded, Campaign c) {
         super(tonnage, et, equipNum, 1.0, omniPodded, c);
         this.shotsNeeded = shots;
         this.oneShot = singleShot;
         this.checkedToday = false;
-        if(type instanceof AmmoType) {
-            this.munition = ((AmmoType)type).getMunitionType();
-        }
+        this.munition = et.getMunitionType();
         if(null != name) {
             this.name += " Bin";
         }
@@ -97,6 +96,11 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         clone.shotsNeeded = this.shotsNeeded;
         clone.munition = this.munition;
         return clone;
+    }
+
+    @Override
+    public AmmoType getType() {
+        return (AmmoType) super.getType();
     }
 
     /* Per TM, ammo for fighters is stored in the fuselage. This makes a difference for omnifighter
@@ -213,21 +217,18 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         updateConditionFromEntity(false);
     }
 
-    public void changeMunition(EquipmentType type) {
-        if (type instanceof AmmoType) {
-            munition = ((AmmoType) type).getMunitionType();
-            this.type = type;
-            this.name = type.getName();
-            this.typeName = type.getInternalName();
-            updateConditionFromEntity(false);
-        }
+    public void changeMunition(AmmoType type) {
+        munition = type.getMunitionType();
+        this.type = type;
+        this.name = type.getName();
+        this.typeName = type.getInternalName();
+        updateConditionFromEntity(false);
     }
 
     private boolean ammoTypeChanged() {
         if (null != unit) {
             Mounted m = unit.getEntity().getEquipment(equipmentNum);
-            return (m == null)
-                    || (m.getType() != type);
+            return (m == null) || !Objects.equals(m.getType(), getType());
         }
         return false;
     }
@@ -367,10 +368,10 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         //may want to think about not having refits load ammo bins but rather reserve
         //some AmmoStorage instead if we implement customization of these units
         int shots = getFullShots() - shotsNeeded;
-        AmmoType curType = (AmmoType)type;
+        AmmoType curType = getType();
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted && mounted.getType() instanceof AmmoType) {
+            if ((null != mounted) && (mounted.getType() instanceof AmmoType)) {
                 shots = mounted.getBaseShotsLeft();
                 mounted.setShotsLeft(0);
                 curType = (AmmoType)mounted.getType();
@@ -392,7 +393,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public MissingPart getMissingPart() {
-        return new MissingAmmoBin(getUnitTonnage(), type, equipmentNum, oneShot, omniPodded, campaign);
+        return new MissingAmmoBin(getUnitTonnage(), getType(), equipmentNum, oneShot, omniPodded, campaign);
     }
 
     public boolean isOneShot() {
@@ -411,13 +412,14 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     public void updateConditionFromEntity(boolean checkForDestruction) {
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                if(mounted.isMissing() || mounted.isDestroyed()) {
+            if (null != mounted) {
+                if (mounted.isMissing() || mounted.isDestroyed()) {
                     mounted.setShotsLeft(0);
                     remove(false);
                     return;
                 }
-                if (type == mounted.getType()) {
+
+                if (Objects.equals(getType(), mounted.getType())) {
                     shotsNeeded = getFullShots() - mounted.getBaseShotsLeft();
                 }
             }
@@ -530,7 +532,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 availability = "<br><font color='green'>" + shotsAvailable + " available " + orderTransitString + "</font>";
             }
 
-            return type.getDesc() + ", " + getShotsNeeded() + " shots needed" + availability;
+            return getType().getDesc() + ", " + getShotsNeeded() + " shots needed" + availability;
         } else {
             return "";
         }
@@ -550,7 +552,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     public static void swapAmmoFromCompatible(Campaign campaign, int needed, AmmoStorage as) {
         AmmoStorage a;
         AmmoType aType;
-        AmmoType curType = (AmmoType)as.getType();
+        AmmoType curType = as.getType();
         int converted = 0;
 
         // TODO: make this less intensive.
@@ -560,7 +562,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             }
             if(part instanceof AmmoStorage) {
                 a = (AmmoStorage)part;
-                aType = ((AmmoType)a.getType());
+                aType = a.getType();
                 if (a.isSamePartType(as)) {
                     continue;
                 }
@@ -597,13 +599,13 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             if (!(part instanceof AmmoStorage) || !part.isPresent() || part.isReservedForRefit()) {
                 return false;
             }
-            AmmoType ammoType = (AmmoType)((AmmoStorage)part).getType();
+            AmmoType ammoType = ((AmmoStorage)part).getType();
             return ammoType.equals(curType)
-                && curType.getMunitionType() == ammoType.getMunitionType();
+                && (curType.getMunitionType() == ammoType.getMunitionType());
         });
 
         if (null != a) {
-            AmmoType aType = (AmmoType)a.getType();
+            AmmoType aType = a.getType();
             if (amount < 0 && campaign.getCampaignOptions().useAmmoByType()
                 && a.getShots() < Math.abs(amount)) {
                 swapAmmoFromCompatible(campaign, Math.abs(amount) * aType.getRackSize(), a);
@@ -617,7 +619,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         } else if (amount < 0
                 && campaign.getCampaignOptions().useAmmoByType()
                 && AmmoBin.ALLOWED_BY_TYPE.contains(curType.getAmmoType())) {
-            campaign.getQuartermaster().addPart(new AmmoStorage(1, curType ,0, campaign), 0);
+            campaign.getQuartermaster().addPart(new AmmoStorage(1, curType, 0, campaign), 0);
             changeAmountAvailable(campaign, amount, curType);
         }
     }
@@ -694,7 +696,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     public int getAmountAvailable() {
-        return getAmountAvailable(campaign, (AmmoType) getType());
+        return getAmountAvailable(campaign, getType());
     }
 
     public static int getAmountAvailable(Campaign campaign, AmmoType ammoType) {
@@ -704,13 +706,13 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 predicate = part -> {
                     return part instanceof AmmoStorage
                             && ammoType.equalsAmmoTypeOnly(((AmmoStorage) part).getType())
-                            && ammoType.getMunitionType() == ((AmmoType) ((AmmoStorage) part).getType()).getMunitionType();
+                            && ammoType.getMunitionType() == ((AmmoStorage) part).getType().getMunitionType();
                 };
             } else {
                 predicate = part -> {
                     return part instanceof AmmoStorage
                             && ammoType.equals(((AmmoStorage) part).getType())
-                            && ammoType.getMunitionType() == ((AmmoType) ((AmmoStorage) part).getType()).getMunitionType();
+                            && ammoType.getMunitionType() == ((AmmoStorage) part).getType().getMunitionType();
                 };
             }
             AmmoStorage a = (AmmoStorage) campaign.getWarehouse().findSparePart(predicate);
@@ -721,7 +723,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                            .filter(part -> part instanceof AmmoStorage && part.isPresent())
                            .mapToInt(part -> {
                                AmmoStorage a = (AmmoStorage)part;
-                               AmmoType aType = (AmmoType)a.getType();
+                               AmmoType aType = a.getType();
                                if (aType.equals(ammoType) && (ammoType.getMunitionType() == aType.getMunitionType())) {
                                    return a.getShots();
                                } else if (isCompatibleAmmo(campaign, aType, ammoType) && (ammoType.getRackSize() != 0)) {
@@ -753,12 +755,12 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public String getAcquisitionDisplayName() {
-        return type.getDesc();
+        return getType().getDesc();
     }
 
     @Override
     public String getAcquisitionExtraDesc() {
-        return ((AmmoType)type).getShots() + " shots (1 ton)";
+        return getType().getShots() + " shots (1 ton)";
     }
 
     @Override
@@ -778,7 +780,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public String getAcquisitionName() {
-        return type.getDesc();
+        return getType().getDesc();
     }
 
     @Override
@@ -804,7 +806,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     public Part getNewPart() {
-        return new AmmoStorage(1,type,((AmmoType)type).getShots(),campaign);
+        return new AmmoStorage(1, getType(), getType().getShots(), campaign);
     }
 
     @Override
@@ -847,7 +849,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public TechAdvancement getTechAdvancement() {
-        return type.getTechAdvancement();
+        return getType().getTechAdvancement();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -12,11 +12,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package mekhq.campaign.parts.equipment;
@@ -78,21 +78,21 @@ public class BattleArmorAmmoBin extends AmmoBin {
 
     /*@Override
     public int getFullShots() {
-    	return super.getFullShots() * getNumTroopers();
+        return super.getFullShots() * getNumTroopers();
     }*/
 
     @Override
     protected int getCurrentShots() {
-    	int shots = getFullShots() * getNumTroopers() - shotsNeeded;
-    	//replace with actual entity values if entity not null because the previous number will not
-    	//be correct for ammo swaps
-    	if(null != unit && null != unit.getEntity()) {
-    		Mounted m = unit.getEntity().getEquipment(equipmentNum);
-    		if(null != m) {
-    			shots = m.getBaseShotsLeft() * getNumTroopers();
-    		}
-    	}
-    	return shots;
+        int shots = getFullShots() * getNumTroopers() - shotsNeeded;
+        //replace with actual entity values if entity not null because the previous number will not
+        //be correct for ammo swaps
+        if(null != unit && null != unit.getEntity()) {
+            Mounted m = unit.getEntity().getEquipment(equipmentNum);
+            if(null != m) {
+                shots = m.getBaseShotsLeft() * getNumTroopers();
+            }
+        }
+        return shots;
     }
 
     @Override
@@ -100,11 +100,11 @@ public class BattleArmorAmmoBin extends AmmoBin {
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if(null != mounted) {
-            	long currentMuniType = 0;
-				if(mounted.getType() instanceof AmmoType) {
-					currentMuniType = ((AmmoType)mounted.getType()).getMunitionType();
-				}
-				if(currentMuniType == getMunitionType()) {
+                long currentMuniType = 0;
+                if(mounted.getType() instanceof AmmoType) {
+                    currentMuniType = ((AmmoType)mounted.getType()).getMunitionType();
+                }
+                if(currentMuniType == getMunitionType()) {
                     shotsNeeded = (getFullShots() - mounted.getBaseShotsLeft()) * getNumTroopers();
                 } else {
                     //we have a change of munitions
@@ -115,22 +115,22 @@ public class BattleArmorAmmoBin extends AmmoBin {
     }
 
     @Override
-	public int getBaseTime() {
-		if(null != unit) {
-			Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-			if(null != mounted) {
-				if (!getType().equals(mounted.getType())) {
-					return 30;
-				}
-			}
-		}
-		return 15;
-	}
+    public int getBaseTime() {
+        if(null != unit) {
+            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
+            if(null != mounted) {
+                if (!getType().equals(mounted.getType())) {
+                    return 30;
+                }
+            }
+        }
+        return 15;
+    }
 
-	@Override
-	public int getDifficulty() {
-		return 0;
-	}
+    @Override
+    public int getDifficulty() {
+        return 0;
+    }
 
     @Override
     public void updateConditionFromPart() {
@@ -154,8 +154,8 @@ public class BattleArmorAmmoBin extends AmmoBin {
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if(null != mounted) {
-            	if (mounted.getType().equals(getType())
-						&& ((AmmoType)mounted.getType()).getMunitionType() == getMunitionType()) {
+                if (mounted.getType().equals(getType())
+                        && ((AmmoType)mounted.getType()).getMunitionType() == getMunitionType()) {
                     //just a simple reload
                     mounted.setShotsLeft(mounted.getBaseShotsLeft() + shotsPerTrooper);
                 } else {
@@ -191,11 +191,11 @@ public class BattleArmorAmmoBin extends AmmoBin {
 
     @Override
     public String checkFixable() {
-    	int amountAvailable = getAmountAvailable();
-    	if(amountAvailable > 0 && amountAvailable < getNumTroopers()) {
-    		return "Cannot do a partial reload of Battle Armor ammo less than the number of troopers";
-    	}
-    	return super.checkFixable();
+        int amountAvailable = getAmountAvailable();
+        if(amountAvailable > 0 && amountAvailable < getNumTroopers()) {
+            return "Cannot do a partial reload of Battle Armor ammo less than the number of troopers";
+        }
+        return super.checkFixable();
 
     }
 
@@ -206,23 +206,23 @@ public class BattleArmorAmmoBin extends AmmoBin {
 
     @Override
     public Part getNewPart() {
-    	int shots = (int) Math.floor(1000 / getType().getKgPerShot());
-		if (shots <= 0) {
-			//FIXME: no idea what to do here, these really should be fixed on the MM side
-			//because presumably this is happening because KgperShot is -1 or 0
-			shots = 20;
-		}
+        int shots = (int) Math.floor(1000 / getType().getKgPerShot());
+        if (shots <= 0) {
+            //FIXME: no idea what to do here, these really should be fixed on the MM side
+            //because presumably this is happening because KgperShot is -1 or 0
+            shots = 20;
+        }
         return new AmmoStorage(1, getType(), shots, campaign);
     }
 
     @Override
     public IAcquisitionWork getAcquisitionWork() {
-    	int shots = (int) Math.floor(1000 / getType().getKgPerShot());
-		if(shots <= 0) {
-			//FIXME: no idea what to do here, these really should be fixed on the MM side
-			//because presumably this is happening because KgperShot is -1 or 0
-			shots = 20;
-		}
+        int shots = (int) Math.floor(1000 / getType().getKgPerShot());
+        if(shots <= 0) {
+            //FIXME: no idea what to do here, these really should be fixed on the MM side
+            //because presumably this is happening because KgperShot is -1 or 0
+            shots = 20;
+        }
         return new AmmoStorage(1, getType(), shots, campaign);
     }
 
@@ -242,26 +242,26 @@ public class BattleArmorAmmoBin extends AmmoBin {
 
     @Override
     public String getAcquisitionDisplayName() {
-    	return type.getDesc();
+        return type.getDesc();
     }
 
     private int calculateShots() {
         int shots = (int) Math.floor(1000 / getType().getKgPerShot());
-		if (shots <= 0) {
-			//FIXME: no idea what to do here, these really should be fixed on the MM side
-			//because presumably this is happening because KgperShot is -1 or 0
-			shots = 20;
-		}
+        if (shots <= 0) {
+            //FIXME: no idea what to do here, these really should be fixed on the MM side
+            //because presumably this is happening because KgperShot is -1 or 0
+            shots = 20;
+        }
 
-		return shots;
+        return shots;
     }
 
-	@Override
-	public String getAcquisitionExtraDesc() {
-		return calculateShots() + " shots";
-	}
+    @Override
+    public String getAcquisitionExtraDesc() {
+        return calculateShots() + " shots";
+    }
 
-	@Override
+    @Override
     public String getAcquisitionBonus() {
         String bonus = getAllAcquisitionMods().getValueAsString();
         if(getAllAcquisitionMods().getValue() > -1) {
@@ -271,25 +271,25 @@ public class BattleArmorAmmoBin extends AmmoBin {
         return "(" + bonus + ")";
     }
 
-	@Override
-	public Part getAcquisitionPart() {
-		return getNewPart();
-	}
+    @Override
+    public Part getAcquisitionPart() {
+        return getNewPart();
+    }
 
     public boolean needsMaintenance() {
         return false;
     }
 
     public boolean canNeverScrap() {
-    	return true;
-	}
+        return true;
+    }
 
     /**
      * Restores the equipment from the name
      */
     public void restore() {
         if (typeName == null) {
-        	typeName = getType().getName();
+            typeName = getType().getName();
         } else {
             type = (AmmoType) EquipmentType.get(typeName);
         }
@@ -301,12 +301,12 @@ public class BattleArmorAmmoBin extends AmmoBin {
         //ammo but we can only do this if we have all the correct ammo rack sizes for the
         //generics (e.g. LRM1, LRM2, LRM3, etc)
         /*if(typeName.contains("BA-")) {
-        	String newTypeName = "IS" + typeName.split("BA-")[1];
-        	EquipmentType newType = EquipmentType.get(newTypeName);
-        	if(null != newType) {
-        		typeName = newTypeName;
-        		type = newType;
-        	}
+            String newTypeName = "IS" + typeName.split("BA-")[1];
+            EquipmentType newType = EquipmentType.get(newTypeName);
+            if(null != newType) {
+                typeName = newTypeName;
+                type = newType;
+            }
         }*/
 
 
@@ -315,7 +315,7 @@ public class BattleArmorAmmoBin extends AmmoBin {
             return;
         }
         try {
-        	equipTonnage = type.getTonnage(null);
+            equipTonnage = type.getTonnage(null);
         } catch(NullPointerException ex) {
             MekHQ.getLogger().error(ex);
         }
@@ -323,6 +323,6 @@ public class BattleArmorAmmoBin extends AmmoBin {
 
     @Override
     public int getMassRepairOptionType() {
-    	return Part.REPAIR_PART_TYPE.AMMO;
+        return Part.REPAIR_PART_TYPE.AMMO;
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -53,7 +53,7 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
         this(0, null, -1, 0, false, null);
     }
 
-    public BattleArmorAmmoBin(int tonnage, EquipmentType et, int equipNum, int shots, boolean singleShot, Campaign c) {
+    public BattleArmorAmmoBin(int tonnage, AmmoType et, int equipNum, int shots, boolean singleShot, Campaign c) {
         super(tonnage, et, equipNum, shots, singleShot, false, c);
     }
 
@@ -117,7 +117,7 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
 		if(null != unit) {
 			Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
 			if(null != mounted) {
-				if(!type.equals(mounted.getType())) {
+				if (!getType().equals(mounted.getType())) {
 					return 30;
 				}
 			}
@@ -152,36 +152,37 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
         if(null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
             if(null != mounted) {
-            	if(mounted.getType().equals(type)
+            	if (mounted.getType().equals(getType())
 						&& ((AmmoType)mounted.getType()).getMunitionType() == getMunitionType()) {
                     //just a simple reload
                     mounted.setShotsLeft(mounted.getBaseShotsLeft() + shotsPerTrooper);
                 } else {
                     //loading a new type of ammo
                     unload();
-                    mounted.changeAmmoType((AmmoType)type);
+                    mounted.changeAmmoType(getType());
                     mounted.setShotsLeft(shotsPerTrooper);
                 }
             }
         }
-        changeAmountAvailable(-1 * shots, (AmmoType)type);
+        changeAmountAvailable(-1 * shots, getType());
         shotsNeeded -= shots;
     }
 
     @Override
     public void unload() {
         int shots = 0;
-        AmmoType curType = (AmmoType)type;
-        if(null != unit) {
+        AmmoType curType = getType();
+        if (null != unit) {
             Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
+            if ((null != mounted) && (mounted.getType() instanceof AmmoType)) {
                 shots = mounted.getBaseShotsLeft() * getNumTroopers();
                 mounted.setShotsLeft(0);
                 curType = (AmmoType)mounted.getType();
             }
         }
+
         shotsNeeded = getFullShots() * getNumTroopers();
-        if(shots > 0) {
+        if (shots > 0) {
             changeAmountAvailable(shots, curType);
         }
     }
@@ -203,24 +204,24 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
 
     @Override
     public Part getNewPart() {
-    	int shots = (int) Math.floor(1000/((AmmoType)type).getKgPerShot());
-		if(shots <= 0) {
+    	int shots = (int) Math.floor(1000 / getType().getKgPerShot());
+		if (shots <= 0) {
 			//FIXME: no idea what to do here, these really should be fixed on the MM side
 			//because presumably this is happening because KgperShot is -1 or 0
 			shots = 20;
 		}
-        return new AmmoStorage(1,type,shots,campaign);
+        return new AmmoStorage(1, getType(), shots, campaign);
     }
 
     @Override
     public IAcquisitionWork getAcquisitionWork() {
-    	int shots = (int) Math.floor(1000/((AmmoType)type).getKgPerShot());
+    	int shots = (int) Math.floor(1000 / getType().getKgPerShot());
 		if(shots <= 0) {
 			//FIXME: no idea what to do here, these really should be fixed on the MM side
 			//because presumably this is happening because KgperShot is -1 or 0
 			shots = 20;
 		}
-        return new AmmoStorage(1,type,shots,campaign);
+        return new AmmoStorage(1, getType(), shots, campaign);
     }
 
     @Override
@@ -243,8 +244,8 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
     }
 
     private int calculateShots() {
-        int shots = (int) Math.floor(1000/((AmmoType)type).getKgPerShot());
-		if(shots <= 0) {
+        int shots = (int) Math.floor(1000 / getType().getKgPerShot());
+		if (shots <= 0) {
 			//FIXME: no idea what to do here, these really should be fixed on the MM side
 			//because presumably this is happening because KgperShot is -1 or 0
 			shots = 20;
@@ -286,9 +287,9 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
      */
     public void restore() {
         if (typeName == null) {
-        	typeName = type.getName();
+        	typeName = getType().getName();
         } else {
-            type = EquipmentType.get(typeName);
+            type = (AmmoType) EquipmentType.get(typeName);
         }
 
 
@@ -308,14 +309,13 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
 
 
         if (type == null) {
-            MekHQ.getLogger().error(BattleArmorAmmoBin.class, "restore",
-                    "Mounted.restore: could not restore equipment type \"" + typeName + "\"");
+            MekHQ.getLogger().error("Mounted.restore: could not restore equipment type \"" + typeName + "\"");
             return;
         }
         try {
         	equipTonnage = type.getTonnage(null);
         } catch(NullPointerException ex) {
-            MekHQ.getLogger().error(BattleArmorAmmoBin.class, "restore", ex);
+            MekHQ.getLogger().error(ex);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -27,6 +27,7 @@ import megamek.common.BattleArmor;
 import megamek.common.CriticalSlot;
 import megamek.common.EquipmentType;
 import megamek.common.Mounted;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.AmmoStorage;
@@ -38,7 +39,7 @@ import mekhq.campaign.work.IAcquisitionWork;
  *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
-public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
+public class BattleArmorAmmoBin extends AmmoBin {
 
     /**
      * Battle Armor ammo bins need to look for shots for all the remaining troopers in the
@@ -53,7 +54,8 @@ public class BattleArmorAmmoBin extends AmmoBin implements IAcquisitionWork {
         this(0, null, -1, 0, false, null);
     }
 
-    public BattleArmorAmmoBin(int tonnage, AmmoType et, int equipNum, int shots, boolean singleShot, Campaign c) {
+    public BattleArmorAmmoBin(int tonnage, @Nullable AmmoType et, int equipNum,
+            int shots, boolean singleShot, @Nullable Campaign c) {
         super(tonnage, et, equipNum, shots, singleShot, false, c);
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -37,6 +37,8 @@ import java.util.Objects;
  */
 public class InfantryAmmoBin extends AmmoBin {
 
+    private static final long serialVersionUID = 2694897334041633188L;
+
     private InfantryWeapon weaponType;
 
     // Used in deserialization
@@ -56,8 +58,8 @@ public class InfantryAmmoBin extends AmmoBin {
      * @param omniPodded  Whether the weapon is pod-mounted on an omnivehicle
      * @param c           The campaign instance
      */
-    public InfantryAmmoBin(int tonnage, AmmoType ammoType, int equipNum, int shots,
-                           InfantryWeapon weaponType, double size, boolean omniPodded, Campaign c) {
+    public InfantryAmmoBin(int tonnage, @Nullable AmmoType ammoType, int equipNum, int shots,
+            @Nullable InfantryWeapon weaponType, double size, boolean omniPodded, @Nullable Campaign c) {
         super(tonnage, ammoType, equipNum, shots, false, omniPodded, c);
         this.size = size;
         if (weaponType != null) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -30,6 +30,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.PrintWriter;
+import java.util.Objects;
 
 /**
  * Ammo bin for infantry weapons used by small support vehicles
@@ -55,7 +56,7 @@ public class InfantryAmmoBin extends AmmoBin {
      * @param omniPodded  Whether the weapon is pod-mounted on an omnivehicle
      * @param c           The campaign instance
      */
-    public InfantryAmmoBin(int tonnage, EquipmentType ammoType, int equipNum, int shots,
+    public InfantryAmmoBin(int tonnage, AmmoType ammoType, int equipNum, int shots,
                            InfantryWeapon weaponType, double size, boolean omniPodded, Campaign c) {
         super(tonnage, ammoType, equipNum, shots, false, omniPodded, c);
         this.size = size;
@@ -111,12 +112,12 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public double getTonnage() {
-        return weaponType.getAmmoWeight();
+        return getWeaponType().getAmmoWeight();
     }
 
     @Override
     public int getFullShots() {
-        return weaponType.getShots() * (int) getSize();
+        return getWeaponType().getShots() * (int) getSize();
     }
 
     /**
@@ -143,12 +144,12 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     protected Money getPricePerTon() {
-        return Money.of(weaponType.getAmmoCost() / weaponType.getAmmoWeight());
+        return Money.of(getWeaponType().getAmmoCost() / getWeaponType().getAmmoWeight());
     }
 
     @Override
     protected int getShotsPerTon() {
-        return (int) Math.floor(weaponType.getShots() / weaponType.getAmmoWeight());
+        return (int) Math.floor(getWeaponType().getShots() / getWeaponType().getAmmoWeight());
     }
 
     @Override
@@ -162,7 +163,7 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public void writeToXmlEnd(PrintWriter pw, int indent) {
-        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "weaponType", weaponType.getInternalName());
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "weaponType", getWeaponType().getInternalName());
         super.writeToXmlEnd(pw, indent);
     }
 
@@ -192,7 +193,7 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public MissingPart getMissingPart() {
-        return new MissingInfantryAmmoBin(getUnitTonnage(), type, equipmentNum, weaponType,
+        return new MissingInfantryAmmoBin(getUnitTonnage(), getType(), equipmentNum, getWeaponType(),
                 size, omniPodded, campaign);
     }
 
@@ -200,14 +201,14 @@ public class InfantryAmmoBin extends AmmoBin {
     public boolean isSamePartType(Part part) {
         return  (part instanceof InfantryAmmoBin)
                 && super.isSamePartType(part)
-                && (weaponType == ((InfantryAmmoBin) part).weaponType)
+                && Objects.equals(getWeaponType(), ((InfantryAmmoBin) part).getWeaponType())
                 && size == ((InfantryAmmoBin) part).size;
     }
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
         if (shotsNeeded < 0) {
-            return type.getDesc() + ", remove " + (-getShotsNeeded());
+            return getType().getDesc() + ", remove " + (-getShotsNeeded());
         } else {
             return super.getDetails(includeRepairDetails);
         }
@@ -216,7 +217,7 @@ public class InfantryAmmoBin extends AmmoBin {
     @Override
     public void changeAmountAvailable(int amount, final AmmoType curType) {
         InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.getWarehouse().findSparePart(part ->
-            InfantryAmmoStorage.isRightAmmo(part, (AmmoType) getType(), getWeaponType()));
+            InfantryAmmoStorage.isRightAmmo(part, getType(), getWeaponType()));
 
         if (a != null) {
             a.changeShots(amount);
@@ -224,7 +225,7 @@ public class InfantryAmmoBin extends AmmoBin {
                 campaign.getWarehouse().removePart(a);
             }
         } else if (amount > 0) {
-            campaign.getQuartermaster().addPart(new InfantryAmmoStorage(1, curType, amount, weaponType, campaign), 0);
+            campaign.getQuartermaster().addPart(new InfantryAmmoStorage(1, curType, amount, getWeaponType(), campaign), 0);
         }
     }
 
@@ -234,10 +235,10 @@ public class InfantryAmmoBin extends AmmoBin {
     }
 
     public int getAmountAvailable() {
-        final AmmoType thisType = (AmmoType) getType();
+        final AmmoType thisType = getType();
         return campaign.getWarehouse().streamSpareParts()
             .filter(part -> part instanceof InfantryAmmoStorage && part.isPresent()
-                    && InfantryAmmoStorage.isRightAmmo(part, thisType, weaponType))
+                    && InfantryAmmoStorage.isRightAmmo(part, thisType, getWeaponType()))
             .mapToInt(part -> ((InfantryAmmoStorage) part).getShots())
             .sum();
     }
@@ -266,21 +267,21 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public String getAcquisitionDisplayName() {
-        return weaponType.getName() + ": " + type.getName();
+        return getWeaponType().getName() + ": " + getType().getName();
     }
 
     @Override
     public String getAcquisitionExtraDesc() {
-        return weaponType.getShots() + " shots (1 clip)";
+        return getWeaponType().getShots() + " shots (1 clip)";
     }
 
     public Part getNewPart() {
-        return new InfantryAmmoStorage(1, type, weaponType.getShots() * (int) getSize(),
-                weaponType, campaign);
+        return new InfantryAmmoStorage(1, getType(), getWeaponType().getShots() * (int) getSize(),
+                getWeaponType(), campaign);
     }
 
     @Override
     public TechAdvancement getTechAdvancement() {
-        return weaponType.getTechAdvancement();
+        return getWeaponType().getTechAdvancement();
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -59,7 +59,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
         this(0, null, -1, 0, 0, null);
     }
 
-    public LargeCraftAmmoBin(int tonnage, EquipmentType et, int equipNum, int shotsNeeded, double capacity,
+    public LargeCraftAmmoBin(int tonnage, AmmoType et, int equipNum, int shotsNeeded, double capacity,
             Campaign c) {
         super(tonnage, et, equipNum, shotsNeeded, false, false, c);
         this.size = capacity;
@@ -385,11 +385,8 @@ public class LargeCraftAmmoBin extends AmmoBin {
 
     @Override
     public IAcquisitionWork getAcquisitionWork() {
-        int shots = 1;
-        if (type instanceof AmmoType) {
-            shots = ((AmmoType) type).getShots() * (int) Math.floor(getUnusedCapacity() / type.getTonnage(null));
-        }
-        return new AmmoStorage(1, type, shots, campaign);
+        int shots = getType().getShots() * (int) Math.floor(getUnusedCapacity() / type.getTonnage(null));
+        return new AmmoStorage(1, getType(), shots, campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -26,7 +26,6 @@ import org.w3c.dom.NodeList;
 
 import megamek.common.AmmoType;
 import megamek.common.CriticalSlot;
-import megamek.common.EquipmentType;
 import megamek.common.Mounted;
 import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
@@ -59,8 +58,8 @@ public class LargeCraftAmmoBin extends AmmoBin {
         this(0, null, -1, 0, 0, null);
     }
 
-    public LargeCraftAmmoBin(int tonnage, AmmoType et, int equipNum, int shotsNeeded, double capacity,
-            Campaign c) {
+    public LargeCraftAmmoBin(int tonnage, @Nullable AmmoType et, int equipNum, int shotsNeeded, double capacity,
+            @Nullable Campaign c) {
         super(tonnage, et, equipNum, shotsNeeded, false, false, c);
         this.size = capacity;
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -28,6 +28,7 @@ import megamek.common.AmmoType;
 import megamek.common.EquipmentType;
 import megamek.common.Jumpship;
 import megamek.common.SmallCraft;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.Part;
@@ -48,8 +49,8 @@ public class MissingAmmoBin extends MissingEquipmentPart {
         this(0, null, -1, false, false, null);
     }
 
-    public MissingAmmoBin(int tonnage, AmmoType et, int equipNum, boolean singleShot,
-            boolean omniPodded, Campaign c) {
+    public MissingAmmoBin(int tonnage, @Nullable AmmoType et, int equipNum, boolean singleShot,
+            boolean omniPodded, @Nullable Campaign c) {
         super(tonnage, et, equipNum, c, 1.0, 1.0, omniPodded);
         this.oneShot = singleShot;
         if(null != name) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -119,7 +119,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
                 && !(part instanceof LargeCraftAmmoBin)) {
             EquipmentPart eqpart = (EquipmentPart)part;
             EquipmentType et = eqpart.getType();
-            return getType().equals(et) && ((AmmoBin)part).getFullShots() == getFullShots();
+            return getType().equals(et) && (((AmmoBin) part).getFullShots() == getFullShots());
         }
         return false;
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -48,13 +48,18 @@ public class MissingAmmoBin extends MissingEquipmentPart {
         this(0, null, -1, false, false, null);
     }
 
-    public MissingAmmoBin(int tonnage, EquipmentType et, int equipNum, boolean singleShot,
+    public MissingAmmoBin(int tonnage, AmmoType et, int equipNum, boolean singleShot,
             boolean omniPodded, Campaign c) {
         super(tonnage, et, equipNum, c, 1.0, 1.0, omniPodded);
         this.oneShot = singleShot;
         if(null != name) {
             this.name += " Bin";
         }
+    }
+
+    @Override
+    public AmmoType getType() {
+        return (AmmoType) super.getType();
     }
 
     /* Per TM, ammo for fighters is stored in the fuselage. This makes a difference for omnifighter
@@ -113,7 +118,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
                 && !(part instanceof LargeCraftAmmoBin)) {
             EquipmentPart eqpart = (EquipmentPart)part;
             EquipmentType et = eqpart.getType();
-            return type.equals(et) && ((AmmoBin)part).getFullShots() == getFullShots();
+            return getType().equals(et) && ((AmmoBin)part).getFullShots() == getFullShots();
         }
         return false;
     }
@@ -123,7 +128,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
     }
 
     protected int getFullShots() {
-        int fullShots = ((AmmoType) type).getShots();
+        int fullShots = getType().getShots();
         if(oneShot) {
             fullShots = 1;
         }
@@ -132,7 +137,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
 
     @Override
     public Part getNewPart() {
-        return new AmmoBin(getUnitTonnage(), type, -1, getFullShots(), oneShot, omniPodded, campaign);
+        return new AmmoBin(getUnitTonnage(), getType(), -1, getFullShots(), oneShot, omniPodded, campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
@@ -23,7 +23,9 @@ import megamek.common.AmmoType;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.Mounted;
+import megamek.common.annotations.Nullable;
 import megamek.common.weapons.infantry.InfantryWeapon;
+import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.Part;
@@ -55,8 +57,8 @@ public class MissingInfantryAmmoBin extends MissingAmmoBin {
      * @param omniPodded  Whether the weapon is pod-mounted on an omnivehicle
      * @param c           The campaign instance
      */
-    public MissingInfantryAmmoBin(int tonnage, AmmoType ammoType, int equipNum, InfantryWeapon weaponType,
-                                  double size, boolean omniPodded, Campaign c) {
+    public MissingInfantryAmmoBin(int tonnage, @Nullable AmmoType ammoType, int equipNum,
+            @Nullable InfantryWeapon weaponType, double size, boolean omniPodded, @Nullable Campaign c) {
         super(tonnage, ammoType, equipNum, false, omniPodded, c);
         this.weaponType = weaponType;
         this.size = size;
@@ -68,10 +70,14 @@ public class MissingInfantryAmmoBin extends MissingAmmoBin {
     @Override
     public void restore() {
         super.restore();
-        name = getWeaponType().getName() + " Ammo Bin";
+        if (getWeaponType() != null) {
+            name = getWeaponType().getName() + " Ammo Bin";
+        } else {
+            MekHQ.getLogger().error("MissingInfantryAmmoBin does not have a weapon type!");
+        }
     }
 
-    public InfantryWeapon getWeaponType() {
+    public @Nullable InfantryWeapon getWeaponType() {
         return weaponType;
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
@@ -19,6 +19,7 @@
 
 package mekhq.campaign.parts.equipment;
 
+import megamek.common.AmmoType;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.Mounted;
@@ -54,7 +55,7 @@ public class MissingInfantryAmmoBin extends MissingAmmoBin {
      * @param omniPodded  Whether the weapon is pod-mounted on an omnivehicle
      * @param c           The campaign instance
      */
-    public MissingInfantryAmmoBin(int tonnage, EquipmentType ammoType, int equipNum, InfantryWeapon weaponType,
+    public MissingInfantryAmmoBin(int tonnage, AmmoType ammoType, int equipNum, InfantryWeapon weaponType,
                                   double size, boolean omniPodded, Campaign c) {
         super(tonnage, ammoType, equipNum, false, omniPodded, c);
         this.weaponType = weaponType;
@@ -67,7 +68,7 @@ public class MissingInfantryAmmoBin extends MissingAmmoBin {
     @Override
     public void restore() {
         super.restore();
-        name = weaponType.getName() + " Ammo Bin";
+        name = getWeaponType().getName() + " Ammo Bin";
     }
 
     public InfantryWeapon getWeaponType() {
@@ -110,7 +111,7 @@ public class MissingInfantryAmmoBin extends MissingAmmoBin {
     public boolean isAcceptableReplacement(Part part, boolean refit) {
         if (part instanceof InfantryAmmoBin) {
             InfantryAmmoBin bin = (InfantryAmmoBin) part;
-            return type.equals(bin.getType()) && weaponType.equals(bin.getWeaponType())
+            return getType().equals(bin.getType()) && getWeaponType().equals(bin.getWeaponType())
                     && (bin.getFullShots() == getFullShots());
         }
         return false;
@@ -118,18 +119,18 @@ public class MissingInfantryAmmoBin extends MissingAmmoBin {
 
     @Override
     protected int getFullShots() {
-        return weaponType.getShots() * (int) size;
+        return getWeaponType().getShots() * (int) size;
     }
 
     @Override
     public Part getNewPart() {
-        return new InfantryAmmoBin(getUnitTonnage(), type, -1, getFullShots(),
-                weaponType, size, omniPodded, campaign);
+        return new InfantryAmmoBin(getUnitTonnage(), getType(), -1, getFullShots(),
+                getWeaponType(), size, omniPodded, campaign);
     }
 
     @Override
     public void writeToXmlEnd(PrintWriter pw, int indent) {
-        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "weaponType", weaponType.getInternalName());
+        MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "weaponType", getWeaponType().getInternalName());
         super.writeToXmlEnd(pw, indent);
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
@@ -46,8 +46,8 @@ public class MissingLargeCraftAmmoBin extends MissingAmmoBin {
         this(0, null, -1, 1.0, null);
     }
 
-    public MissingLargeCraftAmmoBin(int tonnage, AmmoType et, int equipNum, double capacity,
-            Campaign c) {
+    public MissingLargeCraftAmmoBin(int tonnage, @Nullable AmmoType et, int equipNum, double capacity,
+            @Nullable Campaign c) {
         super(tonnage, et, equipNum, false, false, c);
         this.size = capacity;
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
@@ -46,7 +46,7 @@ public class MissingLargeCraftAmmoBin extends MissingAmmoBin {
         this(0, null, -1, 1.0, null);
     }
 
-    public MissingLargeCraftAmmoBin(int tonnage, EquipmentType et, int equipNum, double capacity,
+    public MissingLargeCraftAmmoBin(int tonnage, AmmoType et, int equipNum, double capacity,
             Campaign c) {
         super(tonnage, et, equipNum, false, false, c);
         this.size = capacity;
@@ -123,12 +123,12 @@ public class MissingLargeCraftAmmoBin extends MissingAmmoBin {
 
     @Override
     protected int getFullShots() {
-        return (int) Math.floor(size * ((AmmoType) type).getShots() / type.getTonnage(null));
+        return (int) Math.floor(size * getType().getShots() / getType().getTonnage(null));
     }
 
     @Override
     public Part getNewPart() {
-        return new LargeCraftAmmoBin(getUnitTonnage(), type, -1, getFullShots(), size, campaign);
+        return new LargeCraftAmmoBin(getUnitTonnage(), getType(), -1, getFullShots(), size, campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2647,11 +2647,11 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 int fullShots = oneShot ? 1 : ((AmmoType) m.getType()).getShots();
                 if (null == apart) {
                     if (entity instanceof BattleArmor) {
-                        apart = new BattleArmorAmmoBin((int) entity.getWeight(), m.getType(), eqnum,
+                        apart = new BattleArmorAmmoBin((int) entity.getWeight(), (AmmoType) m.getType(), eqnum,
                                 ((BattleArmor) entity).getSquadSize() * (fullShots - m.getBaseShotsLeft()),
                                 oneShot, getCampaign());
                     } else if (entity.usesWeaponBays()) {
-                        apart = new LargeCraftAmmoBin((int) entity.getWeight(), m.getType(), eqnum,
+                        apart = new LargeCraftAmmoBin((int) entity.getWeight(), (AmmoType) m.getType(), eqnum,
                                 fullShots - m.getBaseShotsLeft(), m.getSize(), getCampaign());
                         ((LargeCraftAmmoBin) apart).setBay(entity.getBayByAmmo(m));
                     } else if (entity.isSupportVehicle()
@@ -2661,11 +2661,11 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                             weapon = weapon.getLinkedBy();
                         }
                         int size = m.getOriginalShots() / ((InfantryWeapon) weapon.getType()).getShots();
-                        apart = new InfantryAmmoBin((int) entity.getWeight(), m.getType(), eqnum,
+                        apart = new InfantryAmmoBin((int) entity.getWeight(), (AmmoType) m.getType(), eqnum,
                                 m.getOriginalShots() - m.getBaseShotsLeft(),
                                 (InfantryWeapon) weapon.getType(), size, weapon.isOmniPodMounted(), getCampaign());
                     } else {
-                        apart = new AmmoBin((int) entity.getWeight(), m.getType(), eqnum,
+                        apart = new AmmoBin((int) entity.getWeight(), (AmmoType) m.getType(), eqnum,
                                 fullShots - m.getBaseShotsLeft(), oneShot, m.isOmniPodMounted(), getCampaign());
                     }
                     addPart(apart);
@@ -3242,17 +3242,19 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             }
         }
         for (Mounted m : entity.getAmmo()) {
+            assert(m.getType() instanceof AmmoType);
+
             int eqNum = entity.getEquipmentNum(m);
             Part part = ammoParts.get(eqNum);
             if (null == part) {
-                part = new LargeCraftAmmoBin((int)entity.getWeight(), m.getType(), eqNum,
+                part = new LargeCraftAmmoBin((int) entity.getWeight(), (AmmoType) m.getType(), eqNum,
                         m.getOriginalShots() - m.getBaseShotsLeft(), m.getAmmoCapacity(), getCampaign());
                 ((LargeCraftAmmoBin) part).setBay(entity.getBayByAmmo(m));
                 toAdd.add(part);
             } else {
                 part.updateConditionFromEntity(false);
                 // Reset the name
-                ((LargeCraftAmmoBin) part).changeMunition(m.getType());
+                ((LargeCraftAmmoBin) part).changeMunition((AmmoType) m.getType());
             }
         }
         for (Part p : toAdd) {
@@ -3269,7 +3271,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
      * @param bay   The weapon bay where the ammo is located
      * @return      The new ammo bin part
      */
-    public LargeCraftAmmoBin addBayAmmoBin(EquipmentType etype, Mounted bay) {
+    public LargeCraftAmmoBin addBayAmmoBin(AmmoType etype, Mounted bay) {
         for (Part p : getParts()) {
             if (p instanceof LargeCraftAmmoBin) {
                 final LargeCraftAmmoBin bin = (LargeCraftAmmoBin) p;

--- a/MekHQ/src/mekhq/gui/adapter/ServicedUnitsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ServicedUnitsTableMouseAdapter.java
@@ -103,7 +103,7 @@ public class ServicedUnitsTableMouseAdapter extends MouseInputAdapter
             }
             AmmoBin ammo = (AmmoBin) part;
             sel = command.split(":")[2];
-            EquipmentType etype = EquipmentType.get(sel);
+            AmmoType etype = (AmmoType) EquipmentType.get(sel);
             ammo.changeMunition(etype);
             MekHQ.triggerEvent(new UnitChangedEvent(part.getUnit()));
         } else if (command.contains("CHANGE_SITE")) {

--- a/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
@@ -33,6 +33,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import megamek.client.ui.swing.BombChoicePanel;
+import megamek.common.AmmoType;
 import megamek.common.BombType;
 import megamek.common.EquipmentType;
 import megamek.common.IBomber;
@@ -155,7 +156,7 @@ public class BombsDialog extends JDialog implements ActionListener {
                     //No bombs of this type in warehouse, add bombs
                     //In this case newLoadout should always be greater than 0, but check to be sure
                     } else if (bombCatalog[type] == 0 && newLoadout[type] > 0) {
-                        AmmoStorage excessBombs = new AmmoStorage(0, EquipmentType.get(BombType.getBombInternalName(type)), newLoadout[type], campaign);
+                        AmmoStorage excessBombs = new AmmoStorage(0, (AmmoType) EquipmentType.get(BombType.getBombInternalName(type)), newLoadout[type], campaign);
                         campaign.getQuartermaster().addPart(excessBombs, 0);
                     }
                 }

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class AmmoStorageTest {
+    @Test
+    public void ammoStorageDeserializationCtorTest() {
+        AmmoStorage ammoStorage = new AmmoStorage();
+        assertNotNull(ammoStorage);
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/InfantryAmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/InfantryAmmoStorageTest.java
@@ -23,10 +23,10 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-public class AmmoStorageTest {
+public class InfantryAmmoStorageTest {
     @Test
     public void ammoStorageDeserializationCtorTest() {
-        AmmoStorage ammoStorage = new AmmoStorage();
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage();
         assertNotNull(ammoStorage);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
@@ -17,16 +17,16 @@
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mekhq.campaign.parts;
+package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-public class AmmoStorageTest {
+public class AmmoBinTest {
     @Test
-    public void ammoStorageDeserializationCtorTest() {
-        AmmoStorage ammoStorage = new AmmoStorage();
-        assertNotNull(ammoStorage);
+    public void deserializationCtorTest() {
+        AmmoBin ammoBin = new AmmoBin();
+        assertNotNull(ammoBin);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/BattleArmorAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/BattleArmorAmmoBinTest.java
@@ -17,16 +17,16 @@
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mekhq.campaign.parts;
+package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-public class AmmoStorageTest {
+public class BattleArmorAmmoBinTest {
     @Test
-    public void ammoStorageDeserializationCtorTest() {
-        AmmoStorage ammoStorage = new AmmoStorage();
-        assertNotNull(ammoStorage);
+    public void deserializationCtorTest() {
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin();
+        assertNotNull(ammoBin);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/InfantryAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/InfantryAmmoBinTest.java
@@ -17,16 +17,16 @@
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mekhq.campaign.parts;
+package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-public class AmmoStorageTest {
+public class InfantryAmmoBinTest {
     @Test
-    public void ammoStorageDeserializationCtorTest() {
-        AmmoStorage ammoStorage = new AmmoStorage();
-        assertNotNull(ammoStorage);
+    public void deserializationCtorTest() {
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin();
+        assertNotNull(ammoBin);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/LargeCraftAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/LargeCraftAmmoBinTest.java
@@ -17,16 +17,16 @@
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mekhq.campaign.parts;
+package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-public class AmmoStorageTest {
+public class LargeCraftAmmoBinTest {
     @Test
-    public void ammoStorageDeserializationCtorTest() {
-        AmmoStorage ammoStorage = new AmmoStorage();
-        assertNotNull(ammoStorage);
+    public void deserializationCtorTest() {
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin();
+        assertNotNull(ammoBin);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingAmmoBinTest.java
@@ -17,16 +17,16 @@
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mekhq.campaign.parts;
+package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-public class AmmoStorageTest {
+public class MissingAmmoBinTest {
     @Test
-    public void ammoStorageDeserializationCtorTest() {
-        AmmoStorage ammoStorage = new AmmoStorage();
-        assertNotNull(ammoStorage);
+    public void deserializationCtorTest() {
+        MissingAmmoBin ammoBin = new MissingAmmoBin();
+        assertNotNull(ammoBin);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingInfantryAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingInfantryAmmoBinTest.java
@@ -17,16 +17,16 @@
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mekhq.campaign.parts;
+package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-public class AmmoStorageTest {
+public class MissingInfantryAmmoBinTest {
     @Test
-    public void ammoStorageDeserializationCtorTest() {
-        AmmoStorage ammoStorage = new AmmoStorage();
-        assertNotNull(ammoStorage);
+    public void deserializationCtorTest() {
+        MissingInfantryAmmoBin ammoBin = new MissingInfantryAmmoBin();
+        assertNotNull(ammoBin);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBinTest.java
@@ -17,16 +17,16 @@
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package mekhq.campaign.parts;
+package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-public class AmmoStorageTest {
+public class MissingLargeCraftAmmoBinTest {
     @Test
-    public void ammoStorageDeserializationCtorTest() {
-        AmmoStorage ammoStorage = new AmmoStorage();
-        assertNotNull(ammoStorage);
+    public void deserializationCtorTest() {
+        MissingLargeCraftAmmoBin ammoBin = new MissingLargeCraftAmmoBin();
+        assertNotNull(ammoBin);
     }
 }


### PR DESCRIPTION
This makes use of a Java feature whereby an override can use a more-derived type in a return value. In this case `AmmoBin` and `AmmoStorage` only support `AmmoType` as their `EquipmentType`, so we reflect that in their constructors and `getType` overloads.

This has two effects:
1. The code is more straightforward.
2. Errors caused by equipment mismatches are at the point of assignment rather than point of usage making tracing easier.