### PR TITLE
Add JaCoCo code coverage plugin to test Gradle task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,16 @@ jobs:
         path: ./mekhq/MekHQ/build/reports/
 
     #
+    # Upload our Code Coverage Reports to CodeCov.io
+    #
+    - name: CodeCov.io Coverage Report
+      uses: codecov/codecov-action@v1
+      with:
+        directory: ./mekhq/MekHQ/build/reports/jacoco/test
+        fail_ci_if_error: false
+        verbose: true
+
+    #
     # If we have a buildScanUri comment on the PR
     #
     # NB: This only works if you're on the main MegaMek\mekhq repo

--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'application'
     id 'maven-publish'
     id 'edu.sc.seis.launch4j' version '2.4.4'
+    id 'jacoco'
 }
 
 sourceSets {
@@ -648,3 +649,12 @@ task cleanPublishingDir (type: Delete) {
 
 publishPublishMMLibraryPublicationToMavenRepository.dependsOn cleanPublishingDir
 
+test {
+    // report is always generated after tests run
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    // tests are required to run before generating the report
+    dependsOn test
+}

--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -657,4 +657,8 @@ test {
 jacocoTestReport {
     // tests are required to run before generating the report
     dependsOn test
+    reports {
+        xml.enabled true
+        html.enabled true
+    }
 }


### PR DESCRIPTION
This adds a Code Coverage report to our test Gradle task. I'll try getting this roped in via the CodeCov app.

![image](https://user-images.githubusercontent.com/8238690/98557483-44c04700-2272-11eb-82f5-7765a665ab3a.png)
