### PR TITLE
Add basic AmmoStorage tests

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -295,6 +295,10 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
     public void changeAmountAvailable(int amount, final AmmoType curType) {
+        if (amount == 0) {
+            return;
+        }
+
         AmmoStorage a = (AmmoStorage) campaign.getWarehouse().findSparePart(part -> {
             return isRightAmmo(part, curType);
         });

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -208,7 +208,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 
 	@Override
     public IAcquisitionWork getAcquisitionWork() {
-        return (IAcquisitionWork)getNewPart();
+        return getNewPart();
     }
 
 	@Override
@@ -274,7 +274,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
 	@Override
-    public Object getNewEquipment() {
+    public AmmoStorage getNewEquipment() {
         return getNewPart();
     }
 
@@ -287,7 +287,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
      * Boolean function that determines if the given part is of the correct ammo.
      * Useful as a predicate for campaign.findSparePart()
      */
-    public static boolean IsRightAmmo(Part part, AmmoType curType) {
+    public static boolean isRightAmmo(Part part, AmmoType curType) {
         return part instanceof AmmoStorage
                 && part.isPresent()
                 && ((AmmoStorage) part).getType().equals(curType)
@@ -296,7 +296,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 
     public void changeAmountAvailable(int amount, final AmmoType curType) {
         AmmoStorage a = (AmmoStorage) campaign.getWarehouse().findSparePart(part -> {
-            return IsRightAmmo(part, curType);
+            return isRightAmmo(part, curType);
         });
 
         if (null != a) {
@@ -349,7 +349,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
 	@Override
-	public Part getAcquisitionPart() {
+	public AmmoStorage getAcquisitionPart() {
 		return getNewPart();
 	}
 
@@ -370,7 +370,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return target;
     }
 
-    public Part getNewPart() {
+    public AmmoStorage getNewPart() {
         return new AmmoStorage(1, getType(), getType().getShots(), campaign);
     }
 
@@ -386,7 +386,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public String getArrivalReport() {
-        double totalShots = quantity * getShots();
+        int totalShots = quantity * getShots();
         String report = getQuantityName(quantity);
         if(totalShots == 1) {
             report += " has arrived";

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -46,28 +46,23 @@ import mekhq.campaign.work.IAcquisitionWork;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
-	private static final long serialVersionUID = 2892728320891712304L;
+    private static final long serialVersionUID = 8555561045042023622L;
 
-	protected long munition;
-	protected int shots;
+    protected int shots;
 
     public AmmoStorage() {
-    	this(0, null, 0, null);
+        this(0, null, 0, null);
     }
 
     public AmmoStorage(int tonnage, @Nullable AmmoType et, int shots, @Nullable Campaign c) {
         super(tonnage, et, -1, 1.0, c);
         this.shots = shots;
-        if (et != null) {
-            this.munition = et.getMunitionType();
-        }
     }
 
     public AmmoStorage clone() {
-    	AmmoStorage storage = new AmmoStorage(0, getType(), shots, campaign);
+        AmmoStorage storage = new AmmoStorage(0, getType(), shots, campaign);
         storage.copyBaseData(this);
-    	storage.munition = this.munition;
-    	return storage;
+        return storage;
     }
 
     @Override
@@ -75,19 +70,12 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return (AmmoType) super.getType();
     }
 
-    /**
-     * Gets the munition type for this ammo storage.
-     */
-    public long getMunitionType() {
-        return munition;
-    }
-
     @Override
     public double getTonnage() {
-    	if (getType().getKgPerShot() > 0) {
-    		return getType().getKgPerShot() * shots/1000.0;
-    	}
-     	return ((double)shots / getType().getShots());
+        if (getType().getKgPerShot() > 0) {
+            return getType().getKgPerShot() * shots/1000.0;
+        }
+         return ((double)shots / getType().getShots());
     }
 
     @Override
@@ -116,140 +104,142 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
             return Money.zero();
         }
 
-    	return getStickerPrice()
+        return getStickerPrice()
                 .multipliedBy(shots)
                 .dividedBy(getType().getShots());
     }
 
     public int getShots() {
-    	return shots;
+        return shots;
     }
 
     @Override
     public boolean isSamePartType(@Nullable Part part) {
         if ((getType() != null) && (part instanceof AmmoStorage)) {
             AmmoStorage other = (AmmoStorage) part;
-            if (getType() instanceof BombType) {
-                return (other.getType() instanceof BombType)
-                        && ((BombType) getType()).getBombType() == ((BombType) other.getType()).getBombType();
-            } else if (other.getType() != null) {
-                return getType().getMunitionType() == other.getType().getMunitionType()
-                        && getType().equals(other.getType());
-            }
+            return isSameAmmoType(getType(), other.getType());
         }
 
         return false;
     }
 
+    public static boolean isSameAmmoType(AmmoType a, AmmoType b) {
+        // TODO: move this to AmmoType::equals and a Comparator
+        if (a instanceof BombType && b instanceof BombType) {
+            return isSameBombType((BombType) a, (BombType) b);
+        } else {
+            return a.equals(b) && (a.getMunitionType() == b.getMunitionType());
+        }
+    }
+
+    public static boolean isSameBombType(BombType a, BombType b) {
+        // TODO: move this to BombType::equals and a Comparator
+        return a.equals(b) && (a.getBombType() == b.getBombType());
+    }
+
     public void changeShots(int s) {
-    	shots = Math.max(0, shots + s);
+        shots = Math.max(0, shots + s);
     }
 
     public void setShots(int s) {
         shots = Math.max(0, s);
     }
 
-	@Override
-	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<equipmentNum>"
-				+equipmentNum
-				+"</equipmentNum>");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
+    @Override
+    public void writeToXml(PrintWriter pw1, int indent) {
+        writeToXmlBegin(pw1, indent);
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<equipmentNum>"
+                +equipmentNum
+                +"</equipmentNum>");
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
                 +"<typeName>"
                 +MekHqXmlUtil.escape(typeName)
                 +"</typeName>");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<munition>"
-				+munition
-				+"</munition>");
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<shots>"
-				+shots
-				+"</shots>");
-		writeToXmlEnd(pw1, indent);
-	}
+        pw1.println(MekHqXmlUtil.indentStr(indent+1)
+                +"<shots>"
+                +shots
+                +"</shots>");
+        writeToXmlEnd(pw1, indent);
+    }
 
-	@Override
-	protected void loadFieldsFromXmlNode(Node wn) {
-		NodeList nl = wn.getChildNodes();
+    @Override
+    protected void loadFieldsFromXmlNode(Node wn) {
+        NodeList nl = wn.getChildNodes();
 
-		for (int x=0; x<nl.getLength(); x++) {
-			Node wn2 = nl.item(x);
-			if (wn2.getNodeName().equalsIgnoreCase("equipmentNum")) {
-				equipmentNum = Integer.parseInt(wn2.getTextContent());
-			} else if (wn2.getNodeName().equalsIgnoreCase("typeName")) {
-				typeName = wn2.getTextContent();
-			} else if (wn2.getNodeName().equalsIgnoreCase("munition")) {
-				munition = Long.parseLong(wn2.getTextContent());
-			} else if (wn2.getNodeName().equalsIgnoreCase("shots")) {
-				shots = Integer.parseInt(wn2.getTextContent());
-			}
-		}
-		restore();
-	}
+        for (int x=0; x<nl.getLength(); x++) {
+            Node wn2 = nl.item(x);
+            if (wn2.getNodeName().equalsIgnoreCase("equipmentNum")) {
+                equipmentNum = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("typeName")) {
+                typeName = wn2.getTextContent();
+            } else if (wn2.getNodeName().equalsIgnoreCase("shots")) {
+                shots = Integer.parseInt(wn2.getTextContent());
+            }
+        }
+        restore();
+    }
 
-	@Override
-	public TechAdvancement getTechAdvancement() {
-	    return getType().getTechAdvancement();
-	}
+    @Override
+    public TechAdvancement getTechAdvancement() {
+        return getType().getTechAdvancement();
+    }
 
-	@Override
-	public void fix() {
-		//nothing to fix
-	}
+    @Override
+    public void fix() {
+        //nothing to fix
+    }
 
-	@Override
-	public MissingPart getMissingPart() {
-		//nothing to do here
-		return null;
-	}
+    @Override
+    public MissingPart getMissingPart() {
+        //nothing to do here
+        return null;
+    }
 
-	@Override
+    @Override
     public IAcquisitionWork getAcquisitionWork() {
         return getNewPart();
     }
 
-	@Override
-	public TargetRoll getAllMods(Person tech) {
-		//nothing to do here
-		return null;
-	}
+    @Override
+    public TargetRoll getAllMods(Person tech) {
+        //nothing to do here
+        return null;
+    }
 
-	@Override
-	public void updateConditionFromEntity(boolean checkForDestruction) {
-		//nothing to do here
-	}
+    @Override
+    public void updateConditionFromEntity(boolean checkForDestruction) {
+        //nothing to do here
+    }
 
-	@Override
-	public void updateConditionFromPart() {
-		//nothing to do here
-	}
+    @Override
+    public void updateConditionFromPart() {
+        //nothing to do here
+    }
 
-	@Override
-	public boolean needsFixing() {
-		return false;
-	}
+    @Override
+    public boolean needsFixing() {
+        return false;
+    }
 
-	public String getDesc() {
-		String toReturn = "<html><font size='2'";
-		String scheduled = "";
-		if (getTech() != null) {
-			scheduled = " (scheduled) ";
-		}
+    public String getDesc() {
+        String toReturn = "<html><font size='2'";
+        String scheduled = "";
+        if (getTech() != null) {
+            scheduled = " (scheduled) ";
+        }
 
-		toReturn += ">";
-		toReturn += "<b>Reload " + getName() + "</b><br/>";
-		toReturn += getDetails() + "<br/>";
-		toReturn += "" + getTimeLeft() + " minutes" + scheduled;
-		toReturn += "</font></html>";
-		return toReturn;
-	}
+        toReturn += ">";
+        toReturn += "<b>Reload " + getName() + "</b><br/>";
+        toReturn += getDetails() + "<br/>";
+        toReturn += "" + getTimeLeft() + " minutes" + scheduled;
+        toReturn += "</font></html>";
+        return toReturn;
+    }
 
     @Override
     public String getDetails() {
-    	return getDetails(true);
+        return getDetails(true);
     }
 
     @Override
@@ -257,15 +247,15 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return shots + " shots";
     }
 
-	@Override
+    @Override
     public String checkFixable() {
         return null;
     }
 
-	@Override
+    @Override
     public String find(int transitDays) {
-	    Part newPart = getNewPart();
-	    newPart.setBrandNew(true);
+        AmmoStorage newPart = getNewPart();
+        newPart.setBrandNew(true);
         if(campaign.getQuartermaster().buyPart(newPart, transitDays)) {
             return "<font color='green'><b> part found</b>.</font> It will be delivered in " + transitDays + " days.";
         } else {
@@ -273,7 +263,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         }
     }
 
-	@Override
+    @Override
     public AmmoStorage getNewEquipment() {
         return getNewPart();
     }
@@ -283,24 +273,15 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return "<font color='red'><b> part not found</b>.</font>";
     }
 
-    /**
-     * Boolean function that determines if the given part is of the correct ammo.
-     * Useful as a predicate for campaign.findSparePart()
-     */
-    public static boolean isRightAmmo(Part part, AmmoType curType) {
-        return part instanceof AmmoStorage
-                && part.isPresent()
-                && ((AmmoStorage) part).getType().equals(curType)
-                && curType.getMunitionType() == ((AmmoStorage) part).getType().getMunitionType();
-    }
-
     public void changeAmountAvailable(int amount, final AmmoType curType) {
         if (amount == 0) {
             return;
         }
 
         AmmoStorage a = (AmmoStorage) campaign.getWarehouse().findSparePart(part -> {
-            return isRightAmmo(part, curType);
+            return (part instanceof AmmoStorage)
+                    && part.isPresent()
+                    && isSameAmmoType(curType, ((AmmoStorage) part).getType());
         });
 
         if (null != a) {
@@ -329,20 +310,20 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public String getAcquisitionDisplayName() {
-    	return getType().getDesc();
+        return getType().getDesc();
     }
 
-	@Override
-	public String getAcquisitionExtraDesc() {
-		return getType().getShots() + " shots (1 ton)";
-	}
+    @Override
+    public String getAcquisitionExtraDesc() {
+        return getType().getShots() + " shots (1 ton)";
+    }
 
     @Override
     public String getAcquisitionName() {
         return getType().getDesc();
     }
 
-	@Override
+    @Override
     public String getAcquisitionBonus() {
         String bonus = getAllAcquisitionMods().getValueAsString();
         if(getAllAcquisitionMods().getValue() > -1) {
@@ -352,10 +333,10 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return "(" + bonus + ")";
     }
 
-	@Override
-	public AmmoStorage getAcquisitionPart() {
-		return getNewPart();
-	}
+    @Override
+    public AmmoStorage getAcquisitionPart() {
+        return getNewPart();
+    }
 
     @Override
     public TargetRoll getAllAcquisitionMods() {

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -73,9 +73,9 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     @Override
     public double getTonnage() {
         if (getType().getKgPerShot() > 0) {
-            return getType().getKgPerShot() * shots/1000.0;
+            return getType().getKgPerShot() * (shots / 1000.0);
         }
-         return ((double)shots / getType().getShots());
+         return ((double) shots / getType().getShots());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -75,6 +75,13 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
         return (AmmoType) super.getType();
     }
 
+    /**
+     * Gets the munition type for this ammo storage.
+     */
+    public long getMunitionType() {
+        return munition;
+    }
+
     @Override
     public double getTonnage() {
     	if (getType().getKgPerShot() > 0) {
@@ -119,17 +126,18 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
     @Override
-    public boolean isSamePartType(Part part) {
-        if (part instanceof AmmoStorage) {
+    public boolean isSamePartType(@Nullable Part part) {
+        if ((getType() != null) && (part instanceof AmmoStorage)) {
+            AmmoStorage other = (AmmoStorage) part;
             if (getType() instanceof BombType) {
-                return ((EquipmentPart)part).getType() instanceof BombType
-                        && ((BombType)getType()).getBombType() == ((BombType)((EquipmentPart)part).getType()).getBombType();
-            } else {
-                return getType().getMunitionType() == ((AmmoStorage) part).getType().getMunitionType()
-                        && getType().equals( (Object) ((EquipmentPart) part).getType());
+                return (other.getType() instanceof BombType)
+                        && ((BombType) getType()).getBombType() == ((BombType) other.getType()).getBombType();
+            } else if (other.getType() != null) {
+                return getType().getMunitionType() == other.getType().getMunitionType()
+                        && getType().equals(other.getType());
             }
-
         }
+
         return false;
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -157,7 +157,8 @@ public class InfantryAmmoStorage extends AmmoStorage {
         return weaponType.getShots() + " shots (1 clip)";
     }
 
-    public Part getNewPart() {
+    @Override
+    public InfantryAmmoStorage getNewPart() {
         return new InfantryAmmoStorage(1, getType(), weaponType.getShots(),
                 weaponType, campaign);
     }

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -74,21 +74,20 @@ public class InfantryAmmoStorage extends AmmoStorage {
     }
 
     public InfantryAmmoStorage clone() {
-        InfantryAmmoStorage storage = new InfantryAmmoStorage(0, getType(), shots, weaponType, campaign);
+        InfantryAmmoStorage storage = new InfantryAmmoStorage(0, getType(), getShots(), getWeaponType(), getCampaign());
         storage.copyBaseData(this);
-        storage.munition = this.munition;
         return storage;
     }
 
 
     @Override
     public double getTonnage() {
-        return weaponType.getAmmoWeight() * getShots() / weaponType.getShots();
+        return getWeaponType().getAmmoWeight() * getShots() / getWeaponType().getShots();
     }
 
     @Override
     public Money getStickerPrice() {
-        return Money.of(weaponType.getAmmoCost() * (double) getShots() / weaponType.getShots());
+        return Money.of(getWeaponType().getAmmoCost() * (double) getShots() / getWeaponType().getShots());
     }
 
     @Override
@@ -99,7 +98,7 @@ public class InfantryAmmoStorage extends AmmoStorage {
     @Override
     public boolean isSamePartType(Part part) {
         return (part instanceof InfantryAmmoStorage)
-                && Objects.equals(getType(), ((InfantryAmmoStorage) part).getType())
+                && isSameAmmoType(getType(), ((InfantryAmmoStorage) part).getType())
                 && Objects.equals(getWeaponType(), ((InfantryAmmoStorage) part).getWeaponType());
     }
 
@@ -123,7 +122,7 @@ public class InfantryAmmoStorage extends AmmoStorage {
 
     @Override
     public TechAdvancement getTechAdvancement() {
-        return weaponType.getTechAdvancement();
+        return getWeaponType().getTechAdvancement();
     }
 
     /**
@@ -131,16 +130,15 @@ public class InfantryAmmoStorage extends AmmoStorage {
      * Useful as a predicate for campaign.findSparePart()
      */
     public static boolean isRightAmmo(Part part, AmmoType curType, WeaponType weaponType) {
-        return part instanceof InfantryAmmoStorage
+        return (part instanceof InfantryAmmoStorage)
                 && part.isPresent()
-                && (((InfantryAmmoStorage) part).getType()).equals(curType)
-                && curType.getMunitionType() == ((AmmoType) ((AmmoStorage) part).getType()).getMunitionType()
+                && isSameAmmoType(curType, ((InfantryAmmoStorage) part).getType())
                 && (((InfantryAmmoStorage) part).getWeaponType()).equals(weaponType);
     }
 
     public void changeAmountAvailable(int amount, final AmmoType curType) {
         InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.getWarehouse().findSparePart(part ->
-                isRightAmmo(part, curType, weaponType));
+                isRightAmmo(part, curType, getWeaponType()));
 
         if (null != a) {
             a.changeShots(amount);
@@ -148,18 +146,18 @@ public class InfantryAmmoStorage extends AmmoStorage {
                 campaign.getWarehouse().removePart(a);
             }
         } else if (amount > 0) {
-            campaign.getQuartermaster().addPart(new InfantryAmmoStorage(1, curType, amount, weaponType, campaign), 0);
+            campaign.getQuartermaster().addPart(new InfantryAmmoStorage(1, curType, amount, getWeaponType(), campaign), 0);
         }
     }
 
     @Override
     public String getAcquisitionExtraDesc() {
-        return weaponType.getShots() + " shots (1 clip)";
+        return getWeaponType().getShots() + " shots (1 clip)";
     }
 
     @Override
     public InfantryAmmoStorage getNewPart() {
-        return new InfantryAmmoStorage(1, getType(), weaponType.getShots(),
-                weaponType, campaign);
+        return new InfantryAmmoStorage(1, getType(), getWeaponType().getShots(),
+                getWeaponType(), campaign);
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -99,7 +99,7 @@ public class EquipmentPart extends Part {
             try {
                 equipTonnage = type.getTonnage(null, size);
             } catch (NullPointerException ex) {
-                MekHQ.getLogger().error(EquipmentPart.class, "EquipmentPart", ex);
+                MekHQ.getLogger().error(ex);
             }
         }
     }
@@ -141,8 +141,7 @@ public class EquipmentPart extends Part {
         }
 
         if (type == null) {
-            MekHQ.getLogger().error(getClass(), "restore",
-                    "Mounted.restore: could not restore equipment type \"" + typeName + "\"");
+            MekHQ.getLogger().error("Mounted.restore: could not restore equipment type \"" + typeName + "\"");
         }
     }
 
@@ -408,7 +407,7 @@ public class EquipmentPart extends Part {
             return unit != null && unit.getEntity() != null && unit.getEntity().getEquipment(equipmentNum) != null
                     && unit.isLocationDestroyed(unit.getEntity().getEquipment(equipmentNum).getLocation());
         } catch (Exception e) {
-            MekHQ.getLogger().error(getClass(), "isMountedOnDestroyedLocation()", e);
+            MekHQ.getLogger().error(e);
         }
         return false;
         /*
@@ -568,7 +567,7 @@ public class EquipmentPart extends Part {
         }
         if (varCost.isZero()) {
             // if we don't know what it is...
-            MekHQ.getLogger().debug(EquipmentPart.class, "I don't know how much " + name + " costs.");
+            MekHQ.getLogger().debug("I don't know how much " + name + " costs.");
         }
         return varCost;
     }

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -61,7 +61,7 @@ public class AmmoStorageTest {
         AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, ammoType.getShots(), mockCampaign);
 
         assertEquals(ammoType, ammoStorage.getType());
-        assertEquals(ammoType.getMunitionType(), ammoStorage.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoType, ammoStorage.getType()));
         assertEquals(ammoType.getShots(), ammoStorage.getShots());
         assertEquals(1.0, ammoStorage.getTonnage(), 0.001);
     }
@@ -88,7 +88,7 @@ public class AmmoStorageTest {
         assertNotNull(clone);
 
         assertEquals(ammoStorage.getType(), clone.getType());
-        assertEquals(ammoStorage.getMunitionType(), clone.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), clone.getType()));
         assertEquals(ammoStorage.getBuyCost(), clone.getBuyCost());
         assertEquals(ammoStorage.getCurrentValue(), clone.getCurrentValue());
         assertEquals(ammoStorage.getShots(), clone.getShots());
@@ -107,7 +107,7 @@ public class AmmoStorageTest {
 
         // ...and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
-        assertEquals(ammoStorage.getMunitionType(), newAmmoStorage.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
         // ...except for the number of shots, which should be instead
@@ -128,7 +128,7 @@ public class AmmoStorageTest {
 
         // ...and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
-        assertEquals(ammoStorage.getMunitionType(), newAmmoStorage.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
         // ...except for the number of shots, which should be instead
@@ -156,7 +156,7 @@ public class AmmoStorageTest {
 
         // ...and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
-        assertEquals(ammoStorage.getMunitionType(), newAmmoStorage.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
         // ...except for the number of shots, which should be instead
@@ -172,7 +172,7 @@ public class AmmoStorageTest {
 
         // ...and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
-        assertEquals(ammoStorage.getMunitionType(), newAmmoStorage.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
         // ...except for the number of shots, which should be instead
@@ -248,31 +248,6 @@ public class AmmoStorageTest {
         otherAmmoStorage = new AmmoStorage(0, isSRM2InfernoAmmo, isSRM2InfernoAmmo.getShots(), mockCampaign);
         assertFalse(ammoStorage.isSamePartType(otherAmmoStorage));
         assertFalse(otherAmmoStorage.isSamePartType(ammoStorage));
-    }
-
-    @Test
-    public void isRightAmmoTest() {
-        AmmoType isAC5Ammo = getAmmoType("ISAC5 Ammo");
-        Campaign mockCampaign = mock(Campaign.class);
-
-        AmmoStorage ammoStorage = new AmmoStorage(0, isAC5Ammo, isAC5Ammo.getShots(), mockCampaign);
-
-        // We're the same as our own ammo type
-        assertTrue(AmmoStorage.isRightAmmo(ammoStorage, isAC5Ammo));
-
-        AmmoType isAC10Ammo = getAmmoType("ISAC10 Ammo");
-
-        // But not some other ammo type
-        assertFalse(AmmoStorage.isRightAmmo(ammoStorage, isAC10Ammo));
-
-        // Create an ammo type with some different munitions available
-        AmmoType isSRM2Ammo = getAmmoType("ISSRM2 Ammo");
-        ammoStorage = new AmmoStorage(0, isSRM2Ammo, isSRM2Ammo.getShots(), mockCampaign);
-
-        // And ensure they're not the same as the same type of ammo, just
-        // a different munition type.
-        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
-        assertFalse(AmmoStorage.isRightAmmo(ammoStorage, isSRM2InfernoAmmo));
     }
 
     @Test
@@ -367,7 +342,7 @@ public class AmmoStorageTest {
         assertEquals(ammoStorage.getId(), deserialized.getId());
         assertEquals(ammoStorage.getEquipmentNum(), deserialized.getEquipmentNum());
         assertEquals(ammoStorage.getType(), deserialized.getType());
-        assertEquals(ammoStorage.getMunitionType(), deserialized.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), deserialized.getType()));
         assertEquals(ammoStorage.getShots(), deserialized.getShots());
     }
 
@@ -403,6 +378,7 @@ public class AmmoStorageTest {
         assertTrue(added.isSpare());
         assertTrue(added.isPresent());
         assertEquals(ammoType, added.getType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoType, added.getType()));
         assertEquals(addedShots, added.getShots());
     }
 
@@ -446,6 +422,7 @@ public class AmmoStorageTest {
         assertTrue(added.isSpare());
         assertTrue(added.isPresent());
         assertEquals(ammoType, added.getType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoType, added.getType()));
         assertEquals(addedShots, added.getShots());
     }
 
@@ -489,6 +466,7 @@ public class AmmoStorageTest {
         assertTrue(added.isSpare());
         assertTrue(added.isPresent());
         assertEquals(ammoType, added.getType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoType, added.getType()));
         assertEquals(addedShots, added.getShots());
     }
 
@@ -527,7 +505,7 @@ public class AmmoStorageTest {
         assertNotNull(updated);
         assertEquals(updated.getId(), existing.getId());
         assertEquals(existing.getType(), updated.getType());
-        assertEquals(existing.getMunitionType(), updated.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(existing.getType(), updated.getType()));
         assertEquals(originalShots + addedShots, updated.getShots());
     }
 
@@ -591,6 +569,7 @@ public class AmmoStorageTest {
         assertEquals(inTransit.getId(), existing.getId());
         assertEquals(inTransit.getDaysToArrival(), existing.getDaysToArrival());
         assertEquals(ammoType, existing.getType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoType, existing.getType()));
         assertEquals(originalShots, existing.getShots());
     }
 
@@ -629,7 +608,7 @@ public class AmmoStorageTest {
         assertNotNull(updated);
         assertEquals(updated.getId(), existing.getId());
         assertEquals(existing.getType(), updated.getType());
-        assertEquals(existing.getMunitionType(), updated.getMunitionType());
+        assertTrue(AmmoStorage.isSameAmmoType(existing.getType(), updated.getType()));
         assertEquals(originalShots + removedShots, updated.getShots());
     }
 

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -20,13 +20,365 @@
 package mekhq.campaign.parts;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import megamek.common.EquipmentType;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.equipment.AmmoBin;
+import mekhq.campaign.work.IAcquisitionWork;
 
 public class AmmoStorageTest {
     @Test
     public void ammoStorageDeserializationCtorTest() {
         AmmoStorage ammoStorage = new AmmoStorage();
         assertNotNull(ammoStorage);
+    }
+
+    @Test
+    public void ammoStorageCtorTest() {
+        AmmoType ammoType = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, ammoType.getShots(), mockCampaign);
+
+        assertEquals(ammoType, ammoStorage.getType());
+        assertEquals(ammoType.getMunitionType(), ammoStorage.getMunitionType());
+        assertEquals(ammoType.getShots(), ammoStorage.getShots());
+        assertEquals(1.0, ammoStorage.getTonnage(), 0.001);
+    }
+
+    @Test
+    public void getMissingPartTest() {
+        AmmoType ammoType = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, ammoType.getShots(), mockCampaign);
+
+        // There should be no missing part.
+        assertNull(ammoStorage.getMissingPart());
+    }
+
+    @Test
+    public void cloneTest() {
+        AmmoType ammoType = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 2 * ammoType.getShots(), mockCampaign);
+
+        AmmoStorage clone = ammoStorage.clone();
+        assertNotNull(clone);
+
+        assertEquals(ammoStorage.getType(), clone.getType());
+        assertEquals(ammoStorage.getMunitionType(), clone.getMunitionType());
+        assertEquals(ammoStorage.getBuyCost(), clone.getBuyCost());
+        assertEquals(ammoStorage.getCurrentValue(), clone.getCurrentValue());
+        assertEquals(ammoStorage.getShots(), clone.getShots());
+    }
+
+    @Test
+    public void getNewPartTest() {
+        AmmoType ammoType = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 2 * ammoType.getShots(), mockCampaign);
+
+        // Create a new part...
+        AmmoStorage newAmmoStorage = ammoStorage.getNewPart();
+        assertNotNull(newAmmoStorage);
+
+        // ...and the new part should be identical in ALMOST every way...
+        assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
+        assertEquals(ammoStorage.getMunitionType(), newAmmoStorage.getMunitionType());
+        assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
+
+        // ...except for the number of shots, which should be instead
+        // equal to the default number of shots for the type.
+        assertEquals(ammoType.getShots(), newAmmoStorage.getShots());
+    }
+
+    @Test
+    public void getNewEquipmentTest() {
+        AmmoType ammoType = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 2 * ammoType.getShots(), mockCampaign);
+
+        // Create a new part...
+        AmmoStorage newAmmoStorage = ammoStorage.getNewEquipment();
+        assertNotNull(newAmmoStorage);
+
+        // ...and the new part should be identical in ALMOST every way...
+        assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
+        assertEquals(ammoStorage.getMunitionType(), newAmmoStorage.getMunitionType());
+        assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
+
+        // ...except for the number of shots, which should be instead
+        // equal to the default number of shots for the type.
+        assertEquals(ammoType.getShots(), newAmmoStorage.getShots());
+    }
+
+    @Test
+    public void getAcquisitionWorkTest() {
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 2 * ammoType.getShots(), mockCampaign);
+
+        // Create a new acquisition work...
+        IAcquisitionWork acquisitionWork = ammoStorage.getAcquisitionWork();
+        assertNotNull(acquisitionWork);
+
+        // Check getNewEquipment()...
+        Object newEquipment = acquisitionWork.getNewEquipment();
+        assertNotNull(newEquipment);
+        assertTrue(newEquipment instanceof AmmoStorage);
+
+        AmmoStorage newAmmoStorage = (AmmoStorage) newEquipment;
+
+        // ...and the new part should be identical in ALMOST every way...
+        assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
+        assertEquals(ammoStorage.getMunitionType(), newAmmoStorage.getMunitionType());
+        assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
+
+        // ...except for the number of shots, which should be instead
+        // equal to the default number of shots for the type.
+        assertEquals(ammoType.getShots(), newAmmoStorage.getShots());
+
+        // Check getAcquisitionPart()
+        Part acquisitionPart = acquisitionWork.getAcquisitionPart();
+        assertNotNull(acquisitionPart);
+        assertTrue(acquisitionPart instanceof AmmoStorage);
+
+        newAmmoStorage = (AmmoStorage) acquisitionPart;
+
+        // ...and the new part should be identical in ALMOST every way...
+        assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
+        assertEquals(ammoStorage.getMunitionType(), newAmmoStorage.getMunitionType());
+        assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
+
+        // ...except for the number of shots, which should be instead
+        // equal to the default number of shots for the type.
+        assertEquals(ammoType.getShots(), newAmmoStorage.getShots());
+    }
+
+    @Test
+    public void ammoStorageShotsTest() {
+        AmmoStorage ammoStorage = new AmmoStorage();
+
+        // We begin empty...
+        assertEquals(0, ammoStorage.getShots());
+
+        // ...and if we add some ammo...
+        ammoStorage.changeShots(10);
+
+        // ...we'll then hold that amount.
+        assertEquals(10, ammoStorage.getShots());
+
+        // We can also remove ammo...
+        ammoStorage.changeShots(-5);
+        assertEquals(5, ammoStorage.getShots());
+
+        // ...but if we try to remove more than exists...
+        ammoStorage.changeShots(-20);
+
+        // ...we'll never have less than zero.
+        assertEquals(0, ammoStorage.getShots());
+
+        // Likewise, if we set the amount of shots...
+        ammoStorage.setShots(20);
+        assertEquals(20, ammoStorage.getShots());
+
+        // ...we still can't set it to be less than zero.
+        ammoStorage.setShots(-20);
+        assertEquals(0, ammoStorage.getShots());
+    }
+
+    @Test
+    public void isSamePartTypeTest() {
+        AmmoType ammoType = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, ammoType.getShots(), mockCampaign);
+
+        // We're the same as ourselves.
+        assertTrue(ammoStorage.isSamePartType(ammoStorage));
+
+        // We're the same as our clone.
+        AmmoStorage clone = ammoStorage.clone();
+        assertTrue(ammoStorage.isSamePartType(clone));
+        assertTrue(clone.isSamePartType(ammoStorage));
+
+        // We're the same as another ammo storage of the same type
+        // but with different constructor values.
+        AmmoStorage otherAmmoStorage = new AmmoStorage(1, ammoType, 0, mockCampaign);
+        assertTrue(ammoStorage.isSamePartType(otherAmmoStorage));
+        assertTrue(otherAmmoStorage.isSamePartType(ammoStorage));
+
+        // We're not the same as some other part.
+        assertFalse(ammoStorage.isSamePartType(new MekSensor()));
+        assertFalse(ammoStorage.isSamePartType(new AmmoBin()));
+        assertFalse(ammoStorage.isSamePartType(new AmmoStorage()));
+
+        // Create an ammo type with some different munitions available
+        AmmoType isSRM2Ammo = getAmmoType("ISSRM2 Ammo");
+        ammoStorage = new AmmoStorage(0, isSRM2Ammo, isSRM2Ammo.getShots(), mockCampaign);
+
+        // And ensure they're not the same as the same type of ammo, just
+        // a different munition type.
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        otherAmmoStorage = new AmmoStorage(0, isSRM2InfernoAmmo, isSRM2InfernoAmmo.getShots(), mockCampaign);
+        assertFalse(ammoStorage.isSamePartType(otherAmmoStorage));
+        assertFalse(otherAmmoStorage.isSamePartType(ammoStorage));
+    }
+
+    @Test
+    public void isRightAmmoTest() {
+        AmmoType isAC5Ammo = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, isAC5Ammo, isAC5Ammo.getShots(), mockCampaign);
+
+        // We're the same as our own ammo type
+        assertTrue(AmmoStorage.isRightAmmo(ammoStorage, isAC5Ammo));
+
+        AmmoType isAC10Ammo = getAmmoType("ISAC10 Ammo");
+
+        // But not some other ammo type
+        assertFalse(AmmoStorage.isRightAmmo(ammoStorage, isAC10Ammo));
+
+        // Create an ammo type with some different munitions available
+        AmmoType isSRM2Ammo = getAmmoType("ISSRM2 Ammo");
+        ammoStorage = new AmmoStorage(0, isSRM2Ammo, isSRM2Ammo.getShots(), mockCampaign);
+
+        // And ensure they're not the same as the same type of ammo, just
+        // a different munition type.
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        assertFalse(AmmoStorage.isRightAmmo(ammoStorage, isSRM2InfernoAmmo));
+    }
+
+    @Test
+    public void getTonnageTest() {
+        AmmoType isAC5Ammo = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, isAC5Ammo, isAC5Ammo.getShots(), mockCampaign);
+
+        // If we have the default number of shots, we should have 1 ton.
+        assertEquals(1.0, ammoStorage.getTonnage(), 0.001);
+
+        // Likewise, if we have double the number of shots, we should have 2 tons.
+        ammoStorage.setShots(2 * isAC5Ammo.getShots());
+        assertEquals(2.0, ammoStorage.getTonnage(), 0.001);
+
+        // And if we have zero shots, we should have zero tons.
+        ammoStorage.setShots(0);
+        assertEquals(0.0, ammoStorage.getTonnage(), 0.001);
+    }
+
+    @Test
+    public void getTonnageKgTest() {
+        AmmoType mockAmmoType = mock(AmmoType.class);
+        double kgPerShot = 0.1;
+        when(mockAmmoType.getKgPerShot()).thenReturn(kgPerShot);
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int shots = 50;
+        AmmoStorage ammoStorage = new AmmoStorage(0, mockAmmoType, shots, mockCampaign);
+        assertEquals((shots * kgPerShot) / 1000.0, ammoStorage.getTonnage(), 0.001);
+    }
+
+    @Test
+    public void getCurrentValueTest() {
+        AmmoType isAC5Ammo = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, isAC5Ammo, 0, mockCampaign);
+
+        // If we have no rounds of ammo, we shouldn't cost anything.
+        assertEquals(Money.zero(), ammoStorage.getCurrentValue());
+
+        // And if we have the default quantity...
+        ammoStorage.setShots(isAC5Ammo.getShots());
+
+        // ...we should cost the default amount.
+        assertEquals(ammoStorage.getBuyCost(), ammoStorage.getCurrentValue());
+        assertEquals(ammoStorage.getStickerPrice(), ammoStorage.getCurrentValue());
+
+        // And if we have twice the amount of ammo...
+        ammoStorage.setShots(2 * isAC5Ammo.getShots());
+
+        // ...we should cost twice as much.
+        assertEquals(ammoStorage.getBuyCost().multipliedBy(2.0), ammoStorage.getCurrentValue());
+    }
+
+    @Test
+    public void ammoStorageWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoStorage ammoStorage = new AmmoStorage(0, isSRM2InfernoAmmo, 3 * isSRM2InfernoAmmo.getShots(), mockCampaign);
+        ammoStorage.setId(25);
+        ammoStorage.setEquipmentNum(42);
+
+        // Write the AmmoStorage XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoStorage.writeToXml(pw, 0);
+
+        // Get the AmmoStorage XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoStorage
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof AmmoStorage);
+
+        AmmoStorage deserialized = (AmmoStorage) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoStorage.getId(), deserialized.getId());
+        assertEquals(ammoStorage.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoStorage.getType(), deserialized.getType());
+        assertEquals(ammoStorage.getMunitionType(), deserialized.getMunitionType());
+        assertEquals(ammoStorage.getShots(), deserialized.getShots());
+    }
+
+    /**
+     * Gets an AmmoType by name (performing any initialization required
+     * on the MM side).
+     * @param name The lookup name for the AmmoType.
+     * @return The ammo type for the given name.
+     */
+    private synchronized static AmmoType getAmmoType(String name) {
+        AmmoType ammoType = (AmmoType) EquipmentType.get(name);
+        assertNotNull(ammoType);
+
+        return ammoType;
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 import megamek.common.AmmoType;
+import megamek.common.BombType;
 import megamek.common.EquipmentType;
 import mekhq.MekHqXmlUtil;
 import mekhq.Version;
@@ -251,6 +252,42 @@ public class AmmoStorageTest {
     }
 
     @Test
+    public void isSamePartTypeBombTest() {
+        BombType bombType = getBombType("HEBomb");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, bombType, bombType.getShots(), mockCampaign);
+
+        // We're the same as ourselves.
+        assertTrue(ammoStorage.isSamePartType(ammoStorage));
+
+        // We're the same as our clone.
+        AmmoStorage clone = ammoStorage.clone();
+        assertTrue(ammoStorage.isSamePartType(clone));
+        assertTrue(clone.isSamePartType(ammoStorage));
+
+        // We're the same as another ammo storage of the same type
+        // but with different constructor values.
+        AmmoStorage otherAmmoStorage = new AmmoStorage(1, bombType, 0, mockCampaign);
+        assertTrue(ammoStorage.isSamePartType(otherAmmoStorage));
+        assertTrue(otherAmmoStorage.isSamePartType(ammoStorage));
+
+        // We're not the same as some other part.
+        assertFalse(ammoStorage.isSamePartType(new MekSensor()));
+        assertFalse(ammoStorage.isSamePartType(new AmmoBin()));
+        assertFalse(ammoStorage.isSamePartType(new AmmoStorage()));
+
+        // Create a bomb ammo type with a different bomb type
+        AmmoType infernoBomb = getBombType("InfernoBomb");
+        otherAmmoStorage = new AmmoStorage(0, infernoBomb, infernoBomb.getShots(), mockCampaign);
+
+        // And ensure they're not the same as the same type of ammo, just
+        // a different munition type.
+        assertFalse(ammoStorage.isSamePartType(otherAmmoStorage));
+        assertFalse(otherAmmoStorage.isSamePartType(ammoStorage));
+    }
+
+    @Test
     public void getTonnageTest() {
         AmmoType isAC5Ammo = getAmmoType("ISAC5 Ammo");
         Campaign mockCampaign = mock(Campaign.class);
@@ -310,6 +347,47 @@ public class AmmoStorageTest {
         AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
         Campaign mockCampaign = mock(Campaign.class);
         AmmoStorage ammoStorage = new AmmoStorage(0, isSRM2InfernoAmmo, 3 * isSRM2InfernoAmmo.getShots(), mockCampaign);
+        ammoStorage.setId(25);
+        ammoStorage.setEquipmentNum(42);
+
+        // Write the AmmoStorage XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoStorage.writeToXml(pw, 0);
+
+        // Get the AmmoStorage XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoStorage
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof AmmoStorage);
+
+        AmmoStorage deserialized = (AmmoStorage) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoStorage.getId(), deserialized.getId());
+        assertEquals(ammoStorage.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoStorage.getType(), deserialized.getType());
+        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), deserialized.getType()));
+        assertEquals(ammoStorage.getShots(), deserialized.getShots());
+    }
+
+    @Test
+    public void ammoStorageBombWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        BombType infernoBomb = getBombType("InfernoBomb");
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoStorage ammoStorage = new AmmoStorage(0, infernoBomb, 3 * infernoBomb.getShots(), mockCampaign);
         ammoStorage.setId(25);
         ammoStorage.setEquipmentNum(42);
 
@@ -667,6 +745,45 @@ public class AmmoStorageTest {
         assertTrue(warehouse.getParts().isEmpty());
     }
 
+    @Test
+    public void changeAmountAvailableBombDecreaseNoneFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        // Setup a warehouse with some other bomb type
+        Warehouse warehouse = new Warehouse();
+        BombType torpedoBomb = getBombType("TorpedoBomb");
+        int originalShots = 2;
+        AmmoStorage otherAmmoStorage = new AmmoStorage(0, torpedoBomb, originalShots, mockCampaign);
+        warehouse.addPart(otherAmmoStorage);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        BombType ammoType = getBombType("ThunderBomb");
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Remove shots from the Campaign when we have a bomb, but it doesn't match
+        int removedShots = -100;
+        ammoStorage.changeAmountAvailable(removedShots, ammoType);
+
+        // ...which should result in nothing changing.
+        AmmoStorage existing = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            existing = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(existing);
+        assertEquals(otherAmmoStorage.getId(), existing.getId());
+        assertEquals(ammoType, existing.getType());
+        assertTrue(AmmoStorage.isSameAmmoType(torpedoBomb, existing.getType()));
+        assertEquals(originalShots, existing.getShots());
+    }
+
     /**
      * Gets an AmmoType by name (performing any initialization required
      * on the MM side).
@@ -674,9 +791,24 @@ public class AmmoStorageTest {
      * @return The ammo type for the given name.
      */
     private synchronized static AmmoType getAmmoType(String name) {
-        AmmoType ammoType = (AmmoType) EquipmentType.get(name);
-        assertNotNull(ammoType);
+        EquipmentType equipmentType = EquipmentType.get(name);
+        assertNotNull(equipmentType);
+        assertTrue(equipmentType instanceof AmmoType);
 
-        return ammoType;
+        return (AmmoType) equipmentType;
+    }
+
+    /**
+     * Gets a BombType by name (performing any initialization required
+     * on the MM side).
+     * @param name The lookup name for the BombType.
+     * @return The bomb type for the given name.
+     */
+    private synchronized static BombType getBombType(String name) {
+        EquipmentType equipmentType = EquipmentType.get(name);
+        assertNotNull(equipmentType);
+        assertTrue(equipmentType instanceof BombType);
+
+        return (BombType) equipmentType;
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -106,12 +106,12 @@ public class AmmoStorageTest {
         AmmoStorage newAmmoStorage = ammoStorage.getNewPart();
         assertNotNull(newAmmoStorage);
 
-        // ...and the new part should be identical in ALMOST every way...
+        // ... and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
         assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
-        // ...except for the number of shots, which should be instead
+        // ... except for the number of shots, which should be instead
         // equal to the default number of shots for the type.
         assertEquals(ammoType.getShots(), newAmmoStorage.getShots());
     }
@@ -127,12 +127,12 @@ public class AmmoStorageTest {
         AmmoStorage newAmmoStorage = ammoStorage.getNewEquipment();
         assertNotNull(newAmmoStorage);
 
-        // ...and the new part should be identical in ALMOST every way...
+        // ... and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
         assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
-        // ...except for the number of shots, which should be instead
+        // ... except for the number of shots, which should be instead
         // equal to the default number of shots for the type.
         assertEquals(ammoType.getShots(), newAmmoStorage.getShots());
     }
@@ -155,12 +155,12 @@ public class AmmoStorageTest {
 
         AmmoStorage newAmmoStorage = (AmmoStorage) newEquipment;
 
-        // ...and the new part should be identical in ALMOST every way...
+        // ... and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
         assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
-        // ...except for the number of shots, which should be instead
+        // ... except for the number of shots, which should be instead
         // equal to the default number of shots for the type.
         assertEquals(ammoType.getShots(), newAmmoStorage.getShots());
 

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -171,12 +171,12 @@ public class AmmoStorageTest {
 
         newAmmoStorage = (AmmoStorage) acquisitionPart;
 
-        // ...and the new part should be identical in ALMOST every way...
+        // ... and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
         assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
-        // ...except for the number of shots, which should be instead
+        // ... except for the number of shots, which should be instead
         // equal to the default number of shots for the type.
         assertEquals(ammoType.getShots(), newAmmoStorage.getShots());
     }
@@ -188,27 +188,27 @@ public class AmmoStorageTest {
         // We begin empty...
         assertEquals(0, ammoStorage.getShots());
 
-        // ...and if we add some ammo...
+        // ... and if we add some ammo...
         ammoStorage.changeShots(10);
 
-        // ...we'll then hold that amount.
+        // ... we'll then hold that amount.
         assertEquals(10, ammoStorage.getShots());
 
         // We can also remove ammo...
         ammoStorage.changeShots(-5);
         assertEquals(5, ammoStorage.getShots());
 
-        // ...but if we try to remove more than exists...
+        // ... but if we try to remove more than exists...
         ammoStorage.changeShots(-20);
 
-        // ...we'll never have less than zero.
+        // ... we'll never have less than zero.
         assertEquals(0, ammoStorage.getShots());
 
         // Likewise, if we set the amount of shots...
         ammoStorage.setShots(20);
         assertEquals(20, ammoStorage.getShots());
 
-        // ...we still can't set it to be less than zero.
+        // ... we still can't set it to be less than zero.
         ammoStorage.setShots(-20);
         assertEquals(0, ammoStorage.getShots());
     }
@@ -331,14 +331,14 @@ public class AmmoStorageTest {
         // And if we have the default quantity...
         ammoStorage.setShots(isAC5Ammo.getShots());
 
-        // ...we should cost the default amount.
+        // ... we should cost the default amount.
         assertEquals(ammoStorage.getBuyCost(), ammoStorage.getCurrentValue());
         assertEquals(ammoStorage.getStickerPrice(), ammoStorage.getCurrentValue());
 
         // And if we have twice the amount of ammo...
         ammoStorage.setShots(2 * isAC5Ammo.getShots());
 
-        // ...we should cost twice as much.
+        // ... we should cost twice as much.
         assertEquals(ammoStorage.getBuyCost().multipliedBy(2.0), ammoStorage.getCurrentValue());
     }
 
@@ -443,7 +443,7 @@ public class AmmoStorageTest {
         int addedShots = 100;
         ammoStorage.changeAmountAvailable(addedShots, ammoType);
 
-        // ...which should result in more ammo being added to the campaign.
+        // ... which should result in more ammo being added to the campaign.
         AmmoStorage added = null;
         for (Part part : warehouse.getParts()) {
             // Only one part in the campaign.
@@ -483,7 +483,7 @@ public class AmmoStorageTest {
         int addedShots = 100;
         ammoStorage.changeAmountAvailable(addedShots, ammoType);
 
-        // ...which should result in more ammo being added to the campaign.
+        // ... which should result in more ammo being added to the campaign.
         AmmoStorage added = null;
         for (Part part : warehouse.getParts()) {
             if (part.isPresent()) {
@@ -526,7 +526,7 @@ public class AmmoStorageTest {
         int addedShots = 100;
         ammoStorage.changeAmountAvailable(addedShots, ammoType);
 
-        // ...which should result in more ammo being added to the campaign.
+        // ... which should result in more ammo being added to the campaign.
         AmmoStorage added = null;
         for (Part part : warehouse.getParts()) {
             if (part.getId() != otherAmmo.getId()) {
@@ -571,7 +571,7 @@ public class AmmoStorageTest {
         int addedShots = 100;
         ammoStorage.changeAmountAvailable(addedShots, ammoType);
 
-        // ...which should result in the existing ammo count increasing in the campaign.
+        // ... which should result in the existing ammo count increasing in the campaign.
         AmmoStorage updated = null;
         for (Part part : warehouse.getParts()) {
             // Only one part present in the campaign.
@@ -606,7 +606,7 @@ public class AmmoStorageTest {
         int removedShots = -100;
         ammoStorage.changeAmountAvailable(removedShots, ammoType);
 
-        // ...which should result in nothing happening.
+        // ... which should result in nothing happening.
         assertTrue(warehouse.getParts().isEmpty());
     }
 
@@ -634,7 +634,7 @@ public class AmmoStorageTest {
         int removedShots = -100;
         ammoStorage.changeAmountAvailable(removedShots, ammoType);
 
-        // ...which should result in nothing changing.
+        // ... which should result in nothing changing.
         AmmoStorage existing = null;
         for (Part part : warehouse.getParts()) {
             // Only one part in the campaign.
@@ -674,7 +674,7 @@ public class AmmoStorageTest {
         int removedShots = -50;
         ammoStorage.changeAmountAvailable(removedShots, ammoType);
 
-        // ...which should result in the existing ammo count decreasing in the campaign.
+        // ... which should result in the existing ammo count decreasing in the campaign.
         AmmoStorage updated = null;
         for (Part part : warehouse.getParts()) {
             // Only one part in the campaign.
@@ -712,7 +712,7 @@ public class AmmoStorageTest {
         // Remove all the shots from the Campaign when we have spare ammo of that type present...
         ammoStorage.changeAmountAvailable(-originalShots, ammoType);
 
-        // ...which should result in the existing ammo being removed from the campaign.
+        // ... which should result in the existing ammo being removed from the campaign.
         assertTrue(warehouse.getParts().isEmpty());
     }
 
@@ -739,7 +739,7 @@ public class AmmoStorageTest {
         // spare ammo of that type present...
         ammoStorage.changeAmountAvailable(-(10 * originalShots), ammoType);
 
-        // ...which should result in the existing ammo being removed from the campaign,
+        // ... which should result in the existing ammo being removed from the campaign,
         // and not some weird situation where some part is there with negative or zero
         // rounds of ammo present.
         assertTrue(warehouse.getParts().isEmpty());
@@ -768,7 +768,7 @@ public class AmmoStorageTest {
         int removedShots = -100;
         ammoStorage.changeAmountAvailable(removedShots, ammoType);
 
-        // ...which should result in nothing changing.
+        // ... which should result in nothing changing.
         AmmoStorage existing = null;
         for (Part part : warehouse.getParts()) {
             // Only one part in the campaign.

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -40,6 +40,8 @@ import megamek.common.EquipmentType;
 import mekhq.MekHqXmlUtil;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.work.IAcquisitionWork;
@@ -367,6 +369,323 @@ public class AmmoStorageTest {
         assertEquals(ammoStorage.getType(), deserialized.getType());
         assertEquals(ammoStorage.getMunitionType(), deserialized.getMunitionType());
         assertEquals(ammoStorage.getShots(), deserialized.getShots());
+    }
+
+    @Test
+    public void changeAmountAvailableNoneFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        // Setup an empty warehouse
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type...
+        int addedShots = 100;
+        ammoStorage.changeAmountAvailable(addedShots, ammoType);
+
+        // ...which should result in more ammo being added to the campaign.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(addedShots, added.getShots());
+    }
+
+    @Test
+    public void changeAmountAvailableNoneFoundBecauseCurrentlyInTransit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        AmmoStorage inTransit = new AmmoStorage(0, ammoType, 0, mockCampaign);
+        inTransit.setDaysToArrival(10);
+        warehouse.addPart(inTransit);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type present...
+        int addedShots = 100;
+        ammoStorage.changeAmountAvailable(addedShots, ammoType);
+
+        // ...which should result in more ammo being added to the campaign.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            if (part.isPresent()) {
+                // Only one part present in the campaign.
+                assertTrue(part instanceof AmmoStorage);
+                added = (AmmoStorage) part;
+            } else {
+                // The other part should be our in transit part
+                assertEquals(inTransit, part);
+            }
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(addedShots, added.getShots());
+    }
+
+    @Test
+    public void changeAmountAvailableNoneFoundBecauseWrongMunitionType() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        AmmoType otherAmmoType = getAmmoType("ISSRM4 Inferno Ammo");
+        AmmoStorage otherAmmo = new AmmoStorage(0, otherAmmoType, 20, mockCampaign);
+        warehouse.addPart(otherAmmo);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type present...
+        int addedShots = 100;
+        ammoStorage.changeAmountAvailable(addedShots, ammoType);
+
+        // ...which should result in more ammo being added to the campaign.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            if (part.getId() != otherAmmo.getId()) {
+                // Only one other part should be in the campaign.
+                assertNull(added);
+                assertTrue(part instanceof AmmoStorage);
+                added = (AmmoStorage) part;
+            } else {
+                // The other part should be our part of another type
+                assertEquals(otherAmmo, part);
+            }
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(addedShots, added.getShots());
+    }
+
+    @Test
+    public void changeAmountAvailableIncreaseFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 1;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Add shots to the Campaign when we have spare ammo of that type present...
+        int addedShots = 100;
+        ammoStorage.changeAmountAvailable(addedShots, ammoType);
+
+        // ...which should result in the existing ammo count increasing in the campaign.
+        AmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part present in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            updated = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(existing.getMunitionType(), updated.getMunitionType());
+        assertEquals(originalShots + addedShots, updated.getShots());
+    }
+
+    @Test
+    public void changeAmountAvailableDecreaseNoneFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        // Setup an empty warehouse
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type...
+        int removedShots = -100;
+        ammoStorage.changeAmountAvailable(removedShots, ammoType);
+
+        // ...which should result in nothing happening.
+        assertTrue(warehouse.getParts().isEmpty());
+    }
+
+    @Test
+    public void changeAmountAvailableDecreaseNoneFoundBecauseCurrentlyInTransit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage inTransit = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        inTransit.setDaysToArrival(10);
+        warehouse.addPart(inTransit);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Try to remove shots from the Campaign when we don't have any spare ammo of that type present...
+        int removedShots = -100;
+        ammoStorage.changeAmountAvailable(removedShots, ammoType);
+
+        // ...which should result in nothing changing.
+        AmmoStorage existing = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            existing = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(existing);
+        assertEquals(inTransit.getId(), existing.getId());
+        assertEquals(inTransit.getDaysToArrival(), existing.getDaysToArrival());
+        assertEquals(ammoType, existing.getType());
+        assertEquals(originalShots, existing.getShots());
+    }
+
+    @Test
+    public void changeAmountAvailableDecreaseFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Remove shots from the Campaign when we have spare ammo of that type present...
+        int removedShots = -50;
+        ammoStorage.changeAmountAvailable(removedShots, ammoType);
+
+        // ...which should result in the existing ammo count decreasing in the campaign.
+        AmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertNull(updated);
+            assertTrue(part instanceof AmmoStorage);
+            updated = (AmmoStorage) part;
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(existing.getMunitionType(), updated.getMunitionType());
+        assertEquals(originalShots + removedShots, updated.getShots());
+    }
+
+    @Test
+    public void changeAmountAvailableDecreaseAll() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Remove all the shots from the Campaign when we have spare ammo of that type present...
+        ammoStorage.changeAmountAvailable(-originalShots, ammoType);
+
+        // ...which should result in the existing ammo being removed from the campaign.
+        assertTrue(warehouse.getParts().isEmpty());
+    }
+
+    @Test
+    public void changeAmountAvailableDecreaseWayMoreThanAll() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
+
+        // Remove way more than the number shots from the Campaign when we have
+        // spare ammo of that type present...
+        ammoStorage.changeAmountAvailable(-(10 * originalShots), ammoType);
+
+        // ...which should result in the existing ammo being removed from the campaign,
+        // and not some weird situation where some part is there with negative or zero
+        // rounds of ammo present.
+        assertTrue(warehouse.getParts().isEmpty());
     }
 
     /**


### PR DESCRIPTION
Adds basic AmmoStorage tests and protects against some basic problems found during testing.

TODO:
- [x] Test changeAmountAvailable
- [x] Test BombType