### PR TITLE
Refactor adding and removing ammo from the Campaign

### DIFF
--- a/MekHQ/src/mekhq/campaign/Quartermaster.java
+++ b/MekHQ/src/mekhq/campaign/Quartermaster.java
@@ -19,9 +19,14 @@
 
 package mekhq.campaign;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
+import megamek.common.AmmoType;
 import megamek.common.Entity;
+import megamek.common.annotations.Nullable;
+import megamek.common.weapons.infantry.InfantryWeapon;
 import mekhq.MekHQ;
 import mekhq.campaign.event.PartArrivedEvent;
 import mekhq.campaign.event.PartChangedEvent;
@@ -29,10 +34,12 @@ import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.Transaction;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
+import mekhq.campaign.parts.InfantryAmmoStorage;
 import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.OmniPod;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
+import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
 
@@ -90,6 +97,11 @@ public class Quartermaster {
             return;
         }
 
+        // don't keep around spare ammo bins
+        if ((part instanceof AmmoBin) && (null == part.getUnit())) {
+            return;
+        }
+
         part.setDaysToArrival(Math.max(transitDays, 0));
         part.setBrandNew(false);
 
@@ -98,6 +110,289 @@ public class Quartermaster {
 
         // Add the part to our warehouse and merge it with any existing part if possible
         getWarehouse().addPart(part, true);
+    }
+
+    /**
+     * Adds ammo to the campaign.
+     * @param ammoType The type of ammo to add.
+     * @param shots The number of rounds of ammo to add.
+     */
+    public void addAmmo(AmmoType ammoType, int shots) {
+        Objects.requireNonNull(ammoType);
+
+        if (shots >= 0) {
+            addPart(new AmmoStorage(0, ammoType, shots, getCampaign()), 0);
+        }
+    }
+
+    /**
+     * Adds infantry ammo to the campaign.
+     * @param ammoType The type of ammo to add.
+     * @param infantryWeapon The type of infantry weapon using the ammo.
+     * @param shots The number of rounds of ammo to add.
+     */
+    public void addAmmo(AmmoType ammoType, InfantryWeapon infantryWeapon, int shots) {
+        Objects.requireNonNull(ammoType);
+        Objects.requireNonNull(infantryWeapon);
+
+        if (shots >= 0) {
+            addPart(new InfantryAmmoStorage(0, ammoType, shots, infantryWeapon, getCampaign()), 0);
+        }
+    }
+
+    /**
+     * Removes ammo from the campaign, if available.
+     * @param ammoType The type of ammo to remove.
+     * @param shotsNeeded The number of rounds of ammo needed.
+     * @return The number of rounds of ammo removed from the campaign.
+     *         This value may be less than or equal to {@code shotsNeeded}.
+     */
+    public int removeAmmo(AmmoType ammoType, int shotsNeeded) {
+        Objects.requireNonNull(ammoType);
+
+        if (shotsNeeded <= 0) {
+            return 0;
+        }
+
+        AmmoStorage ammoStorage = findSpareAmmo(ammoType);
+
+        int shotsRemoved = removeAmmo(ammoStorage, shotsNeeded);
+        shotsNeeded -= shotsRemoved;
+
+        // See if we've still need some more ammo ...
+        if (shotsNeeded > 0) {
+            // ... then check if we can use compatible ammo ...
+            if (getCampaignOptions().useAmmoByType()) {
+                // ... and if so, remove some more from the campaign (if available).
+                shotsRemoved += removeCompatibleAmmo(ammoType, shotsNeeded);
+            }
+        }
+
+        // Inform the caller how many shots we actually removed for them.
+        return shotsRemoved;
+    }
+
+    /**
+     * Remove ammo directly from an AmmoStorage part.
+     * @param shotsNeeded The number of shots needed.
+     * @return The number of shots removed.
+     */
+    private int removeAmmo(@Nullable AmmoStorage ammoStorage, int shotsNeeded) {
+        if ((ammoStorage == null) || (ammoStorage.getShots() == 0)) {
+            return 0;
+        }
+
+        // We've got at least one round of ammo,
+        // so calculate how many shots we can take
+        // from this AmmoStorage.
+        int shotsRemoved = Math.min(ammoStorage.getShots(), shotsNeeded);
+
+        // Update the number of rounds available ...
+        ammoStorage.changeShots(-shotsRemoved);
+        if (ammoStorage.getShots() == 0) {
+            // ... and remove the part if we've run out.
+            getWarehouse().removePart(ammoStorage);
+        } else {
+            MekHQ.triggerEvent(new PartChangedEvent(ammoStorage));
+        }
+
+        return shotsRemoved;
+    }
+
+    /**
+     * Removes compatible ammo from the campaign, if available.
+     * @param ammoType The type of ammo to remove.
+     * @param shotsNeeded The number of rounds of ammo needed.
+     * @return The number of rounds of ammo removed from the campaign.
+     *         This value may be less than or equal to {@code shotsNeeded}.
+     */
+    public int removeCompatibleAmmo(AmmoType ammoType, int shotsNeeded) {
+        Objects.requireNonNull(ammoType);
+
+        if (shotsNeeded <= 0) {
+            return 0;
+        }
+
+        int shotsRemoved = 0;
+
+        List<AmmoStorage> compatibleAmmo = findCompatibleSpareAmmo(ammoType);
+        for (AmmoStorage compatible : compatibleAmmo) {
+            if (shotsNeeded <= 0) {
+                break;
+            }
+
+            // Check to see if it has at least one shot we can use in our target ammo type ...
+            int shotsAvailable = convertShots(compatible.getType(), compatible.getShots(), ammoType);
+            if (shotsAvailable <= 0) {
+                // ... and if not, skip this ammo storage.
+                continue;
+            }
+
+            // Calculate the shots needed in the compatible ammo type ...
+            int compatibleShotsNeeded = convertShots(ammoType, shotsNeeded, compatible.getType());
+
+            // Try removing that ammo from the compatible ammo storage.
+            int compatibleShotsRemoved = removeAmmo(compatible, compatibleShotsNeeded);
+            if (compatibleShotsRemoved > 0) {
+                // If we did remove some ammo, adjust the number of shots we removed and needed
+                int shotsFound = convertShots(compatible.getType(), compatibleShotsRemoved, ammoType);
+                shotsRemoved += shotsFound;
+                shotsNeeded -= shotsFound;
+            }
+        }
+
+        return shotsRemoved;
+    }
+
+    /**
+     * Finds spare ammo of a given type, if any.
+     * @param ammoType The AmmoType to search for.
+     * @return The matching spare {@code AmmoStorage} part, otherwise {@code null}.
+     */
+    private @Nullable AmmoStorage findSpareAmmo(AmmoType ammoType) {
+        return (AmmoStorage) getWarehouse().findSparePart(part -> {
+            if (!isAvailableAsSpareAmmo(part)) {
+                return false;
+            }
+            return ((AmmoStorage) part).isSameAmmoType(ammoType);
+        });
+    }
+
+    /**
+     * Find compatible ammo in the warehouse.
+     * @param ammoType The AmmoType to search for compatible types.
+     * @return A list of spare {@code AmmoStorage} parts in the warehouse.
+     */
+    private List<AmmoStorage> findCompatibleSpareAmmo(AmmoType ammoType) {
+        List<AmmoStorage> compatibleAmmo = new ArrayList<>();
+        getWarehouse().forEachSparePart(part -> {
+            if (!isAvailableAsSpareAmmo(part)) {
+                return;
+            }
+
+            AmmoStorage spare = (AmmoStorage) part;
+            if (spare.isSameAmmoType(ammoType)) {
+                // We are looking for compatible ammo, not identical ammo.
+                return;
+            }
+
+            // If we found a spare ammo bin with at least one shot available ...
+            if (spare.isCompatibleAmmo(ammoType) && (spare.getShots() > 0)) {
+                // ... add it to our list of compatible ammo.
+                compatibleAmmo.add(spare);
+            }
+        });
+
+        return compatibleAmmo;
+    }
+
+    /**
+     * Converts shots from one ammo type to another.
+     * NB: it is up to the caller to ensure the ammo types are compatible.
+     * @param from The AmmoType for which {@code shots} represents.
+     * @param shots The number of shots of {@code from}.
+     * @param to The AmmoType which {@code shots} should be converted to.
+     * @return The value of {@code shots} when converted to a specific AmmoType.
+     */
+    private static int convertShots(AmmoType from, int shots, AmmoType to) {
+        int rounds = shots * Math.max(from.getRackSize(), 1);
+
+        // Use integer division to 'round down'
+        return rounds / Math.max(to.getRackSize(), 1);
+    }
+
+    /**
+     * Gets the amount of ammo available of a given type.
+     * @param ammoType The type of ammo.
+     * @return The number of shots available of the given ammo type.
+     */
+    public int getAmmoAvailable(AmmoType ammoType) {
+        Objects.requireNonNull(ammoType);
+
+        if (!getCampaignOptions().useAmmoByType()) {
+            // PERF: if we're not using ammo by type, we can use
+            //       a MUCH faster lookup for spare ammo.
+            AmmoStorage spare = findSpareAmmo(ammoType);
+            return (spare != null) ? spare.getShots() : 0;
+        } else {
+            // If we're using ammo by type, stream through all of
+            // the ammo that matches strictly or is compatible.
+            return getWarehouse()
+                    .streamSpareParts()
+                    .filter(Quartermaster::isAvailableAsSpareAmmo)
+                    .mapToInt(part -> {
+                        AmmoStorage spare = (AmmoStorage) part;
+                        if (spare.isSameAmmoType(ammoType)) {
+                            return spare.getShots();
+                        } else if (spare.isCompatibleAmmo(ammoType)) {
+                            return convertShots(spare.getType(), spare.getShots(), ammoType);
+                        }
+                        return 0;
+                    })
+                    .sum();
+        }
+    }
+
+    /**
+     * Gets a value indicating whether or not a given {@code Part}
+     * is available for use as spare ammo.
+     * @param part The part to check if it can be used as spare ammo.
+     */
+    private static boolean isAvailableAsSpareAmmo(@Nullable Part part) {
+        return (part instanceof AmmoStorage)
+                && part.isPresent()
+                && !part.isReservedForRefit();
+    }
+
+    /**
+     * Gets the amount of ammo available of a given type.
+     * @param ammoType The type of ammo.
+     * @return The number of shots available of the given ammo type.
+     */
+    public int getAmmoAvailable(AmmoType ammoType, InfantryWeapon weaponType) {
+        Objects.requireNonNull(ammoType);
+
+        InfantryAmmoStorage spare = findSpareAmmo(ammoType, weaponType);
+        return (spare != null) ? spare.getShots() : 0;
+    }
+
+    /**
+     * Finds spare infantry ammo of a given type, if any.
+     * @param ammoType The {@code AmmoType} to search for.
+     * @param weaponType The {@code InfantryWeapon} which carries the ammo.
+     * @return The matching spare {@code InfantryAmmoStorage} part, otherwise {@code null}.
+     */
+    private @Nullable InfantryAmmoStorage findSpareAmmo(AmmoType ammoType, InfantryWeapon weaponType) {
+        return (InfantryAmmoStorage) getWarehouse().findSparePart(part -> {
+            if (!(part instanceof InfantryAmmoStorage) || !isAvailableAsSpareAmmo(part)) {
+                return false;
+            }
+            return ((InfantryAmmoStorage) part).isSameAmmoType(ammoType, weaponType);
+        });
+    }
+
+    /**
+     * Removes infantry ammo from the campaign, if available.
+     * @param ammoType The type of ammo to remove.
+     * @param infantryWeapon The infantry weapon using the ammo.
+     * @param shotsNeeded The number of rounds of ammo needed.
+     * @return The number of rounds of ammo removed from the campaign.
+     *         This value may be less than or equal to {@code shotsNeeded}.
+     */
+    public int removeAmmo(AmmoType ammoType, InfantryWeapon infantryWeapon, int shotsNeeded) {
+        Objects.requireNonNull(ammoType);
+
+        if (shotsNeeded <= 0) {
+            return 0;
+        }
+
+        InfantryAmmoStorage ammoStorage = findSpareAmmo(ammoType, infantryWeapon);
+
+        int shotsRemoved = removeAmmo(ammoStorage, shotsNeeded);
+        shotsNeeded -= shotsRemoved;
+
+        // Inform the caller how many shots we actually removed for them.
+        return shotsRemoved;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Quartermaster.java
+++ b/MekHQ/src/mekhq/campaign/Quartermaster.java
@@ -251,10 +251,8 @@ public class Quartermaster {
      */
     private @Nullable AmmoStorage findSpareAmmo(AmmoType ammoType) {
         return (AmmoStorage) getWarehouse().findSparePart(part -> {
-            if (!isAvailableAsSpareAmmo(part)) {
-                return false;
-            }
-            return ((AmmoStorage) part).isSameAmmoType(ammoType);
+            return isAvailableAsSpareAmmo(part)
+                    && ((AmmoStorage) part).isSameAmmoType(ammoType);
         });
     }
 
@@ -389,7 +387,6 @@ public class Quartermaster {
         InfantryAmmoStorage ammoStorage = findSpareAmmo(ammoType, infantryWeapon);
 
         int shotsRemoved = removeAmmo(ammoStorage, shotsNeeded);
-        shotsNeeded -= shotsRemoved;
 
         // Inform the caller how many shots we actually removed for them.
         return shotsRemoved;

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -52,6 +52,7 @@ import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.enums.PrisonerStatus;
 import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.unit.actions.AdjustLargeCraftAmmoAction;
 import mekhq.gui.FileDialogs;
 
 /**
@@ -1508,7 +1509,7 @@ public class ResolveScenarioTracker {
                 }
                 unit.setEntity(en);
                 if (en.usesWeaponBays()) {
-                    unit.adjustLargeCraftAmmo();
+                    new AdjustLargeCraftAmmoAction().execute(campaign, unit);
                 }
                 unit.runDiagnostic(true);
                 unit.resetPilotAndEntity();

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -365,123 +365,7 @@ public class CampaignXmlParser {
         timestamp = System.currentTimeMillis();
 
         // Process parts...
-        List<Part> removeParts = new ArrayList<>();
-        for (Part prt : retVal.getParts()) {
-            prt.fixReferences(retVal);
-
-            Unit u = prt.getUnit();
-            if (null != u) {
-                // get rid of any equipmentparts without locations or mounteds
-                if (prt instanceof EquipmentPart) {
-                    Mounted m = u.getEntity().getEquipment(
-                            ((EquipmentPart) prt).getEquipmentNum());
-                    if (null == m || m.getLocation() == Entity.LOC_NONE) {
-                        removeParts.add(prt);
-                        continue;
-                    }
-                    // Remove existing duplicate parts.
-                    Part duplicatePart = u.getPartForEquipmentNum(((EquipmentPart) prt).getEquipmentNum(), prt.getLocation());
-                    if ((duplicatePart instanceof EquipmentPart)
-                            && ((EquipmentPart) prt).getType().equals(((EquipmentPart) duplicatePart).getType())) {
-                        removeParts.add(prt);
-                        continue;
-                    }
-                }
-                if (prt instanceof MissingEquipmentPart) {
-                    Mounted m = u.getEntity().getEquipment(
-                            ((MissingEquipmentPart) prt).getEquipmentNum());
-                    if (null == m || m.getLocation() == Entity.LOC_NONE) {
-                        removeParts.add(prt);
-                        continue;
-                    }
-                }
-                //if the type is a BayWeapon, remove
-                if (prt instanceof EquipmentPart
-                        && ((EquipmentPart) prt).getType() instanceof BayWeapon) {
-                    removeParts.add(prt);
-                    continue;
-                }
-
-                if (prt instanceof MissingEquipmentPart
-                        && ((MissingEquipmentPart) prt).getType() instanceof BayWeapon) {
-                    removeParts.add(prt);
-                    continue;
-                }
-
-                // if actuators on units have no location (on version 1.23 and
-                // earlier) then remove them and let initializeParts (called
-                // later) create new ones
-                if ((prt instanceof MekActuator) && (prt.getLocation() == Entity.LOC_NONE)) {
-                    removeParts.add(prt);
-                } else if ((prt instanceof MissingMekActuator) && (prt.getLocation() == Entity.LOC_NONE)) {
-                    removeParts.add(prt);
-                } else if (((u.getEntity() instanceof SmallCraft) || (u.getEntity() instanceof Jumpship))
-                        && ((prt instanceof EnginePart) || (prt instanceof MissingEnginePart))) {
-                    //units from earlier versions might have the wrong kind of engine
-                    removeParts.add(prt);
-                } else {
-                    u.addPart(prt);
-                    if (prt instanceof AmmoBin) {
-                        ((AmmoBin) prt).restoreMunitionType();
-                    }
-                }
-
-            }
-            if (prt instanceof MissingPart) {
-                // Missing Parts should only exist on units, but there have
-                // been cases where they continue to float around outside of units
-                // so this should clean that up
-                if (null == u) {
-                    removeParts.add(prt);
-                } else {
-                    // run this to make sure that slots for missing parts are set as
-                    // unrepairable
-                    // because they will not be in missing locations
-                    prt.updateConditionFromPart();
-                }
-            }
-            // old versions didnt distinguish tank engines
-            if (prt instanceof EnginePart && prt.getName().contains("Vehicle")) {
-                boolean isHover = null != u
-                        && u.getEntity().getMovementMode() == EntityMovementMode.HOVER && u.getEntity() instanceof Tank;
-                ((EnginePart) prt).fixTankFlag(isHover);
-            }
-            // clan flag might not have been properly set in early versions
-            if (prt instanceof EnginePart && prt.getName().contains("(Clan")
-                    && prt.getTechBase() != Part.T_CLAN) {
-                ((EnginePart) prt).fixClanFlag();
-            }
-            if (prt instanceof MissingEnginePart && null != u
-                    && u.getEntity() instanceof Tank) {
-                boolean isHover = u.getEntity().getMovementMode() == EntityMovementMode.HOVER;
-                ((MissingEnginePart) prt).fixTankFlag(isHover);
-            }
-            if (prt instanceof MissingEnginePart
-                    && prt.getName().contains("(Clan") && prt.getTechBase() != Part.T_CLAN) {
-                ((MissingEnginePart) prt).fixClanFlag();
-            }
-
-            if ((version.getMajorVersion() == 0)
-                    && ((version.getMinorVersion() < 44)
-                            || ((version.getMinorVersion() == 43) && (version.getSnapshot() < 7)))) {
-                if ((prt instanceof MekLocation)
-                        && (((MekLocation) prt).getStructureType() == EquipmentType.T_STRUCTURE_ENDO_STEEL)) {
-                    if (null != u) {
-                        ((MekLocation) prt).setClan(TechConstants.isClan(u.getEntity().getStructureTechLevel()));
-                    } else {
-                        ((MekLocation) prt).setClan(retVal.getFaction().isClan());
-                    }
-                } else if ((prt instanceof MissingMekLocation)
-                        && (((MissingMekLocation) prt).getStructureType() == EquipmentType.T_STRUCTURE_ENDO_STEEL)) {
-                    if (null != u) {
-                        ((MissingMekLocation) prt).setClan(TechConstants.isClan(u.getEntity().getStructureTechLevel()));
-                    }
-                }
-            }
-        }
-        for (Part prt : removeParts) {
-            retVal.getWarehouse().removePart(prt);
-        }
+        postProcessParts(retVal, version);
 
         MekHQ.getLogger().info(String.format("[Campaign Load] Parts processed in %dms",
             System.currentTimeMillis() - timestamp));
@@ -657,7 +541,7 @@ public class CampaignXmlParser {
 
         //Check all parts that are reserved for refit and if the refit id unit
         //is not refitting or is gone then unreserve
-        for (Part part : retVal.getParts()) {
+        for (Part part : retVal.getWarehouse().getParts()) {
             if (part.isReservedForRefit()) {
                 Unit u = part.getRefitUnit();
                 if ((null == u) || !u.isRefitting()) {
@@ -1402,81 +1286,6 @@ public class CampaignXmlParser {
 
             Part p = Part.generateInstanceFromXML(wn2, version);
 
-            // deal with the Weapon as Heat Sink problem from earlier versions
-            if (p instanceof HeatSink && !p.getName().contains("Heat Sink")) {
-                continue;
-            }
-
-            if (((p instanceof EquipmentPart) && ((EquipmentPart) p).getType() == null)
-                    || ((p instanceof MissingEquipmentPart) && ((MissingEquipmentPart) p).getType() == null)) {
-                MekHQ.getLogger().warning(CampaignXmlParser.class, "Could not find matching EquipmentType for part " + p.getName());
-                continue;
-            }
-
-            // deal with equipmentparts that are now subtyped
-            int pid = p.getId();
-            if (isLegacyMASC(p)) {
-                p = new MASC(p.getUnitTonnage(), ((EquipmentPart) p).getType(),
-                        ((EquipmentPart) p).getEquipmentNum(), retVal, 0, p.isOmniPodded());
-                p.setId(pid);
-            }
-            if (isLegacyMissingMASC(p)) {
-                p = new MissingMASC(p.getUnitTonnage(),
-                        ((MissingEquipmentPart) p).getType(), ((MissingEquipmentPart) p).getEquipmentNum(), retVal,
-                        p.getTonnage(), 0, p.isOmniPodded());
-                p.setId(pid);
-            }
-            // deal with true values for sensor and life support on non-Mech
-            // heads
-            if (p instanceof MekLocation
-                    && ((MekLocation) p).getLoc() != Mech.LOC_HEAD) {
-                ((MekLocation) p).setSensors(false);
-                ((MekLocation) p).setLifeSupport(false);
-            }
-
-            if (version.getMinorVersion() < 3 && !p.needsFixing()
-                    && !p.isSalvaging()) {
-                // repaired parts were not getting experience properly reset
-                p.setSkillMin(SkillType.EXP_GREEN);
-            }
-
-            //if for some reason we couldn't find a type for equipment part, then remove it
-            if ((p instanceof EquipmentPart && null == ((EquipmentPart)p).getType())
-                    || (p instanceof MissingEquipmentPart && null == ((MissingEquipmentPart) p).getType())) {
-                p = null;
-            }
-
-            if ((null != p) && (p.getUnit() != null)
-                    && ((version.getMinorVersion() < 43)
-                            || ((version.getMinorVersion() == 43) && (version.getSnapshot() < 5)))
-                    && ((p instanceof AmmoBin) || (p instanceof MissingAmmoBin))) {
-                Unit u = p.getUnit();
-                if (u.getEntity().usesWeaponBays()) {
-                    Mounted ammo;
-                    if (p instanceof EquipmentPart) {
-                        ammo = u.getEntity().getEquipment(((EquipmentPart) p).getEquipmentNum());
-                    } else {
-                        ammo = u.getEntity().getEquipment(((MissingEquipmentPart) p).getEquipmentNum());
-                    }
-                    if (null != ammo) {
-                        if (p instanceof AmmoBin) {
-                            p = new LargeCraftAmmoBin(p.getUnitTonnage(),
-                                    ((AmmoBin) p).getType(),
-                                    ((AmmoBin) p).getEquipmentNum(),
-                                    ((AmmoBin) p).getShotsNeeded(),
-                                    ammo.getAmmoCapacity(), retVal);
-                            ((LargeCraftAmmoBin) p).setBay(u.getEntity().getBayByAmmo(ammo));
-                        } else {
-                            p = new MissingLargeCraftAmmoBin(p.getUnitTonnage(),
-                                    ((MissingAmmoBin) p).getType(),
-                                    ((MissingAmmoBin) p).getEquipmentNum(),
-                                    ammo.getAmmoCapacity(), retVal);
-                            ((MissingLargeCraftAmmoBin) p).setBay(u.getEntity().getBayByAmmo(ammo));
-                        }
-                    }
-                }
-            }
-
             if (p != null) {
                 parts.add(p);
             }
@@ -1485,6 +1294,233 @@ public class CampaignXmlParser {
         retVal.importParts(parts);
 
         MekHQ.getLogger().info("Load Part Nodes Complete!");
+    }
+
+    private static void postProcessParts(Campaign retVal, Version version) {
+        Map<Integer, Part> replaceParts = new HashMap<>();
+        List<Part> removeParts = new ArrayList<>();
+        for (Part prt : retVal.getWarehouse().getParts()) {
+            prt.fixReferences(retVal);
+
+            // Remove fundamentally broken equipment parts
+            if (((prt instanceof EquipmentPart) && ((EquipmentPart) prt).getType() == null)
+                    || ((prt instanceof MissingEquipmentPart) && ((MissingEquipmentPart) prt).getType() == null)) {
+                MekHQ.getLogger().warning("Could not find matching EquipmentType for part " + prt.getName());
+                removeParts.add(prt);
+                continue;
+            }
+
+            // deal with equipmentparts that are now subtyped
+            if (isLegacyMASC(prt)) {
+                Part replacement = new MASC(prt.getUnitTonnage(), ((EquipmentPart) prt).getType(),
+                        ((EquipmentPart) prt).getEquipmentNum(), retVal, 0, prt.isOmniPodded());
+                replacement.setId(prt.getId());
+                replacement.setUnit(prt.getUnit());
+                replaceParts.put(prt.getId(), replacement);
+            }
+
+            if (isLegacyMissingMASC(prt)) {
+                Part replacement = new MissingMASC(prt.getUnitTonnage(),
+                        ((MissingEquipmentPart) prt).getType(), ((MissingEquipmentPart) prt).getEquipmentNum(), retVal,
+                        prt.getTonnage(), 0, prt.isOmniPodded());
+                replacement.setId(prt.getId());
+                replacement.setUnit(prt.getUnit());
+                replaceParts.put(prt.getId(), replacement);
+            }
+
+            // Fixup LargeCraftAmmoBins from old versions
+            if ((prt.getUnit() != null) && (prt.getUnit().getEntity() != null)
+                    && ((version.getMinorVersion() < 43)
+                            || ((version.getMinorVersion() == 43) && (version.getSnapshot() < 5)))
+                    && ((prt instanceof AmmoBin) || (prt instanceof MissingAmmoBin))) {
+                if (prt.getUnit().getEntity().usesWeaponBays()) {
+                    Mounted ammo;
+                    if (prt instanceof EquipmentPart) {
+                        ammo = prt.getUnit().getEntity().getEquipment(((EquipmentPart) prt).getEquipmentNum());
+                    } else {
+                        ammo = prt.getUnit().getEntity().getEquipment(((MissingEquipmentPart) prt).getEquipmentNum());
+                    }
+                    if (null != ammo) {
+                        if (prt instanceof AmmoBin) {
+                            LargeCraftAmmoBin replacement = new LargeCraftAmmoBin(prt.getUnitTonnage(),
+                                    ((AmmoBin) prt).getType(),
+                                    ((AmmoBin) prt).getEquipmentNum(),
+                                    ((AmmoBin) prt).getShotsNeeded(),
+                                    ammo.getSize(), retVal);
+                            replacement.setId(prt.getId());
+                            replacement.setUnit(prt.getUnit());
+                            replacement.setBay(prt.getUnit().getEntity().getBayByAmmo(ammo));
+                            replaceParts.put(prt.getId(), replacement);
+                        } else {
+                            MissingLargeCraftAmmoBin replacement = new MissingLargeCraftAmmoBin(prt.getUnitTonnage(),
+                                    ((MissingAmmoBin) prt).getType(),
+                                    ((MissingAmmoBin) prt).getEquipmentNum(),
+                                    ammo.getSize(), retVal);
+                            replacement.setId(prt.getId());
+                            replacement.setUnit(prt.getUnit());
+                            replacement.setBay(prt.getUnit().getEntity().getBayByAmmo(ammo));
+                            replaceParts.put(prt.getId(), replacement);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Replace parts that need to be replaced
+        for (Map.Entry<Integer, Part> entry : replaceParts.entrySet()) {
+            int partId = entry.getKey();
+            Part oldPart = retVal.getWarehouse().getPart(partId);
+            if (oldPart != null) {
+                retVal.getWarehouse().removePart(oldPart);
+            }
+
+            retVal.getWarehouse().addPart(entry.getValue());
+        }
+
+        // After replacing parts, go back through and remove more broken parts
+        for (Part prt : retVal.getWarehouse().getParts()) {
+            // deal with the Weapon as Heat Sink problem from earlier versions
+            if (prt instanceof HeatSink && !prt.getName().contains("Heat Sink")) {
+                removeParts.add(prt);
+                continue;
+            }
+
+            Unit u = prt.getUnit();
+            if (null != u) {
+                // get rid of any equipmentparts without locations or mounteds
+                if (prt instanceof EquipmentPart) {
+                    Mounted m = u.getEntity().getEquipment(
+                            ((EquipmentPart) prt).getEquipmentNum());
+                    if ((m == null) || (m.getLocation() == Entity.LOC_NONE)) {
+                        // ... don't remove ammo bins as they may not have a location
+                        if (!(prt instanceof AmmoBin)) {
+                            removeParts.add(prt);
+                            continue;
+                        }
+                    }
+                    // Remove existing duplicate parts.
+                    Part duplicatePart = u.getPartForEquipmentNum(((EquipmentPart) prt).getEquipmentNum(), prt.getLocation());
+                    if ((duplicatePart instanceof EquipmentPart)
+                            && ((EquipmentPart) prt).getType().equals(((EquipmentPart) duplicatePart).getType())) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+                }
+                if (prt instanceof MissingEquipmentPart) {
+                    Mounted m = u.getEntity().getEquipment(
+                            ((MissingEquipmentPart) prt).getEquipmentNum());
+                    if (null == m || m.getLocation() == Entity.LOC_NONE) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+                }
+
+                //if the type is a BayWeapon, remove
+                if (prt instanceof EquipmentPart
+                        && ((EquipmentPart) prt).getType() instanceof BayWeapon) {
+                    removeParts.add(prt);
+                    continue;
+                }
+
+                if (prt instanceof MissingEquipmentPart
+                        && ((MissingEquipmentPart) prt).getType() instanceof BayWeapon) {
+                    removeParts.add(prt);
+                    continue;
+                }
+
+                // if actuators on units have no location (on version 1.23 and
+                // earlier) then remove them and let initializeParts (called
+                // later) create new ones
+                if ((prt instanceof MekActuator) && (prt.getLocation() == Entity.LOC_NONE)) {
+                    removeParts.add(prt);
+                } else if ((prt instanceof MissingMekActuator) && (prt.getLocation() == Entity.LOC_NONE)) {
+                    removeParts.add(prt);
+                } else if (((u.getEntity() instanceof SmallCraft) || (u.getEntity() instanceof Jumpship))
+                        && ((prt instanceof EnginePart) || (prt instanceof MissingEnginePart))) {
+                    //units from earlier versions might have the wrong kind of engine
+                    removeParts.add(prt);
+                } else {
+                    u.addPart(prt);
+                }
+            }
+
+            // deal with true values for sensor and life support on non-Mech
+            // heads
+            if (prt instanceof MekLocation
+                    && ((MekLocation) prt).getLoc() != Mech.LOC_HEAD) {
+                ((MekLocation) prt).setSensors(false);
+                ((MekLocation) prt).setLifeSupport(false);
+            }
+
+            if (version.getMinorVersion() < 3 && !prt.needsFixing()
+                    && !prt.isSalvaging()) {
+                // repaired parts were not getting experience properly reset
+                prt.setSkillMin(SkillType.EXP_GREEN);
+            }
+
+            if (prt instanceof MissingPart) {
+                // Missing Parts should only exist on units, but there have
+                // been cases where they continue to float around outside of units
+                // so this should clean that up
+                if (null == u) {
+                    removeParts.add(prt);
+                } else {
+                    // run this to make sure that slots for missing parts are set as
+                    // unrepairable
+                    // because they will not be in missing locations
+                    prt.updateConditionFromPart();
+                }
+            }
+
+            // old versions didnt distinguish tank engines
+            if (prt instanceof EnginePart && prt.getName().contains("Vehicle")) {
+                boolean isHover = null != u
+                        && u.getEntity().getMovementMode() == EntityMovementMode.HOVER && u.getEntity() instanceof Tank;
+                ((EnginePart) prt).fixTankFlag(isHover);
+            }
+
+            // clan flag might not have been properly set in early versions
+            if (prt instanceof EnginePart && prt.getName().contains("(Clan")
+                    && prt.getTechBase() != Part.T_CLAN) {
+                ((EnginePart) prt).fixClanFlag();
+            }
+            if (prt instanceof MissingEnginePart && null != u
+                    && u.getEntity() instanceof Tank) {
+                boolean isHover = u.getEntity().getMovementMode() == EntityMovementMode.HOVER;
+                ((MissingEnginePart) prt).fixTankFlag(isHover);
+            }
+            if (prt instanceof MissingEnginePart
+                    && prt.getName().contains("(Clan") && prt.getTechBase() != Part.T_CLAN) {
+                ((MissingEnginePart) prt).fixClanFlag();
+            }
+
+            if ((version.getMajorVersion() == 0)
+                    && ((version.getMinorVersion() < 44)
+                            || ((version.getMinorVersion() == 43) && (version.getSnapshot() < 7)))) {
+                if ((prt instanceof MekLocation)
+                        && (((MekLocation) prt).getStructureType() == EquipmentType.T_STRUCTURE_ENDO_STEEL)) {
+                    if (null != u) {
+                        ((MekLocation) prt).setClan(TechConstants.isClan(u.getEntity().getStructureTechLevel()));
+                    } else {
+                        ((MekLocation) prt).setClan(retVal.getFaction().isClan());
+                    }
+                } else if ((prt instanceof MissingMekLocation)
+                        && (((MissingMekLocation) prt).getStructureType() == EquipmentType.T_STRUCTURE_ENDO_STEEL)) {
+                    if (null != u) {
+                        ((MissingMekLocation) prt).setClan(TechConstants.isClan(u.getEntity().getStructureTechLevel()));
+                    }
+                }
+            }
+
+            // Spare Ammo bins are useless
+            if ((prt instanceof AmmoBin) && prt.isSpare()) {
+                removeParts.add(prt);
+            }
+        }
+        for (Part prt : removeParts) {
+            MekHQ.getLogger().debug("Removing part #" + prt.getId() + " " + prt.getName());
+            retVal.getWarehouse().removePart(prt);
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1380,7 +1380,7 @@ public class CampaignXmlParser {
         // After replacing parts, go back through and remove more broken parts
         for (Part prt : retVal.getWarehouse().getParts()) {
             // deal with the Weapon as Heat Sink problem from earlier versions
-            if (prt instanceof HeatSink && !prt.getName().contains("Heat Sink")) {
+            if ((prt instanceof HeatSink) && !prt.getName().contains("Heat Sink")) {
                 removeParts.add(prt);
                 continue;
             }
@@ -1409,21 +1409,21 @@ public class CampaignXmlParser {
                 if (prt instanceof MissingEquipmentPart) {
                     Mounted m = u.getEntity().getEquipment(
                             ((MissingEquipmentPart) prt).getEquipmentNum());
-                    if (null == m || m.getLocation() == Entity.LOC_NONE) {
+                    if ((null == m) || (m.getLocation() == Entity.LOC_NONE)) {
                         removeParts.add(prt);
                         continue;
                     }
                 }
 
                 //if the type is a BayWeapon, remove
-                if (prt instanceof EquipmentPart
-                        && ((EquipmentPart) prt).getType() instanceof BayWeapon) {
+                if ((prt instanceof EquipmentPart)
+                        && (((EquipmentPart) prt).getType() instanceof BayWeapon)) {
                     removeParts.add(prt);
                     continue;
                 }
 
-                if (prt instanceof MissingEquipmentPart
-                        && ((MissingEquipmentPart) prt).getType() instanceof BayWeapon) {
+                if ((prt instanceof MissingEquipmentPart)
+                        && (((MissingEquipmentPart) prt).getType() instanceof BayWeapon)) {
                     removeParts.add(prt);
                     continue;
                 }
@@ -1446,13 +1446,13 @@ public class CampaignXmlParser {
 
             // deal with true values for sensor and life support on non-Mech
             // heads
-            if (prt instanceof MekLocation
-                    && ((MekLocation) prt).getLoc() != Mech.LOC_HEAD) {
+            if ((prt instanceof MekLocation)
+                    && (((MekLocation) prt).getLoc() != Mech.LOC_HEAD)) {
                 ((MekLocation) prt).setSensors(false);
                 ((MekLocation) prt).setLifeSupport(false);
             }
 
-            if (version.getMinorVersion() < 3 && !prt.needsFixing()
+            if ((version.getMinorVersion() < 3) && !prt.needsFixing()
                     && !prt.isSalvaging()) {
                 // repaired parts were not getting experience properly reset
                 prt.setSkillMin(SkillType.EXP_GREEN);
@@ -1473,24 +1473,24 @@ public class CampaignXmlParser {
             }
 
             // old versions didnt distinguish tank engines
-            if (prt instanceof EnginePart && prt.getName().contains("Vehicle")) {
+            if ((prt instanceof EnginePart) && prt.getName().contains("Vehicle")) {
                 boolean isHover = null != u
                         && u.getEntity().getMovementMode() == EntityMovementMode.HOVER && u.getEntity() instanceof Tank;
                 ((EnginePart) prt).fixTankFlag(isHover);
             }
 
             // clan flag might not have been properly set in early versions
-            if (prt instanceof EnginePart && prt.getName().contains("(Clan")
-                    && prt.getTechBase() != Part.T_CLAN) {
+            if ((prt instanceof EnginePart) && prt.getName().contains("(Clan")
+                    && (prt.getTechBase() != Part.T_CLAN)) {
                 ((EnginePart) prt).fixClanFlag();
             }
-            if (prt instanceof MissingEnginePart && null != u
-                    && u.getEntity() instanceof Tank) {
+            if ((prt instanceof MissingEnginePart) && (null != u)
+                    && (u.getEntity() instanceof Tank)) {
                 boolean isHover = u.getEntity().getMovementMode() == EntityMovementMode.HOVER;
                 ((MissingEnginePart) prt).fixTankFlag(isHover);
             }
-            if (prt instanceof MissingEnginePart
-                    && prt.getName().contains("(Clan") && prt.getTechBase() != Part.T_CLAN) {
+            if ((prt instanceof MissingEnginePart)
+                    && prt.getName().contains("(Clan") && (prt.getTechBase() != Part.T_CLAN)) {
                 ((MissingEnginePart) prt).fixClanFlag();
             }
 

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -28,7 +28,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import megamek.common.AmmoType;
-import megamek.common.BombType;
 import megamek.common.ITechnology;
 import megamek.common.TargetRoll;
 import megamek.common.TechAdvancement;
@@ -116,25 +115,30 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     @Override
     public boolean isSamePartType(@Nullable Part part) {
         if ((getType() != null) && (part instanceof AmmoStorage)) {
-            AmmoStorage other = (AmmoStorage) part;
-            return isSameAmmoType(getType(), other.getType());
+            return getType().equals(((AmmoStorage) part).getType());
         }
 
         return false;
     }
 
-    public static boolean isSameAmmoType(AmmoType a, AmmoType b) {
-        // TODO: move this to AmmoType::equals and a Comparator
-        if (a instanceof BombType && b instanceof BombType) {
-            return isSameBombType((BombType) a, (BombType) b);
-        } else {
-            return a.equals(b) && (a.getMunitionType() == b.getMunitionType());
-        }
+    /**
+     * Gets a value indicating whether or an {@code AmmoType} is
+     * the same as this instance's ammo.
+     * @param otherAmmoType The other {@code AmmoType}.
+     */
+    public boolean isSameAmmoType(AmmoType otherAmmoType) {
+        return getType().equalsAmmoTypeOnly(otherAmmoType)
+            && (getType().getMunitionType() == otherAmmoType.getMunitionType())
+            && (getType().getRackSize() == otherAmmoType.getRackSize());
     }
 
-    public static boolean isSameBombType(BombType a, BombType b) {
-        // TODO: move this to BombType::equals and a Comparator
-        return a.equals(b) && (a.getBombType() == b.getBombType());
+    /**
+     * Gets a value indicating whether or not an {@code AmmoType}
+     * is compatible with this instance's ammo.
+     * @param otherAmmoType The other {@code AmmoType}.
+     */
+    public boolean isCompatibleAmmo(AmmoType otherAmmoType) {
+        return getType().isCompatibleWith(otherAmmoType);
     }
 
     public void changeShots(int s) {
@@ -148,18 +152,8 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         writeToXmlBegin(pw1, indent);
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<equipmentNum>"
-                +equipmentNum
-                +"</equipmentNum>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<typeName>"
-                +MekHqXmlUtil.escape(typeName)
-                +"</typeName>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<shots>"
-                +shots
-                +"</shots>");
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "typeName", getType().getInternalName());
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "shots", shots);
         writeToXmlEnd(pw1, indent);
     }
 
@@ -167,16 +161,15 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     protected void loadFieldsFromXmlNode(Node wn) {
         NodeList nl = wn.getChildNodes();
 
-        for (int x=0; x<nl.getLength(); x++) {
+        for (int x = 0; x < nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            if (wn2.getNodeName().equalsIgnoreCase("equipmentNum")) {
-                equipmentNum = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("typeName")) {
+            if (wn2.getNodeName().equalsIgnoreCase("typeName")) {
                 typeName = wn2.getTextContent();
             } else if (wn2.getNodeName().equalsIgnoreCase("shots")) {
                 shots = Integer.parseInt(wn2.getTextContent());
             }
         }
+
         restore();
     }
 
@@ -271,27 +264,6 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     @Override
     public String failToFind() {
         return "<font color='red'><b> part not found</b>.</font>";
-    }
-
-    public void changeAmountAvailable(int amount, final AmmoType curType) {
-        if (amount == 0) {
-            return;
-        }
-
-        AmmoStorage a = (AmmoStorage) campaign.getWarehouse().findSparePart(part -> {
-            return (part instanceof AmmoStorage)
-                    && part.isPresent()
-                    && isSameAmmoType(curType, ((AmmoStorage) part).getType());
-        });
-
-        if (null != a) {
-            a.changeShots(amount);
-            if (a.getShots() <= 0) {
-                campaign.getWarehouse().removePart(a);
-            }
-        } else if(amount > 0) {
-            campaign.getQuartermaster().addPart(new AmmoStorage(1, curType, amount, campaign), 0);
-        }
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -98,8 +98,24 @@ public class InfantryAmmoStorage extends AmmoStorage {
     @Override
     public boolean isSamePartType(Part part) {
         return (part instanceof InfantryAmmoStorage)
-                && isSameAmmoType(getType(), ((InfantryAmmoStorage) part).getType())
-                && Objects.equals(getWeaponType(), ((InfantryAmmoStorage) part).getWeaponType());
+                && isSameAmmoType(((InfantryAmmoStorage) part).getType(), ((InfantryAmmoStorage) part).getWeaponType());
+    }
+
+    /**
+     * Gets a value indicating whether or not the {@code AmmoType} for the {@code InfantryWeapon}
+     * is the same as this instance.
+     * @param ammoType The {@code AmmoType}.
+     * @param weaponType The {@code InfantryWeapon} carrying the ammo.
+     */
+    public boolean isSameAmmoType(AmmoType ammoType, InfantryWeapon weaponType) {
+        return isSameAmmoType(ammoType)
+                && Objects.equals(getWeaponType(), weaponType);
+    }
+
+    @Override
+    public boolean isCompatibleAmmo(AmmoType otherAmmoType) {
+        // Cannot change between infantry ammo types
+        return false;
     }
 
     @Override
@@ -123,31 +139,6 @@ public class InfantryAmmoStorage extends AmmoStorage {
     @Override
     public TechAdvancement getTechAdvancement() {
         return getWeaponType().getTechAdvancement();
-    }
-
-    /**
-     * Boolean function that determines if the given part is of the correct ammo.
-     * Useful as a predicate for campaign.findSparePart()
-     */
-    public static boolean isRightAmmo(Part part, AmmoType curType, WeaponType weaponType) {
-        return (part instanceof InfantryAmmoStorage)
-                && part.isPresent()
-                && isSameAmmoType(curType, ((InfantryAmmoStorage) part).getType())
-                && (((InfantryAmmoStorage) part).getWeaponType()).equals(weaponType);
-    }
-
-    public void changeAmountAvailable(int amount, final AmmoType curType) {
-        InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.getWarehouse().findSparePart(part ->
-                isRightAmmo(part, curType, getWeaponType()));
-
-        if (null != a) {
-            a.changeShots(amount);
-            if (a.getShots() <= 0) {
-                campaign.getWarehouse().removePart(a);
-            }
-        } else if (amount > 0) {
-            campaign.getQuartermaster().addPart(new InfantryAmmoStorage(1, curType, amount, getWeaponType(), campaign), 0);
-        }
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -25,7 +25,6 @@ import java.io.PrintWriter;
 
 import megamek.common.ITechnology;
 import megamek.common.TargetRoll;
-import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
@@ -348,18 +347,6 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
     @Override
     public String failToFind() {
         return "<font color='red'><b> part not found</b>.</font>";
-    }
-
-    @Override
-    public void writeToXmlBegin(PrintWriter pw1, int indent) {
-        super.writeToXmlBegin(pw1, indent);
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<daysToWait>"
-                +daysToWait
-                +"</daysToWait>");
-        if (hasReplacementPart()) {
-            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "replacementId", getReplacementPart().getId());
-        }
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -86,7 +86,6 @@ import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.HeatSink;
 import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
-import mekhq.campaign.parts.equipment.MissingAmmoBin;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
@@ -366,7 +365,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 // the old parts list here.
                 if (oPart instanceof LargeCraftAmmoBin
                         && part instanceof LargeCraftAmmoBin
-                        && ((LargeCraftAmmoBin) oPart).getType() == ((LargeCraftAmmoBin) part).getType()) {
+                        && ((LargeCraftAmmoBin) oPart).getType().equals(((LargeCraftAmmoBin) part).getType())) {
                     lcBinsToChange.add(oPart);
                 }
 
@@ -551,40 +550,21 @@ public class Refit extends Part implements IAcquisitionWork {
                 //armor always gets added to the shopping list - it will be checked for differently
                 //NOT ANYMORE - I think this is overkill, lets just reuse existing armor parts
             } else if (nPart instanceof AmmoBin) {
-                AmmoType type = (AmmoType) ((AmmoBin) nPart).getType();
+                AmmoBin ammoBin = (AmmoBin) nPart;
+                AmmoType type = ammoBin.getType();
+
+                ammoNeeded.merge(type, ammoBin.getFullShots(), Integer::sum);
+                shoppingList.add(nPart);
+
                 if (nPart instanceof LargeCraftAmmoBin) {
-                    ammoNeeded.merge(type, ((LargeCraftAmmoBin) nPart).getFullShots(), Integer::sum);
                     // Adding ammo requires base 15 minutes per ton of ammo or 60 minutes per capital missile
                     if (type.hasFlag(AmmoType.F_CAP_MISSILE) || type.hasFlag(AmmoType.F_CRUISE_MISSILE) || type.hasFlag(AmmoType.F_SCREEN)) {
-                        time += 60 * ((LargeCraftAmmoBin) nPart).getFullShots();
+                        time += 60 * ammoBin.getFullShots();
                     } else {
                         time += (int) Math.ceil(15 * Math.max(1, nPart.getTonnage()));
                     }
-                    shoppingList.add(nPart);
                 } else {
                     time += 120;
-                    ammoNeeded.merge(type, type.getShots(), Integer::sum);
-                    //check for ammo bins in storage to avoid the proliferation of infinite ammo bins
-                    MissingAmmoBin mab = (MissingAmmoBin)nPart.getMissingPart();
-                    Part replacement = mab.findReplacement(true);
-                    //check quantity
-                    //TODO: the one weakness here is that we will not pick up damaged parts
-                    if ((null != replacement) && (null == partQuantity.get(replacement))) {
-                        partQuantity.put(replacement, replacement.getQuantity());
-                    }
-
-                    if ((null != replacement) && (partQuantity.get(replacement) > 0)) {
-                        newUnitParts.add(replacement);
-                        //adjust quantity
-                        partQuantity.put(replacement, partQuantity.get(replacement)-1);
-                        //If the quantity is now 0 set usedForRefitPlanning flag so findReplacement ignores this item
-                        if (partQuantity.get(replacement) == 0) {
-                            replacement.setUsedForRefitPlanning(true);
-                            plannedReplacementParts.add(replacement);
-                        }
-                    } else {
-                        shoppingList.add(nPart);
-                    }
                 }
             } else if (nPart instanceof SpacecraftCoolingSystem) {
                 int sinkType = ((SpacecraftCoolingSystem)nPart).getSinkType();
@@ -805,7 +785,7 @@ public class Refit extends Part implements IAcquisitionWork {
             }
             if (oPart instanceof AmmoBin) {
                 int remainingShots = ((AmmoBin)oPart).getFullShots() - ((AmmoBin)oPart).getShotsNeeded();
-                AmmoType type = (AmmoType)((AmmoBin)oPart).getType();
+                AmmoType type = ((AmmoBin)oPart).getType();
                 if (remainingShots > 0) {
                     if (oPart instanceof LargeCraftAmmoBin) {
                         if (type.hasFlag(AmmoType.F_CAP_MISSILE) || type.hasFlag(AmmoType.F_CRUISE_MISSILE) || type.hasFlag(AmmoType.F_SCREEN)) {
@@ -862,7 +842,7 @@ public class Refit extends Part implements IAcquisitionWork {
         //TODO: use ammo removed from the old unit in the case of changing between full ton and half
         //ton MG or OS/regular.
         for (AmmoType type : ammoNeeded.keySet()) {
-            int shotsNeeded = Math.max(ammoNeeded.get(type) - AmmoBin.getAmountAvailable(campaign, type), 0);
+            int shotsNeeded = Math.max(ammoNeeded.get(type) - campaign.getQuartermaster().getAmmoAvailable(type), 0);
             int shotsPerTon = type.getShots();
             if ((shotsNeeded > 0) && (shotsPerTon > 0)) {
                 cost = cost.plus(Money.of(type.getCost(newEntity, false, -1) * ((double) shotsNeeded / shotsPerTon)));
@@ -1052,7 +1032,7 @@ public class Refit extends Part implements IAcquisitionWork {
             if (part instanceof AmmoBin) {
                 AmmoBin bin = (AmmoBin) part;
                 bin.setShotsNeeded(bin.getFullShots());
-                shotsNeeded.merge((AmmoType) bin.getType(), bin.getShotsNeeded(), Integer::sum);
+                shotsNeeded.merge(bin.getType(), bin.getShotsNeeded(), Integer::sum);
             }
         }
 
@@ -1065,42 +1045,35 @@ public class Refit extends Part implements IAcquisitionWork {
                 newUnitParts.add(part);
                 AmmoBin bin = (AmmoBin) part;
                 bin.setShotsNeeded(bin.getFullShots());
-                shotsNeeded.merge((AmmoType) bin.getType(), bin.getShotsNeeded(), Integer::sum);
+                shotsNeeded.merge(bin.getType(), bin.getShotsNeeded(), Integer::sum);
                 iter.remove();
             }
         }
 
         // If we need ammunition, put it into two buckets:
-        // 1. Shots to buy
-        // 2. Shots from the warehouse
+        // 1. Shots from the warehouse
+        // 2. Shots to buy
         for (AmmoType atype : shotsNeeded.keySet()) {
-            int needed = shotsNeeded.get(atype);
-            int available = AmmoBin.getAmountAvailable(campaign, atype);
+            int shotsToBuy = shotsNeeded.get(atype);
 
-            // Add to our shopping list however many shots we need to purchase
-            int shotsToBuy = Math.max(0, shotsNeeded.get(atype) - available);
-            if (shotsToBuy > 0) {
-                int tons = (int) Math.ceil((double) shotsToBuy / atype.getShots());
-                AmmoStorage ammo = new AmmoStorage(0, atype, atype.getShots() * tons, campaign);
+            // Try pulling from our stock ...
+            int shotsRemoved = campaign.getQuartermaster().removeAmmo(atype, shotsToBuy);
+            if (shotsRemoved > 0) {
+                shotsToBuy -= shotsRemoved;
 
-                newUnitParts.add(ammo);
-                shoppingList.add(ammo);
-
-                // Reduce the amount we need by the amount we bought
-                needed -= shotsToBuy;
-            }
-
-            // Now we can go through our available inventory and snag them
-            if (needed > 0) {
-                // pull from our stock...
-                AmmoBin.changeAmountAvailable(campaign, -needed, atype);
-
-                // ...and add that to our list of new unit parts
-                int tons = (int) Math.ceil((double) needed / atype.getShots());
-                AmmoStorage ammo = new AmmoStorage(tons, atype, atype.getShots() * tons, campaign);
+                // ... and add that to our list of new unit parts.
+                AmmoStorage ammo = new AmmoStorage(0, atype, shotsRemoved, campaign);
                 ammo.setRefitUnit(oldUnit);
                 campaign.getQuartermaster().addPart(ammo, 0);
                 newUnitParts.add(ammo);
+            }
+
+            // Add to our shopping list however many shots we need to purchase
+            if (shotsToBuy > 0) {
+                int tons = (int) Math.ceil((double) shotsToBuy / atype.getShots());
+                AmmoStorage ammo = new AmmoStorage(0, atype, tons * atype.getShots(), campaign);
+                newUnitParts.add(ammo);
+                shoppingList.add(ammo);
             }
         }
 
@@ -1127,8 +1100,10 @@ public class Refit extends Part implements IAcquisitionWork {
                     part.setRefitUnit(oldUnit);
                     getCampaign().getQuartermaster().addPart(part, 0);
                     newUnitParts.add(part);
+
+                    // Check if we need more ammo
                     if (bin.needsFixing()) {
-                        getCampaign().getShoppingList().addShoppingItem(bin, 1, getCampaign());
+                        getCampaign().getShoppingList().addShoppingItem(bin.getNewPart(), 1, getCampaign());
                     }
                 }
                 else if (part instanceof IAcquisitionWork) {
@@ -1300,16 +1275,6 @@ public class Refit extends Part implements IAcquisitionWork {
     public void cancel() {
         oldUnit.setRefit(null);
 
-        // Return our reserved ammo back to the campaign
-        for (Part part : newUnitParts) {
-            if (part instanceof AmmoStorage) {
-                // merge back into the campaign
-                AmmoStorage ammoStorage = (AmmoStorage) part;
-                AmmoBin.changeAmountAvailable(campaign, ammoStorage.getShots(), (AmmoType) ammoStorage.getType());
-                getCampaign().getWarehouse().removePart(part);
-            }
-        }
-
         for (Part part : newUnitParts) {
             part.setRefitUnit(null);
 
@@ -1320,11 +1285,7 @@ public class Refit extends Part implements IAcquisitionWork {
                     ((AmmoBin) part).unload();
                     getCampaign().getWarehouse().removePart(part);
                 } else {
-                    Part spare = getCampaign().getWarehouse().checkForExistingSparePart(part);
-                    if (null != spare) {
-                        spare.incrementQuantity();
-                        getCampaign().getWarehouse().removePart(part);
-                    }
+                    getCampaign().getQuartermaster().addPart(part, 0);
                 }
             }
         }
@@ -1485,9 +1446,10 @@ public class Refit extends Part implements IAcquisitionWork {
                     continue;
                 }
             } else if (part instanceof AmmoStorage) {
+                // FIXME: why are we merging this back in?!
                 // merge back into the campaign before completing the refit
                 AmmoStorage ammoStorage = (AmmoStorage) part;
-                AmmoBin.changeAmountAvailable(campaign, ammoStorage.getShots(), (AmmoType) ammoStorage.getType());
+                getCampaign().getQuartermaster().addAmmo(ammoStorage.getType(), ammoStorage.getShots());
                 getCampaign().getWarehouse().removePart(part);
                 continue;
             }
@@ -1517,15 +1479,17 @@ public class Refit extends Part implements IAcquisitionWork {
         }
 
         for (Part p : newParts) {
-            if (p instanceof LargeCraftAmmoBin) {
+            if (p instanceof AmmoBin) {
                 //All large craft ammo got unloaded into the warehouse earlier, though the part IDs have now changed.
                 //Consider all LC ammobins empty and load them back up.
-                ((AmmoBin) p).setShotsNeeded(((AmmoBin) p).getFullShots());
-                ((AmmoBin) p).loadBin();
-            } else if (p instanceof AmmoBin) {
+                if (p instanceof LargeCraftAmmoBin) {
+                    ((AmmoBin) p).setShotsNeeded(((AmmoBin) p).getFullShots());
+                }
+
                 ((AmmoBin) p).loadBin();
             }
         }
+        
         if (null != newArmorSupplies) {
             getCampaign().getWarehouse().removePart(newArmorSupplies);
         }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -785,7 +785,7 @@ public class Refit extends Part implements IAcquisitionWork {
             }
             if (oPart instanceof AmmoBin) {
                 int remainingShots = ((AmmoBin)oPart).getFullShots() - ((AmmoBin)oPart).getShotsNeeded();
-                AmmoType type = ((AmmoBin)oPart).getType();
+                AmmoType type = ((AmmoBin) oPart).getType();
                 if (remainingShots > 0) {
                     if (oPart instanceof LargeCraftAmmoBin) {
                         if (type.hasFlag(AmmoType.F_CAP_MISSILE) || type.hasFlag(AmmoType.F_CRUISE_MISSILE) || type.hasFlag(AmmoType.F_SCREEN)) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -22,10 +22,7 @@
 package mekhq.campaign.parts.equipment;
 
 import java.io.PrintWriter;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.function.Predicate;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -45,12 +42,9 @@ import megamek.common.TechAdvancement;
 import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Availability;
-import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.PartInventory;
 import mekhq.campaign.personnel.Person;
@@ -63,31 +57,19 @@ import mekhq.campaign.work.IAcquisitionWork;
 public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     private static final long serialVersionUID = 2892728320891712304L;
 
-    public static final Integer[] ALLOWED_BY_TYPE_ARRAY = { AmmoType.T_LRM, AmmoType.T_LRM_PRIMITIVE, AmmoType.T_LRM_STREAK, AmmoType.T_LRM_TORPEDO,
-        AmmoType.T_LRM_TORPEDO_COMBO, AmmoType.T_SRM, AmmoType.T_SRM_ADVANCED, AmmoType.T_SRM_PRIMITIVE, AmmoType.T_SRM_STREAK, AmmoType.T_SRM_TORPEDO,
-        AmmoType.T_MRM, AmmoType.T_MRM_STREAK, AmmoType.T_ROCKET_LAUNCHER, AmmoType.T_EXLRM, AmmoType.T_PXLRM, AmmoType.T_HSRM, AmmoType.T_MML,
-        AmmoType.T_NLRM };
-    public static final HashSet<Integer> ALLOWED_BY_TYPE = new HashSet<>(Arrays.asList(ALLOWED_BY_TYPE_ARRAY));
-
-    protected long munition;
     protected int shotsNeeded;
-    protected boolean checkedToday;
     protected boolean oneShot;
 
     public AmmoBin() {
         this(0, null, -1, 0, false, false, null);
     }
 
-    public AmmoBin(int tonnage, @Nullable AmmoType et, int equipNum, int shots, boolean singleShot,
+    public AmmoBin(int tonnage, @Nullable AmmoType et, int equipNum, int shotsNeeded, boolean singleShot,
             boolean omniPodded, @Nullable Campaign c) {
         super(tonnage, et, equipNum, 1.0, omniPodded, c);
-        this.shotsNeeded = shots;
+        this.shotsNeeded = shotsNeeded;
         this.oneShot = singleShot;
-        this.checkedToday = false;
-        if (et != null) {
-            this.munition = et.getMunitionType();
-        }
-        if(null != name) {
+        if (name != null) {
             this.name += " Bin";
         }
     }
@@ -97,7 +79,6 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 omniPodded, campaign);
         clone.copyBaseData(this);
         clone.shotsNeeded = this.shotsNeeded;
-        clone.munition = this.munition;
         return clone;
     }
 
@@ -130,26 +111,30 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public double getTonnage() {
-        return (1.0 * getFullShots())/((AmmoType)type).getShots();
+        return getFullShots() / (double) getType().getShots();
     }
 
     public int getFullShots() {
-        int fullShots = ((AmmoType)type).getShots();
-        if(unit != null) {
-            Mounted m = unit.getEntity().getEquipment(equipmentNum);
-            if(null != m && m.getOriginalShots() > 0) {
-                fullShots = m.getOriginalShots();
+        if (oneShot) {
+            return 1;
+        }
+
+        int fullShots = getType().getShots();
+
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            if (mounted.getOriginalShots() > 0) {
+                fullShots = mounted.getOriginalShots();
+            }
+
+            if (unit.getEntity() instanceof Protomech) {
+                // If protomechs are using alternate munitions then cut in half
+                if (getType().getMunitionType() != AmmoType.M_STANDARD) {
+                    fullShots = fullShots / 2;
+                }
             }
         }
-        if(null != unit && unit.getEntity() instanceof Protomech) {
-            //if protomechs are using alternate munitions then cut in half
-            if(((AmmoType)type).getMunitionType() != AmmoType.M_STANDARD) {
-                fullShots = fullShots / 2;
-            }
-        }
-        if(oneShot) {
-            fullShots = 1;
-        }
+
         return fullShots;
     }
 
@@ -158,7 +143,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     public Money getValueNeeded() {
-        if (getShotsPerTon() <= 0) {
+        if ((getShotsPerTon() <= 0) || (shotsNeeded <= 0)) {
             return Money.zero();
         }
 
@@ -168,25 +153,23 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     protected Money getPricePerTon() {
-        //if on a unit, then use the ammo type on the existing entity, to avoid getting it wrong due to
-        //ammo swaps
-        EquipmentType curType = type;
-        if(null != unit && null != unit.getEntity()) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted && (mounted.getType() instanceof AmmoType)) {
-                curType = mounted.getType();
-            }
-        }
+        Mounted mounted = getMounted();
+
+        // If on a unit, then use the ammo type on the existing entity,
+        // to avoid getting it wrong due to ammo swaps
+        EquipmentType curType = (mounted != null) ? mounted.getType() : getType();
+
         return Money.of(curType.getRawCost());
     }
 
     protected int getShotsPerTon() {
-        AmmoType atype = (AmmoType)type;
+        AmmoType atype = getType();
         if(atype.getKgPerShot() > 0) {
-            return (int)Math.floor(1000.0/atype.getKgPerShot());
+            return (int) Math.floor(1000.0 / atype.getKgPerShot());
         }
+
         //if not listed by kg per shot, we assume this is a single ton increment
-        return ((AmmoType)type).getShots();
+        return getType().getShots();
     }
 
     @Override
@@ -206,102 +189,56 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     public int getShotsNeeded() {
-        return (ammoTypeChanged()? getFullShots() : shotsNeeded);
-    }
-
-    public void changeMunition(long m) {
-        this.munition = m;
-        for (AmmoType atype : Utilities.getMunitionsFor(unit.getEntity(),(AmmoType)type, CampaignOptions.TECH_EXPERIMENTAL)) {
-            if (atype.getMunitionType() == munition) {
-                type = atype;
-                break;
-            }
-        }
-        updateConditionFromEntity(false);
+        return ammoTypeChanged() ? getFullShots() : shotsNeeded;
     }
 
     public void changeMunition(AmmoType type) {
-        munition = type.getMunitionType();
         this.type = type;
         this.name = type.getName();
         this.typeName = type.getInternalName();
         updateConditionFromEntity(false);
     }
 
-    private boolean ammoTypeChanged() {
-        if (null != unit) {
-            Mounted m = unit.getEntity().getEquipment(equipmentNum);
-            return (m == null) || !Objects.equals(m.getType(), getType());
-        }
-        return false;
+    protected boolean ammoTypeChanged() {
+        Mounted mounted = getMounted();
+        return (mounted != null)
+                && !getType().equals(mounted.getType());
     }
 
     @Override
-    public void writeToXml(PrintWriter pw1, int indent) {
-        writeToXmlBegin(pw1, indent);
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<equipmentNum>"
-                +equipmentNum
-                +"</equipmentNum>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<typeName>"
-                +MekHqXmlUtil.escape(type.getInternalName())
-                +"</typeName>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<munition>"
-                +munition
-                +"</munition>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<shotsNeeded>"
-                +shotsNeeded
-                +"</shotsNeeded>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<checkedToday>"
-                +checkedToday
-                +"</checkedToday>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<oneShot>"
-                +oneShot
-                +"</oneShot>");
-        writeToXmlEnd(pw1, indent);
+    protected void writeToXmlEnd(PrintWriter pw1, int indent) {
+        // CAW: InfantryAmmoBin may have negative shots needed
+        if (shotsNeeded != 0) {
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "shotsNeeded", shotsNeeded);
+        }
+
+        if (oneShot) {
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "oneShot", oneShot);
+        }
+
+        super.writeToXmlEnd(pw1, indent);
     }
 
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
-        super.loadFieldsFromXmlNode(wn);
         NodeList nl = wn.getChildNodes();
 
-        for (int x=0; x<nl.getLength(); x++) {
+        for (int x = 0; x < nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            if (wn2.getNodeName().equalsIgnoreCase("equipmentNum")) {
-                equipmentNum = Integer.parseInt(wn2.getTextContent());
-            }
-            else if (wn2.getNodeName().equalsIgnoreCase("typeName")) {
-                typeName = wn2.getTextContent();
-            } else if (wn2.getNodeName().equalsIgnoreCase("munition")) {
-                munition = Long.parseLong(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("shotsNeeded")) {
+            if (wn2.getNodeName().equalsIgnoreCase("shotsNeeded")) {
                 shotsNeeded = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("checkedToday")) {
-                checkedToday = wn2.getTextContent().equalsIgnoreCase("true");
             } else if (wn2.getNodeName().equalsIgnoreCase("oneShot")) {
                 oneShot = wn2.getTextContent().equalsIgnoreCase("true");
             }
         }
-        restore();
+
+        super.loadFieldsFromXmlNode(wn);
     }
 
-    public void restoreMunitionType() {
-        for (AmmoType atype : Utilities.getMunitionsFor(unit.getEntity(),(AmmoType)type, CampaignOptions.TECH_EXPERIMENTAL)) {
-            if (atype.getMunitionType() == munition && atype.getInternalName().equals(type.getInternalName())) {
-                type = atype;
-                break;
-            }
-        }
-    }
-
+    // FIXME: does not take into account BombType
+    @Deprecated
     public long getMunitionType() {
-        return munition;
+        return getType().getMunitionType();
     }
 
     @Override
@@ -324,34 +261,64 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     public void loadBin() {
-        int shots = Math.min(getAmountAvailable(), getShotsNeeded());
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted) {
-                EquipmentType mType = mounted.getType();
-                if (mType instanceof AmmoType) {
-                    if (!ammoTypeChanged()) {
-                        //just a simple reload
-                        mounted.setShotsLeft(mounted.getBaseShotsLeft() + shots);
-                    } else {
-                        //loading a new type of ammo
-                        unload();
-                        mounted.changeAmmoType((AmmoType)type);
-                        mounted.setShotsLeft(shots);
-                    }
-
-                    changeAmountAvailable(-1 * shots, (AmmoType)type);
-                    shotsNeeded -= shots;
-                }
-                else {
-                    MekHQ.getLogger().warning(mType.getName() + " is not valid equipment for " + getName() + " to restock ammo on unit " + unit.getName());
-                }
-            }
+        Mounted mounted = getMounted();
+        if (mounted == null) {
+            return;
         }
+
+        // Try to remove the ammo needed.
+        int shots = requisitionAmmo(getType(), getShotsNeeded());
+        if (!ammoTypeChanged()) {
+            // just a simple reload
+            mounted.setShotsLeft(mounted.getBaseShotsLeft() + shots);
+        } else {
+            // loading a new type of ammo
+            unload();
+            mounted.changeAmmoType(getType());
+            mounted.setShotsLeft(shots);
+        }
+
+        shotsNeeded -= shots;
     }
 
+    /**
+     * Gets the underlying {@link Mounted} which manages
+     * this {@code AmmoBin} on the {@link Unit}.
+     * @return The {@code Mounted} or {@code null} if no valid
+     *         piece of equipment exists on the {@code Unit}.
+     */
+    protected @Nullable Mounted getMounted() {
+        if ((getUnit() != null) && (getUnit().getEntity() != null)) {
+            Mounted mounted = getUnit().getEntity().getEquipment(getEquipmentNum());
+            if ((mounted != null) && (mounted.getType() instanceof AmmoType)) {
+                return mounted;
+            }
+
+            MekHQ.getLogger().warning("Missing valid equipment for " + getName() + " to manage ammo on unit " + getUnit().getName());
+        }
+
+        return null;
+    }
+
+    /**
+     * Requisitions ammo of a given type from the quartermaster.
+     *
+     * @param ammoType The {@code AmmoType} being requisitioned.
+     * @param shotsNeeded The number of shots needed from the quartermaster.
+     * @return The number of shots requisitioned. This may be less than {@code shotsNeeded}.
+     */
+    protected int requisitionAmmo(AmmoType ammoType, int shotsNeeded) {
+        Objects.requireNonNull(ammoType);
+
+        return campaign.getQuartermaster().removeAmmo(ammoType, shotsNeeded);
+    }
+
+    /**
+     * Sets the number of shots needed in the {@code AmmoBin}.
+     * @param shots The number of shots needed.
+     */
     public void setShotsNeeded(int shots) {
-        this.shotsNeeded = shots;
+        this.shotsNeeded = Math.max(0, shots);
     }
 
     @Override
@@ -371,32 +338,48 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         //may want to think about not having refits load ammo bins but rather reserve
         //some AmmoStorage instead if we implement customization of these units
         int shots = getFullShots() - shotsNeeded;
-        AmmoType curType = getType();
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if ((null != mounted) && (mounted.getType() instanceof AmmoType)) {
-                shots = mounted.getBaseShotsLeft();
-                mounted.setShotsLeft(0);
-                curType = (AmmoType)mounted.getType();
-            }
+
+        Mounted mounted = getMounted();
+        AmmoType ammoType = (mounted != null) ? ((AmmoType) mounted.getType()) : getType();
+        if (mounted != null) {
+            shots = mounted.getBaseShotsLeft();
+            mounted.setShotsLeft(0);
         }
+
         shotsNeeded = getFullShots();
-        if(shots > 0) {
-            changeAmountAvailable(shots, curType);
+
+        // Return ammo to the campaign
+        returnAmmo(ammoType, shots);
+    }
+
+    /**
+     * Returns ammo unloaded from the bin to the quartermaster.
+     *
+     * @param ammoType The {@code AmmoType} unloaded.
+     * @param shotsUnloaded The number of shots of ammo unloaded.
+     */
+    protected void returnAmmo(AmmoType ammoType, int shotsUnloaded) {
+        Objects.requireNonNull(ammoType);
+
+        if (shotsUnloaded > 0) {
+            getCampaign().getQuartermaster().addAmmo(ammoType, shotsUnloaded);
         }
     }
 
     @Override
     public void remove(boolean salvage) {
-        if(salvage) {
+        if (salvage) {
             unload();
         }
         super.remove(salvage);
+
+        // We don't keep around ammo bins anymore
+        getCampaign().getWarehouse().removePart(this);
     }
 
     @Override
-    public MissingPart getMissingPart() {
-        return new MissingAmmoBin(getUnitTonnage(), getType(), equipmentNum, oneShot, omniPodded, campaign);
+    public MissingAmmoBin getMissingPart() {
+        return new MissingAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), isOneShot(), omniPodded, campaign);
     }
 
     public boolean isOneShot() {
@@ -413,39 +396,33 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted) {
-                if (mounted.isMissing() || mounted.isDestroyed()) {
-                    mounted.setShotsLeft(0);
-                    remove(false);
-                    return;
-                }
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            if (mounted.isMissing() || mounted.isDestroyed()) {
+                mounted.setShotsLeft(0);
+                remove(false);
+                return;
+            }
 
-                if (Objects.equals(getType(), mounted.getType())) {
-                    shotsNeeded = getFullShots() - mounted.getBaseShotsLeft();
-                }
+            if (getType().equals(mounted.getType())) {
+                shotsNeeded = getFullShots() - mounted.getBaseShotsLeft();
             }
         }
     }
 
     @Override
     public int getBaseTime() {
-        if(isSalvaging()) {
+        if (isSalvaging()) {
             return isOmniPodded()? 30 : 120;
         }
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                long currentMuniType = 0;
-                if(mounted.getType() instanceof AmmoType) {
-                    currentMuniType = ((AmmoType)mounted.getType()).getMunitionType();
-                }
-                if(getMunitionType() != currentMuniType) {
-                    return 30;
-                }
-            }
+
+        Mounted mounted = getMounted();
+        if ((mounted != null) && !getType().equals(mounted.getType())) {
+            // If we're not the same ammo type as our unit, it takes longer
+            // to do work on the AmmoBin.
+            return 30;
         }
+
         return 15;
     }
 
@@ -467,24 +444,25 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public void updateConditionFromPart() {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                mounted.setHit(false);
-                mounted.setDestroyed(false);
-                mounted.setRepairable(true);
-                unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
-                mounted.setShotsLeft(getFullShots() - shotsNeeded);
-            }
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            mounted.setHit(false);
+            mounted.setDestroyed(false);
+            mounted.setRepairable(true);
+            getUnit().repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
+            mounted.setShotsLeft(getFullShots() - shotsNeeded);
         }
     }
 
     @Override
     public boolean isSamePartType(Part part) {
-        return  (part instanceof AmmoBin)
+        // AmmoBins are the same type of part if they can hold the same
+        // AmmoType and number of rounds of ammo (i.e. they are the same
+        // irrespective of "munition type" or "bomb type").
+        return (part instanceof AmmoBin)
                 && !(part instanceof LargeCraftAmmoBin)
-                && getType().equals( ((AmmoBin)part).getType() )
-                && ((AmmoBin)part).getFullShots() == getFullShots();
+                && getType().isCompatibleWith(((AmmoBin) part).getType())
+                && ((AmmoBin) part).getFullShots() == getFullShots();
     }
 
     @Override
@@ -552,194 +530,12 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         return null;
     }
 
-    public static void swapAmmoFromCompatible(Campaign campaign, int needed, AmmoStorage as) {
-        AmmoStorage a;
-        AmmoType aType;
-        AmmoType curType = as.getType();
-        int converted = 0;
-
-        // TODO: make this less intensive.
-        for(Part part : campaign.getWarehouse().getSpareParts()) {
-            if(!part.isPresent()) {
-                continue;
-            }
-            if(part instanceof AmmoStorage) {
-                a = (AmmoStorage)part;
-                aType = a.getType();
-                if (a.isSamePartType(as)) {
-                    continue;
-                }
-                if (!isCompatibleAmmo(campaign, aType, curType)) {
-                    continue;
-                }
-                if (a.getShots() == 0) {
-                    continue;
-                }
-                // Finally, do the conversion. Run until the other ammo type runs out or we have enough
-                converted = aType.getRackSize();
-                changeAmountAvailable(campaign, -1, aType);
-                while (converted < needed && a.getShots() > 0) {
-                    converted += aType.getRackSize();
-                    changeAmountAvailable(campaign, -1, aType);
-                }
-                needed -= converted;
-                // If we have enough, we're done.
-                if (converted >= needed) {
-                    break;
-                }
-            }
-        }
-        converted = (int) Math.round((double) converted / curType.getRackSize());
-        changeAmountAvailable(campaign, converted, curType);
-    }
-
-    public void changeAmountAvailable(int amount, final AmmoType curType) {
-        changeAmountAvailable(campaign, amount, curType);
-    }
-
-    public static void changeAmountAvailable(Campaign campaign, int amount, final AmmoType curType) {
-        AmmoStorage a = (AmmoStorage)campaign.getWarehouse().findSparePart(part -> {
-            if (!(part instanceof AmmoStorage) || !part.isPresent() || part.isReservedForRefit()) {
-                return false;
-            }
-            AmmoType ammoType = ((AmmoStorage) part).getType();
-            return ammoType.equals(curType)
-                && (curType.getMunitionType() == ammoType.getMunitionType());
-        });
-
-        if (null != a) {
-            AmmoType aType = a.getType();
-            if (amount < 0 && campaign.getCampaignOptions().useAmmoByType()
-                && a.getShots() < Math.abs(amount)) {
-                swapAmmoFromCompatible(campaign, Math.abs(amount) * aType.getRackSize(), a);
-            }
-            a.changeShots(amount);
-            if (a.getShots() <= 0) {
-                campaign.getWarehouse().removePart(a);
-            }
-        } else if (amount > 0) {
-            campaign.getQuartermaster().addPart(new AmmoStorage(1, curType, amount, campaign), 0);
-        } else if (amount < 0
-                && campaign.getCampaignOptions().useAmmoByType()
-                && AmmoBin.ALLOWED_BY_TYPE.contains(curType.getAmmoType())) {
-            campaign.getQuartermaster().addPart(new AmmoStorage(1, curType, 0, campaign), 0);
-            changeAmountAvailable(campaign, amount, curType);
-        }
-    }
-
-    public boolean isCompatibleAmmo(AmmoType a1, AmmoType a2) {
-        return isCompatibleAmmo(campaign, a1, a2);
-    }
-
-    public static boolean isCompatibleAmmo(Campaign campaign, AmmoType a1, AmmoType a2) {
-
-        // If the option isn't on, we don't use this!
-        if (!(campaign.getCampaignOptions().useAmmoByType())) {
-            return false;
-        }
-
-        // NPE protection
-        if (a1 == null || a2 == null) {
-            return false;
-        }
-
-        // If it isn't an allowed type, then nope!
-        if (!AmmoBin.ALLOWED_BY_TYPE.contains(a1.getAmmoType()) || !AmmoBin.ALLOWED_BY_TYPE.contains(a2.getAmmoType())) {
-            return false;
-        }
-
-        // Now we begin to compare
-        boolean result = false;
-
-        // MML Launchers, ugh.
-        if ((a1.getAmmoType() == AmmoType.T_MML || a2.getAmmoType() == AmmoType.T_MML)
-                && a1.getMunitionType() == a2.getMunitionType()) {
-            // LRMs...
-            if (a1.getAmmoType() == AmmoType.T_MML && a1.hasFlag(AmmoType.F_MML_LRM) && a2.getAmmoType() == AmmoType.T_LRM) {
-                result = true;
-            } else if (a2.getAmmoType() == AmmoType.T_MML && a2.hasFlag(AmmoType.F_MML_LRM) && a1.getAmmoType() == AmmoType.T_LRM) {
-                result = true;
-            }
-            // SRMs
-            if (a1.getAmmoType() == AmmoType.T_MML && !a1.hasFlag(AmmoType.F_MML_LRM) && a2.getAmmoType() == AmmoType.T_SRM) {
-                result = true;
-            } else if (a2.getAmmoType() == AmmoType.T_MML && !a2.hasFlag(AmmoType.F_MML_LRM) && a1.getAmmoType() == AmmoType.T_SRM) {
-                result = true;
-            }
-        }
-
-        // AR-10 Launchers, ugh.
-        /*if (a1.getAmmoType() == AmmoType.T_AR10 || a2.getAmmoType() == AmmoType.T_AR10) {
-            // Barracuda
-            if (a1.getAmmoType() == AmmoType.T_AR10 && a1.hasFlag(AmmoType.F_AR10_BARRACUDA) && a2.getAmmoType() == AmmoType.T_BARRACUDA) {
-                result = true;
-            } else if (a2.getAmmoType() == AmmoType.T_AR10 && a2.hasFlag(AmmoType.F_AR10_BARRACUDA) && a1.getAmmoType() == AmmoType.T_BARRACUDA) {
-                result = true;
-            }
-            // Killer Whale
-            if (a1.getAmmoType() == AmmoType.T_AR10 && a1.hasFlag(AmmoType.F_AR10_KILLER_WHALE) && a2.getAmmoType() == AmmoType.T_KILLER_WHALE) {
-                result = true;
-            } else if (a2.getAmmoType() == AmmoType.T_AR10 && a2.hasFlag(AmmoType.F_AR10_KILLER_WHALE) && a1.getAmmoType() == AmmoType.T_KILLER_WHALE) {
-                result = true;
-            }
-            // White Shark
-            if (a1.getAmmoType() == AmmoType.T_AR10 && a1.hasFlag(AmmoType.F_AR10_WHITE_SHARK) && a2.getAmmoType() == AmmoType.T_WHITE_SHARK) {
-                result = true;
-            } else if (a2.getAmmoType() == AmmoType.T_AR10 && a2.hasFlag(AmmoType.F_AR10_WHITE_SHARK) && a1.getAmmoType() == AmmoType.T_WHITE_SHARK) {
-                result = true;
-            }
-        }*/
-
-        // General Launchers
-        if (a1.getAmmoType() == a2.getAmmoType() && a1.getMunitionType() == a2.getMunitionType()) {
-            result = true;
-        }
-
-        return result;
-    }
-
     public int getAmountAvailable() {
-        return getAmountAvailable(campaign, getType());
-    }
-
-    public static int getAmountAvailable(Campaign campaign, AmmoType ammoType) {
-        if (campaign.getCampaignOptions().useAmmoByType()) {
-            Predicate<Part> predicate;
-            if (AmmoBin.ALLOWED_BY_TYPE.contains(ammoType.getAmmoType())) {
-                predicate = part -> {
-                    return part instanceof AmmoStorage
-                            && ammoType.equalsAmmoTypeOnly(((AmmoStorage) part).getType())
-                            && ammoType.getMunitionType() == ((AmmoStorage) part).getType().getMunitionType();
-                };
-            } else {
-                predicate = part -> {
-                    return part instanceof AmmoStorage
-                            && ammoType.equals(((AmmoStorage) part).getType())
-                            && ammoType.getMunitionType() == ((AmmoStorage) part).getType().getMunitionType();
-                };
-            }
-            AmmoStorage a = (AmmoStorage) campaign.getWarehouse().findSparePart(predicate);
-            return a != null ? a.getShots() : 0;
-        } else {
-            return campaign.getWarehouse()
-                           .streamSpareParts()
-                           .filter(part -> part instanceof AmmoStorage && part.isPresent())
-                           .mapToInt(part -> {
-                               AmmoStorage a = (AmmoStorage)part;
-                               AmmoType aType = a.getType();
-                               if (aType.equals(ammoType) && (ammoType.getMunitionType() == aType.getMunitionType())) {
-                                   return a.getShots();
-                               } else if (isCompatibleAmmo(campaign, aType, ammoType) && (ammoType.getRackSize() != 0)) {
-                                   return (a.getShots() * aType.getRackSize()) / ammoType.getRackSize();
-                               }
-                               return 0;
-                           })
-                           .sum();
-        }
+        return campaign.getQuartermaster().getAmmoAvailable(getType());
     }
 
     public boolean isEnoughSpareAmmoAvailable() {
-        return getAmountAvailable() >= shotsNeeded;
+        return getAmountAvailable() >= getShotsNeeded();
     }
 
     @Override
@@ -804,17 +600,21 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     }
 
     @Override
-    public Object getNewEquipment() {
+    public AmmoStorage getNewEquipment() {
         return getNewPart();
     }
 
-    public Part getNewPart() {
-        return new AmmoStorage(1, getType(), getType().getShots(), campaign);
+    public AmmoStorage getNewPart() {
+        // Get at least one ton, possibly more, so that when we go
+        // to buy ammo for a One Shot bin we don't nickel and dime ourselves.
+        int shots = Math.max(getType().getShots(), getFullShots());
+        return new AmmoStorage(1, getType(), shots, getCampaign());
     }
 
     @Override
     public IAcquisitionWork getAcquisitionWork() {
-        return getMissingPart();
+        // FIXME: is this MissingPart or AmmoStorage? Inconsistency between subtypes
+        return getNewPart();
     }
 
     @Override
@@ -843,11 +643,8 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
      */
     @Override
     public boolean isOmniPodded() {
-        if (getUnit() == null || getUnit().getEntity() == null) {
-            return false;
-        }
-        Mounted m = getUnit().getEntity().getEquipment(equipmentNum);
-        return m != null && m.isOmniPodMounted();
+        Mounted mounted = getMounted();
+        return (mounted != null) && mounted.isOmniPodMounted();
     }
 
     @Override
@@ -864,5 +661,4 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
     public boolean isExtinctIn(int year, boolean clan, int techFaction) {
         return isExtinct(year, clan, techFaction);
     }
-
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -31,9 +31,7 @@ import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.AmmoStorage;
-import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.PartInventory;
-import mekhq.campaign.work.IAcquisitionWork;
 
 /**
  *
@@ -59,6 +57,15 @@ public class BattleArmorAmmoBin extends AmmoBin {
         super(tonnage, et, equipNum, shots, singleShot, false, c);
     }
 
+    @Override
+    public BattleArmorAmmoBin clone() {
+        BattleArmorAmmoBin clone = new BattleArmorAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), shotsNeeded, isOneShot(),
+                campaign);
+        clone.copyBaseData(this);
+        clone.shotsNeeded = this.shotsNeeded;
+        return clone;
+    }
+
     public int getNumTroopers() {
         if(null != unit && unit.getEntity() instanceof BattleArmor) {
             //we are going to base this on the full squad size, even though this makes understrength
@@ -70,61 +77,39 @@ public class BattleArmorAmmoBin extends AmmoBin {
         return 0;
     }
 
-    //no salvaging of BA parts
+    // No salvaging of BA parts
     @Override
     public boolean isSalvaging() {
         return false;
     }
 
-    /*@Override
-    public int getFullShots() {
-        return super.getFullShots() * getNumTroopers();
-    }*/
-
     @Override
     protected int getCurrentShots() {
-        int shots = getFullShots() * getNumTroopers() - shotsNeeded;
-        //replace with actual entity values if entity not null because the previous number will not
-        //be correct for ammo swaps
-        if(null != unit && null != unit.getEntity()) {
-            Mounted m = unit.getEntity().getEquipment(equipmentNum);
-            if(null != m) {
-                shots = m.getBaseShotsLeft() * getNumTroopers();
-            }
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            // Replace with actual entity values if entity not null because
+            // the previous number will not be correct for ammo swaps
+            return mounted.getBaseShotsLeft() * getNumTroopers();
         }
-        return shots;
+
+        return (getFullShots() * getNumTroopers()) - shotsNeeded;
     }
 
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                long currentMuniType = 0;
-                if(mounted.getType() instanceof AmmoType) {
-                    currentMuniType = ((AmmoType)mounted.getType()).getMunitionType();
-                }
-                if(currentMuniType == getMunitionType()) {
-                    shotsNeeded = (getFullShots() - mounted.getBaseShotsLeft()) * getNumTroopers();
-                } else {
-                    //we have a change of munitions
-                    shotsNeeded = getFullShots() * getNumTroopers();
-                }
-            }
+        Mounted mounted = getMounted();
+        if ((mounted != null) && !ammoTypeChanged()) {
+            // Same ammo type, just a reload
+            shotsNeeded = (getFullShots() - mounted.getBaseShotsLeft()) * getNumTroopers();
+        } else {
+            // We have a change of munitions
+            shotsNeeded = getFullShots() * getNumTroopers();
         }
     }
 
     @Override
     public int getBaseTime() {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                if (!getType().equals(mounted.getType())) {
-                    return 30;
-                }
-            }
-        }
-        return 15;
+        return ammoTypeChanged() ? 30 : 15;
     }
 
     @Override
@@ -134,59 +119,52 @@ public class BattleArmorAmmoBin extends AmmoBin {
 
     @Override
     public void updateConditionFromPart() {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                mounted.setHit(false);
-                mounted.setDestroyed(false);
-                mounted.setRepairable(true);
-                unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
-                mounted.setShotsLeft(getFullShots() - shotsNeeded/getNumTroopers());
-            }
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            mounted.setHit(false);
+            mounted.setDestroyed(false);
+            mounted.setRepairable(true);
+            getUnit().repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
+            mounted.setShotsLeft(getFullShots() - shotsNeeded/getNumTroopers());
         }
     }
 
     @Override
     public void loadBin() {
-        int shots = Math.min(getAmountAvailable(), shotsNeeded);
-        int shotsPerTrooper = shots / getNumTroopers();
-        shots = shotsPerTrooper * getNumTroopers();
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                if (mounted.getType().equals(getType())
-                        && ((AmmoType)mounted.getType()).getMunitionType() == getMunitionType()) {
-                    //just a simple reload
-                    mounted.setShotsLeft(mounted.getBaseShotsLeft() + shotsPerTrooper);
-                } else {
-                    //loading a new type of ammo
-                    unload();
-                    mounted.changeAmmoType(getType());
-                    mounted.setShotsLeft(shotsPerTrooper);
-                }
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            // Calculate the actual shots needed
+            int shotsPerTrooper = shotsNeeded / getNumTroopers();
+            int shots = requisitionAmmo(getType(), shotsPerTrooper * getNumTroopers());
+
+            if (!ammoTypeChanged()) {
+                // Just a simple reload
+                mounted.setShotsLeft(mounted.getBaseShotsLeft() + shotsPerTrooper);
+            } else {
+                // Loading a new type of ammo
+                unload();
+                mounted.changeAmmoType(getType());
+                mounted.setShotsLeft(shotsPerTrooper);
             }
+
+            shotsNeeded -= shots;
         }
-        changeAmountAvailable(-1 * shots, getType());
-        shotsNeeded -= shots;
     }
 
     @Override
     public void unload() {
         int shots = 0;
+
         AmmoType curType = getType();
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if ((null != mounted) && (mounted.getType() instanceof AmmoType)) {
-                shots = mounted.getBaseShotsLeft() * getNumTroopers();
-                mounted.setShotsLeft(0);
-                curType = (AmmoType)mounted.getType();
-            }
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            shots = mounted.getBaseShotsLeft() * getNumTroopers();
+            mounted.setShotsLeft(0);
+            curType = (AmmoType) mounted.getType();
         }
 
         shotsNeeded = getFullShots() * getNumTroopers();
-        if (shots > 0) {
-            changeAmountAvailable(shots, curType);
-        }
+        returnAmmo(curType, shots);
     }
 
     @Override
@@ -205,25 +183,8 @@ public class BattleArmorAmmoBin extends AmmoBin {
     }
 
     @Override
-    public Part getNewPart() {
-        int shots = (int) Math.floor(1000 / getType().getKgPerShot());
-        if (shots <= 0) {
-            //FIXME: no idea what to do here, these really should be fixed on the MM side
-            //because presumably this is happening because KgperShot is -1 or 0
-            shots = 20;
-        }
-        return new AmmoStorage(1, getType(), shots, campaign);
-    }
-
-    @Override
-    public IAcquisitionWork getAcquisitionWork() {
-        int shots = (int) Math.floor(1000 / getType().getKgPerShot());
-        if(shots <= 0) {
-            //FIXME: no idea what to do here, these really should be fixed on the MM side
-            //because presumably this is happening because KgperShot is -1 or 0
-            shots = 20;
-        }
-        return new AmmoStorage(1, getType(), shots, campaign);
+    public AmmoStorage getNewPart() {
+        return new AmmoStorage(1, getType(), calculateShots(), campaign);
     }
 
     @Override
@@ -240,12 +201,7 @@ public class BattleArmorAmmoBin extends AmmoBin {
         return toReturn;
     }
 
-    @Override
-    public String getAcquisitionDisplayName() {
-        return type.getDesc();
-    }
-
-    private int calculateShots() {
+    protected int calculateShots() {
         int shots = (int) Math.floor(1000 / getType().getKgPerShot());
         if (shots <= 0) {
             //FIXME: no idea what to do here, these really should be fixed on the MM side
@@ -272,14 +228,6 @@ public class BattleArmorAmmoBin extends AmmoBin {
     }
 
     @Override
-    public Part getAcquisitionPart() {
-        return getNewPart();
-    }
-
-    public boolean needsMaintenance() {
-        return false;
-    }
-
     public boolean canNeverScrap() {
         return true;
     }
@@ -287,6 +235,7 @@ public class BattleArmorAmmoBin extends AmmoBin {
     /**
      * Restores the equipment from the name
      */
+    @Override
     public void restore() {
         if (typeName == null) {
             typeName = getType().getName();
@@ -319,10 +268,5 @@ public class BattleArmorAmmoBin extends AmmoBin {
         } catch(NullPointerException ex) {
             MekHQ.getLogger().error(ex);
         }
-    }
-
-    @Override
-    public int getMassRepairOptionType() {
-        return Part.REPAIR_PART_TYPE.AMMO;
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -125,7 +125,7 @@ public class BattleArmorAmmoBin extends AmmoBin {
             mounted.setDestroyed(false);
             mounted.setRepairable(true);
             getUnit().repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
-            mounted.setShotsLeft(getFullShots() - shotsNeeded/getNumTroopers());
+            mounted.setShotsLeft(getFullShots() - (shotsNeeded / getNumTroopers()));
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -55,13 +55,14 @@ public class InfantryAmmoBin extends AmmoBin {
      * @param equipNum    The equipment index on the unit
      * @param shots       The number of shots of ammo needed to refill the bin
      * @param weaponType  The weapon this ammo is for
+     * @param clips       The number of clips of ammo
      * @param omniPodded  Whether the weapon is pod-mounted on an omnivehicle
      * @param c           The campaign instance
      */
     public InfantryAmmoBin(int tonnage, @Nullable AmmoType ammoType, int equipNum, int shots,
-            @Nullable InfantryWeapon weaponType, double size, boolean omniPodded, @Nullable Campaign c) {
+            @Nullable InfantryWeapon weaponType, int clips, boolean omniPodded, @Nullable Campaign c) {
         super(tonnage, ammoType, equipNum, shots, false, omniPodded, c);
-        this.size = size;
+        this.size = clips;
         if (weaponType != null) {
             this.weaponType = weaponType;
             name = weaponType.getName() + " Ammo Bin";
@@ -71,6 +72,7 @@ public class InfantryAmmoBin extends AmmoBin {
     @Override
     public void restore() {
         super.restore();
+
         name = weaponType.getName() + " Ammo Bin";
     }
 
@@ -81,12 +83,18 @@ public class InfantryAmmoBin extends AmmoBin {
         return weaponType;
     }
 
+    /**
+     * Gets the number of clips stored in this ammo bin.
+     */
+    public int getClips() {
+        return (int) getSize();
+    }
+
     @Override
     public InfantryAmmoBin clone() {
         InfantryAmmoBin clone = new InfantryAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), shotsNeeded,
-                weaponType, size, omniPodded, campaign);
+                getWeaponType(), getClips(), omniPodded, campaign);
         clone.copyBaseData(this);
-        clone.munition = this.munition;
         return clone;
     }
 
@@ -102,12 +110,12 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public int getLocation() {
-        if (unit != null) {
-            Mounted m = unit.getEntity().getEquipment(equipmentNum);
-            while (m.getLinkedBy() != null) {
-                m = m.getLinkedBy();
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            while (mounted.getLinkedBy() != null) {
+                mounted = mounted.getLinkedBy();
             }
-            return m.getLocation();
+            return mounted.getLocation();
         }
         return Entity.LOC_NONE;
     }
@@ -119,7 +127,7 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public int getFullShots() {
-        return getWeaponType().getShots() * (int) getSize();
+        return getWeaponType().getShots() * getClips();
     }
 
     /**
@@ -135,12 +143,48 @@ public class InfantryAmmoBin extends AmmoBin {
         // Wait until loading/unloading to change the full number of shots on the Entity.
     }
 
+    /**
+     * Sets the number of shots needed in the {@code InfantryAmmoBin}.
+     *
+     * NB: this can be negative if the capacity has changed.
+     *
+     * @param shots The number of shots needed.
+     */
+    @Override
+    public void setShotsNeeded(int shots) {
+        this.shotsNeeded = shots;
+    }
+
     @Override
     public void loadBin() {
+        Mounted mounted = getMounted();
+
+        // Check if we have too much ammo in the bin ...
+        if (shotsNeeded < 0) {
+            // ... and if so, unload the bin first.
+            unload();
+        }
+
         super.loadBin();
-        if (unit != null) {
-            Mounted mount = unit.getEntity().getEquipment(getEquipmentNum());
-            mount.setOriginalShots(getFullShots());
+
+        if (mounted != null) {
+            mounted.setOriginalShots(getFullShots());
+        }
+    }
+
+    @Override
+    protected int requisitionAmmo(AmmoType ammoType, int shotsNeeded) {
+        Objects.requireNonNull(ammoType);
+
+        return getCampaign().getQuartermaster().removeAmmo(ammoType, getWeaponType(), shotsNeeded);
+    }
+
+    @Override
+    protected void returnAmmo(AmmoType ammoType, int shotsUnloaded) {
+        Objects.requireNonNull(ammoType);
+
+        if (shotsUnloaded > 0) {
+            getCampaign().getQuartermaster().addAmmo(ammoType, getWeaponType(), shotsUnloaded);
         }
     }
 
@@ -157,15 +201,17 @@ public class InfantryAmmoBin extends AmmoBin {
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
         super.updateConditionFromEntity(checkForDestruction);
-        if (unit != null) {
-            Mounted mount = unit.getEntity().getEquipment(getEquipmentNum());
-            shotsNeeded = mount.getOriginalShots() - mount.getBaseShotsLeft();
+
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            shotsNeeded = mounted.getOriginalShots() - mounted.getBaseShotsLeft();
         }
     }
 
     @Override
     public void writeToXmlEnd(PrintWriter pw, int indent) {
         MekHqXmlUtil.writeSimpleXmlTag(pw, indent + 1, "weaponType", getWeaponType().getInternalName());
+
         super.writeToXmlEnd(pw, indent);
     }
 
@@ -179,6 +225,8 @@ public class InfantryAmmoBin extends AmmoBin {
                 this.weaponType = (InfantryWeapon) EquipmentType.get(wn.getTextContent().trim());
             }
         }
+
+        super.loadFieldsFromXmlNode(node);
     }
 
     @Override
@@ -190,21 +238,22 @@ public class InfantryAmmoBin extends AmmoBin {
         if ((partner != null) && (partner.getShotsNeeded() < 0)) {
             partner.loadBin();
         }
+
         loadBin();
     }
 
     @Override
-    public MissingPart getMissingPart() {
-        return new MissingInfantryAmmoBin(getUnitTonnage(), getType(), equipmentNum, getWeaponType(),
-                size, omniPodded, campaign);
+    public MissingInfantryAmmoBin getMissingPart() {
+        return new MissingInfantryAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(), getWeaponType(),
+                getClips(), omniPodded, campaign);
     }
 
     @Override
     public boolean isSamePartType(Part part) {
         return  (part instanceof InfantryAmmoBin)
-                && super.isSamePartType(part)
+                && getType().equals(((InfantryAmmoBin) part).getType())
                 && Objects.equals(getWeaponType(), ((InfantryAmmoBin) part).getWeaponType())
-                && size == ((InfantryAmmoBin) part).size;
+                && getClips() == ((InfantryAmmoBin) part).getClips();
     }
 
     @Override
@@ -217,32 +266,8 @@ public class InfantryAmmoBin extends AmmoBin {
     }
 
     @Override
-    public void changeAmountAvailable(int amount, final AmmoType curType) {
-        InfantryAmmoStorage a = (InfantryAmmoStorage) campaign.getWarehouse().findSparePart(part ->
-            InfantryAmmoStorage.isRightAmmo(part, getType(), getWeaponType()));
-
-        if (a != null) {
-            a.changeShots(amount);
-            if (a.getShots() <= 0) {
-                campaign.getWarehouse().removePart(a);
-            }
-        } else if (amount > 0) {
-            campaign.getQuartermaster().addPart(new InfantryAmmoStorage(1, curType, amount, getWeaponType(), campaign), 0);
-        }
-    }
-
-    @Override
-    public boolean isCompatibleAmmo(AmmoType a1, AmmoType a2) {
-        return false;
-    }
-
     public int getAmountAvailable() {
-        final AmmoType thisType = getType();
-        return campaign.getWarehouse().streamSpareParts()
-            .filter(part -> part instanceof InfantryAmmoStorage && part.isPresent()
-                    && InfantryAmmoStorage.isRightAmmo(part, thisType, getWeaponType()))
-            .mapToInt(part -> ((InfantryAmmoStorage) part).getShots())
-            .sum();
+        return getCampaign().getQuartermaster().getAmmoAvailable(getType(), getWeaponType());
     }
 
     /**
@@ -250,13 +275,14 @@ public class InfantryAmmoBin extends AmmoBin {
      * @return The other bin for the same weapon, or null if there isn't one.
      */
     public @Nullable InfantryAmmoBin findPartnerBin() {
-        if (unit != null) {
-            Mounted mount = unit.getEntity().getEquipment(getEquipmentNum());
+        Mounted mounted = getMounted();
+        if (mounted != null) {
             int index = -1;
-            if (mount.getLinked() != null) {
-                index = unit.getEntity().getEquipmentNum(mount.getLinked());
-            } else if (mount.getLinkedBy().getType() instanceof AmmoType) {
-                index = unit.getEntity().getEquipmentNum(mount.getLinkedBy());
+            if (mounted.getLinked() != null) {
+                index = unit.getEntity().getEquipmentNum(mounted.getLinked());
+            } else if ((mounted.getLinkedBy() != null)
+                    && (mounted.getLinkedBy().getType() instanceof AmmoType)) {
+                index = unit.getEntity().getEquipmentNum(mounted.getLinkedBy());
             }
             for (Part part : unit.getParts()) {
                 if ((part instanceof InfantryAmmoBin) && (((InfantryAmmoBin) part).getEquipmentNum() == index)) {
@@ -277,9 +303,9 @@ public class InfantryAmmoBin extends AmmoBin {
         return getWeaponType().getShots() + " shots (1 clip)";
     }
 
-    public Part getNewPart() {
-        return new InfantryAmmoStorage(1, getType(), getWeaponType().getShots() * (int) getSize(),
-                getWeaponType(), campaign);
+    @Override
+    public InfantryAmmoStorage getNewPart() {
+        return new InfantryAmmoStorage(1, getType(), getFullShots(), getWeaponType(), getCampaign());
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -50,6 +50,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
     private int bayEqNum = -1;
 
     transient private Mounted bay;
+    transient private double ammoTonnage;
 
     public LargeCraftAmmoBin() {
         this(0, null, -1, 0, 0, null);
@@ -59,6 +60,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
             @Nullable Campaign c) {
         super(tonnage, et, equipNum, shotsNeeded, false, false, c);
         this.size = capacity;
+        this.ammoTonnage = (et != null) ? et.getTonnage(null) : 1.0;
     }
 
     @Override
@@ -131,7 +133,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
 
     @Override
     public double getTonnage() {
-        return getCurrentShots() * getType().getTonnage(null) / getType().getShots();
+        return getCapacity();
     }
 
     /**
@@ -145,12 +147,12 @@ public class LargeCraftAmmoBin extends AmmoBin {
      * Gets the unused capacity of the bay, in tons.
      */
     public double getUnusedCapacity() {
-        return getCapacity() - Math.ceil(getCurrentShots() * getType().getTonnage(null) / getType().getShots());
+        return getCapacity() - Math.ceil(getCurrentShots() * ammoTonnage / getType().getShots());
     }
 
     @Override
     public int getFullShots() {
-        return (int) Math.floor(getCapacity() * getType().getShots() / getType().getTonnage(null));
+        return (int) Math.floor(getCapacity() * getType().getShots() / ammoTonnage);
     }
 
     @Override
@@ -191,6 +193,15 @@ public class LargeCraftAmmoBin extends AmmoBin {
         }
 
         super.loadFieldsFromXmlNode(wn);
+    }
+
+    @Override
+    public void restore() {
+        super.restore();
+
+        if (getType() != null) {
+            ammoTonnage = getType().getTonnage(null);
+        }
     }
 
     @Override
@@ -287,7 +298,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
                     || getType().hasFlag(AmmoType.F_SCREEN)) {
                 return 60;
             }
-            return (int) Math.ceil(15 * getType().getTonnage(null));
+            return (int) Math.ceil(15 * ammoTonnage);
         }
     }
 
@@ -314,7 +325,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
     @Override
     public boolean needsFixing() {
         return (shotsNeeded < 0)
-                || ((shotsNeeded > 0) && (type.getTonnage(null) <= Math.ceil(bayAvailableCapacity())));
+                || ((shotsNeeded > 0) && (ammoTonnage <= Math.ceil(bayAvailableCapacity())));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -330,7 +330,9 @@ public class LargeCraftAmmoBin extends AmmoBin {
             for (Part p : unit.getParts()) {
                 if (p instanceof LargeCraftAmmoBin) {
                     final LargeCraftAmmoBin bin = (LargeCraftAmmoBin) p;
-                    if ((getBayEqNum() == bin.getBayEqNum()) && getType().equals(bin.getType())) {
+                    if ((getBayEqNum() == bin.getBayEqNum())
+                            && getType().equalsAmmoTypeOnly(bin.getType())
+                            && (getType().getRackSize() == bin.getType().getRackSize())) {
                         space += bin.getUnusedCapacity();
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -31,11 +31,8 @@ import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.parts.AmmoStorage;
-import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.PartInventory;
-import mekhq.campaign.work.IAcquisitionWork;
 
 /**
  * Ammo bin for a weapon bay that combines multiple tons of ammo into a single bin. Reload times
@@ -50,7 +47,7 @@ import mekhq.campaign.work.IAcquisitionWork;
 public class LargeCraftAmmoBin extends AmmoBin {
     private static final long serialVersionUID = -7931419849350769887L;
 
-    private int bayEqNum;
+    private int bayEqNum = -1;
 
     transient private Mounted bay;
 
@@ -69,6 +66,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
         LargeCraftAmmoBin clone = new LargeCraftAmmoBin(getUnitTonnage(), getType(), getEquipmentNum(),
                 shotsNeeded, size, campaign);
         clone.copyBaseData(this);
+        clone.bayEqNum = bayEqNum;
         return clone;
     }
 
@@ -77,26 +75,34 @@ public class LargeCraftAmmoBin extends AmmoBin {
      *         or null if there is no unit or the ammo bin is not in any bay.
      */
     public @Nullable Mounted getBay() {
-        if ((null != bay) || (null == unit)) {
+        if (getUnit() == null) {
             return null;
+        } else if (bay != null) {
+            return bay;
         }
+
         if (bayEqNum >= 0) {
-            Mounted m = unit.getEntity().getEquipment(bayEqNum);
-            if (m.getBayAmmo().contains(equipmentNum)) {
+            Mounted m = getUnit().getEntity().getEquipment(bayEqNum);
+            if ((m != null) && m.getBayAmmo().contains(equipmentNum)) {
                 bay = m;
                 return bay;
             }
         }
-        for (Mounted m : unit.getEntity().getWeaponBayList()) {
+
+        for (Mounted m : getUnit().getEntity().getWeaponBayList()) {
             if (m.getBayAmmo().contains(equipmentNum)) {
                 return m;
             }
         }
-        MekHQ.getLogger().warning(LargeCraftAmmoBin.class, "Could not find weapon bay for " + typeName + " for " + unit.getName());
+
+        MekHQ.getLogger().warning("Could not find weapon bay for " + typeName + " for " + unit.getName());
         return null;
     }
 
-
+    /**
+     * Gets the equipment number of the bay to which this ammo bin is assigned,
+     * otherwise {@code -1}
+     */
     public int getBayEqNum() {
         return bayEqNum;
     }
@@ -117,38 +123,44 @@ public class LargeCraftAmmoBin extends AmmoBin {
      * @param bayEqNum the number of the bay that will contain this ammo bin
      */
     public void setBay(int bayEqNum) {
-        if (null != unit) {
-            this.bayEqNum = bayEqNum;
+        this.bayEqNum = bayEqNum;
+        if (getUnit() != null) {
             bay = unit.getEntity().getEquipment(bayEqNum);
         }
     }
 
     @Override
     public double getTonnage() {
-        return getCurrentShots() * type.getTonnage(null) / ((AmmoType) type).getShots();
+        return getCurrentShots() * getType().getTonnage(null) / getType().getShots();
     }
 
+    /**
+     * Gets the capacity of the bay, in tons.
+     */
     public double getCapacity() {
         return size;
     }
 
+    /**
+     * Gets the unused capacity of the bay, in tons.
+     */
     public double getUnusedCapacity() {
-        return size - Math.ceil(getCurrentShots() * type.getTonnage(null) / ((AmmoType) type).getShots());
+        return getCapacity() - Math.ceil(getCurrentShots() * getType().getTonnage(null) / getType().getShots());
     }
 
     @Override
     public int getFullShots() {
-        return (int) Math.floor(size * ((AmmoType) type).getShots() / type.getTonnage(null));
+        return (int) Math.floor(getCapacity() * getType().getShots() / getType().getTonnage(null));
     }
 
     @Override
     public Money getValueNeeded() {
-        if (getShotsPerTon() <= 0) {
+        if ((getShotsPerTon() <= 0) || (shotsNeeded <= 0)) {
             return Money.zero();
         }
 
         return adjustCostsForCampaignOptions(getPricePerTon()
-                .multipliedBy(size)
+                .multipliedBy(getCapacity())
                 .multipliedBy(shotsNeeded)
                 .dividedBy(getShotsPerTon()));
     }
@@ -161,68 +173,66 @@ public class LargeCraftAmmoBin extends AmmoBin {
     }
 
     @Override
-    public void writeToXml(PrintWriter pw1, int indent) {
-        writeToXmlBegin(pw1, indent);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "equipmentNum", equipmentNum);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "typeName", typeName);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "shotsNeeded", shotsNeeded);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "capacity", size);
+    protected void writeToXmlEnd(PrintWriter pw1, int indent) {
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "bayEqNum", bayEqNum);
-        writeToXmlEnd(pw1, indent);
+
+        super.writeToXmlEnd(pw1, indent);
     }
 
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
-        super.loadFieldsFromXmlNode(wn);
         NodeList nl = wn.getChildNodes();
 
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            if (wn2.getNodeName().equalsIgnoreCase("capacity")) {
-                size = Double.parseDouble(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("bayEqNum")) {
+            if (wn2.getNodeName().equalsIgnoreCase("bayEqNum")) {
                 bayEqNum = Integer.parseInt(wn2.getTextContent());
             }
         }
-        restore();
+
+        super.loadFieldsFromXmlNode(wn);
     }
 
     @Override
     public void fix() {
+        // We can only work on one ton at a time
         if (shotsNeeded < 0) {
-            unloadSingle();
+            unloadSingleTon();
         } else {
-            loadBinSingle();
+            loadBinSingleTon();
         }
     }
 
-    public void loadBinSingle() {
-        int shots = Math.min(getAmountAvailable(), Math.min(shotsNeeded, ((AmmoType) type).getShots()));
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted && mounted.getType() instanceof AmmoType) {
-                mounted.setShotsLeft(mounted.getBaseShotsLeft() + shots);
-            }
+    /**
+     * Load a single ton of ammo into the bay.
+     */
+    public void loadBinSingleTon() {
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            int shots = requisitionAmmo(getType(), Math.min(shotsNeeded, getType().getShots()));
+
+            mounted.setShotsLeft(mounted.getBaseShotsLeft() + shots);
+
+            shotsNeeded -= shots;
         }
-        changeAmountAvailable(-1 * shots, (AmmoType)type);
-        shotsNeeded -= shots;
     }
 
-    public void unloadSingle() {
-        int shots = Math.min(getCurrentShots(), ((AmmoType) type).getShots());
-        AmmoType curType = (AmmoType)type;
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted && mounted.getType() instanceof AmmoType) {
-                shots = Math.min(mounted.getBaseShotsLeft(), shots);
-                mounted.setShotsLeft(mounted.getBaseShotsLeft() - shots);
-                curType = (AmmoType)mounted.getType();
-            }
+    /**
+     * Unload a single ton of ammo from the bay.
+     */
+    public void unloadSingleTon() {
+        int shots = Math.min(getCurrentShots(), getType().getShots());
+        AmmoType curType = getType();
+
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            shots = Math.min(mounted.getBaseShotsLeft(), shots);
+            mounted.setShotsLeft(mounted.getBaseShotsLeft() - shots);
+            curType = (AmmoType) mounted.getType();
         }
+
         shotsNeeded += shots;
-        if (shots > 0) {
-            changeAmountAvailable(shots, curType);
-        }
+        returnAmmo(curType, shots);
     }
 
     @Override
@@ -238,31 +248,30 @@ public class LargeCraftAmmoBin extends AmmoBin {
     }
 
     @Override
-    public MissingPart getMissingPart() {
+    public MissingAmmoBin getMissingPart() {
+        // Large Craft Ammo Bins cannot be removed or destroyed
         return null;
     }
 
     @Override
+    public boolean canNeverScrap() {
+        // Large Craft Ammo Bins cannot be removed or destroyed
+        return true;
+    }
+
+    @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (mounted == null) {
-                MekHQ.getLogger().warning(LargeCraftAmmoBin.class,
-                        unit.getName() + " has a null Mounted at equipment number " + equipmentNum);
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            size = mounted.getSize();
+            type = mounted.getType();
+            if (mounted.isMissing() || mounted.isDestroyed()) {
+                mounted.setShotsLeft(0);
+                shotsNeeded = getFullShots();
                 return;
             }
-            if (!(mounted.getType() instanceof AmmoType)) {
-                MekHQ.getLogger().warning(LargeCraftAmmoBin.class, unit.getName() + " has an "
-                        + mounted.getName() + " that thinks it's an ammo bin at equipment number " + equipmentNum);
-            } else {
-                size = mounted.getSize();
-                type = mounted.getType();
-                if (mounted.isMissing() || mounted.isDestroyed()) {
-                    mounted.setShotsLeft(0);
-                    return;
-                }
-                shotsNeeded = getFullShots() - mounted.getBaseShotsLeft();
-            }
+
+            shotsNeeded = getFullShots() - mounted.getBaseShotsLeft();
         }
     }
 
@@ -273,35 +282,33 @@ public class LargeCraftAmmoBin extends AmmoBin {
         } else {
             //Capital Missiles take a flat 60m per missile per errata
             //Better set this for cruise missiles and screen launchers too.
-            if (type.hasFlag(AmmoType.F_CAP_MISSILE)
-                    || type.hasFlag(AmmoType.F_CRUISE_MISSILE)
-                    || type.hasFlag(AmmoType.F_SCREEN)) {
+            if (getType().hasFlag(AmmoType.F_CAP_MISSILE)
+                    || getType().hasFlag(AmmoType.F_CRUISE_MISSILE)
+                    || getType().hasFlag(AmmoType.F_SCREEN)) {
                 return 60;
             }
-            return (int) Math.ceil(15 * type.getTonnage(null));
+            return (int) Math.ceil(15 * getType().getTonnage(null));
         }
     }
 
     @Override
     public void updateConditionFromPart() {
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted) {
-                mounted.setHit(false);
-                mounted.setDestroyed(false);
-                mounted.setRepairable(true);
-                mounted.changeAmmoType((AmmoType) type);
-                unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
-                mounted.setShotsLeft(getFullShots() - shotsNeeded);
-                mounted.setSize(size);
-            }
+        Mounted mounted = getMounted();
+        if (mounted != null) {
+            mounted.setHit(false);
+            mounted.setDestroyed(false);
+            mounted.setRepairable(true);
+            mounted.changeAmmoType(getType());
+            unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
+            mounted.setShotsLeft(getFullShots() - shotsNeeded);
+            mounted.setSize(size);
         }
     }
 
     @Override
     public boolean isSamePartType(Part part) {
-        return  part instanceof LargeCraftAmmoBin
-                        && getType().equals( ((AmmoBin)part).getType() );
+        return (part instanceof LargeCraftAmmoBin)
+                && getType().isCompatibleWith(((AmmoBin) part).getType());
     }
 
     @Override
@@ -317,16 +324,14 @@ public class LargeCraftAmmoBin extends AmmoBin {
      *
      * @return The amount of unused capacity that can be used to reload ammo.
      */
-    private double bayAvailableCapacity() {
+    protected double bayAvailableCapacity() {
         if (null != unit) {
             double space = 0.0;
             for (Part p : unit.getParts()) {
                 if (p instanceof LargeCraftAmmoBin) {
                     final LargeCraftAmmoBin bin = (LargeCraftAmmoBin) p;
-                    if ((bin.getBayEqNum() == bayEqNum)
-                            && (((AmmoType) bin.getType()).getAmmoType() == ((AmmoType) type).getAmmoType())
-                            && (((AmmoType) bin.getType()).getRackSize() == ((AmmoType) type).getRackSize())) {
-                        space += bin.getCapacity() - bin.getTonnage();
+                    if ((getBayEqNum() == bin.getBayEqNum()) && getType().equals(bin.getType())) {
+                        space += bin.getUnusedCapacity();
                     }
                 }
             }
@@ -365,7 +370,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
             return super.getDetails(includeRepairDetails);
         }
         if (shotsNeeded < 0) {
-            return type.getDesc() + ", " + (-shotsNeeded) + " shots to remove";
+            return getType().getDesc() + ", " + (-shotsNeeded) + " shots to remove";
         }
         if (null != unit) {
             String availability = "";
@@ -376,21 +381,14 @@ public class LargeCraftAmmoBin extends AmmoBin {
             } else if (shotsAvailable < shotsNeeded) {
                 availability = "<br><font color='red'>Only " + shotsAvailable + " available ("+ inventories.getTransitOrderedDetails() + ")</font>";
             }
-            return ((AmmoType)type).getDesc() + ", " + shotsNeeded + " shots needed" + availability;
+            return getType().getDesc() + ", " + shotsNeeded + " shots needed" + availability;
         } else {
             return "";
         }
     }
 
     @Override
-    public IAcquisitionWork getAcquisitionWork() {
-        int shots = getType().getShots() * (int) Math.floor(getUnusedCapacity() / type.getTonnage(null));
-        return new AmmoStorage(1, getType(), shots, campaign);
-    }
-
-    @Override
     public boolean isOmniPoddable() {
         return false;
     }
-
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -98,6 +98,17 @@ public class MissingAmmoBin extends MissingEquipmentPart {
     }
 
     @Override
+    public void reservePart() {
+        // No need to reserve a part for a missing AmmoBin, they're free.
+    }
+
+    @Override
+    public void cancelReservation() {
+        // We do not need to return a replacement part, they're free/fake
+        setReplacementPart(null); // CAW: clears out anything from a prior version
+    }
+
+    @Override
     public void fix() {
         AmmoBin replacement = getNewPart();
         unit.addPart(replacement);

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -138,11 +138,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
     }
 
     protected int getFullShots() {
-        if (oneShot) {
-            return 1;
-        }
-
-        return getType().getShots();
+        return oneShot ? 1 : getType().getShots();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -25,7 +25,6 @@ import java.io.PrintWriter;
 
 import megamek.common.Aero;
 import megamek.common.AmmoType;
-import megamek.common.EquipmentType;
 import megamek.common.Jumpship;
 import megamek.common.SmallCraft;
 import megamek.common.annotations.Nullable;
@@ -89,39 +88,38 @@ public class MissingAmmoBin extends MissingEquipmentPart {
     }
 
     @Override
-    public void fix() {
-        Part replacement = findReplacement(false);
-        if(null != replacement) {
-            Part actualReplacement = getActualReplacement((AmmoBin) replacement);
-            unit.addPart(actualReplacement);
-            campaign.getQuartermaster().addPart(actualReplacement, 0);
-            replacement.decrementQuantity();
-            ((EquipmentPart)actualReplacement).setEquipmentNum(equipmentNum);
-            remove(false);
-            //assign the replacement part to the unit
-            actualReplacement.updateConditionFromPart();
-        }
+    public boolean hasReplacementPart() {
+        return true;
     }
 
-    protected Part getActualReplacement(AmmoBin found) {
-        //Check to see if munition types are different
-        if (getType() == found.getType()) {
-            return found.clone();
-        } else {
-            return new AmmoBin(getUnitTonnage(), getType(), getEquipmentNum(),
-                    getFullShots(), isOneShot(), isOmniPodded(), campaign);
-        }
+    @Override
+    public Part getReplacementPart() {
+        return getNewPart();
+    }
+
+    @Override
+    public void fix() {
+        AmmoBin replacement = getNewPart();
+        unit.addPart(replacement);
+        campaign.getQuartermaster().addPart(replacement, 0);
+
+        remove(false);
+
+        // Add the replacement part to the unit
+        replacement.setEquipmentNum(getEquipmentNum());
+        replacement.updateConditionFromPart();
     }
 
     @Override
     public boolean isAcceptableReplacement(Part part, boolean refit) {
-        if ((part instanceof AmmoBin)
-                && !(part instanceof LargeCraftAmmoBin)) {
-            EquipmentPart eqpart = (EquipmentPart)part;
-            EquipmentType et = eqpart.getType();
-            return getType().equals(et) && (((AmmoBin) part).getFullShots() == getFullShots());
-        }
-        return false;
+        return (part instanceof AmmoBin)
+                // Do not try to replace a MissingAmmoBin with anything other
+                // than an AmmoBin. Subclasses should use a similar check, which
+                // breaks Composability to a degree but in this case we've used
+                // subclasses where they're not truly composable.
+                && (part.getClass() == AmmoBin.class)
+                && getType().equals(((AmmoBin) part).getType())
+                && (isOneShot() == ((AmmoBin) part).isOneShot());
     }
 
     public boolean isOneShot() {
@@ -129,59 +127,40 @@ public class MissingAmmoBin extends MissingEquipmentPart {
     }
 
     protected int getFullShots() {
-        int fullShots = getType().getShots();
-        if(oneShot) {
-            fullShots = 1;
+        if (oneShot) {
+            return 1;
         }
-        return fullShots;
+
+        return getType().getShots();
     }
 
     @Override
-    public Part getNewPart() {
+    public AmmoBin getNewPart() {
         return new AmmoBin(getUnitTonnage(), getType(), -1, getFullShots(), oneShot, omniPodded, campaign);
     }
 
     @Override
-    public void writeToXml(PrintWriter pw1, int indent) {
-        writeToXmlBegin(pw1, indent);
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<equipmentNum>"
-                +equipmentNum
-                +"</equipmentNum>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<typeName>"
-                +MekHqXmlUtil.escape(typeName)
-                +"</typeName>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<daysToWait>"
-                +daysToWait
-                +"</daysToWait>");
-        pw1.println(MekHqXmlUtil.indentStr(indent+1)
-                +"<oneShot>"
-                +oneShot
-                +"</oneShot>");
-        writeToXmlEnd(pw1, indent);
+    protected void writeToXmlEnd(PrintWriter pw1, int indent) {
+        if (oneShot) {
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "oneShot", oneShot);
+        }
+
+        super.writeToXmlEnd(pw1, indent);
     }
 
     @Override
     protected void loadFieldsFromXmlNode(Node wn) {
-        super.loadFieldsFromXmlNode(wn);
+
         NodeList nl = wn.getChildNodes();
 
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            if (wn2.getNodeName().equalsIgnoreCase("equipmentNum")) {
-                equipmentNum = Integer.parseInt(wn2.getTextContent());
-            }
-            else if (wn2.getNodeName().equalsIgnoreCase("typeName")) {
-                typeName = wn2.getTextContent();
-            } else if (wn2.getNodeName().equalsIgnoreCase("daysToWait")) {
-                daysToWait = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("oneShot")) {
+            if (wn2.getNodeName().equalsIgnoreCase("oneShot")) {
                 oneShot = wn2.getTextContent().equalsIgnoreCase("true");
             }
         }
-        restore();
+
+        super.loadFieldsFromXmlNode(wn);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3263,42 +3263,6 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         }
     }
 
-    /**
-     * Adds a new zero-capacity ammo bin to the bay as part of an ammo swap. If the bay has a zeroed-out
-     * bin, sets the ammo type on that one and returns it instead of creating a new one.
-     *
-     * @param etype The type of ammo being changed to
-     * @param bay   The weapon bay where the ammo is located
-     * @return      The new ammo bin part
-     */
-    public LargeCraftAmmoBin addBayAmmoBin(AmmoType etype, Mounted bay) {
-        for (Part p : getParts()) {
-            if (p instanceof LargeCraftAmmoBin) {
-                final LargeCraftAmmoBin bin = (LargeCraftAmmoBin) p;
-                if ((bin.getCapacity() == 0) && (bin.getBay() == bay)) {
-                    bin.changeMunition(etype);
-                    bin.updateConditionFromPart();
-                    return bin;
-                }
-            }
-        }
-        try {
-            Mounted m = entity.addEquipment(etype, bay.getLocation(), bay.isRearMounted(), 0);
-            int anum = entity.getEquipmentNum(m);
-            bay.addAmmoToBay(anum);
-            LargeCraftAmmoBin bin = new LargeCraftAmmoBin((int) entity.getWeight(), etype, anum,
-                    0, 0, getCampaign());
-            addPart(bin);
-            getCampaign().getQuartermaster().addPart(bin, 0);
-            return bin;
-        } catch (LocationFullException ex) {
-            MekHQ.getLogger().error(Unit.class, "Location full exception attempting to add " + etype.getDesc() + " to unit " + getName());
-            MekHQ.getLogger().error(Unit.class, ex);
-            return null;
-        }
-
-    }
-
     public List<Part> getParts() {
         return parts;
     }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3226,43 +3226,6 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         }
     }
 
-    /**
-     * Checks for additional ammo bins and adds the appropriate part.
-     *
-     * Large craft can combine all the ammo of a single type into a single bin. Switching the munition type
-     * of one or more tons of ammo can require the addition of an ammo bin and can change the ammo bin
-     * capacity.
-     */
-    public void adjustLargeCraftAmmo() {
-        Map<Integer,Part> ammoParts = new HashMap<>();
-        List<Part> toAdd = new ArrayList<>();
-        for (Part p : parts) {
-            if (p instanceof LargeCraftAmmoBin) {
-                ammoParts.put(((LargeCraftAmmoBin) p).getEquipmentNum(), p);
-            }
-        }
-        for (Mounted m : entity.getAmmo()) {
-            assert(m.getType() instanceof AmmoType);
-
-            int eqNum = entity.getEquipmentNum(m);
-            Part part = ammoParts.get(eqNum);
-            if (null == part) {
-                part = new LargeCraftAmmoBin((int) entity.getWeight(), (AmmoType) m.getType(), eqNum,
-                        m.getOriginalShots() - m.getBaseShotsLeft(), m.getAmmoCapacity(), getCampaign());
-                ((LargeCraftAmmoBin) part).setBay(entity.getBayByAmmo(m));
-                toAdd.add(part);
-            } else {
-                part.updateConditionFromEntity(false);
-                // Reset the name
-                ((LargeCraftAmmoBin) part).changeMunition((AmmoType) m.getType());
-            }
-        }
-        for (Part p : toAdd) {
-            addPart(p);
-            getCampaign().getQuartermaster().addPart(p, 0);
-        }
-    }
-
     public List<Part> getParts() {
         return parts;
     }

--- a/MekHQ/src/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoAction.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020 Megamek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.unit.actions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import megamek.common.AmmoType;
+import megamek.common.Mounted;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
+import mekhq.campaign.unit.Unit;
+
+/**
+ * Checks for additional ammo bins and adds the appropriate part.
+ *
+ * Large craft can combine all the ammo of a single type into a single bin. Switching the munition type
+ * of one or more tons of ammo can require the addition of an ammo bin and can change the ammo bin
+ * capacity.
+ */
+public class AdjustLargeCraftAmmoAction implements IUnitAction {
+
+    @Override
+    public void execute(Campaign campaign, Unit unit) {
+        if (!unit.getEntity().usesWeaponBays()) {
+            return;
+        }
+
+        Map<Integer, LargeCraftAmmoBin> ammoParts = new HashMap<>();
+        for (Part p : unit.getParts()) {
+            if (p instanceof LargeCraftAmmoBin) {
+                LargeCraftAmmoBin ammoBin = (LargeCraftAmmoBin) p;
+                ammoParts.put(ammoBin.getEquipmentNum(), ammoBin);
+            }
+        }
+
+        List<Part> toAdd = new ArrayList<>();
+        for (Mounted m : unit.getEntity().getAmmo()) {
+            assert(m.getType() instanceof AmmoType);
+
+            int eqNum = unit.getEntity().getEquipmentNum(m);
+            LargeCraftAmmoBin part = ammoParts.get(eqNum);
+            if (null == part) {
+                part = new LargeCraftAmmoBin((int) unit.getEntity().getWeight(), (AmmoType) m.getType(), eqNum,
+                        m.getOriginalShots() - m.getBaseShotsLeft(), m.getSize(), campaign);
+                part.setBay(unit.getEntity().getBayByAmmo(m));
+                toAdd.add(part);
+            } else {
+                // Reset the AmmoType
+                part.changeMunition((AmmoType) m.getType());
+            }
+        }
+
+        for (Part p : toAdd) {
+            unit.addPart(p);
+            campaign.getQuartermaster().addPart(p, 0);
+        }
+    }
+}

--- a/MekHQ/src/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoAction.java
@@ -19,9 +19,7 @@
 
 package mekhq.campaign.unit.actions;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import megamek.common.AmmoType;
@@ -54,7 +52,6 @@ public class AdjustLargeCraftAmmoAction implements IUnitAction {
             }
         }
 
-        List<Part> toAdd = new ArrayList<>();
         for (Mounted m : unit.getEntity().getAmmo()) {
             assert(m.getType() instanceof AmmoType);
 
@@ -63,17 +60,19 @@ public class AdjustLargeCraftAmmoAction implements IUnitAction {
             if (null == part) {
                 part = new LargeCraftAmmoBin((int) unit.getEntity().getWeight(), (AmmoType) m.getType(), eqNum,
                         m.getOriginalShots() - m.getBaseShotsLeft(), m.getSize(), campaign);
+
+                // Add the part to the unit
+                unit.addPart(part);
+
+                // Add the part to the bay (NOTE: must be on a unit first)
                 part.setBay(unit.getEntity().getBayByAmmo(m));
-                toAdd.add(part);
+
+                // Add the part to the Campaign
+                campaign.getQuartermaster().addPart(part, 0);
             } else {
                 // Reset the AmmoType
                 part.changeMunition((AmmoType) m.getType());
             }
-        }
-
-        for (Part p : toAdd) {
-            unit.addPart(p);
-            campaign.getQuartermaster().addPart(p, 0);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/unit/actions/SwapAmmoTypeAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/SwapAmmoTypeAction.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.unit.actions;
+
+import java.util.Objects;
+
+import megamek.common.AmmoType;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.event.PartChangedEvent;
+import mekhq.campaign.event.UnitChangedEvent;
+import mekhq.campaign.parts.equipment.AmmoBin;
+import mekhq.campaign.unit.Unit;
+
+/**
+ * Swaps the {@code AmmoType} for an {@code AmmoBin} on a {@code Unit}.
+ */
+public class SwapAmmoTypeAction implements IUnitAction {
+
+    private final AmmoBin ammoBin;
+    private final AmmoType ammoType;
+
+    /**
+     * Initializes a new instance of the {@code SwapAmmoTypeAction} class.
+     * @param ammoBin The {@code AmmoBin} to swap ammo.
+     * @param ammoType The new {@code AmmoType} to use in the {@code ammoBin}.
+     */
+    public SwapAmmoTypeAction(AmmoBin ammoBin, AmmoType ammoType) {
+        this.ammoBin = Objects.requireNonNull(ammoBin);
+        this.ammoType = Objects.requireNonNull(ammoType);
+    }
+
+    @Override
+    public void execute(Campaign campaign, Unit unit) {
+        if (!Objects.equals(ammoBin.getUnit(), unit)) {
+            return;
+        }
+
+        ammoBin.changeMunition(ammoType);
+        MekHQ.triggerEvent(new PartChangedEvent(ammoBin));
+        MekHQ.triggerEvent(new UnitChangedEvent(unit));
+    }
+}

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -41,7 +41,6 @@ import javax.swing.SortOrder;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
-import megamek.common.AmmoType;
 import megamek.common.MiscType;
 import megamek.common.TargetRoll;
 import megamek.common.WeaponType;
@@ -60,6 +59,7 @@ import mekhq.campaign.event.PersonEvent;
 import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.event.UnitRefitEvent;
 import mekhq.campaign.event.UnitRemovedEvent;
+import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.EnginePart;
 import mekhq.campaign.parts.MekActuator;
@@ -69,7 +69,6 @@ import mekhq.campaign.parts.MekLocation;
 import mekhq.campaign.parts.MekSensor;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.TankLocation;
-import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Skill;
@@ -100,12 +99,11 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     private static final int SG_LOC = 4;
     private static final int SG_WEAP = 5;
     private static final int SG_AMMO = 6;
-    private static final int SG_AMMO_BIN = 7;
-    private static final int SG_MISC = 8;
-    private static final int SG_ENGINE = 9;
-    private static final int SG_GYRO = 10;
-    private static final int SG_ACT = 11;
-    private static final int SG_NUM = 12;
+    private static final int SG_MISC = 7;
+    private static final int SG_ENGINE = 8;
+    private static final int SG_GYRO = 9;
+    private static final int SG_ACT = 10;
+    private static final int SG_NUM = 11;
 
     // parts views
     private static final int SV_ALL = 0;
@@ -415,11 +413,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
                 } else if (nGroup == SG_WEAP) {
                     inGroup = part instanceof EquipmentPart && ((EquipmentPart) part).getType() instanceof WeaponType;
                 } else if (nGroup == SG_AMMO) {
-                    inGroup = part instanceof EquipmentPart && !(part instanceof AmmoBin)
-                            && ((EquipmentPart) part).getType() instanceof AmmoType;
-                } else if (nGroup == SG_AMMO_BIN) {
-                    inGroup = part instanceof EquipmentPart && (part instanceof AmmoBin)
-                            && ((EquipmentPart) part).getType() instanceof AmmoType;
+                    inGroup = part instanceof AmmoStorage;
                 } else if (nGroup == SG_MISC) {
                     inGroup = part instanceof EquipmentPart && ((EquipmentPart) part).getType() instanceof MiscType;
                 } else if (nGroup == SG_ENGINE) {
@@ -464,8 +458,6 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
             return "Weapons";
         case SG_AMMO:
             return "Ammunition";
-        case SG_AMMO_BIN:
-            return "Ammunition Bins";
         case SG_MISC:
             return "Miscellaneous Equipment";
         case SG_ENGINE:

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -861,7 +861,7 @@ public class CampaignExportWizard extends JDialog {
                 return ((Armor) part).getArmorWeight(count);
             } else if (part instanceof AmmoStorage) {
                 AmmoStorage ammoPart = (AmmoStorage) part;
-                AmmoType ammoType = (AmmoType) ammoPart.getType();
+                AmmoType ammoType = ammoPart.getType();
                 return ammoType.getKgPerShot() * count / 1000.0;
             } else {
                 return count * part.getTonnage() * 1.0;

--- a/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
@@ -34,6 +34,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.unit.actions.AdjustLargeCraftAmmoAction;
 import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
 
@@ -99,7 +100,7 @@ public class LargeCraftAmmoSwapDialog extends JDialog {
         // Actually apply the ammo change
         mainPanel.apply();
         // Rebuild bin parts as necessary
-        unit.adjustLargeCraftAmmo();
+        new AdjustLargeCraftAmmoAction().execute(unit.getCampaign(), unit);
         // Update the parts and set the number of shots needed based on the current size and the number
         // of shots stored.
         for (Part p : unit.getParts()) {

--- a/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LargeCraftAmmoSwapDialog.java
@@ -29,7 +29,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import megamek.client.ui.swing.BayMunitionsChoicePanel;
-import megamek.common.AmmoType;
 import megamek.common.Mounted;
 import mekhq.MekHQ;
 import mekhq.campaign.parts.Part;
@@ -116,7 +115,7 @@ public class LargeCraftAmmoSwapDialog extends JDialog {
                     shotsToChange = oldShots;
                 }
                 if (shotsToChange > 0) {
-                    bin.changeAmountAvailable(shotsToChange, (AmmoType) bin.getType());
+                    unit.getCampaign().getQuartermaster().addAmmo(bin.getType(), shotsToChange);
                 }
                 if (shotsByBay.containsKey(bin.getBay())) {
                     Map<String,Integer> oldAmmo = shotsByBay.get(bin.getBay());

--- a/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
@@ -40,7 +40,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
-import megamek.common.AmmoType;
 import megamek.common.MiscType;
 import megamek.common.TargetRoll;
 import megamek.common.WeaponType;
@@ -50,6 +49,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.AeroSensor;
+import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Avionics;
 import mekhq.campaign.parts.BattleArmorSuit;
@@ -469,8 +469,7 @@ public class PartsStoreDialog extends JDialog {
                     return (part instanceof EquipmentPart)
                             && (((EquipmentPart) part).getType() instanceof WeaponType);
                 } else if (nGroup == SG_AMMO) {
-                    return ((part instanceof EquipmentPart)
-                            && (((EquipmentPart) part).getType() instanceof AmmoType));
+                    return part instanceof AmmoStorage;
                 } else if (nGroup == SG_MISC) {
                     return ((part instanceof EquipmentPart)
                             && (((EquipmentPart) part).getType() instanceof MiscType)

--- a/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
@@ -56,7 +56,7 @@ public class SmallSVAmmoSwapDialog extends JDialog {
         // from there.
         for (Part part : unit.getParts()) {
             if ((part instanceof InfantryAmmoBin)
-                    && (((AmmoType) ((InfantryAmmoBin) part).getType()).getMunitionType() == AmmoType.M_INFERNO)) {
+                    && (((InfantryAmmoBin) part).getType().getMunitionType() == AmmoType.M_INFERNO)) {
                 WeaponRow row = new WeaponRow((InfantryAmmoBin) part);
                 rows.add(row);
                 panMain.add(row);
@@ -102,14 +102,14 @@ public class SmallSVAmmoSwapDialog extends JDialog {
             this.infernoBin = infernoBin;
             this.standardBin = infernoBin.findPartnerBin();
             if (standardBin != null) {
-                totalClips = (int) (infernoBin.getSize() + standardBin.getSize());
+                totalClips = infernoBin.getClips() + standardBin.getClips();
             }
             initUI(String.format("%s (%s)", infernoBin.getWeaponType().getName(),
                     infernoBin.getUnit().getEntity().getLocationAbbr(infernoBin.getLocation())));
         }
 
         private void initUI(String title) {
-            spnInferno.setModel(new SpinnerNumberModel((int) infernoBin.getSize(), 0, totalClips, 1));
+            spnInferno.setModel(new SpinnerNumberModel(infernoBin.getClips(), 0, totalClips, 1));
             setLayout(new GridBagLayout());
             GridBagConstraints gbc = new GridBagConstraints();
             gbc.anchor = GridBagConstraints.WEST;
@@ -130,7 +130,7 @@ public class SmallSVAmmoSwapDialog extends JDialog {
             if (standardBin != null) {
                 add(new JLabel(resourceMap.getString("standard")), gbc);
                 gbc.gridx++;
-                lblStandardClips.setText(String.valueOf((int) standardBin.getSize()));
+                lblStandardClips.setText(String.valueOf(standardBin.getClips()));
                 add(lblStandardClips, gbc);
                 gbc.gridx++;
                 add(new JLabel(resourceMap.getString("inferno")), gbc);

--- a/MekHQ/unittests/mekhq/campaign/QuartermasterTest.java
+++ b/MekHQ/unittests/mekhq/campaign/QuartermasterTest.java
@@ -24,8 +24,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import megamek.common.AmmoType;
 import megamek.common.Entity;
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.Infantry;
+import megamek.common.weapons.infantry.InfantryWeapon;
 import mekhq.EventSpy;
 import mekhq.campaign.event.PartArrivedEvent;
 import mekhq.campaign.event.PartChangedEvent;
@@ -34,6 +37,8 @@ import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.Transaction;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
+import mekhq.campaign.parts.InfantryAmmoStorage;
+import mekhq.campaign.parts.MekLocation;
 import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.OmniPod;
 import mekhq.campaign.parts.Part;
@@ -43,6 +48,7 @@ import mekhq.campaign.unit.Unit;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.AmmoUtilities.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -1700,5 +1706,1074 @@ public class QuartermasterTest {
                 return mockOmniPart;
             }
         };
+    }
+
+    @Test
+    public void addAmmoNoSpareFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        // Setup an empty warehouse
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, addedShots);
+
+        // ... which should result in more ammo being added to the campaign.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(addedShots, added.getShots());
+        assertEquals(addedShots, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void addAmmoNoSpareFoundBecauseCurrentlyInTransit() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        AmmoStorage inTransit = new AmmoStorage(0, ammoType, ammoType.getShots(), mockCampaign);
+        inTransit.setDaysToArrival(10);
+        warehouse.addPart(inTransit);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type present...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, addedShots);
+
+        // ... which should result in more ammo being added to the campaign.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            if (part.isPresent()) {
+                // Only one part present in the campaign.
+                assertTrue(part instanceof AmmoStorage);
+                added = (AmmoStorage) part;
+            } else {
+                // The other part should be our in transit part
+                assertEquals(inTransit, part);
+            }
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(addedShots, added.getShots());
+        assertEquals(addedShots, quartermaster.getAmmoAvailable(ammoType));
+        assertEquals(ammoType.getShots(), inTransit.getShots());
+    }
+
+    @Test
+    public void addAmmoNoSpareFoundBecauseWrongMunitionType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        AmmoType otherAmmoType = getAmmoType("ISSRM4 Inferno Ammo");
+        AmmoStorage otherAmmo = new AmmoStorage(0, otherAmmoType, otherAmmoType.getShots(), mockCampaign);
+        warehouse.addPart(otherAmmo);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type present...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, addedShots);
+
+        // ... which should result in more ammo being added to the campaign.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            if (part.getId() != otherAmmo.getId()) {
+                // Only one other part should be in the campaign.
+                assertNull(added);
+                assertTrue(part instanceof AmmoStorage);
+                added = (AmmoStorage) part;
+            } else {
+                // The other part should be our part of another type
+                assertEquals(otherAmmo, part);
+            }
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(addedShots, added.getShots());
+        assertEquals(addedShots, quartermaster.getAmmoAvailable(ammoType));
+        assertEquals(otherAmmoType.getShots(), otherAmmo.getShots());
+    }
+
+    @Test
+    public void addAmmoSpareFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo on hand
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 1;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Add shots to the Campaign when we have spare ammo of that type present...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, addedShots);
+
+        // ... which should result in the existing ammo count increasing in the campaign.
+        AmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part present in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            updated = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(originalShots + addedShots, updated.getShots());
+        assertEquals(originalShots + addedShots, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void addAmmoSpareFoundWithOtherJunk() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo on hand plus other junk
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 1;
+        AmmoStorage existingInTransit = new AmmoStorage(0, ammoType, originalShots + 5, mockCampaign);
+        existingInTransit.setDaysToArrival(10);
+        warehouse.addPart(existingInTransit);
+        Part otherPart = new MekLocation();
+        warehouse.addPart(otherPart);
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Add shots to the Campaign when we have spare ammo of that type present...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, addedShots);
+
+        // ... which should result in the existing ammo count increasing in the campaign.
+        AmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            if ((part instanceof AmmoStorage) && part.isPresent()) {
+                // Only one part present in the campaign.
+                updated = (AmmoStorage) part;
+                break;
+            }
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(originalShots + addedShots, updated.getShots());
+        assertEquals(originalShots + addedShots, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void addAmmoNone() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 1;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Add nothing to the Campaign when we have spare ammo of that type present...
+        quartermaster.addAmmo(ammoType, 0);
+
+        // ... which should result in the existing ammo count staying the same in the campaign.
+        AmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part present in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            updated = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(originalShots, updated.getShots());
+        assertEquals(originalShots, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void addAmmoNegative() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 1;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Add less than nothing to the Campaign when we have spare ammo of that type present...
+        quartermaster.addAmmo(ammoType, -100);
+
+        // ... which should result in the existing ammo count staying the same in the campaign.
+        AmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part present in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            updated = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(originalShots, updated.getShots());
+        assertEquals(originalShots, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void removeAmmoNoneFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        // Setup an empty warehouse
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+
+        // Request ammo from the quartermaster when we don't have any
+        int shotsNeeded = 100;
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, shotsNeeded);
+
+        // ... which should result in nothing happening.
+        assertEquals(0, shotsRemoved);
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void removeAmmoNoneFoundBecauseCurrentlyInTransit() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage inTransit = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        inTransit.setDaysToArrival(10);
+        warehouse.addPart(inTransit);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Try to remove shots from the Campaign when we don't have any spare ammo of that type present...
+        int shotsNeeded = originalShots;
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, shotsNeeded);
+
+        assertEquals(0, shotsRemoved);
+
+        // ... which should result in nothing changing.
+        AmmoStorage existing = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertTrue(part instanceof AmmoStorage);
+            existing = (AmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(existing);
+        assertEquals(inTransit.getId(), existing.getId());
+        assertEquals(inTransit.getDaysToArrival(), existing.getDaysToArrival());
+        assertEquals(ammoType, existing.getType());
+        assertEquals(originalShots, existing.getShots());
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void removeAmmoFoundEnoughAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Remove shots from the Campaign when we have spare ammo of that type present...
+        int shotsNeeded = 50;
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, shotsNeeded);
+
+        assertEquals(shotsNeeded, shotsRemoved);
+
+        // ... which should result in the existing ammo count decreasing in the campaign.
+        AmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertNull(updated);
+            assertTrue(part instanceof AmmoStorage);
+            updated = (AmmoStorage) part;
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(originalShots - shotsNeeded, updated.getShots());
+        assertEquals(originalShots - shotsNeeded, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+
+    @Test
+    public void removeAmmoNoneOrNegative() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Remove nothing.
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, 0);
+
+        assertEquals(0, shotsRemoved);
+
+        // ... which should result in the existing ammo staying exactly the same.
+        assertFalse(warehouse.getParts().isEmpty());
+        assertEquals(originalShots, quartermaster.getAmmoAvailable(ammoType));
+
+        // Remove less than nothing.
+        shotsRemoved = quartermaster.removeAmmo(ammoType, -100);
+
+        assertEquals(0, shotsRemoved);
+
+        // ... which should result in the existing ammo staying exactly the same.
+        assertFalse(warehouse.getParts().isEmpty());
+        assertEquals(originalShots, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void removeAmmoAll() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Remove all the shots from the Campaign when we have spare ammo of that type present...
+        int shotsNeeded = originalShots;
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, originalShots);
+
+        assertEquals(shotsNeeded, shotsRemoved);
+
+        // ... which should result in the existing ammo being removed from the campaign.
+        assertTrue(warehouse.getParts().isEmpty());
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void removeAmmoWayMoreThanAvailable() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+
+        // Setup a warehouse with ammo in transit and available
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        AmmoStorage inTransit = new AmmoStorage(0, ammoType, originalShots + 1, mockCampaign);
+        inTransit.setDaysToArrival(10);
+        warehouse.addPart(inTransit);
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Remove way more than the number shots from the Campaign when we have
+        // spare ammo of that type present...
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, 10 * originalShots);
+
+        assertEquals(originalShots, shotsRemoved);
+
+        // ... which should result in the existing ammo being removed from the campaign,
+        // and not some weird situation where some part is there with negative or zero
+        // rounds of ammo present.
+        assertFalse(warehouse.getParts().contains(existing));
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void removeAmmoWayMoreThanAvailableButCompatibleAmmoExists() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaignOptions.useAmmoByType()).thenReturn(true);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+        AmmoType compatibleAmmoType = getAmmoType("ISSRM2 Inferno Ammo");
+
+        // Setup a warehouse with compatible ammo types
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // We only have one ton of the ammo we want.
+        int originalShots = ammoType.getShots();
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+
+        // But we have gobs of compatible ammunition.
+        int compatibleShots = compatibleAmmoType.getShots() * 10;
+        AmmoStorage compatible = new AmmoStorage(0, compatibleAmmoType, compatibleShots, mockCampaign);
+        warehouse.addPart(compatible);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Ask for two tons of ammo (double what we have on hand)
+        int shotsNeeded = 2 * ammoType.getShots();
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, shotsNeeded);
+
+        // Between the ammo on hand and our compatible ammo, we should have enough.
+        assertEquals(shotsNeeded, shotsRemoved);
+
+        // ... which should result in the existing ammo being removed from the campaign,
+        // and not some weird situation where some part is there with negative or zero
+        // rounds of ammo present.
+        assertTrue(existing.getId() < 0);
+        assertEquals(0, existing.getShots());
+        assertFalse(warehouse.getParts().contains(existing));
+
+        // ... but should leave the compatible ammo available, just less the correct
+        // number of rounds.
+        assertTrue(warehouse.getParts().contains(compatible));
+
+        // Calculate the shots removed from the compatible ammo type ...
+        int compatibleShotsRemoved = ((shotsRemoved - originalShots) * ammoType.getRackSize())
+                / compatibleAmmoType.getRackSize();
+
+        // ... and ensure they were deducted.
+        assertEquals(compatibleShots - compatibleShotsRemoved, compatible.getShots());
+
+        // Also ensure we calculate the correct amount of ammo available.
+        int convertedShots = ((compatibleShots - compatibleShotsRemoved) * compatibleAmmoType.getRackSize())
+                / ammoType.getRackSize();
+        assertEquals(convertedShots, quartermaster.getAmmoAvailable(ammoType));
+        assertEquals(compatibleShots - compatibleShotsRemoved, quartermaster.getAmmoAvailable(compatibleAmmoType));
+    }
+
+    @Test
+    public void removeAmmoWhenExactlyEnoughCompatibleAmmoExists() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaignOptions.useAmmoByType()).thenReturn(true);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+        AmmoType compatibleAmmoType = getAmmoType("ISSRM2 Inferno Ammo");
+
+        // Setup a warehouse with compatible ammo types
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // We have JUST enough compatible ammo
+        int compatibleShots = compatibleAmmoType.getShots();
+        AmmoStorage compatible = new AmmoStorage(0, compatibleAmmoType, compatibleShots, mockCampaign);
+        warehouse.addPart(compatible);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Ask for one ton of ammo (exactly what we have on hand in a compatible ammo type)
+        int shotsNeeded = ammoType.getShots();
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, shotsNeeded);
+
+        // Between the ammo on hand and our compatible ammo, we should have enough.
+        assertEquals(shotsNeeded, shotsRemoved);
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+
+        // ... which should result in the existing ammo being removed from the campaign,
+        // and not some weird situation where some part is there with negative or zero
+        // rounds of ammo present.
+        assertFalse(warehouse.getParts().contains(compatible));
+        assertEquals(0, compatible.getShots());
+        assertEquals(0, quartermaster.getAmmoAvailable(compatibleAmmoType));
+    }
+
+    @Test
+    public void removeAmmoWayMoreThanAvailableButCompatibleAndIncompatibleAmmoExists() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaignOptions.useAmmoByType()).thenReturn(true);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+        AmmoType compatibleAmmoType = getAmmoType("ISSRM2 Inferno Ammo");
+        AmmoType incompatibleAmmoType = getAmmoType("ISSRM2 Ammo");
+
+        // Setup a warehouse with compatible ammo types
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // We only have one ton of the ammo we want.
+        int originalShots = ammoType.getShots();
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+
+        // But we have gobs of compatible and incompatible ammunition.
+        int incompatibleShots = incompatibleAmmoType.getShots() * 10;
+        AmmoStorage incompatible = new AmmoStorage(0, incompatibleAmmoType, incompatibleShots, mockCampaign);
+        warehouse.addPart(incompatible);
+
+        int compatibleShots = compatibleAmmoType.getShots() * 10;
+        AmmoStorage compatible = new AmmoStorage(0, compatibleAmmoType, compatibleShots, mockCampaign);
+        warehouse.addPart(compatible);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Ask for two tons of ammo (double what we have on hand)
+        int shotsNeeded = 2 * ammoType.getShots();
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, shotsNeeded);
+
+        // Between the ammo on hand and our compatible ammo, we should have enough.
+        assertEquals(shotsNeeded, shotsRemoved);
+
+        // ... which should result in the existing ammo being removed from the campaign,
+        // and not some weird situation where some part is there with negative or zero
+        // rounds of ammo present.
+        assertTrue(existing.getId() < 0);
+        assertEquals(0, existing.getShots());
+        assertFalse(warehouse.getParts().contains(existing));
+
+        // ... but should leave the compatible ammo available, just less the correct
+        // number of rounds.
+        assertTrue(warehouse.getParts().contains(compatible));
+
+        // Calculate the shots removed from the compatible ammo type ...
+        int compatibleShotsRemoved = ((shotsRemoved - originalShots) * ammoType.getRackSize())
+                / compatibleAmmoType.getRackSize();
+
+        // ... and ensure they were deducted.
+        assertEquals(compatibleShots - compatibleShotsRemoved, compatible.getShots());
+
+        // ... and we're taking this into account when we ask for the amount available.
+        assertEquals(compatibleShots - compatibleShotsRemoved, quartermaster.getAmmoAvailable(compatibleAmmoType));
+
+        // ... and we did not touch our incompatible ammo.
+        assertEquals(incompatibleShots, incompatible.getShots());
+        assertEquals(incompatibleShots, quartermaster.getAmmoAvailable(incompatibleAmmoType));
+    }
+
+    @Test
+    public void removeAmmoWayMoreThanAvailableButNotEnoughCompatibleAmmoExists() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaignOptions.useAmmoByType()).thenReturn(true);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
+        AmmoType compatibleAmmoType = getAmmoType("ISSRM2 Inferno Ammo");
+
+        // Setup a warehouse with compatible ammo types
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // We only have one ton of the ammo we want.
+        int originalShots = ammoType.getShots();
+        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
+        warehouse.addPart(existing);
+
+        // But we have just a skosh of compatible ammunition (not enough to convert).
+        int compatibleShots = 1;
+        AmmoStorage compatible = new AmmoStorage(0, compatibleAmmoType, compatibleShots, mockCampaign);
+        warehouse.addPart(compatible);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Ask for two tons of ammo (double what we have on hand)
+        int shotsNeeded = 2 * ammoType.getShots();
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, shotsNeeded);
+
+        // We only have enough for half of our request.
+        assertEquals(originalShots, shotsRemoved);
+
+        // ... which should result in the existing ammo being removed from the campaign,
+        // and not some weird situation where some part is there with negative or zero
+        // rounds of ammo present.
+        assertTrue(existing.getId() < 0);
+        assertEquals(0, existing.getShots());
+        assertFalse(warehouse.getParts().contains(existing));
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+
+        // ... but should leave the compatible ammo available, because there wasn't
+        // quite enough of it to use any.
+        assertTrue(warehouse.getParts().contains(compatible));
+
+        // ... and ensure they were NOT deducted.
+        assertEquals(compatibleShots, compatible.getShots());
+        assertEquals(compatibleShots, quartermaster.getAmmoAvailable(compatibleAmmoType));
+    }
+
+    @Test
+    public void addInfantryAmmoNoSpareFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        // Setup an empty warehouse
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, weaponType, addedShots);
+
+        // ... which should result in more ammo being added to the campaign.
+        InfantryAmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertTrue(part instanceof InfantryAmmoStorage);
+            added = (InfantryAmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(weaponType, added.getWeaponType());
+        assertTrue(added.isSameAmmoType(ammoType, weaponType));
+        assertEquals(addedShots, added.getShots());
+        assertEquals(addedShots, quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void addInfantryAmmoNoSpareFoundBecauseCurrentlyInTransit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        InfantryAmmoStorage inTransit = new InfantryAmmoStorage(0, ammoType, ammoType.getShots(), weaponType, mockCampaign);
+        inTransit.setDaysToArrival(10);
+        warehouse.addPart(inTransit);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type present...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, weaponType, addedShots);
+
+        // ... which should result in more ammo being added to the campaign.
+        InfantryAmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            if (part.isPresent()) {
+                // Only one part present in the campaign.
+                assertTrue(part instanceof InfantryAmmoStorage);
+                added = (InfantryAmmoStorage) part;
+            } else {
+                // The other part should be our in transit part
+                assertEquals(inTransit, part);
+            }
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(weaponType, added.getWeaponType());
+        assertTrue(added.isSameAmmoType(ammoType, weaponType));
+        assertEquals(addedShots, added.getShots());
+        assertEquals(addedShots, quartermaster.getAmmoAvailable(ammoType, weaponType));
+        assertEquals(ammoType.getShots(), inTransit.getShots());
+    }
+
+    @Test
+    public void addInfantryAmmoNoSpareFoundBecauseWrongWeaponType() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon otherWeaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_TAG);
+        InfantryAmmoStorage otherAmmo = new InfantryAmmoStorage(0, ammoType, ammoType.getShots(), otherWeaponType, mockCampaign);
+        warehouse.addPart(otherAmmo);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Add shots to the Campaign when we don't have any spare ammo of that type present...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, weaponType, addedShots);
+
+        // ... which should result in more ammo being added to the campaign.
+        InfantryAmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            if (part.getId() != otherAmmo.getId()) {
+                // Only one other part should be in the campaign.
+                assertNull(added);
+                assertTrue(part instanceof InfantryAmmoStorage);
+                added = (InfantryAmmoStorage) part;
+            } else {
+                // The other part should be our part of another type
+                assertEquals(otherAmmo, part);
+            }
+        }
+
+        assertNotNull(added);
+        assertTrue(added.isSpare());
+        assertTrue(added.isPresent());
+        assertEquals(ammoType, added.getType());
+        assertEquals(weaponType, added.getWeaponType());
+        assertTrue(added.isSameAmmoType(ammoType, weaponType));
+        assertFalse(added.isSameAmmoType(ammoType, otherWeaponType));
+        assertEquals(addedShots, added.getShots());
+        assertEquals(addedShots, quartermaster.getAmmoAvailable(ammoType, weaponType));
+        assertEquals(ammoType.getShots(), otherAmmo.getShots());
+        assertEquals(otherAmmo.getShots(), quartermaster.getAmmoAvailable(ammoType, otherWeaponType));
+    }
+
+    @Test
+    public void addInfantryAmmoSpareFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 1;
+        InfantryAmmoStorage existing = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Add shots to the Campaign when we have spare ammo of that type present...
+        int addedShots = 100;
+        quartermaster.addAmmo(ammoType, weaponType, addedShots);
+
+        // ... which should result in the existing ammo count increasing in the campaign.
+        InfantryAmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part present in the campaign.
+            assertTrue(part instanceof InfantryAmmoStorage);
+            updated = (InfantryAmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(existing.getWeaponType(), updated.getWeaponType());
+        assertTrue(existing.isSameAmmoType(ammoType, weaponType));
+        assertEquals(originalShots + addedShots, updated.getShots());
+        assertEquals(originalShots + addedShots, quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void removeInfantryAmmoNoneFound() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        // Setup an empty warehouse
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Request ammo from the quartermaster when we don't have any
+        int shotsNeeded = 100;
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, weaponType, shotsNeeded);
+
+        // ... which should result in nothing happening.
+        assertEquals(0, shotsRemoved);
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void removeInfantryAmmoNoneFoundBecauseCurrentlyInTransit() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        InfantryAmmoStorage inTransit = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
+        inTransit.setDaysToArrival(10);
+        warehouse.addPart(inTransit);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Try to remove shots from the Campaign when we don't have any spare ammo of that type present...
+        int shotsNeeded = originalShots;
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, weaponType, shotsNeeded);
+
+        assertEquals(0, shotsRemoved);
+
+        // ... which should result in nothing changing.
+        InfantryAmmoStorage existing = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertTrue(part instanceof InfantryAmmoStorage);
+            existing = (InfantryAmmoStorage) part;
+            break;
+        }
+
+        assertNotNull(existing);
+        assertEquals(inTransit.getId(), existing.getId());
+        assertEquals(inTransit.getDaysToArrival(), existing.getDaysToArrival());
+        assertEquals(ammoType, existing.getType());
+        assertEquals(weaponType, existing.getWeaponType());
+        assertEquals(originalShots, existing.getShots());
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void removeInfantryAmmoFoundEnoughAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        InfantryAmmoStorage existing = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Remove shots from the Campaign when we have spare ammo of that type present...
+        int shotsNeeded = 50;
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, weaponType, shotsNeeded);
+
+        assertEquals(shotsNeeded, shotsRemoved);
+
+        // ... which should result in the existing ammo count decreasing in the campaign.
+        InfantryAmmoStorage updated = null;
+        for (Part part : warehouse.getParts()) {
+            // Only one part in the campaign.
+            assertNull(updated);
+            assertTrue(part instanceof InfantryAmmoStorage);
+            updated = (InfantryAmmoStorage) part;
+        }
+
+        assertNotNull(updated);
+        assertEquals(updated.getId(), existing.getId());
+        assertEquals(existing.getType(), updated.getType());
+        assertEquals(existing.getWeaponType(), updated.getWeaponType());
+        assertEquals(originalShots - shotsNeeded, updated.getShots());
+        assertEquals(originalShots - shotsNeeded, quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void removeInfantryAmmoAll() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        InfantryAmmoStorage existing = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Remove all the shots from the Campaign when we have spare ammo of that type present...
+        int shotsNeeded = originalShots;
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, weaponType, originalShots);
+
+        assertEquals(shotsNeeded, shotsRemoved);
+
+        // ... which should result in the existing ammo being removed from the campaign.
+        assertTrue(warehouse.getParts().isEmpty());
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void removeInfantryAmmoWayMoreThanAvailable() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Setup a warehouse with ammo in transit
+        Warehouse warehouse = new Warehouse();
+        int originalShots = 100;
+        InfantryAmmoStorage existing = new InfantryAmmoStorage(0, ammoType, originalShots, weaponType, mockCampaign);
+        warehouse.addPart(existing);
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+
+        // And a basic quartermaster
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Remove way more than the number shots from the Campaign when we have
+        // spare ammo of that type present...
+        int shotsRemoved = quartermaster.removeAmmo(ammoType, weaponType, 10 * originalShots);
+
+        assertEquals(originalShots, shotsRemoved);
+
+        // ... which should result in the existing ammo being removed from the campaign,
+        // and not some weird situation where some part is there with negative or zero
+        // rounds of ammo present.
+        assertTrue(warehouse.getParts().isEmpty());
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType, weaponType));
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -27,11 +27,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -278,6 +279,53 @@ public class AmmoStorageTest {
         // a different munition type.
         assertFalse(ammoStorage.isSamePartType(otherAmmoStorage));
         assertFalse(otherAmmoStorage.isSamePartType(ammoStorage));
+    }
+
+    @Test
+    public void isSameAmmoTypeTest() {
+        AmmoType ammoType = getAmmoType("ISAC5 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, ammoType.getShots(), mockCampaign);
+
+        // We're the same as ourselves.
+        assertTrue(ammoStorage.isSameAmmoType(ammoType));
+
+        // Create an ammo type with some different munitions available
+        AmmoType isSRM2Ammo = getAmmoType("ISSRM2 Ammo");
+        assertFalse(ammoStorage.isSameAmmoType(isSRM2Ammo));
+
+        ammoStorage = new AmmoStorage(0, isSRM2Ammo, isSRM2Ammo.getShots(), mockCampaign);
+
+        // And ensure they're not the same as the same type of ammo, just
+        // a different munition type.
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        assertFalse(ammoStorage.isSameAmmoType(isSRM2InfernoAmmo));
+    }
+
+    @Test
+    public void isSameAmmoTypeFullHalfTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        // Create Full and Half bins
+        Map<String, String> fullAndHalfs = new HashMap<>();
+        fullAndHalfs.put("IS Ammo MG - Full", "IS Machine Gun Ammo - Half");
+        fullAndHalfs.put("Clan Machine Gun Ammo - Full", "Clan Machine Gun Ammo - Half");
+        fullAndHalfs.put("IS Light Machine Gun Ammo - Full", "IS Light Machine Gun Ammo - Half");
+        fullAndHalfs.put("Clan Light Machine Gun Ammo - Full", "Clan Light Machine Gun Ammo - Half");
+        fullAndHalfs.put("IS Heavy Machine Gun Ammo - Full", "IS Heavy Machine Gun Ammo - Half");
+        fullAndHalfs.put("Clan Heavy Machine Gun Ammo - Full", "Clan Heavy Machine Gun Ammo - Half");
+        fullAndHalfs.put("IS Ammo Nail/Rivet - Full", "IS Ammo Nail/Rivet - Half");
+        for (Map.Entry<String, String> pair : fullAndHalfs.entrySet()) {
+            AmmoType fullType = getAmmoType(pair.getKey());
+            AmmoType halfType = getAmmoType(pair.getValue());
+
+            AmmoStorage full = new AmmoStorage(0, fullType, fullType.getShots(), mockCampaign);
+            assertTrue(full.isSameAmmoType(halfType));
+
+            AmmoStorage half = new AmmoStorage(0, halfType, halfType.getShots(), mockCampaign);
+            assertTrue(half.isSameAmmoType(fullType));
+        }
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoStorageTest.java
@@ -21,6 +21,7 @@ package mekhq.campaign.parts;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.AmmoUtilities.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -38,12 +39,9 @@ import org.xml.sax.SAXException;
 
 import megamek.common.AmmoType;
 import megamek.common.BombType;
-import megamek.common.EquipmentType;
 import mekhq.MekHqXmlUtil;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.work.IAcquisitionWork;
@@ -63,7 +61,6 @@ public class AmmoStorageTest {
         AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, ammoType.getShots(), mockCampaign);
 
         assertEquals(ammoType, ammoStorage.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoType, ammoStorage.getType()));
         assertEquals(ammoType.getShots(), ammoStorage.getShots());
         assertEquals(1.0, ammoStorage.getTonnage(), 0.001);
     }
@@ -90,7 +87,6 @@ public class AmmoStorageTest {
         assertNotNull(clone);
 
         assertEquals(ammoStorage.getType(), clone.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), clone.getType()));
         assertEquals(ammoStorage.getBuyCost(), clone.getBuyCost());
         assertEquals(ammoStorage.getCurrentValue(), clone.getCurrentValue());
         assertEquals(ammoStorage.getShots(), clone.getShots());
@@ -109,7 +105,6 @@ public class AmmoStorageTest {
 
         // ... and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
         // ... except for the number of shots, which should be instead
@@ -130,7 +125,6 @@ public class AmmoStorageTest {
 
         // ... and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
         // ... except for the number of shots, which should be instead
@@ -158,7 +152,6 @@ public class AmmoStorageTest {
 
         // ... and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
         // ... except for the number of shots, which should be instead
@@ -174,7 +167,6 @@ public class AmmoStorageTest {
 
         // ... and the new part should be identical in ALMOST every way...
         assertEquals(ammoStorage.getType(), newAmmoStorage.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), newAmmoStorage.getType()));
         assertEquals(ammoStorage.getBuyCost(), newAmmoStorage.getBuyCost());
 
         // ... except for the number of shots, which should be instead
@@ -349,7 +341,6 @@ public class AmmoStorageTest {
         Campaign mockCampaign = mock(Campaign.class);
         AmmoStorage ammoStorage = new AmmoStorage(0, isSRM2InfernoAmmo, 3 * isSRM2InfernoAmmo.getShots(), mockCampaign);
         ammoStorage.setId(25);
-        ammoStorage.setEquipmentNum(42);
 
         // Write the AmmoStorage XML
         StringWriter sw = new StringWriter();
@@ -380,7 +371,6 @@ public class AmmoStorageTest {
         assertEquals(ammoStorage.getId(), deserialized.getId());
         assertEquals(ammoStorage.getEquipmentNum(), deserialized.getEquipmentNum());
         assertEquals(ammoStorage.getType(), deserialized.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), deserialized.getType()));
         assertEquals(ammoStorage.getShots(), deserialized.getShots());
     }
 
@@ -390,7 +380,6 @@ public class AmmoStorageTest {
         Campaign mockCampaign = mock(Campaign.class);
         AmmoStorage ammoStorage = new AmmoStorage(0, infernoBomb, 3 * infernoBomb.getShots(), mockCampaign);
         ammoStorage.setId(25);
-        ammoStorage.setEquipmentNum(42);
 
         // Write the AmmoStorage XML
         StringWriter sw = new StringWriter();
@@ -421,396 +410,6 @@ public class AmmoStorageTest {
         assertEquals(ammoStorage.getId(), deserialized.getId());
         assertEquals(ammoStorage.getEquipmentNum(), deserialized.getEquipmentNum());
         assertEquals(ammoStorage.getType(), deserialized.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoStorage.getType(), deserialized.getType()));
         assertEquals(ammoStorage.getShots(), deserialized.getShots());
-    }
-
-    @Test
-    public void changeAmountAvailableNoneFound() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        // Setup an empty warehouse
-        Warehouse warehouse = new Warehouse();
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Add shots to the Campaign when we don't have any spare ammo of that type...
-        int addedShots = 100;
-        ammoStorage.changeAmountAvailable(addedShots, ammoType);
-
-        // ... which should result in more ammo being added to the campaign.
-        AmmoStorage added = null;
-        for (Part part : warehouse.getParts()) {
-            // Only one part in the campaign.
-            assertTrue(part instanceof AmmoStorage);
-            added = (AmmoStorage) part;
-            break;
-        }
-
-        assertNotNull(added);
-        assertTrue(added.isSpare());
-        assertTrue(added.isPresent());
-        assertEquals(ammoType, added.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoType, added.getType()));
-        assertEquals(addedShots, added.getShots());
-    }
-
-    @Test
-    public void changeAmountAvailableNoneFoundBecauseCurrentlyInTransit() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
-
-        // Setup a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
-        AmmoStorage inTransit = new AmmoStorage(0, ammoType, 0, mockCampaign);
-        inTransit.setDaysToArrival(10);
-        warehouse.addPart(inTransit);
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Add shots to the Campaign when we don't have any spare ammo of that type present...
-        int addedShots = 100;
-        ammoStorage.changeAmountAvailable(addedShots, ammoType);
-
-        // ... which should result in more ammo being added to the campaign.
-        AmmoStorage added = null;
-        for (Part part : warehouse.getParts()) {
-            if (part.isPresent()) {
-                // Only one part present in the campaign.
-                assertTrue(part instanceof AmmoStorage);
-                added = (AmmoStorage) part;
-            } else {
-                // The other part should be our in transit part
-                assertEquals(inTransit, part);
-            }
-        }
-
-        assertNotNull(added);
-        assertTrue(added.isSpare());
-        assertTrue(added.isPresent());
-        assertEquals(ammoType, added.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoType, added.getType()));
-        assertEquals(addedShots, added.getShots());
-    }
-
-    @Test
-    public void changeAmountAvailableNoneFoundBecauseWrongMunitionType() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        // Setup a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
-        AmmoType otherAmmoType = getAmmoType("ISSRM4 Inferno Ammo");
-        AmmoStorage otherAmmo = new AmmoStorage(0, otherAmmoType, 20, mockCampaign);
-        warehouse.addPart(otherAmmo);
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Add shots to the Campaign when we don't have any spare ammo of that type present...
-        int addedShots = 100;
-        ammoStorage.changeAmountAvailable(addedShots, ammoType);
-
-        // ... which should result in more ammo being added to the campaign.
-        AmmoStorage added = null;
-        for (Part part : warehouse.getParts()) {
-            if (part.getId() != otherAmmo.getId()) {
-                // Only one other part should be in the campaign.
-                assertNull(added);
-                assertTrue(part instanceof AmmoStorage);
-                added = (AmmoStorage) part;
-            } else {
-                // The other part should be our part of another type
-                assertEquals(otherAmmo, part);
-            }
-        }
-
-        assertNotNull(added);
-        assertTrue(added.isSpare());
-        assertTrue(added.isPresent());
-        assertEquals(ammoType, added.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoType, added.getType()));
-        assertEquals(addedShots, added.getShots());
-    }
-
-    @Test
-    public void changeAmountAvailableIncreaseFound() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
-
-        // Setup a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
-        int originalShots = 1;
-        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
-        warehouse.addPart(existing);
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Add shots to the Campaign when we have spare ammo of that type present...
-        int addedShots = 100;
-        ammoStorage.changeAmountAvailable(addedShots, ammoType);
-
-        // ... which should result in the existing ammo count increasing in the campaign.
-        AmmoStorage updated = null;
-        for (Part part : warehouse.getParts()) {
-            // Only one part present in the campaign.
-            assertTrue(part instanceof AmmoStorage);
-            updated = (AmmoStorage) part;
-            break;
-        }
-
-        assertNotNull(updated);
-        assertEquals(updated.getId(), existing.getId());
-        assertEquals(existing.getType(), updated.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(existing.getType(), updated.getType()));
-        assertEquals(originalShots + addedShots, updated.getShots());
-    }
-
-    @Test
-    public void changeAmountAvailableDecreaseNoneFound() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        // Setup an empty warehouse
-        Warehouse warehouse = new Warehouse();
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Add shots to the Campaign when we don't have any spare ammo of that type...
-        int removedShots = -100;
-        ammoStorage.changeAmountAvailable(removedShots, ammoType);
-
-        // ... which should result in nothing happening.
-        assertTrue(warehouse.getParts().isEmpty());
-    }
-
-    @Test
-    public void changeAmountAvailableDecreaseNoneFoundBecauseCurrentlyInTransit() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Ammo");
-
-        // Setup a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
-        int originalShots = 100;
-        AmmoStorage inTransit = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
-        inTransit.setDaysToArrival(10);
-        warehouse.addPart(inTransit);
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Try to remove shots from the Campaign when we don't have any spare ammo of that type present...
-        int removedShots = -100;
-        ammoStorage.changeAmountAvailable(removedShots, ammoType);
-
-        // ... which should result in nothing changing.
-        AmmoStorage existing = null;
-        for (Part part : warehouse.getParts()) {
-            // Only one part in the campaign.
-            assertTrue(part instanceof AmmoStorage);
-            existing = (AmmoStorage) part;
-            break;
-        }
-
-        assertNotNull(existing);
-        assertEquals(inTransit.getId(), existing.getId());
-        assertEquals(inTransit.getDaysToArrival(), existing.getDaysToArrival());
-        assertEquals(ammoType, existing.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(ammoType, existing.getType()));
-        assertEquals(originalShots, existing.getShots());
-    }
-
-    @Test
-    public void changeAmountAvailableDecreaseFound() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
-
-        // Setup a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
-        int originalShots = 100;
-        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
-        warehouse.addPart(existing);
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Remove shots from the Campaign when we have spare ammo of that type present...
-        int removedShots = -50;
-        ammoStorage.changeAmountAvailable(removedShots, ammoType);
-
-        // ... which should result in the existing ammo count decreasing in the campaign.
-        AmmoStorage updated = null;
-        for (Part part : warehouse.getParts()) {
-            // Only one part in the campaign.
-            assertNull(updated);
-            assertTrue(part instanceof AmmoStorage);
-            updated = (AmmoStorage) part;
-        }
-
-        assertNotNull(updated);
-        assertEquals(updated.getId(), existing.getId());
-        assertEquals(existing.getType(), updated.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(existing.getType(), updated.getType()));
-        assertEquals(originalShots + removedShots, updated.getShots());
-    }
-
-    @Test
-    public void changeAmountAvailableDecreaseAll() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
-
-        // Setup a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
-        int originalShots = 100;
-        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
-        warehouse.addPart(existing);
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Remove all the shots from the Campaign when we have spare ammo of that type present...
-        ammoStorage.changeAmountAvailable(-originalShots, ammoType);
-
-        // ... which should result in the existing ammo being removed from the campaign.
-        assertTrue(warehouse.getParts().isEmpty());
-    }
-
-    @Test
-    public void changeAmountAvailableDecreaseWayMoreThanAll() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        AmmoType ammoType = getAmmoType("ISSRM4 Inferno Ammo");
-
-        // Setup a warehouse with ammo in transit
-        Warehouse warehouse = new Warehouse();
-        int originalShots = 100;
-        AmmoStorage existing = new AmmoStorage(0, ammoType, originalShots, mockCampaign);
-        warehouse.addPart(existing);
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Remove way more than the number shots from the Campaign when we have
-        // spare ammo of that type present...
-        ammoStorage.changeAmountAvailable(-(10 * originalShots), ammoType);
-
-        // ... which should result in the existing ammo being removed from the campaign,
-        // and not some weird situation where some part is there with negative or zero
-        // rounds of ammo present.
-        assertTrue(warehouse.getParts().isEmpty());
-    }
-
-    @Ignore("Fixed in PR 2229")
-    @Test
-    public void changeAmountAvailableBombDecreaseNoneFound() {
-        Campaign mockCampaign = mock(Campaign.class);
-
-        // Setup a warehouse with some other bomb type
-        Warehouse warehouse = new Warehouse();
-        BombType torpedoBomb = getBombType("TorpedoBomb");
-        int originalShots = 2;
-        AmmoStorage otherAmmoStorage = new AmmoStorage(0, torpedoBomb, originalShots, mockCampaign);
-        warehouse.addPart(otherAmmoStorage);
-        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
-
-        // And a basic quartermaster
-        Quartermaster quartermaster = new Quartermaster(mockCampaign);
-        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
-
-        BombType ammoType = getBombType("ThunderBomb");
-        AmmoStorage ammoStorage = new AmmoStorage(0, ammoType, 0, mockCampaign);
-
-        // Remove shots from the Campaign when we have a bomb, but it doesn't match
-        int removedShots = -100;
-        ammoStorage.changeAmountAvailable(removedShots, ammoType);
-
-        // ... which should result in nothing changing.
-        AmmoStorage existing = null;
-        for (Part part : warehouse.getParts()) {
-            // Only one part in the campaign.
-            assertTrue(part instanceof AmmoStorage);
-            existing = (AmmoStorage) part;
-            break;
-        }
-
-        assertNotNull(existing);
-        assertEquals(otherAmmoStorage.getId(), existing.getId());
-        assertEquals(ammoType, existing.getType());
-        assertTrue(AmmoStorage.isSameAmmoType(torpedoBomb, existing.getType()));
-        assertEquals(originalShots, existing.getShots());
-    }
-
-    /**
-     * Gets an AmmoType by name (performing any initialization required
-     * on the MM side).
-     * @param name The lookup name for the AmmoType.
-     * @return The ammo type for the given name.
-     */
-    private synchronized static AmmoType getAmmoType(String name) {
-        EquipmentType equipmentType = EquipmentType.get(name);
-        assertNotNull(equipmentType);
-        assertTrue(equipmentType instanceof AmmoType);
-
-        return (AmmoType) equipmentType;
-    }
-
-    /**
-     * Gets a BombType by name (performing any initialization required
-     * on the MM side).
-     * @param name The lookup name for the BombType.
-     * @return The bomb type for the given name.
-     */
-    private synchronized static BombType getBombType(String name) {
-        EquipmentType equipmentType = EquipmentType.get(name);
-        assertNotNull(equipmentType);
-        assertTrue(equipmentType instanceof BombType);
-
-        return (BombType) equipmentType;
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/AmmoUtilities.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/AmmoUtilities.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts;
+
+import static org.junit.Assert.*;
+
+import megamek.common.AmmoType;
+import megamek.common.BombType;
+import megamek.common.EquipmentType;
+import megamek.common.weapons.infantry.InfantryWeapon;
+
+public class AmmoUtilities {
+    /**
+     * Gets an AmmoType by name (performing any initialization required
+     * on the MM side).
+     * @param name The lookup name for the AmmoType.
+     * @return The ammo type for the given name.
+     */
+    public synchronized static AmmoType getAmmoType(String name) {
+        EquipmentType equipmentType = EquipmentType.get(name);
+        assertNotNull(equipmentType);
+        assertTrue(equipmentType instanceof AmmoType);
+
+        return (AmmoType) equipmentType;
+    }
+
+    /**
+     * Gets a BombType by name (performing any initialization required
+     * on the MM side).
+     * @param name The lookup name for the BombType.
+     * @return The bomb type for the given name.
+     */
+    public synchronized static BombType getBombType(String name) {
+        EquipmentType equipmentType = EquipmentType.get(name);
+        assertNotNull(equipmentType);
+        assertTrue(equipmentType instanceof BombType);
+
+        return (BombType) equipmentType;
+    }
+
+    /**
+     * Gets a InfantryWeapon by name (performing any initialization required
+     * on the MM side).
+     * @param name The lookup name for the InfantryWeapon.
+     * @return The bomb type for the given name.
+     */
+    public synchronized static InfantryWeapon getInfantryWeapon(String name) {
+        EquipmentType equipmentType = EquipmentType.get(name);
+        assertNotNull(equipmentType);
+        assertTrue(equipmentType instanceof InfantryWeapon);
+
+        return (InfantryWeapon) equipmentType;
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/InfantryAmmoStorageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/InfantryAmmoStorageTest.java
@@ -20,13 +20,189 @@
 package mekhq.campaign.parts;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.AmmoUtilities.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import megamek.common.EquipmentTypeLookup;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
 
 public class InfantryAmmoStorageTest {
     @Test
-    public void ammoStorageDeserializationCtorTest() {
+    public void infantryAmmoStorageDeserializationCtorTest() {
         InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage();
         assertNotNull(ammoStorage);
+    }
+
+    @Test
+    public void infantryAmmoStorageCtorTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int shots = weaponType.getShots() * 3;
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage(0, ammoType, shots, weaponType, mockCampaign);
+        assertEquals(ammoType, ammoStorage.getType());
+        assertEquals(weaponType, ammoStorage.getWeaponType());
+        assertEquals(shots, ammoStorage.getShots());
+    }
+
+    @Test
+    public void cloneTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int shots = weaponType.getShots() * 3;
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage(0, ammoType, shots, weaponType, mockCampaign);
+
+        InfantryAmmoStorage clone = ammoStorage.clone();
+        assertEquals(ammoStorage.getType(), clone.getType());
+        assertEquals(ammoStorage.getWeaponType(), clone.getWeaponType());
+        assertEquals(ammoStorage.getShots(), clone.getShots());
+    }
+
+    @Test
+    public void getNewPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int shots = ammoType.getShots() * 3;
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage(0, ammoType, shots, weaponType, mockCampaign);
+
+        InfantryAmmoStorage newPart = ammoStorage.getNewPart();
+        assertEquals(ammoStorage.getType(), newPart.getType());
+        assertEquals(ammoStorage.getWeaponType(), newPart.getWeaponType());
+        assertEquals(weaponType.getShots(), newPart.getShots());
+    }
+
+    @Test
+    public void getTechAdvancementTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage(0, ammoType, 0, weaponType, mockCampaign);
+
+        assertEquals(weaponType.getTechAdvancement(), ammoStorage.getTechAdvancement());
+    }
+
+    @Test
+    public void infantryAmmoStorageWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        Campaign mockCampaign = mock(Campaign.class);
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage(0, ammoType, 7 * ammoType.getShots(), weaponType, mockCampaign);
+        ammoStorage.setId(25);
+
+        // Write the AmmoStorage XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoStorage.writeToXml(pw, 0);
+
+        // Get the AmmoStorage XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoStorage
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof InfantryAmmoStorage);
+
+        InfantryAmmoStorage deserialized = (InfantryAmmoStorage) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoStorage.getId(), deserialized.getId());
+        assertEquals(ammoStorage.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoStorage.getType(), deserialized.getType());
+        assertEquals(ammoStorage.getWeaponType(), deserialized.getWeaponType());
+        assertEquals(ammoStorage.getShots(), deserialized.getShots());
+        assertEquals(ammoStorage.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void isSameAmmoTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        InfantryWeapon otherWeaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_TAG);
+
+        int shots = ammoType.getShots() * 3;
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage(0, ammoType, shots, weaponType, mockCampaign);
+
+        assertTrue(ammoStorage.isSameAmmoType(ammoType, weaponType));
+        assertFalse(ammoStorage.isSameAmmoType(ammoType, otherWeaponType));
+        assertFalse(ammoStorage.isSameAmmoType(otherAmmoType, weaponType));
+        assertFalse(ammoStorage.isSameAmmoType(otherAmmoType, otherWeaponType));
+    }
+
+    @Test
+    public void isCompatibleAmmoTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int shots = ammoType.getShots() * 3;
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage(0, ammoType, shots, weaponType, mockCampaign);
+
+        assertFalse(ammoStorage.isCompatibleAmmo(ammoType));
+        assertFalse(ammoStorage.isCompatibleAmmo(otherAmmoType));
+    }
+
+    @Test
+    public void isSamePartTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        InfantryWeapon otherWeaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_TAG);
+
+        InfantryAmmoStorage ammoStorage = new InfantryAmmoStorage(0, ammoType, 0, weaponType, mockCampaign);
+
+        Part otherPart = new InfantryAmmoStorage(0, ammoType, 0, weaponType, mockCampaign);
+        assertTrue(ammoStorage.isSamePartType(otherPart));
+
+        otherPart = new InfantryAmmoStorage(0, otherAmmoType, 0, weaponType, mockCampaign);
+        assertFalse(ammoStorage.isSamePartType(otherPart));
+
+        otherPart = new InfantryAmmoStorage(0, ammoType, 0, otherWeaponType, mockCampaign);
+        assertFalse(ammoStorage.isSamePartType(otherPart));
+
+        otherPart = new InfantryAmmoStorage(0, otherAmmoType, 0, otherWeaponType, mockCampaign);
+        assertFalse(ammoStorage.isSamePartType(otherPart));
+
+        otherPart = new AmmoStorage(0, ammoType, 0, mockCampaign);
+        assertFalse(ammoStorage.isSamePartType(otherPart));
+
+        otherPart = new MekLocation();
+        assertFalse(ammoStorage.isSamePartType(otherPart));
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -48,6 +48,7 @@ import mekhq.MekHqXmlUtil;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Quartermaster;
 import mekhq.campaign.Warehouse;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.equipment.AmmoBin;
@@ -69,6 +70,8 @@ public class RefitTest {
         Campaign mockCampaign = mock(Campaign.class);
         Warehouse mockWarehouse = mock(Warehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
@@ -102,6 +105,8 @@ public class RefitTest {
         Campaign mockCampaign = mock(Campaign.class);
         Warehouse mockWarehouse = mock(Warehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
@@ -178,6 +183,8 @@ public class RefitTest {
         when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
         Warehouse mockWarehouse = mock(Warehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
@@ -289,6 +296,8 @@ public class RefitTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         Warehouse mockWarehouse = mock(Warehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
@@ -368,6 +377,8 @@ public class RefitTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         Warehouse mockWarehouse = mock(Warehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
         Person mockTech = mock(Person.class);
         UUID techId = UUID.randomUUID();
         when(mockTech.getId()).thenReturn(techId);
@@ -484,6 +495,8 @@ public class RefitTest {
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         Warehouse mockWarehouse = mock(Warehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getFleaFLE4();
@@ -587,6 +600,8 @@ public class RefitTest {
         Warehouse mockWarehouse = mock(Warehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         doReturn(null).when(mockWarehouse).findSparePart(any());
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
         Person mockTech = mock(Person.class);
         UUID techId = UUID.randomUUID();
         when(mockTech.getId()).thenReturn(techId);

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
@@ -619,8 +619,7 @@ public class AmmoBinTest {
         assertEquals(isSRM2InfernoAmmo, ammoBin.getType());
         assertTrue(ammoBin.needsFixing());
 
-        // TODO: determine if this should be uncommented
-        // assertEquals(isSRM2InfernoAmmo.getShots(), ammoBin.getShotsNeeded());
+        assertEquals(isSRM2InfernoAmmo.getShots(), ammoBin.getShotsNeeded());
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/AmmoBinTest.java
@@ -20,13 +20,1433 @@
 package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.AmmoUtilities.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.Mounted;
+import megamek.common.Protomech;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.parts.AmmoStorage;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
+import mekhq.campaign.work.IAcquisitionWork;
 
 public class AmmoBinTest {
     @Test
     public void deserializationCtorTest() {
         AmmoBin ammoBin = new AmmoBin();
         assertNotNull(ammoBin);
+    }
+
+    @Test
+    public void ammoBinCtorTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        int equipmentNum = 18;
+        int shotsNeeded = ammoType.getShots();
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        assertEquals(ammoType, ammoBin.getType());
+        assertEquals(equipmentNum, ammoBin.getEquipmentNum());
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        assertEquals(ammoType.getShots(), ammoBin.getFullShots());
+        assertEquals(mockCampaign, ammoBin.getCampaign());
+    }
+
+    @Test
+    public void cloneTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        int equipmentNum = 18;
+        int shotsNeeded = ammoType.getShots() - 1;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // Ensure the clone has all the same stuff
+        AmmoBin clone = ammoBin.clone();
+        assertEquals(ammoBin.getType(), clone.getType());
+        assertEquals(ammoBin.getEquipmentNum(), clone.getEquipmentNum());
+        assertEquals(ammoBin.getShotsNeeded(), clone.getShotsNeeded());
+        assertEquals(ammoBin.getFullShots(), clone.getFullShots());
+        assertEquals(ammoBin.getCampaign(), clone.getCampaign());
+        assertEquals(ammoBin.getName(), clone.getName());
+    }
+
+    @Test
+    public void needsMaintenanceTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, ammoType.getShots(), false, false, mockCampaign);
+
+        // AmmoBins do not need maintenance, even when empty.
+        assertFalse(ammoBin.needsMaintenance());
+    }
+
+    @Test
+    public void isPriceAdjustedForAmountTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, ammoType.getShots(), false, false, mockCampaign);
+
+        assertTrue(ammoBin.isPriceAdjustedForAmount());
+    }
+
+    @Test
+    public void massRepairOptionTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, ammoType.getShots(), false, false, mockCampaign);
+
+        assertEquals(Part.REPAIR_PART_TYPE.AMMO, ammoBin.getMassRepairOptionType());
+    }
+
+    @Test
+    public void isOmniPoddableTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, ammoType.getShots(), false, false, mockCampaign);
+
+        assertTrue(ammoBin.isOmniPoddable());
+    }
+
+    @Test
+    public void getTechAdvancementTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, ammoType.getShots(), false, false, mockCampaign);
+
+        assertEquals(ammoType.getTechAdvancement(), ammoBin.getTechAdvancement());
+    }
+
+    @Test
+    public void getNewPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, 0, false, false, mockCampaign);
+
+        // Ensure the new part has all the same stuff
+        AmmoStorage ammoStorage = ammoBin.getNewPart();
+        assertEquals(ammoBin.getType(), ammoStorage.getType());
+        assertEquals(ammoType.getShots(), ammoStorage.getShots());
+        assertEquals(ammoBin.getCampaign(), ammoStorage.getCampaign());
+    }
+
+    @Test
+    public void getNewEquipmentTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, 0, false, false, mockCampaign);
+
+        // Ensure the new part has all the same stuff
+        AmmoStorage ammoStorage = ammoBin.getNewEquipment();
+        assertEquals(ammoBin.getType(), ammoStorage.getType());
+        assertEquals(ammoType.getShots(), ammoStorage.getShots());
+        assertEquals(ammoBin.getCampaign(), ammoStorage.getCampaign());
+    }
+
+    @Test
+    public void getAcquisitionWorkTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        boolean isOneShot = false;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, 0, isOneShot, false, mockCampaign);
+
+        // Grab the missing part via IAcquisitionWork
+        IAcquisitionWork acquisitionPart = ammoBin.getAcquisitionWork();
+        assertTrue(acquisitionPart instanceof AmmoStorage);
+
+        AmmoStorage ammoStorage = (AmmoStorage) acquisitionPart;
+        assertEquals(ammoBin.getType(), ammoStorage.getType());
+        assertEquals(ammoType.getShots(), ammoStorage.getShots());
+        assertEquals(ammoBin.getCampaign(), ammoStorage.getCampaign());
+
+        isOneShot = true;
+        ammoBin = new AmmoBin(0, ammoType, -1, 0, isOneShot, false, mockCampaign);
+
+        // Check that we buy a ton, even if the bin is one shot
+        acquisitionPart = ammoBin.getAcquisitionWork();
+        assertTrue(acquisitionPart instanceof AmmoStorage);
+
+        ammoStorage = (AmmoStorage) acquisitionPart;
+        assertEquals(ammoBin.getType(), ammoStorage.getType());
+        assertEquals(ammoType.getShots(), ammoStorage.getShots());
+        assertEquals(ammoBin.getCampaign(), ammoStorage.getCampaign());
+    }
+
+    @Test
+    public void getMissingPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        int equipmentNum = 18;
+        boolean isOneShot = false;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, 0, isOneShot, false, mockCampaign);
+
+        // Ensure the missing part has all the same stuff
+        MissingAmmoBin missingBin = ammoBin.getMissingPart();
+        assertEquals(ammoBin.getType(), missingBin.getType());
+        assertEquals(ammoBin.getEquipmentNum(), missingBin.getEquipmentNum());
+        assertEquals(ammoBin.getFullShots(), missingBin.getFullShots());
+        assertEquals(ammoBin.getCampaign(), missingBin.getCampaign());
+        assertEquals(ammoBin.getName(), missingBin.getName());
+        assertEquals(ammoBin.isOneShot(), missingBin.isOneShot());
+
+        isOneShot = true;
+        ammoBin = new AmmoBin(0, ammoType, equipmentNum, 0, isOneShot, false, mockCampaign);
+
+        // Ensure the missing part has all the same stuff
+        missingBin = ammoBin.getMissingPart();
+        assertEquals(ammoBin.getType(), missingBin.getType());
+        assertEquals(ammoBin.getEquipmentNum(), missingBin.getEquipmentNum());
+        assertEquals(ammoBin.getFullShots(), missingBin.getFullShots());
+        assertEquals(ammoBin.getCampaign(), missingBin.getCampaign());
+        assertEquals(ammoBin.getName(), missingBin.getName());
+        assertEquals(ammoBin.isOneShot(), missingBin.isOneShot());
+    }
+
+    @Test
+    public void setShotsNeeded() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISAC10 Ammo");
+
+        // Create an Ammo Bin with some ammo ...
+        int shotsNeeded = 1;
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        // Ensure the ammo bin starts with the shots we asked for.
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        assertTrue(ammoBin.needsFixing());
+
+        // Set the number of shots needed ...
+        ammoBin.setShotsNeeded(ammoType.getShots());
+
+        // ... and ensure we get the correct count back.
+        assertEquals(ammoType.getShots(), ammoBin.getShotsNeeded());
+        assertTrue(ammoBin.needsFixing());
+
+        // Ensure we never need negative shots.
+        ammoBin.setShotsNeeded(-1);
+        assertEquals(0, ammoBin.getShotsNeeded());
+        assertFalse(ammoBin.needsFixing());
+    }
+
+    @Test
+    public void getFullShotsUsesAmmoTypeShotsIfNoEntityOrMounted() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISAC10 Ammo");
+
+        // Create an ammo bin without a unit (?) or entity or valid mount ...
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, 0, false, false, mockCampaign);
+
+        // ... and ensure it reports the shots from the ammo type
+        assertEquals(ammoType.getShots(), ammoBin.getFullShots());
+    }
+
+    @Test
+    public void getFullShotsOneShotAmmoReturnsOneShot() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISAC10 Ammo");
+
+        // Create a One Shot ammo bin ...
+        boolean isOneShot = true;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, 0, isOneShot, false, mockCampaign);
+
+        // ... and ensure it only reports a single shot
+        assertEquals(1, ammoBin.getFullShots());
+    }
+
+    @Test
+    public void getFullShotsUsesOriginalShotsFromMounted() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISAC10 Ammo");
+
+        // Create an ammo bin with a given ammo type ...
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, 0, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        int originalShots = 32;
+        when(mockMounted.getOriginalShots()).thenReturn(originalShots);
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and ensure it reports the shots from the mounted and not the ammo type
+        assertEquals(originalShots, ammoBin.getFullShots());
+    }
+
+    @Test
+    public void getFullShotsForProtomechsReducedInHalfForNonStandardMunitions() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an ammobin with a non-standard munition type ...
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, 0, false, false, mockCampaign);
+
+        // ... place the ammo bin on a Protomech unit ...
+        Unit mockUnit = mock(Unit.class);
+        Protomech mockEntity = mock(Protomech.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        int originalShots = 32;
+        when(mockMounted.getOriginalShots()).thenReturn(originalShots);
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and ensure it reports the shots from the ammo type
+        assertEquals(originalShots / 2, ammoBin.getFullShots());
+    }
+
+    @Test
+    public void getBaseTimeSalvagingTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Not an omnipodded ammo bin ...
+        boolean isOmniPodded = false;
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, 0, false, isOmniPodded, mockCampaign);
+        Unit unit = mock(Unit.class);
+        when(unit.isSalvage()).thenReturn(true);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(mounted.isOmniPodMounted()).thenReturn(isOmniPodded);
+        when(entity.getEquipment(eq(equipmentNum))).thenReturn(mounted);
+        ammoBin.setUnit(unit);
+
+        // Salvage of a normal ammo bin is 120 minutes
+        assertEquals(120, ammoBin.getBaseTime());
+
+        // An omnipodded ammo bin ...
+        isOmniPodded = true;
+        ammoBin = new AmmoBin(0, ammoType, equipmentNum, 0, false, isOmniPodded, mockCampaign);
+        when(mounted.isOmniPodMounted()).thenReturn(isOmniPodded);
+        ammoBin.setUnit(unit);
+
+        // Salvage of an omni ammo bin is 30 minutes
+        assertEquals(30, ammoBin.getBaseTime());
+    }
+
+    @Test
+    public void getBaseTimeRepairTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // An ammo bin whose ammo type matches the mount ...
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, 0, false, false, mockCampaign);
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(eq(equipmentNum))).thenReturn(mounted);
+        ammoBin.setUnit(unit);
+
+        // Repair of a normal ammo bin is 15 minutes if the ammo types match
+        assertEquals(15, ammoBin.getBaseTime());
+
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Ammo");
+
+        // An ammo bin whose ammo type does NOT match the mount ...
+        ammoBin = new AmmoBin(0, ammoType, equipmentNum, 0, false, false, mockCampaign);
+        when(mounted.getType()).thenReturn(otherAmmoType);
+        ammoBin.setUnit(unit);
+
+        // Repair of a bin with different ammo types is 30 minutes
+        assertEquals(30, ammoBin.getBaseTime());
+    }
+
+    @Test
+    public void ammoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoBin ammoBin = new AmmoBin(0, isSRM2InfernoAmmo, 42, isSRM2InfernoAmmo.getShots() - 1, false, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof AmmoBin);
+
+        AmmoBin deserialized = (AmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void oneShotAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoBin ammoBin = new AmmoBin(0, isSRM2InfernoAmmo, 42, 0, true, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof AmmoBin);
+
+        AmmoBin deserialized = (AmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.isOneShot(), deserialized.isOneShot());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void fullAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoBin ammoBin = new AmmoBin(0, isSRM2InfernoAmmo, 42, 0, false, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof AmmoBin);
+
+        AmmoBin deserialized = (AmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void emptyAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoBin ammoBin = new AmmoBin(0, isSRM2InfernoAmmo, 42, isSRM2InfernoAmmo.getShots(), false, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof AmmoBin);
+
+        AmmoBin deserialized = (AmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void changeMunitionTest() {
+        AmmoType isSRM2Ammo = getAmmoType("ISSRM2 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int equipmentNum = 19;
+        AmmoBin ammoBin = new AmmoBin(0, isSRM2Ammo, equipmentNum, 0, false, false, mockCampaign);
+
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(isSRM2Ammo);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(isSRM2Ammo.getShots());
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+        ammoBin.setUnit(mockUnit);
+
+        // Before we do anything there should be nothing to fix on a full bin.
+        assertFalse(ammoBin.needsFixing());
+
+        // Pick a different munition type
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        ammoBin.changeMunition(isSRM2InfernoAmmo);
+
+        assertEquals(isSRM2InfernoAmmo, ammoBin.getType());
+        assertTrue(ammoBin.needsFixing());
+
+        // TODO: determine if this should be uncommented
+        // assertEquals(isSRM2InfernoAmmo.getShots(), ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void changeMunitionSerializationTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoBin ammoBin = new AmmoBin(0, isSRM2InfernoAmmo, -1, 0, false, false, mockCampaign);
+
+        // Pick a different munition type
+        AmmoType isSRM2Ammo = getAmmoType("ISSRM2 Ammo");
+        ammoBin.changeMunition(isSRM2Ammo);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof AmmoBin);
+
+        AmmoBin deserialized = (AmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void unloadEmptyBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an empty Ammo Bin...
+        int shotsNeeded = ammoType.getShots();
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, shotsNeeded, false, false, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // Nothing should be added to the Warehouse.
+        assertTrue(warehouse.getParts().isEmpty());
+    }
+
+    @Test
+    public void unloadFullBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create a full Ammo Bin...
+        int shotsNeeded = 0;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, shotsNeeded, false, false, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // We should now have a 1 ton of ammo in our warehouse
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(ammoType.getShots(), added.getShots());
+    }
+
+    @Test
+    public void unloadPartialBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin with just one round...
+        int shotsNeeded = ammoType.getShots() - 1;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, shotsNeeded, false, false, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // We should now have that ammo in our warehouse.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(1, added.getShots());
+    }
+
+    @Test
+    public void salvageEmptyBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an empty Ammo Bin...
+        int shotsNeeded = ammoType.getShots();
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, shotsNeeded, false, false, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // Nothing should be added to the Warehouse.
+        assertTrue(warehouse.getParts().isEmpty());
+        assertEquals(0, ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void salvageFullBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create a full Ammo Bin...
+        int shotsNeeded = 0;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, shotsNeeded, false, false, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // We should now have a 1 ton of ammo in our warehouse
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(ammoType.getShots(), added.getShots());
+        assertEquals(ammoType.getShots(), ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void salvagePartialBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin with just one round...
+        int shotsNeeded = ammoType.getShots() - 1;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, shotsNeeded, false, false, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // We should now have that ammo in our warehouse.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(1, added.getShots());
+        assertEquals(1, ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void loadBinWithoutUnitDoesNothing() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin with no ammo...
+        int shotsNeeded = ammoType.getShots();
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, shotsNeeded, false, false, mockCampaign);
+
+        // ...and try to load it when the warehouse is empty.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void loadBinWithoutSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and try to load it when the warehouse is empty.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+    }
+
+    @Test
+    public void loadBinWithOnlySpareAmmoOfWrongType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add ammo of the wrong type to the warehouse ...
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Inferno Ammo");
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots());
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed ...
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+
+        // ... nor how many shots are available of the wrong type.
+        assertEquals(otherAmmoType.getShots(), quartermaster.getAmmoAvailable(otherAmmoType));
+    }
+
+    @Test
+    public void loadBinWithJustEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the right type to the warehouse ...
+        quartermaster.addAmmo(ammoType, ammoType.getShots());
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more ammo available in the warehouse
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadBinWithMoreThanEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        // Create an Ammo Bin with plenty of ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add more than enough ammo of the right type to the warehouse ...
+        int shotsOnHand = 10 * ammoType.getShots();
+        quartermaster.addAmmo(ammoType, shotsOnHand);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and only the ammo needed was pulled from the warehouse
+        assertEquals(shotsOnHand - shotsNeeded, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadEmptyBinAfterChangingAmmoType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of both types to the warehouse ...
+        quartermaster.addAmmo(ammoType, ammoType.getShots());
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots());
+
+        // ... then change the munition type of the ammo bin ...
+        ammoBin.changeMunition(otherAmmoType);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).changeAmmoType(eq(otherAmmoType));
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more of the new ammo available in the warehouse.
+        assertEquals(0, quartermaster.getAmmoAvailable(otherAmmoType));
+
+        // ... but the correct amount of our original ammo type.
+        assertEquals(ammoType.getShots(), quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadFullBinAfterChangingAmmoType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin full of ammo ...
+        int shotsNeeded = 0;
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(ammoType.getShots());
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the new type to the warehouse ...
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots());
+
+        // ... then change the munition type of the ammo bin ...
+        ammoBin.changeMunition(otherAmmoType);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).changeAmmoType(eq(otherAmmoType));
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more of the new ammo available in the warehouse.
+        assertEquals(0, quartermaster.getAmmoAvailable(otherAmmoType));
+
+        // ... but the correct amount of our original ammo type unloaded from the bin.
+        assertEquals(ammoType.getShots(), quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixBinWithoutUnitDoesNothing() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin with no ammo...
+        int shotsNeeded = ammoType.getShots();
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, -1, shotsNeeded, false, false, mockCampaign);
+
+        // ...and try to load it when the warehouse is empty.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void fixBinWithoutSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and try to load it when the warehouse is empty.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+    }
+
+    @Test
+    public void fixBinWithOnlySpareAmmoOfWrongType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add ammo of the wrong type to the warehouse ...
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Inferno Ammo");
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots());
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed ...
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+
+        // ... nor how many shots are available of the wrong type.
+        assertEquals(otherAmmoType.getShots(), quartermaster.getAmmoAvailable(otherAmmoType));
+    }
+
+    @Test
+    public void fixBinWithJustEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the right type to the warehouse ...
+        quartermaster.addAmmo(ammoType, ammoType.getShots());
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more ammo available in the warehouse
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixBinWithMoreThanEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        // Create an Ammo Bin with plenty of ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add more than enough ammo of the right type to the warehouse ...
+        int shotsOnHand = 10 * ammoType.getShots();
+        quartermaster.addAmmo(ammoType, shotsOnHand);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and only the ammo needed was pulled from the warehouse
+        assertEquals(shotsOnHand - shotsNeeded, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixEmptyBinAfterChangingAmmoType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of both types to the warehouse ...
+        quartermaster.addAmmo(ammoType, ammoType.getShots());
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots());
+
+        // ... then change the munition type of the ammo bin ...
+        ammoBin.changeMunition(otherAmmoType);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).changeAmmoType(eq(otherAmmoType));
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more of the new ammo available in the warehouse.
+        assertEquals(0, quartermaster.getAmmoAvailable(otherAmmoType));
+
+        // ... but the correct amount of our original ammo type.
+        assertEquals(ammoType.getShots(), quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixFullBinAfterChangingAmmoType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create an Ammo Bin full of ammo ...
+        int shotsNeeded = 0;
+        int equipmentNum = 42;
+        AmmoBin ammoBin = new AmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(ammoType.getShots());
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the new type to the warehouse ...
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots());
+
+        // ... then change the munition type of the ammo bin ...
+        ammoBin.changeMunition(otherAmmoType);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).changeAmmoType(eq(otherAmmoType));
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more of the new ammo available in the warehouse.
+        assertEquals(0, quartermaster.getAmmoAvailable(otherAmmoType));
+
+        // ... but the correct amount of our original ammo type unloaded from the bin.
+        assertEquals(ammoType.getShots(), quartermaster.getAmmoAvailable(ammoType));
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/BattleArmorAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/BattleArmorAmmoBinTest.java
@@ -20,13 +20,252 @@
 package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.AmmoUtilities.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.Part;
 
 public class BattleArmorAmmoBinTest {
     @Test
     public void deserializationCtorTest() {
         BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin();
         assertNotNull(ammoBin);
+    }
+
+    @Test
+    public void canNeverScrapTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        int equipmentNum = 18;
+        int shotsNeeded = ammoType.getShots();
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, mockCampaign);
+
+        assertTrue(ammoBin.canNeverScrap());
+    }
+
+    @Test
+    public void needsMaintenanceTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        int equipmentNum = 18;
+        int shotsNeeded = ammoType.getShots();
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, mockCampaign);
+
+        assertFalse(ammoBin.needsMaintenance());
+    }
+
+    @Test
+    public void battleArmorAmmoBinCtorTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        int equipmentNum = 18;
+        int shotsNeeded = ammoType.getShots();
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, mockCampaign);
+
+        assertEquals(ammoType, ammoBin.getType());
+        assertEquals(equipmentNum, ammoBin.getEquipmentNum());
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        assertEquals(ammoType.getShots(), ammoBin.getFullShots());
+        assertEquals(mockCampaign, ammoBin.getCampaign());
+    }
+
+    @Test
+    public void cloneTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        int equipmentNum = 18;
+        int shotsNeeded = ammoType.getShots() - 1;
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, mockCampaign);
+
+        // Ensure the clone has all the same stuff
+        BattleArmorAmmoBin clone = ammoBin.clone();
+        assertEquals(ammoBin.getType(), clone.getType());
+        assertEquals(ammoBin.getEquipmentNum(), clone.getEquipmentNum());
+        assertEquals(ammoBin.getShotsNeeded(), clone.getShotsNeeded());
+        assertEquals(ammoBin.getFullShots(), clone.getFullShots());
+        assertEquals(ammoBin.getCampaign(), clone.getCampaign());
+        assertEquals(ammoBin.getName(), clone.getName());
+    }
+
+    @Test
+    public void battleArmorAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, isSRM2InfernoAmmo, 42, isSRM2InfernoAmmo.getShots() - 1, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the BattleArmorAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the BattleArmorAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the BattleArmorAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof BattleArmorAmmoBin);
+
+        BattleArmorAmmoBin deserialized = (BattleArmorAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void oneShotBattleArmorAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, isSRM2InfernoAmmo, 42, 0, true, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the BattleArmorAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the BattleArmorAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the BattleArmorAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof BattleArmorAmmoBin);
+
+        BattleArmorAmmoBin deserialized = (BattleArmorAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.isOneShot(), deserialized.isOneShot());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void fullBattleArmorAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, isSRM2InfernoAmmo, 42, 0, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the BattleArmorAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the BattleArmorAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the BattleArmorAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof BattleArmorAmmoBin);
+
+        BattleArmorAmmoBin deserialized = (BattleArmorAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void emptyBattleArmorAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, isSRM2InfernoAmmo, 42, isSRM2InfernoAmmo.getShots(), false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the BattleArmorAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the BattleArmorAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the BattleArmorAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof BattleArmorAmmoBin);
+
+        BattleArmorAmmoBin deserialized = (BattleArmorAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/InfantryAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/InfantryAmmoBinTest.java
@@ -439,8 +439,7 @@ public class InfantryAmmoBinTest {
 
         assertEquals(infernoAmmoType, ammoBin.getType());
 
-        // TODO: determine if this should be uncommented
-        // assertEquals(infernoAmmoType.getShots(), ammoBin.getShotsNeeded());
+        assertEquals(infernoAmmoType.getShots() * clips, ammoBin.getShotsNeeded());
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/InfantryAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/InfantryAmmoBinTest.java
@@ -20,13 +20,1450 @@
 package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
+import static mekhq.campaign.parts.AmmoUtilities.*;
 
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.EquipmentTypeLookup;
+import megamek.common.Infantry;
+import megamek.common.Mounted;
+import megamek.common.SupportTank;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.parts.InfantryAmmoStorage;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
 
 public class InfantryAmmoBinTest {
     @Test
     public void deserializationCtorTest() {
         InfantryAmmoBin ammoBin = new InfantryAmmoBin();
         assertNotNull(ammoBin);
+    }
+
+    @Test
+    public void ammoBinCtorTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int equipmentNum = 18;
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        assertEquals(ammoType, ammoBin.getType());
+        assertEquals(weaponType, ammoBin.getWeaponType());
+        assertEquals(equipmentNum, ammoBin.getEquipmentNum());
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        assertEquals(weaponType.getShots() * clips, ammoBin.getFullShots());
+        assertEquals(mockCampaign, ammoBin.getCampaign());
+    }
+
+    @Test
+    public void cloneTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int equipmentNum = 18;
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * (clips - 1);
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // Ensure the clone has all the same stuff
+        InfantryAmmoBin clone = ammoBin.clone();
+        assertEquals(ammoBin.getType(), clone.getType());
+        assertEquals(ammoBin.getEquipmentNum(), clone.getEquipmentNum());
+        assertEquals(ammoBin.getShotsNeeded(), clone.getShotsNeeded());
+        assertEquals(ammoBin.getFullShots(), clone.getFullShots());
+        assertEquals(ammoBin.getCampaign(), clone.getCampaign());
+        assertEquals(ammoBin.getName(), clone.getName());
+    }
+
+    @Test
+    public void getMissingPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int equipmentNum = 18;
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, 0, weaponType, clips, false, mockCampaign);
+
+        // Ensure the clone has all the same stuff
+        MissingInfantryAmmoBin missingBin = ammoBin.getMissingPart();
+        assertEquals(ammoBin.getType(), missingBin.getType());
+        assertEquals(ammoBin.getWeaponType(), missingBin.getWeaponType());
+        assertEquals(ammoBin.getClips(), missingBin.getClips());
+        assertEquals(ammoBin.getEquipmentNum(), missingBin.getEquipmentNum());
+        assertEquals(ammoBin.getFullShots(), missingBin.getFullShots());
+        assertEquals(ammoBin.getCampaign(), missingBin.getCampaign());
+        assertEquals(ammoBin.getName(), missingBin.getName());
+    }
+
+    @Test
+    public void setShotsNeeded() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with some ammo ...
+        int clips = 5;
+        int shotsNeeded = 1;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+        ammoBin.setUnit(mockUnit);
+
+        // Ensure the ammo bin starts with the shots we asked for.
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+
+        // Set the number of shots needed ...
+        ammoBin.setShotsNeeded(weaponType.getShots() * clips);
+
+        // ... and ensure we get the correct count back.
+        assertEquals(weaponType.getShots() * clips, ammoBin.getShotsNeeded());
+
+        // Ensure we allow negative shots (used by changeCapacity).
+        ammoBin.setShotsNeeded(-1);
+        assertEquals(-1, ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void getFullShotsUsesWeaponTypeShots() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an ammo bin without a unit (?) or entity or valid mount ...
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, 0, weaponType, clips, false, mockCampaign);
+
+        // ... and ensure it reports the shots from the ammo type
+        assertEquals(weaponType.getShots() * clips, ammoBin.getFullShots());
+    }
+
+    @Test
+    public void getBaseTimeSalvagingTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Not an omnipodded ammo bin ...
+        boolean isOmniPodded = false;
+        int equipmentNum = 42;
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, 0, weaponType, clips,  isOmniPodded, mockCampaign);
+        Unit unit = mock(Unit.class);
+        when(unit.isSalvage()).thenReturn(true);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(mounted.isOmniPodMounted()).thenReturn(isOmniPodded);
+        when(entity.getEquipment(eq(equipmentNum))).thenReturn(mounted);
+        ammoBin.setUnit(unit);
+
+        // Salvage of a normal ammo bin is 120 minutes
+        assertEquals(120, ammoBin.getBaseTime());
+
+        // An omnipodded ammo bin ...
+        isOmniPodded = true;
+        ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, 0, weaponType, clips, isOmniPodded, mockCampaign);
+        when(mounted.isOmniPodMounted()).thenReturn(isOmniPodded);
+        ammoBin.setUnit(unit);
+
+        // Salvage of an omni ammo bin is 30 minutes
+        assertEquals(30, ammoBin.getBaseTime());
+    }
+
+    @Test
+    public void getBaseTimeRepairTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // An ammo bin whose ammo type matches the mount ...
+        int equipmentNum = 42;
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, 0, weaponType, clips, false, mockCampaign);
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(eq(equipmentNum))).thenReturn(mounted);
+        ammoBin.setUnit(unit);
+
+        // Repair of a normal ammo bin is 15 minutes if the ammo types match
+        assertEquals(15, ammoBin.getBaseTime());
+
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+
+        // An ammo bin whose ammo type does NOT match the mount ...
+        ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, 0, weaponType, clips, false, mockCampaign);
+        when(mounted.getType()).thenReturn(otherAmmoType);
+        ammoBin.setUnit(unit);
+
+        // Repair of a bin with different ammo types is 30 minutes
+        assertEquals(30, ammoBin.getBaseTime());
+    }
+
+    @Test
+    public void ammoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType infernoAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        Campaign mockCampaign = mock(Campaign.class);
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, infernoAmmoType, 42, weaponType.getShots() - (clips - 1), weaponType, clips, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the InfantryAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the InfantryAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the InfantryAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof InfantryAmmoBin);
+
+        InfantryAmmoBin deserialized = (InfantryAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void oneShotAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType infernoAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        Campaign mockCampaign = mock(Campaign.class);
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, infernoAmmoType, 42, 0, weaponType, clips, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the InfantryAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the InfantryAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the InfantryAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof InfantryAmmoBin);
+
+        InfantryAmmoBin deserialized = (InfantryAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.isOneShot(), deserialized.isOneShot());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void fullAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType infernoAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        Campaign mockCampaign = mock(Campaign.class);
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, infernoAmmoType, 42, 0, weaponType, clips, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the InfantryAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the InfantryAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the InfantryAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof InfantryAmmoBin);
+
+        InfantryAmmoBin deserialized = (InfantryAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void emptyAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType infernoAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        Campaign mockCampaign = mock(Campaign.class);
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, infernoAmmoType, 42, infernoAmmoType.getShots(), weaponType, clips, false, mockCampaign);
+        ammoBin.setId(25);
+
+        // Write the InfantryAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the InfantryAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the InfantryAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof InfantryAmmoBin);
+
+        InfantryAmmoBin deserialized = (InfantryAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void changeMunitionTest() {
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, 0, weaponType, clips, false, mockCampaign);
+
+        // Pick a different munition type
+        AmmoType infernoAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        ammoBin.changeMunition(infernoAmmoType);
+
+        assertEquals(infernoAmmoType, ammoBin.getType());
+
+        // TODO: determine if this should be uncommented
+        // assertEquals(infernoAmmoType.getShots(), ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void changeMunitionSerializationTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType infernoAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int clips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, infernoAmmoType, -1, 0, weaponType, clips, false, mockCampaign);
+
+        // Pick a different munition type
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        ammoBin.changeMunition(ammoType);
+
+        // Write the InfantryAmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the InfantryAmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the InfantryAmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof InfantryAmmoBin);
+
+        InfantryAmmoBin deserialized = (InfantryAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void unloadEmptyBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an empty Ammo Bin...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // Nothing should be added to the Warehouse.
+        assertTrue(warehouse.getParts().isEmpty());
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void unloadFullBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create a full Ammo Bin...
+        int clips = 5;
+        int shotsNeeded = 0;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // We should now have a 1 ton of ammo in our warehouse
+        InfantryAmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof InfantryAmmoStorage);
+            added = (InfantryAmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(weaponType.getShots() * clips, added.getShots());
+        assertEquals(weaponType.getShots() * clips, quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void unloadPartialBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with just one round...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * (clips - 1);
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // We should now have that ammo in our warehouse.
+        InfantryAmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof InfantryAmmoStorage);
+            added = (InfantryAmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(weaponType.getShots(), added.getShots()); // Just one clip
+        assertEquals(weaponType.getShots(), quartermaster.getAmmoAvailable(ammoType, weaponType));
+        assertEquals(weaponType.getShots(), ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void salvageEmptyBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an empty Ammo Bin...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // Nothing should be added to the Warehouse.
+        assertTrue(warehouse.getParts().isEmpty());
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType, weaponType));
+        assertEquals(0, ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void salvageFullBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create a full Ammo Bin...
+        int clips = 5;
+        int shotsNeeded = 0;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // We should now have a 1 ton of ammo in our warehouse
+        InfantryAmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof InfantryAmmoStorage);
+            added = (InfantryAmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(weaponType.getShots() * clips, added.getShots());
+        assertEquals(weaponType.getShots() * clips, quartermaster.getAmmoAvailable(ammoType, weaponType));
+        assertEquals(weaponType.getShots() * clips, ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void salvagePartialBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with just one clip...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * (clips - 1);
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // We should now have that ammo in our warehouse.
+        InfantryAmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof InfantryAmmoStorage);
+            added = (InfantryAmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(weaponType.getShots(), added.getShots()); // Just one clip.
+        assertEquals(weaponType.getShots(), quartermaster.getAmmoAvailable(ammoType, weaponType));
+    }
+
+    @Test
+    public void loadBinWithoutUnitDoesNothing() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ...and try to load it when the warehouse is empty.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void loadBinWithoutSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and try to load it when the warehouse is empty.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+    }
+
+    @Test
+    public void loadBinWithOnlySpareAmmoOfWrongType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add ammo of the wrong type to the warehouse ...
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        quartermaster.addAmmo(otherAmmoType, weaponType, weaponType.getShots() * clips);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed ...
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+
+        // ... nor how many shots are available of the wrong type.
+        assertEquals(weaponType.getShots() * clips, quartermaster.getAmmoAvailable(otherAmmoType));
+    }
+
+    @Test
+    public void loadBinWithJustEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the right type to the warehouse ...
+        quartermaster.addAmmo(ammoType, weaponType, weaponType.getShots() * clips);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more ammo available in the warehouse
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadBinWithMoreThanEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with plenty of ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add more than enough ammo of the right type to the warehouse ...
+        int shotsOnHand = 10 * clips * weaponType.getShots();
+        quartermaster.addAmmo(ammoType, weaponType, shotsOnHand);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and only the ammo needed was pulled from the warehouse
+        assertEquals(shotsOnHand - shotsNeeded, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadEmptyBinAfterChangingAmmoType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getOriginalShots()).thenReturn(weaponType.getShots() * clips);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of both types to the warehouse ...
+        quartermaster.addAmmo(ammoType, weaponType, weaponType.getShots() * clips);
+        quartermaster.addAmmo(otherAmmoType, weaponType, weaponType.getShots() * clips);
+
+        // ... then change the munition type of the ammo bin ...
+        ammoBin.changeMunition(otherAmmoType);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).changeAmmoType(eq(otherAmmoType));
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more of the new ammo available in the warehouse.
+        assertEquals(0, quartermaster.getAmmoAvailable(otherAmmoType));
+
+        // ... but the correct amount of our original ammo type.
+        assertEquals(weaponType.getShots() * clips, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadFullBinAfterChangingAmmoType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin full of ammo ...
+        int clips = 5;
+        int shotsNeeded = 0;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getOriginalShots()).thenReturn(weaponType.getShots() * clips);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(weaponType.getShots() * clips);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the new type to the warehouse ...
+        quartermaster.addAmmo(otherAmmoType, weaponType, weaponType.getShots() * clips);
+
+        // ... then change the munition type of the ammo bin ...
+        ammoBin.changeMunition(otherAmmoType);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).changeAmmoType(eq(otherAmmoType));
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more of the new ammo available in the warehouse.
+        assertEquals(0, quartermaster.getAmmoAvailable(otherAmmoType));
+
+        // ... but the correct amount of our original ammo type unloaded from the bin.
+        assertEquals(weaponType.getShots() * clips, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixBinWithoutUnitDoesNothing() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ...and try to load it when the warehouse is empty.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void fixBinWithoutSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and try to load it when the warehouse is empty.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+    }
+
+    @Test
+    public void fixBinWithOnlySpareAmmoOfWrongType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add ammo of the wrong type to the warehouse ...
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        quartermaster.addAmmo(otherAmmoType, weaponType, weaponType.getShots() * clips);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed ...
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+
+        // ... nor how many shots are available of the wrong type.
+        assertEquals(weaponType.getShots() * clips, quartermaster.getAmmoAvailable(otherAmmoType));
+    }
+
+    @Test
+    public void fixBinWithJustEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the right type to the warehouse ...
+        quartermaster.addAmmo(ammoType, weaponType, weaponType.getShots() * clips);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more ammo available in the warehouse
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixBinWithMoreThanEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with plenty of ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add more than enough ammo of the right type to the warehouse ...
+        int shotsOnHand = 10 * weaponType.getShots() * clips;
+        quartermaster.addAmmo(ammoType, weaponType, shotsOnHand);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and only the ammo needed was pulled from the warehouse
+        assertEquals(shotsOnHand - shotsNeeded, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixEmptyBinAfterChangingAmmoType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin with no ammo ...
+        int clips = 5;
+        int shotsNeeded = weaponType.getShots() * clips;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of both types to the warehouse ...
+        quartermaster.addAmmo(ammoType, weaponType, weaponType.getShots() * clips);
+        quartermaster.addAmmo(otherAmmoType, weaponType, weaponType.getShots() * clips);
+
+        // ... then change the munition type of the ammo bin ...
+        ammoBin.changeMunition(otherAmmoType);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).changeAmmoType(eq(otherAmmoType));
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more of the new ammo available in the warehouse.
+        assertEquals(0, quartermaster.getAmmoAvailable(otherAmmoType));
+
+        // ... but the correct amount of our original ammo type.
+        assertEquals(weaponType.getShots() * clips, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixFullBinAfterChangingAmmoType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin full of ammo ...
+        int clips = 5;
+        int shotsNeeded = 0;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Infantry mockEntity = mock(Infantry.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getOriginalShots()).thenReturn(weaponType.getShots() * clips);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(weaponType.getShots() * clips);
+        doAnswer(invocation -> {
+            // Update the ammo type returned by mounted
+            AmmoType newAmmoType = invocation.getArgument(0);
+            when(mockMounted.getType()).thenReturn(newAmmoType);
+            return null;
+        }).when(mockMounted).changeAmmoType(any());
+        doAnswer(invocation -> {
+            // Update the shots left when we're updated
+            int shotsLeft = invocation.getArgument(0);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(shotsLeft);
+            return null;
+        }).when(mockMounted).setShotsLeft(anyInt());
+
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the new type to the warehouse ...
+        quartermaster.addAmmo(otherAmmoType, weaponType, weaponType.getShots() * clips);
+
+        // ... then change the munition type of the ammo bin ...
+        ammoBin.changeMunition(otherAmmoType);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).changeAmmoType(eq(otherAmmoType));
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more of the new ammo available in the warehouse.
+        assertEquals(0, quartermaster.getAmmoAvailable(otherAmmoType));
+
+        // ... but the correct amount of our original ammo type unloaded from the bin.
+        assertEquals(weaponType.getShots() * clips, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void isSamePartTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        InfantryWeapon otherWeaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_TAG);
+
+        int clips = 5;
+        int shotsNeeded = 0;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, shotsNeeded, weaponType, clips, false, mockCampaign);
+
+        // Same ammo type, weapon type, and clips
+        InfantryAmmoBin otherAmmoBin = new InfantryAmmoBin(0, ammoType, -1, ammoType.getShots(), weaponType, clips, false, mockCampaign);
+
+        assertTrue(ammoBin.isSamePartType(otherAmmoBin));
+        assertTrue(otherAmmoBin.isSamePartType(ammoBin));
+
+        // Different ammo type, same weapon type and clips
+        otherAmmoBin = new InfantryAmmoBin(0, otherAmmoType, -1, otherAmmoType.getShots(), weaponType, clips, false, mockCampaign);
+
+        assertFalse(ammoBin.isSamePartType(otherAmmoBin));
+        assertFalse(otherAmmoBin.isSamePartType(ammoBin));
+
+        // Same ammo type and clips, different weapon type
+        otherAmmoBin = new InfantryAmmoBin(0, ammoType, -1, 0, otherWeaponType, clips, false, mockCampaign);
+
+        assertFalse(ammoBin.isSamePartType(otherAmmoBin));
+        assertFalse(otherAmmoBin.isSamePartType(ammoBin));
+
+        // Same ammo type and weapon type, different clips
+        otherAmmoBin = new InfantryAmmoBin(0, ammoType, -1, ammoType.getShots(), weaponType, clips + 1, false, mockCampaign);
+
+        assertFalse(ammoBin.isSamePartType(otherAmmoBin));
+        assertFalse(otherAmmoBin.isSamePartType(ammoBin));
+
+        // Different ammo type and weapon types, same clips
+        otherAmmoBin = new InfantryAmmoBin(0, otherAmmoType, -1, 0, otherWeaponType, clips, false, mockCampaign);
+
+        assertFalse(ammoBin.isSamePartType(otherAmmoBin));
+        assertFalse(otherAmmoBin.isSamePartType(ammoBin));
+
+        // Different ammo type, weapon types, and clips
+        otherAmmoBin = new InfantryAmmoBin(0, otherAmmoType, -1, 0, otherWeaponType, clips + 1, false, mockCampaign);
+
+        assertFalse(ammoBin.isSamePartType(otherAmmoBin));
+        assertFalse(otherAmmoBin.isSamePartType(ammoBin));
+    }
+
+    @Test
+    public void changeCapacityTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int originalClips = 5;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, -1, 0, weaponType, originalClips, false, mockCampaign);
+
+        assertEquals(0, ammoBin.getShotsNeeded());
+        assertEquals(originalClips, ammoBin.getClips());
+
+        // Decrease capacity
+        int clips = 4;
+        ammoBin.changeCapacity(clips);
+
+        assertEquals(-weaponType.getShots(), ammoBin.getShotsNeeded());
+        assertEquals(clips, ammoBin.getClips());
+
+        originalClips = 5;
+        ammoBin = new InfantryAmmoBin(0, ammoType, -1, 0, weaponType, originalClips, false, mockCampaign);
+
+        // Increase capacity
+        clips = 10;
+        ammoBin.changeCapacity(clips);
+
+        assertEquals(weaponType.getShots() * (clips - originalClips), ammoBin.getShotsNeeded());
+        assertEquals(clips, ammoBin.getClips());
+    }
+
+    @Test
+    public void findPartnerBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType infernoAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Create an Ammo Bin to handle standard ammo ...
+        int clips = 5;
+        int equipmentNum = 42;
+        InfantryAmmoBin ammoBin = new InfantryAmmoBin(0, ammoType, equipmentNum, 0, weaponType, clips, false, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        SupportTank mockEntity = mock(SupportTank.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+
+        // Create a Mounted for the standard ammo bin ...
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockEntity.getEquipmentNum(eq(mockMounted))).thenReturn(equipmentNum);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // Create an Inferno Ammo Bin ...
+        int infernoClips = 3;
+        int infernoEquipmentNum = 12;
+        InfantryAmmoBin infernoAmmoBin = new InfantryAmmoBin(0, infernoAmmoType, infernoEquipmentNum, 0, weaponType, infernoClips, false, mockCampaign);
+
+        // Create a Mounted for the Inferno ammo bin ...
+        Mounted mockInfernoMounted = mock(Mounted.class);
+        when(mockInfernoMounted.getType()).thenReturn(infernoAmmoType);
+        when(mockInfernoMounted.getLinkedBy()).thenReturn(mockMounted);
+        when(mockMounted.getLinked()).thenReturn(mockInfernoMounted);
+        when(mockEntity.getEquipmentNum(eq(mockInfernoMounted))).thenReturn(infernoEquipmentNum);
+        when(mockEntity.getEquipment(eq(infernoEquipmentNum))).thenReturn(mockInfernoMounted);
+        infernoAmmoBin.setUnit(mockUnit);
+
+        // Create an AmmoBin which clearly isn't correct
+        int incorrectEquipmentNum = 18;
+        InfantryAmmoBin incorrectBin = new InfantryAmmoBin(0, ammoType, incorrectEquipmentNum, 0, weaponType, 1, false, mockCampaign);
+        Mounted mockIncorrectMounted = mock(Mounted.class);
+        when(mockIncorrectMounted.getType()).thenReturn(ammoType);
+        when(mockEntity.getEquipmentNum(eq(mockIncorrectMounted))).thenReturn(incorrectEquipmentNum);
+        when(mockEntity.getEquipment(eq(incorrectEquipmentNum))).thenReturn(mockIncorrectMounted);
+        incorrectBin.setUnit(mockUnit);
+
+        // Ensure the unit returns these parts
+        when(mockUnit.getParts()).thenReturn(Arrays.asList(new Part[] {
+            incorrectBin, ammoBin, infernoAmmoBin,
+        }));
+
+        // Check that findPartnerBin pulls the correct bins ...
+        assertEquals(infernoAmmoBin, ammoBin.findPartnerBin());
+        assertEquals(ammoBin, infernoAmmoBin.findPartnerBin());
+        assertNull(incorrectBin.findPartnerBin());
+
+        // Create an ammo bin not on a unit ...
+        incorrectBin = new InfantryAmmoBin(0, ammoType, incorrectEquipmentNum, 0, weaponType, 1, false, mockCampaign);
+
+        // ... which should return null.
+        assertNull(incorrectBin.findPartnerBin());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/LargeCraftAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/LargeCraftAmmoBinTest.java
@@ -430,7 +430,7 @@ public class LargeCraftAmmoBinTest {
         // Setup another bin that isn't a match.
         LargeCraftAmmoBin otherBin = mock(LargeCraftAmmoBin.class);
         when(otherBin.getBayEqNum()).thenReturn(bayNum);
-        when(otherBin.getType()).thenReturn(getAmmoType("ISLRM20 Artemis-capable Ammo"));
+        when(otherBin.getType()).thenReturn(getAmmoType("ISLRM15 Ammo"));
 
         Unit unit = mock(Unit.class);
         when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin, otherBin, }));
@@ -465,7 +465,7 @@ public class LargeCraftAmmoBinTest {
         // Setup another bin that isn't a match.
         LargeCraftAmmoBin otherBin = mock(LargeCraftAmmoBin.class);
         when(otherBin.getBayEqNum()).thenReturn(bayNum);
-        when(otherBin.getType()).thenReturn(getAmmoType("ISLRM20 Artemis-capable Ammo"));
+        when(otherBin.getType()).thenReturn(getAmmoType("ISLRM15 Ammo"));
 
         Unit unit = mock(Unit.class);
         when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin, otherBin, }));

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/LargeCraftAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/LargeCraftAmmoBinTest.java
@@ -20,13 +20,1454 @@
 package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.AmmoUtilities.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Vector;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.Mounted;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.parts.AmmoStorage;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
 
 public class LargeCraftAmmoBinTest {
     @Test
     public void deserializationCtorTest() {
         LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin();
         assertNotNull(ammoBin);
+    }
+
+    @Test
+    public void largeCraftAmmoBinCtorTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        int equipmentNum = 18;
+        int shotsNeeded = ammoType.getShots();
+        double capacity = 12.0;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        assertEquals(ammoType, ammoBin.getType());
+        assertEquals(equipmentNum, ammoBin.getEquipmentNum());
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        assertEquals(capacity, ammoBin.getCapacity(), 0.001);
+        assertEquals((int)(ammoType.getShots() * capacity), ammoBin.getFullShots());
+        assertEquals(mockCampaign, ammoBin.getCampaign());
+    }
+
+    @Test
+    public void cloneTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        int equipmentNum = 18;
+        int bayNum = 31;
+        int shotsNeeded = ammoType.getShots() - 1;
+        double capacity = 12.0;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+        ammoBin.setBay(bayNum);
+
+        // Ensure the clone has all the same stuff
+        LargeCraftAmmoBin clone = ammoBin.clone();
+        assertEquals(ammoBin.getType(), clone.getType());
+        assertEquals(ammoBin.getEquipmentNum(), clone.getEquipmentNum());
+        assertEquals(ammoBin.getBayEqNum(), clone.getBayEqNum());
+        assertEquals(ammoBin.getShotsNeeded(), clone.getShotsNeeded());
+        assertEquals(ammoBin.getFullShots(), clone.getFullShots());
+        assertEquals(ammoBin.getCampaign(), clone.getCampaign());
+        assertEquals(ammoBin.getName(), clone.getName());
+        assertEquals(ammoBin.getCapacity(), clone.getCapacity(), 0.001);
+    }
+
+    @Test
+    public void getNewPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        double capacity = 5.0;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, 0, capacity, mockCampaign);
+
+        // Ensure the new part has all the same stuff
+        AmmoStorage ammoStorage = ammoBin.getNewPart();
+        assertEquals(ammoBin.getType(), ammoStorage.getType());
+        assertEquals(ammoBin.getFullShots(), ammoStorage.getShots());
+        assertEquals(ammoBin.getCampaign(), ammoStorage.getCampaign());
+    }
+
+    @Test
+    public void cannotDestroyLargeCraftAmmoBin() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        int equipmentNum = 18;
+        int shotsNeeded = ammoType.getShots() - 1;
+        double capacity = 12.0;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        assertNull(ammoBin.getMissingPart());
+        assertTrue(ammoBin.canNeverScrap());
+    }
+
+    @Test
+    public void largeCraftAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        int equipmentNum = 18;
+        int bayNum = 31;
+        int shotsNeeded = ammoType.getShots();
+        double capacity = 12.0;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+        ammoBin.setId(25);
+
+        // Setup the unit for the ammo bin
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted bay = mock(Mounted.class);
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+
+        ammoBin.setUnit(unit);
+        ammoBin.setBay(bayNum);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ammoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof LargeCraftAmmoBin);
+
+        LargeCraftAmmoBin deserialized = (LargeCraftAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(ammoBin.getId(), deserialized.getId());
+        assertEquals(ammoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(ammoBin.getBayEqNum(), deserialized.getBayEqNum());
+        assertEquals(ammoBin.getType(), deserialized.getType());
+        assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
+        assertEquals(ammoBin.getCapacity(), deserialized.getCapacity(), 0.001);
+        assertEquals(ammoBin.getFullShots(), deserialized.getFullShots());
+        assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void getBayReturnsBayMatchingEqNum() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create a missing ammo bin on a unit
+        int equipmentNum = 18;
+        int bayNum = 31;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, 0, 25.0, mockCampaign);
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted bay = mock(Mounted.class);
+        Vector<Integer> bayAmmo = new Vector<Integer>();
+        bayAmmo.addElement(equipmentNum);
+        when(bay.getBayAmmo()).thenReturn(bayAmmo);
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+
+        // Set the bay as if we're in deserialization code
+        ammoBin.setBay(bayNum);
+
+        ammoBin.setUnit(unit);
+
+        assertEquals(bay, ammoBin.getBay());
+    }
+
+    @Test
+    public void getBayFallsBackToMatchingWeaponBayIfMissingBayEquipment() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create a large craft ammo bin on a unit, whose bay isn't at the bay number
+        int equipmentNum = 18;
+        int bayNum = 31;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, 0, 25.0, mockCampaign);
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted wrongWeaponBay = mock(Mounted.class);
+        when(wrongWeaponBay.getBayAmmo()).thenReturn(new Vector<Integer>());
+        Mounted weaponBay = mock(Mounted.class);
+        Vector<Integer> bayAmmo = new Vector<Integer>();
+        bayAmmo.addElement(equipmentNum);
+        when(weaponBay.getBayAmmo()).thenReturn(bayAmmo);
+        when(entity.getEquipment(bayNum)).thenReturn(weaponBay);
+        ArrayList<Mounted> weaponBays = new ArrayList<>();
+        weaponBays.add(wrongWeaponBay);
+        weaponBays.add(weaponBay);
+        when(entity.getWeaponBayList()).thenReturn(weaponBays);
+
+        // Add the ammo bin to the unit and attach it to a non-existent bay
+        ammoBin.setUnit(unit);
+        ammoBin.setBay(bayNum);
+
+        assertEquals(weaponBay, ammoBin.getBay());
+    }
+
+    @Test
+    public void getBayFallsBackToMatchingWeaponBayIfNoBayEquipment() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create a large craft ammo bin on a unit, whose bay isn't at the bay number
+        int equipmentNum = 18;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, 0, 25.0, mockCampaign);
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted wrongWeaponBay = mock(Mounted.class);
+        when(wrongWeaponBay.getBayAmmo()).thenReturn(new Vector<Integer>());
+        Mounted weaponBay = mock(Mounted.class);
+        Vector<Integer> bayAmmo = new Vector<Integer>();
+        bayAmmo.addElement(equipmentNum);
+        when(weaponBay.getBayAmmo()).thenReturn(bayAmmo);
+        ArrayList<Mounted> weaponBays = new ArrayList<>();
+        weaponBays.add(wrongWeaponBay);
+        weaponBays.add(weaponBay);
+        when(entity.getWeaponBayList()).thenReturn(weaponBays);
+
+        // Add the ammo bin to the unit without setting up a bay
+        ammoBin.setUnit(unit);
+
+        assertEquals(weaponBay, ammoBin.getBay());
+    }
+
+    @Test
+    public void getBayReturnsNullIfNoMatch() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an ammo bin on a unit
+        int equipmentNum = 18;
+        int bayNum = 31;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, 0, 25.0, mockCampaign);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted bay = mock(Mounted.class);
+        when(bay.getBayAmmo()).thenReturn(new Vector<Integer>());
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+        when(entity.getWeaponBayList()).thenReturn(new ArrayList<>());
+
+        // Set the bay without actually setting it (if through deserialization)
+        ammoBin.setBay(bayNum);
+
+        ammoBin.setUnit(unit);
+
+        assertNull(ammoBin.getBay());
+    }
+
+    @Test
+    public void getBayReturnsSetBayValue() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an ammo bin on a unit
+        int equipmentNum = 18;
+        int bayNum = 31;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, 0, 25.0, mockCampaign);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted bay = mock(Mounted.class);
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+
+        ammoBin.setUnit(unit);
+        ammoBin.setBay(bay);
+
+        assertEquals(bay, ammoBin.getBay());
+    }
+
+    @Test
+    public void bayAvailableCapacityZeroWithoutUnit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an ammo bin not on a unit ...
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, 0, 25.0, mockCampaign);
+
+        // ... and it should have no available capacity.
+        assertEquals(0.0, ammoBin.bayAvailableCapacity(), 0.0);
+    }
+
+    @Test
+    public void bayAvailableCapacityEmptyOnlyBayOnUnit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an ammo bin on a unit
+        int equipmentNum = 18;
+        int bayNum = 31;
+        int capacity = 5;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        Unit unit = mock(Unit.class);
+        when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin }));
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted bay = mock(Mounted.class);
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+
+        ammoBin.setUnit(unit);
+        ammoBin.setBay(bay);
+
+        // ... and it should have all available capacity.
+        assertEquals(capacity, ammoBin.bayAvailableCapacity(), 0.001);
+    }
+
+    @Test
+    public void bayAvailableCapacityFullOnlyBayOnUnit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an ammo bin on a unit
+        int equipmentNum = 18;
+        int bayNum = 31;
+        int capacity = 5;
+        int shotsNeeded = 0;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        Unit unit = mock(Unit.class);
+        when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin }));
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted bay = mock(Mounted.class);
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+
+        ammoBin.setUnit(unit);
+        ammoBin.setBay(bay);
+
+        // ... and it should have no available capacity.
+        assertEquals(0.0, ammoBin.bayAvailableCapacity(), 0.0);
+    }
+
+    @Test
+    public void bayAvailableCapacityEmptyOnlyBayOfTypeOnUnit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an ammo bin on a unit
+        int equipmentNum = 18;
+        int bayNum = 31;
+        int capacity = 5;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // Setup another bin that isn't a match.
+        LargeCraftAmmoBin otherBin = mock(LargeCraftAmmoBin.class);
+        when(otherBin.getBayEqNum()).thenReturn(bayNum);
+        when(otherBin.getType()).thenReturn(getAmmoType("ISLRM20 Artemis-capable Ammo"));
+
+        Unit unit = mock(Unit.class);
+        when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin, otherBin, }));
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted bay = mock(Mounted.class);
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+
+        ammoBin.setUnit(unit);
+        ammoBin.setBay(bay);
+
+        // ... and it should have all available capacity.
+        assertEquals(capacity, ammoBin.bayAvailableCapacity(), 0.001);
+    }
+
+    @Test
+    public void bayAvailableCapacityFullOnlyBayOfTypeOnUnit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an ammo bin on a unit
+        int equipmentNum = 18;
+        int bayNum = 31;
+        int capacity = 5;
+        int shotsNeeded = 0;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // Setup another bin that isn't a match.
+        LargeCraftAmmoBin otherBin = mock(LargeCraftAmmoBin.class);
+        when(otherBin.getBayEqNum()).thenReturn(bayNum);
+        when(otherBin.getType()).thenReturn(getAmmoType("ISLRM20 Artemis-capable Ammo"));
+
+        Unit unit = mock(Unit.class);
+        when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin, otherBin, }));
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted bay = mock(Mounted.class);
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+
+        ammoBin.setUnit(unit);
+        ammoBin.setBay(bay);
+
+        // ... and it should have no available capacity.
+        assertEquals(0.0, ammoBin.bayAvailableCapacity(), 0.0);
+    }
+
+    @Test
+    public void unloadEmptyBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an empty Ammo Bin...
+        int shotsNeeded = ammoType.getShots();
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, 1.0, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // Nothing should be added to the Warehouse.
+        assertTrue(warehouse.getParts().isEmpty());
+    }
+
+    @Test
+    public void unloadFullBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create a full Ammo Bin...
+        int shotsNeeded = 0;
+        int capacity = 3;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, capacity, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // We should now have a 1 ton of ammo in our warehouse
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(ammoType.getShots() * capacity, added.getShots());
+        assertEquals(ammoType.getShots() * capacity, ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void unloadPartialBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with just one round...
+        int shotsNeeded = ammoType.getShots() - 1;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, 1.0, mockCampaign);
+
+        // ...and unload it.
+        ammoBin.unload();
+
+        // We should now have that ammo in our warehouse.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(1, added.getShots());
+    }
+
+    @Test
+    public void salvageEmptyBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an empty Ammo Bin...
+        int shotsNeeded = ammoType.getShots();
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, 1.0, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // Nothing should be added to the Warehouse.
+        assertTrue(warehouse.getParts().isEmpty());
+        assertEquals(0, ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void salvageFullBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create a full Ammo Bin...
+        int shotsNeeded = 0;
+        int capacity = 2;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, capacity, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // We should now have a 1 ton of ammo in our warehouse
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(ammoType.getShots() * capacity, added.getShots());
+        assertEquals(ammoType.getShots() * capacity, ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void salvagePartialBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with just one round...
+        int shotsNeeded = ammoType.getShots() - 1;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, 1.0, mockCampaign);
+
+        // ...and salvage it.
+        ammoBin.remove(true);
+
+        // We should now have that ammo in our warehouse
+        // and the ammo bin should still be there.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(1, added.getShots());
+        assertEquals(1, ammoBin.getAmountAvailable());
+    }
+
+    @Test
+    public void unloadSingleTonEmptyBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an empty Ammo Bin...
+        int equipmentNum = 18;
+        int capacity = 2;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ...and unload one ton.
+        ammoBin.unloadSingleTon();
+
+        // Nothing should be added to the Warehouse.
+        assertTrue(warehouse.getParts().isEmpty());
+    }
+
+    @Test
+    public void unloadSingleTonFullBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create a full Ammo Bin...
+        int equipmentNum = 19;
+        int shotsNeeded = 0;
+        int capacity = 3;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(ammoType.getShots() * capacity);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ...and unload one ton.
+        ammoBin.unloadSingleTon();
+
+        // We should now have a 1 ton of ammo in our warehouse
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(ammoType.getShots(), added.getShots());
+        assertEquals(ammoType.getShots(), ammoBin.getAmountAvailable());
+
+        // And confirm we only removed one ton
+        assertEquals(ammoType.getShots() * (capacity - 1), ammoBin.getCurrentShots());
+        verify(mockMounted, times(1)).setShotsLeft(eq(ammoType.getShots() * (capacity - 1)));
+    }
+
+    @Test
+    public void unloadSingleTonPartialBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with three tons...
+        int equipmentNum = 19;
+        int capacity = 5;
+        int capacityNeeded = 2;
+        int shotsNeeded = ammoType.getShots() * capacityNeeded;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(ammoType.getShots() * (capacity - capacityNeeded));
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ...and unload only up to a ton.
+        ammoBin.unloadSingleTon();
+
+        // We should now have that ammo in our warehouse.
+        AmmoStorage added = null;
+        for (Part part : warehouse.getParts()) {
+            assertNull(added);
+            assertTrue(part instanceof AmmoStorage);
+            added = (AmmoStorage) part;
+        }
+
+        // Confirm the added part has the correct values
+        assertEquals(ammoType, added.getType());
+        assertEquals(ammoType.getShots(), added.getShots());
+
+        // And that the AmmoBin should have two tons remaining
+        int expectedShotsLeft = ammoType.getShots() * (capacity - capacityNeeded - 1);
+        assertEquals(expectedShotsLeft, ammoBin.getCurrentShots());
+        verify(mockMounted, times(1)).setShotsLeft(eq(expectedShotsLeft));
+    }
+
+    @Test
+    public void loadBinWithoutUnitDoesNothing() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with no ammo...
+        int capacity = 10;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, capacity, mockCampaign);
+
+        // ...and try to load it when the warehouse is empty.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void loadBinWithoutSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 7;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and try to load it when the warehouse is empty.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+    }
+
+    @Test
+    public void loadBinWithOnlySpareAmmoOfWrongType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 2;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add ammo of the wrong type to the warehouse ...
+        AmmoType otherAmmoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots() * capacity);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have not changed how many shots are needed ...
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+
+        // ... nor how many shots are available of the wrong type.
+        assertEquals(otherAmmoType.getShots() * capacity, quartermaster.getAmmoAvailable(otherAmmoType));
+    }
+
+    @Test
+    public void loadBinWithJustEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 3;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the right type to the warehouse ...
+        quartermaster.addAmmo(ammoType, ammoType.getShots() * capacity);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and no more ammo available in the warehouse
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadBinWithMoreThanEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with plenty of ammo ...
+        int capacity = 4;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add more than enough ammo of the right type to the warehouse ...
+        int shotsOnHand = 10 * capacity * ammoType.getShots();
+        quartermaster.addAmmo(ammoType, shotsOnHand);
+
+        // ... and try to load it.
+        ammoBin.loadBin();
+
+        // We should have no shots needed ...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and only the ammo needed was pulled from the warehouse
+        assertEquals(shotsOnHand - shotsNeeded, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadBinSingleTonWithoutUnitDoesNothing() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with no ammo...
+        int capacity = 10;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, capacity, mockCampaign);
+
+        // ...and try to load it when the warehouse is empty.
+        ammoBin.loadBinSingleTon();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void loadBinSingleTonWithoutSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 7;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and try to load it when the warehouse is empty.
+        ammoBin.loadBinSingleTon();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+    }
+
+    @Test
+    public void loadBinSingleTonithOnlySpareAmmoOfWrongType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 2;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add ammo of the wrong type to the warehouse ...
+        AmmoType otherAmmoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots() * capacity);
+
+        // ... and try to load it.
+        ammoBin.loadBinSingleTon();
+
+        // We should have not changed how many shots are needed ...
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+
+        // ... nor how many shots are available of the wrong type.
+        assertEquals(otherAmmoType.getShots() * capacity, quartermaster.getAmmoAvailable(otherAmmoType));
+    }
+
+    @Test
+    public void loadBinSingleTonWithJustEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 3;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the right type to the warehouse ...
+        quartermaster.addAmmo(ammoType, ammoType.getShots());
+
+        // ... and try to load one ton.
+        ammoBin.loadBinSingleTon();
+
+        // We should still have some ammo needed ...
+        assertEquals(shotsNeeded - ammoType.getShots(), ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(ammoType.getShots()));
+
+        // ... and no more ammo available in the warehouse
+        assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void loadBinSingleTonWithMoreThanEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with plenty of ammo ...
+        int capacity = 4;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add more than enough ammo of the right type to the warehouse ...
+        int shotsOnHand = 10 * capacity * ammoType.getShots();
+        quartermaster.addAmmo(ammoType, shotsOnHand);
+
+        // ... and try to load one ton.
+        ammoBin.loadBinSingleTon();
+
+        // We should still need some ammo ...
+        assertEquals(shotsNeeded - ammoType.getShots(), ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(ammoType.getShots()));
+
+        // ... and only the ammo needed was pulled from the warehouse
+        assertEquals(shotsOnHand - ammoType.getShots(), quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void needsFixingEmptyBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an empty Ammo Bin...
+        int equipmentNum = 13;
+        int capacity = 5;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        when(mockUnit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin }));
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // Empty bins need fixing.
+        assertTrue(ammoBin.needsFixing());
+    }
+
+    @Test
+    public void needsFixingFullBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create a full Ammo Bin...
+        int equipmentNum = 13;
+        int shotsNeeded = 0;
+        int capacity = 3;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        when(mockUnit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin }));
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // Full bins do not.
+        assertFalse(ammoBin.needsFixing());
+    }
+
+    @Test
+    public void needsFixingPartialBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with just one ton ...
+        int equipmentNum = 13;
+        int capacity = 3;
+        int shotsNeeded = ammoType.getShots() * (capacity - 1);
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        when(mockUnit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin }));
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // Partial bins do need fixing.
+        assertTrue(ammoBin.needsFixing());
+    }
+
+    @Test
+    public void needsFixingOverflowingBinTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with one ton too many...
+        int equipmentNum = 13;
+        int capacity = 3;
+        int shotsNeeded = -ammoType.getShots();
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        when(mockUnit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin }));
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // Overflowing bins do need fixing.
+        assertTrue(ammoBin.needsFixing());
+    }
+
+    @Test
+    public void fixBinWithoutUnitDoesNothing() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with no ammo...
+        int capacity = 3;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, -1, shotsNeeded, capacity, mockCampaign);
+
+        // ...and try to load it when the warehouse is empty.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void fixBinWithoutSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 3;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and try to load it when the warehouse is empty.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+    }
+
+    @Test
+    public void fixBinWithOnlySpareAmmoOfWrongType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 3;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add ammo of the wrong type to the warehouse ...
+        AmmoType otherAmmoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+        quartermaster.addAmmo(otherAmmoType, otherAmmoType.getShots());
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have not changed how many shots are needed ...
+        assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(0));
+
+        // ... nor how many shots are available of the wrong type.
+        assertEquals(otherAmmoType.getShots(), quartermaster.getAmmoAvailable(otherAmmoType));
+    }
+
+    @Test
+    public void fixBinWithJustEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Artemis-capable Ammo");
+
+        // Create an Ammo Bin with no ammo ...
+        int capacity = 3;
+        int shotsNeeded = ammoType.getShots() * capacity;
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add just enough ammo of the right type to the warehouse ...
+        quartermaster.addAmmo(ammoType, shotsNeeded);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have loaded one ton ...
+        assertEquals(ammoType.getShots() * (capacity - 1), ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(ammoType.getShots()));
+
+        // ... and have more ammo available in the warehouse
+        assertEquals(ammoType.getShots() * (capacity - 1), quartermaster.getAmmoAvailable(ammoType));
+    }
+
+    @Test
+    public void fixBinWithMoreThanEnoughSpareAmmo() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISLRM20 Ammo");
+
+        // Create an Ammo Bin with plenty of ammo ...
+        int capacity = 3;
+        int shotsNeeded = ammoType.getShots();
+        int equipmentNum = 42;
+        LargeCraftAmmoBin ammoBin = new LargeCraftAmmoBin(0, ammoType, equipmentNum, shotsNeeded, capacity, mockCampaign);
+
+        // ... place the ammo bin on a unit ...
+        Unit mockUnit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(mockUnit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(ammoType);
+        when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        ammoBin.setUnit(mockUnit);
+
+        // ... and add more than enough ammo of the right type to the warehouse ...
+        int shotsOnHand = 10 * capacity * ammoType.getShots();
+        quartermaster.addAmmo(ammoType, shotsOnHand);
+
+        // ... and try to load it.
+        ammoBin.fix();
+
+        // We should have loaded one ton, which is just enough...
+        assertEquals(0, ammoBin.getShotsNeeded());
+        verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded));
+
+        // ... and have more ammo available in the warehouse
+        assertEquals(shotsOnHand - ammoType.getShots(), quartermaster.getAmmoAvailable(ammoType));
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingAmmoBinTest.java
@@ -20,13 +20,350 @@
 package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
+import static mekhq.campaign.parts.AmmoUtilities.*;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.Mounted;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.parts.MekLocation;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
 
 public class MissingAmmoBinTest {
     @Test
     public void deserializationCtorTest() {
         MissingAmmoBin ammoBin = new MissingAmmoBin();
         assertNotNull(ammoBin);
+    }
+
+    @Test
+    public void missingAmmoBinMassRepairOptionType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        MissingAmmoBin missingAmmoBin = new MissingAmmoBin(0, ammoType, 18, false, false, mockCampaign);
+
+        assertEquals(Part.REPAIR_PART_TYPE.AMMO, missingAmmoBin.getMassRepairOptionType());
+    }
+
+    @Test
+    public void getNewPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        MissingAmmoBin missingAmmoBin = new MissingAmmoBin(0, ammoType, 18, false, false, mockCampaign);
+
+        // Get a new part that represents the missing bin
+        AmmoBin newPart = missingAmmoBin.getNewPart();
+        assertEquals(missingAmmoBin.getType(), newPart.getType());
+        assertTrue(newPart.getEquipmentNum() < 0);
+        assertEquals(missingAmmoBin.getFullShots(), newPart.getFullShots());
+        assertEquals(missingAmmoBin.getCampaign(), newPart.getCampaign());
+        assertEquals(missingAmmoBin.getName(), newPart.getName());
+        assertEquals(missingAmmoBin.isOneShot(), newPart.isOneShot());
+        assertFalse(newPart.isOmniPodded());
+
+        // One-shot, Omnipodded missing ammo bin
+        ammoType = getAmmoType("ISSRM6 Ammo");
+        missingAmmoBin = new MissingAmmoBin(0, ammoType, 18, true, true, mockCampaign);
+
+        // Get a new part that represents the missing bin
+        newPart = missingAmmoBin.getNewPart();
+        assertEquals(missingAmmoBin.getType(), newPart.getType());
+        assertTrue(newPart.getEquipmentNum() < 0);
+        assertEquals(missingAmmoBin.getFullShots(), newPart.getFullShots());
+        assertEquals(missingAmmoBin.getCampaign(), newPart.getCampaign());
+        assertEquals(missingAmmoBin.getName(), newPart.getName());
+        assertEquals(missingAmmoBin.isOneShot(), newPart.isOneShot());
+        assertFalse(newPart.isOmniPodded());
+    }
+
+    @Test
+    public void missingAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        MissingAmmoBin missingAmmoBin = new MissingAmmoBin(0, isSRM2InfernoAmmo, 42, false, false, mockCampaign);
+        missingAmmoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        missingAmmoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof MissingAmmoBin);
+
+        MissingAmmoBin deserialized = (MissingAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(missingAmmoBin.getId(), deserialized.getId());
+        assertEquals(missingAmmoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(missingAmmoBin.getType(), deserialized.getType());
+        assertEquals(missingAmmoBin.getFullShots(), deserialized.getFullShots());
+        assertEquals(missingAmmoBin.isOneShot(), deserialized.isOneShot());
+        assertEquals(missingAmmoBin.isOmniPodded(), deserialized.isOmniPodded());
+        assertEquals(missingAmmoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void oneShotMissingAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        MissingAmmoBin missingAmmoBin = new MissingAmmoBin(0, isSRM2InfernoAmmo, 42, true, true, mockCampaign);
+        missingAmmoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        missingAmmoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof MissingAmmoBin);
+
+        MissingAmmoBin deserialized = (MissingAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(missingAmmoBin.getId(), deserialized.getId());
+        assertEquals(missingAmmoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(missingAmmoBin.getType(), deserialized.getType());
+        assertEquals(missingAmmoBin.getFullShots(), deserialized.getFullShots());
+        assertEquals(missingAmmoBin.isOneShot(), deserialized.isOneShot());
+        assertEquals(missingAmmoBin.isOmniPodded(), deserialized.isOmniPodded());
+        assertEquals(missingAmmoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void isAcceptableReplacementSameTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Ammo");
+
+        MissingAmmoBin missingAmmoBin = new MissingAmmoBin(0, ammoType, 18, false, false, mockCampaign);
+
+        // Same type AmmoBin
+        AmmoBin replacementBin = new AmmoBin(0, ammoType, -1, 0, false, false, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Use an Ammo with a different munition type
+        missingAmmoBin = new MissingAmmoBin(0, otherAmmoType, 18, false, false, mockCampaign);
+        replacementBin = new AmmoBin(0, otherAmmoType, -1, 0, false, false, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Use a one-shot ammo bin
+        missingAmmoBin = new MissingAmmoBin(0, otherAmmoType, 18, true, false, mockCampaign);
+        replacementBin = new AmmoBin(0, otherAmmoType, -1, 0, true, false, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Use an omni-podded ammo bin
+        missingAmmoBin = new MissingAmmoBin(0, otherAmmoType, 18, false, true, mockCampaign);
+        replacementBin = new AmmoBin(0, otherAmmoType, -1, 0, false, false, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+    }
+
+    @Test
+    public void isAcceptableReplacementDifferentTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Ammo");
+
+        MissingAmmoBin missingAmmoBin = new MissingAmmoBin(0, ammoType, 18, false, false, mockCampaign);
+
+        // Different Ammo Type
+        AmmoBin replacementBin = new AmmoBin(0, otherAmmoType, -1, 0, false, false, mockCampaign);
+
+        // Check and see if this replacement fails.
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Same ammo type, different one-shot status
+        missingAmmoBin = new MissingAmmoBin(0, ammoType, 18, false, false, mockCampaign);
+        replacementBin = new AmmoBin(0, ammoType, -1, 0, true, false, mockCampaign);
+
+        // Check and see if this replacement fails.
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Another different one-shot status
+        missingAmmoBin = new MissingAmmoBin(0, ammoType, 18, true, false, mockCampaign);
+        replacementBin = new AmmoBin(0, ammoType, -1, 0, false, false, mockCampaign);
+
+        // Check and see if this replacement fails.
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Different AmmoBin type
+        InfantryAmmoBin otherAmmoBin = mock(InfantryAmmoBin.class);
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherAmmoBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherAmmoBin, true));
+
+        // Different Part type
+        MekLocation otherPartType = mock(MekLocation.class);
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherPartType, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherPartType, true));
+    }
+
+    @Test
+    public void fixFindsAcceptableReplacementTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        // Create a missing ammo bin on a unit
+        int equipmentNum = 18;
+        MissingAmmoBin missingAmmoBin = new MissingAmmoBin(0, ammoType, equipmentNum, false, false, mockCampaign);
+        Unit unit = mock(Unit.class);
+        ArgumentCaptor<Part> replacementCaptor = ArgumentCaptor.forClass(Part.class);
+        doAnswer(ans -> {
+            Part replacement = ans.getArgument(0);
+            replacement.setUnit(unit);
+            return null;
+        }).when(unit).addPart(replacementCaptor.capture());
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        missingAmmoBin.setUnit(unit);
+        quartermaster.addPart(missingAmmoBin, 0);
+
+        // Attempt to fix the missing ammo bin
+        missingAmmoBin.fix();
+
+        // 0. missingAmmoBin should be removed from the unit and campaign
+        assertTrue(missingAmmoBin.getId() < 0);
+        assertFalse(warehouse.getParts().contains(missingAmmoBin));
+        assertNull(missingAmmoBin.getUnit());
+
+        // 1. Unit should have received a new replacement
+        Part replacementPart = replacementCaptor.getValue();
+        assertNotNull(replacementPart);
+        assertTrue(replacementPart instanceof AmmoBin);
+
+        // 2. And the replacement should match the missing ammo bin
+        AmmoBin replacementAmmoBin = (AmmoBin) replacementPart;
+        assertTrue(replacementAmmoBin.getId() > 0);
+        assertEquals(unit, replacementAmmoBin.getUnit());
+        assertEquals(ammoType, replacementAmmoBin.getType());
+        assertEquals(equipmentNum, replacementAmmoBin.getEquipmentNum());
+        assertEquals(missingAmmoBin.isOneShot(), replacementAmmoBin.isOneShot());
+        assertEquals(missingAmmoBin.getFullShots(), replacementAmmoBin.getShotsNeeded());
+    }
+
+    @Test
+    public void fixFindsAcceptableOneShotReplacementTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create a missing ammo bin on a unit
+        int equipmentNum = 18;
+        MissingAmmoBin missingAmmoBin = new MissingAmmoBin(0, ammoType, equipmentNum, true, false, mockCampaign);
+        Unit unit = mock(Unit.class);
+        ArgumentCaptor<Part> replacementCaptor = ArgumentCaptor.forClass(Part.class);
+        doAnswer(ans -> {
+            Part replacement = ans.getArgument(0);
+            replacement.setUnit(unit);
+            return null;
+        }).when(unit).addPart(replacementCaptor.capture());
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        missingAmmoBin.setUnit(unit);
+        quartermaster.addPart(missingAmmoBin, 0);
+
+        // Attempt to fix the missing ammo bin
+        missingAmmoBin.fix();
+
+        // 0. missingAmmoBin should be removed from the unit and campaign
+        assertTrue(missingAmmoBin.getId() < 0);
+        assertFalse(warehouse.getParts().contains(missingAmmoBin));
+        assertNull(missingAmmoBin.getUnit());
+
+        // 1. Unit should have received a new replacement
+        Part replacementPart = replacementCaptor.getValue();
+        assertNotNull(replacementPart);
+        assertTrue(replacementPart instanceof AmmoBin);
+
+        // 2. And the replacement should match the missing ammo bin
+        AmmoBin replacementAmmoBin = (AmmoBin) replacementPart;
+        assertTrue(replacementAmmoBin.getId() > 0);
+        assertEquals(unit, replacementAmmoBin.getUnit());
+        assertEquals(ammoType, replacementAmmoBin.getType());
+        assertEquals(equipmentNum, replacementAmmoBin.getEquipmentNum());
+        assertEquals(missingAmmoBin.isOneShot(), replacementAmmoBin.isOneShot());
+        assertEquals(missingAmmoBin.getFullShots(), replacementAmmoBin.getShotsNeeded());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingInfantryAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingInfantryAmmoBinTest.java
@@ -20,13 +20,316 @@
 package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
+import static mekhq.campaign.parts.AmmoUtilities.*;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.EquipmentTypeLookup;
+import megamek.common.Mounted;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.parts.MekLocation;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
 
 public class MissingInfantryAmmoBinTest {
     @Test
     public void deserializationCtorTest() {
         MissingInfantryAmmoBin ammoBin = new MissingInfantryAmmoBin();
         assertNotNull(ammoBin);
+    }
+
+
+    @Test
+    public void missingAmmoBinMassRepairOptionType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        MissingInfantryAmmoBin missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, 18, weaponType, 1, false, mockCampaign);
+
+        assertEquals(Part.REPAIR_PART_TYPE.AMMO, missingAmmoBin.getMassRepairOptionType());
+    }
+
+    @Test
+    public void getNewPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        int clips = 5;
+        MissingInfantryAmmoBin missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, 18, weaponType, clips, false, mockCampaign);
+
+        // Get a new part that represents the missing bin
+        InfantryAmmoBin newPart = missingAmmoBin.getNewPart();
+        assertEquals(missingAmmoBin.getType(), newPart.getType());
+        assertEquals(missingAmmoBin.getWeaponType(), newPart.getWeaponType());
+        assertTrue(newPart.getEquipmentNum() < 0);
+        assertEquals(missingAmmoBin.getFullShots(), newPart.getFullShots());
+        assertEquals(missingAmmoBin.getCampaign(), newPart.getCampaign());
+        assertEquals(missingAmmoBin.getName(), newPart.getName());
+        assertFalse(newPart.isOmniPodded());
+
+        // Omnipodded missing ammo bin
+        ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, 18, weaponType, clips, true, mockCampaign);
+
+        // Get a new part that represents the missing bin
+        newPart = missingAmmoBin.getNewPart();
+        assertEquals(missingAmmoBin.getType(), newPart.getType());
+        assertEquals(missingAmmoBin.getWeaponType(), newPart.getWeaponType());
+        assertTrue(newPart.getEquipmentNum() < 0);
+        assertEquals(missingAmmoBin.getFullShots(), newPart.getFullShots());
+        assertEquals(missingAmmoBin.getCampaign(), newPart.getCampaign());
+        assertEquals(missingAmmoBin.getName(), newPart.getName());
+        assertFalse(newPart.isOmniPodded());
+    }
+
+    @Test
+    public void missingAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        Campaign mockCampaign = mock(Campaign.class);
+        MissingInfantryAmmoBin missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, 18, weaponType, 6, false, mockCampaign);
+        missingAmmoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        missingAmmoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof MissingInfantryAmmoBin);
+
+        MissingInfantryAmmoBin deserialized = (MissingInfantryAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(missingAmmoBin.getId(), deserialized.getId());
+        assertEquals(missingAmmoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(missingAmmoBin.getType(), deserialized.getType());
+        assertEquals(missingAmmoBin.getWeaponType(), deserialized.getWeaponType());
+        assertEquals(missingAmmoBin.getFullShots(), deserialized.getFullShots());
+        assertEquals(missingAmmoBin.isOmniPodded(), deserialized.isOmniPodded());
+        assertEquals(missingAmmoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void omnipoddedMissingInfantryAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        Campaign mockCampaign = mock(Campaign.class);
+        MissingInfantryAmmoBin missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, 18, weaponType, 6, true, mockCampaign);
+        missingAmmoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        missingAmmoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof MissingInfantryAmmoBin);
+
+        MissingInfantryAmmoBin deserialized = (MissingInfantryAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(missingAmmoBin.getId(), deserialized.getId());
+        assertEquals(missingAmmoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(missingAmmoBin.getType(), deserialized.getType());
+        assertEquals(missingAmmoBin.getWeaponType(), deserialized.getWeaponType());
+        assertEquals(missingAmmoBin.getFullShots(), deserialized.getFullShots());
+        assertEquals(missingAmmoBin.isOmniPodded(), deserialized.isOmniPodded());
+        assertEquals(missingAmmoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void isAcceptableReplacementSameTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        InfantryWeapon otherWeaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_TAG);
+
+        int clips = 6;
+        MissingInfantryAmmoBin missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, 18, weaponType, clips, true, mockCampaign);
+
+        // Same type AmmoBin
+        InfantryAmmoBin replacementBin = new InfantryAmmoBin(0, ammoType, -1, 0, weaponType, clips, false, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Use an Ammo with a different weapon types
+        missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, 18, otherWeaponType, clips, false, mockCampaign);
+        replacementBin = new InfantryAmmoBin(0, ammoType, -1, 0, otherWeaponType, clips, false, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Use an Ammo with a different munition type
+        missingAmmoBin = new MissingInfantryAmmoBin(0, otherAmmoType, 18, weaponType, clips, false, mockCampaign);
+        replacementBin = new InfantryAmmoBin(0, otherAmmoType, -1, 0, weaponType, clips, false, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Use an omni-podded ammo bin
+        missingAmmoBin = new MissingInfantryAmmoBin(0, otherAmmoType, 18, weaponType, clips, true, mockCampaign);
+        replacementBin = new InfantryAmmoBin(0, otherAmmoType, -1, 0, weaponType, clips, false, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+    }
+
+    @Test
+    public void isAcceptableReplacementDifferentTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        AmmoType otherAmmoType = getAmmoType(EquipmentTypeLookup.INFANTRY_INFERNO_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        InfantryWeapon otherWeaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_TAG);
+
+        int clips = 6;
+        MissingInfantryAmmoBin missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, 18, weaponType, clips, true, mockCampaign);
+
+        // Different Ammo Type
+        InfantryAmmoBin replacementBin = new InfantryAmmoBin(0, otherAmmoType, -1, 0, weaponType, clips, false, mockCampaign);
+
+        // Check and see if this replacement fails.
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Different Weapon Type
+        replacementBin = new InfantryAmmoBin(0, ammoType, -1, 0, otherWeaponType, clips, false, mockCampaign);
+
+        // Check and see if this replacement fails.
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Different number of clips
+        replacementBin = new InfantryAmmoBin(0, ammoType, -1, 0, weaponType, clips + 1, false, mockCampaign);
+
+        // Check and see if this replacement fails.
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Different AmmoBin type
+        AmmoBin otherAmmoBin = mock(AmmoBin.class);
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherAmmoBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherAmmoBin, true));
+
+        // Different Part type
+        MekLocation otherPartType = mock(MekLocation.class);
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherPartType, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherPartType, true));
+    }
+
+    @Test
+    public void fixFindsAcceptableReplacementTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType(EquipmentTypeLookup.INFANTRY_AMMO);
+        InfantryWeapon weaponType = getInfantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        int clips = 6;
+
+        // Create a missing ammo bin on a unit
+        int equipmentNum = 18;
+        MissingInfantryAmmoBin missingAmmoBin = new MissingInfantryAmmoBin(0, ammoType, equipmentNum, weaponType, clips, false, mockCampaign);
+        Unit unit = mock(Unit.class);
+        ArgumentCaptor<Part> replacementCaptor = ArgumentCaptor.forClass(Part.class);
+        doAnswer(ans -> {
+            Part replacement = ans.getArgument(0);
+            replacement.setUnit(unit);
+            return null;
+        }).when(unit).addPart(replacementCaptor.capture());
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        missingAmmoBin.setUnit(unit);
+        quartermaster.addPart(missingAmmoBin, 0);
+
+        // Attempt to fix the missing ammo bin
+        missingAmmoBin.fix();
+
+        // 0. missingAmmoBin should be removed from the unit and campaign
+        assertTrue(missingAmmoBin.getId() < 0);
+        assertFalse(warehouse.getParts().contains(missingAmmoBin));
+        assertNull(missingAmmoBin.getUnit());
+
+        // 1. Unit should have received a new replacement
+        Part replacementPart = replacementCaptor.getValue();
+        assertNotNull(replacementPart);
+        assertTrue(replacementPart instanceof InfantryAmmoBin);
+
+        // 2. And the replacement should match the missing ammo bin
+        InfantryAmmoBin replacementAmmoBin = (InfantryAmmoBin) replacementPart;
+        assertTrue(replacementAmmoBin.getId() > 0);
+        assertEquals(unit, replacementAmmoBin.getUnit());
+        assertEquals(ammoType, replacementAmmoBin.getType());
+        assertEquals(weaponType, replacementAmmoBin.getWeaponType());
+        assertEquals(clips, replacementAmmoBin.getClips());
+        assertEquals(equipmentNum, replacementAmmoBin.getEquipmentNum());
+        assertEquals(missingAmmoBin.getFullShots(), replacementAmmoBin.getShotsNeeded());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBinTest.java
@@ -20,13 +20,228 @@
 package mekhq.campaign.parts.equipment;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Vector;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
+import static mekhq.campaign.parts.AmmoUtilities.*;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.Mounted;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.parts.MekLocation;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
 
 public class MissingLargeCraftAmmoBinTest {
     @Test
     public void deserializationCtorTest() {
         MissingLargeCraftAmmoBin ammoBin = new MissingLargeCraftAmmoBin();
         assertNotNull(ammoBin);
+    }
+
+    @Test
+    public void missingLargeCraftAmmoBinMassRepairOptionType() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        MissingLargeCraftAmmoBin missingAmmoBin = new MissingLargeCraftAmmoBin(0, ammoType, 18, 25.0, mockCampaign);
+
+        assertEquals(Part.REPAIR_PART_TYPE.AMMO, missingAmmoBin.getMassRepairOptionType());
+    }
+
+    @Test
+    public void getNewPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        MissingLargeCraftAmmoBin missingAmmoBin = new MissingLargeCraftAmmoBin(0, ammoType, 18, 25.0, mockCampaign);
+
+        // Get a new part that represents the missing bin
+        AmmoBin newPart = missingAmmoBin.getNewPart();
+        assertEquals(missingAmmoBin.getType(), newPart.getType());
+        assertTrue(newPart.getEquipmentNum() < 0);
+        assertEquals(missingAmmoBin.getFullShots(), newPart.getFullShots());
+        assertEquals(missingAmmoBin.getCampaign(), newPart.getCampaign());
+        assertEquals(missingAmmoBin.getName(), newPart.getName());
+        assertFalse(newPart.isOneShot());
+        assertFalse(newPart.isOmniPodded());
+    }
+
+    @Test
+    public void missingAmmoBinWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        AmmoType isSRM2InfernoAmmo = getAmmoType("ISSRM2 Inferno Ammo");
+        Campaign mockCampaign = mock(Campaign.class);
+        MissingLargeCraftAmmoBin missingAmmoBin = new MissingLargeCraftAmmoBin(0, isSRM2InfernoAmmo, 42, 25.0, mockCampaign);
+        missingAmmoBin.setId(25);
+
+        // Write the AmmoBin XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        missingAmmoBin.writeToXml(pw, 0);
+
+        // Get the AmmoBin XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the AmmoBin
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof MissingLargeCraftAmmoBin);
+
+        MissingLargeCraftAmmoBin deserialized = (MissingLargeCraftAmmoBin) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(missingAmmoBin.getId(), deserialized.getId());
+        assertEquals(missingAmmoBin.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(missingAmmoBin.getType(), deserialized.getType());
+        assertEquals(missingAmmoBin.getFullShots(), deserialized.getFullShots());
+        assertEquals(missingAmmoBin.isOneShot(), deserialized.isOneShot());
+        assertEquals(missingAmmoBin.isOmniPodded(), deserialized.isOmniPodded());
+        assertEquals(missingAmmoBin.getName(), deserialized.getName());
+    }
+
+    @Test
+    public void isAcceptableReplacementSameTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Ammo");
+
+        MissingLargeCraftAmmoBin missingAmmoBin = new MissingLargeCraftAmmoBin(0, ammoType, 18, 25.0, mockCampaign);
+
+        // Same type AmmoBin
+        LargeCraftAmmoBin replacementBin = new LargeCraftAmmoBin(0, ammoType, -1, 0, 25.0, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Use an Ammo with a different munition type
+        missingAmmoBin = new MissingLargeCraftAmmoBin(0, otherAmmoType, 18, 25.0, mockCampaign);
+        replacementBin = new LargeCraftAmmoBin(0, otherAmmoType, -1, 0, 25.0, mockCampaign);
+
+        // Check and see if same type AmmoBin replacement works.
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertTrue(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+    }
+
+    @Test
+    public void isAcceptableReplacementDifferentTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        AmmoType ammoType = getAmmoType("ISSRM6 Inferno Ammo");
+        AmmoType otherAmmoType = getAmmoType("ISSRM6 Ammo");
+
+        MissingLargeCraftAmmoBin missingAmmoBin = new MissingLargeCraftAmmoBin(0, ammoType, 18, 25.0, mockCampaign);
+
+        // Different Ammo Type
+        LargeCraftAmmoBin replacementBin = new LargeCraftAmmoBin(0, otherAmmoType, -1, 0, 25.0, mockCampaign);
+
+        // Check and see if this replacement fails.
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Same ammo type, different capacity
+        missingAmmoBin = new MissingLargeCraftAmmoBin(0, ammoType, 18, 25.0, mockCampaign);
+        replacementBin = new LargeCraftAmmoBin(0, ammoType, -1, 0, 35.0, mockCampaign);
+
+        // Check and see if this replacement fails.
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(replacementBin, true));
+
+        // Different AmmoBin type
+        AmmoBin otherAmmoBin = mock(AmmoBin.class);
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherAmmoBin, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherAmmoBin, true));
+
+        // Different Part type
+        MekLocation otherPartType = mock(MekLocation.class);
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherPartType, false));
+        assertFalse(missingAmmoBin.isAcceptableReplacement(otherPartType, true));
+    }
+
+    @Test
+    public void fixFindsAcceptableReplacementTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        AmmoType ammoType = getAmmoType("ISSRM6 Ammo");
+
+        // Create a missing ammo bin on a unit
+        int equipmentNum = 18;
+        int bayNum = 31;
+        MissingLargeCraftAmmoBin missingAmmoBin = new MissingLargeCraftAmmoBin(0, ammoType, equipmentNum, 25.0, mockCampaign);
+        Unit unit = mock(Unit.class);
+        ArgumentCaptor<Part> replacementCaptor = ArgumentCaptor.forClass(Part.class);
+        doAnswer(ans -> {
+            Part replacement = ans.getArgument(0);
+            replacement.setUnit(unit);
+            return null;
+        }).when(unit).addPart(replacementCaptor.capture());
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getType()).thenReturn(ammoType);
+        when(entity.getEquipment(equipmentNum)).thenReturn(mounted);
+        Mounted bay = mock(Mounted.class);
+        Vector<Integer> bayAmmo = new Vector<Integer>();
+        bayAmmo.addElement(equipmentNum);
+        when(bay.getBayAmmo()).thenReturn(bayAmmo);
+        when(entity.getEquipment(bayNum)).thenReturn(bay);
+        missingAmmoBin.setUnit(unit);
+        missingAmmoBin.setBay(bayNum);
+        quartermaster.addPart(missingAmmoBin, 0);
+
+        // Attempt to fix the missing ammo bin
+        missingAmmoBin.fix();
+
+        // 0. missingAmmoBin should be removed from the unit and campaign
+        assertTrue(missingAmmoBin.getId() < 0);
+        assertFalse(warehouse.getParts().contains(missingAmmoBin));
+        assertNull(missingAmmoBin.getUnit());
+
+        // 1. Unit should have received a new replacement
+        Part replacementPart = replacementCaptor.getValue();
+        assertNotNull(replacementPart);
+        assertTrue(replacementPart instanceof LargeCraftAmmoBin);
+
+        // 2. And the replacement should match the missing ammo bin
+        LargeCraftAmmoBin replacementAmmoBin = (LargeCraftAmmoBin) replacementPart;
+        assertTrue(replacementAmmoBin.getId() > 0);
+        assertEquals(unit, replacementAmmoBin.getUnit());
+        assertEquals(ammoType, replacementAmmoBin.getType());
+        assertEquals(equipmentNum, replacementAmmoBin.getEquipmentNum());
+        assertEquals(missingAmmoBin.isOneShot(), replacementAmmoBin.isOneShot());
+        assertEquals(missingAmmoBin.getFullShots(), replacementAmmoBin.getShotsNeeded());
+        assertEquals(bay, replacementAmmoBin.getBay());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoActionTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package mekhq.campaign.unit.actions;
 
 import static org.junit.Assert.*;

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoActionTest.java
@@ -36,6 +36,7 @@ import megamek.common.Mounted;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Quartermaster;
 import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
 import mekhq.campaign.unit.Unit;
 
@@ -161,6 +162,104 @@ public class AdjustLargeCraftAmmoActionTest {
         LargeCraftAmmoBin ammoBin = mock(LargeCraftAmmoBin.class);
         when(ammoBin.getEquipmentNum()).thenReturn(equipmentNum);
         when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin }));
+
+        AdjustLargeCraftAmmoAction action = new AdjustLargeCraftAmmoAction();
+
+        action.execute(campaign, unit);
+
+        // Ensure we didn't add any new parts
+        verify(unit, times(0)).addPart(any());
+        verify(quartermaster, times(0)).addPart(any(), anyInt());
+
+        // Ensure we updated the part's type
+        verify(ammoBin, times(1)).changeMunition(eq(ammoType0));
+    }
+
+    @Test
+    public void addsMissingBinsSkipsNonLargeCraftBins() {
+        Campaign campaign = mock(Campaign.class);
+        Quartermaster quartermaster = mock(Quartermaster.class);
+        when(campaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Put together a unit with 1 bay, with 1 ammo type
+        Unit unit = mock(Unit.class);
+        when(unit.getCampaign()).thenReturn(campaign);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(entity.getWeight()).thenReturn(500.0);
+        int equipmentNum = 11;
+        Mounted bin0 = mock(Mounted.class);
+        doReturn(equipmentNum).when(entity).getEquipmentNum(eq(bin0));
+        AmmoType ammoType0 = getAmmoType("ISLRM20 Ammo");
+        when(bin0.getType()).thenReturn(ammoType0);
+        int capacity = 10;
+        when(bin0.getSize()).thenReturn((double) capacity);
+        when(bin0.getOriginalShots()).thenReturn(capacity * ammoType0.getShots());
+        int onHand = capacity - 1;
+        when(bin0.getBaseShotsLeft()).thenReturn(onHand * ammoType0.getShots());
+        ArrayList<Mounted> ammo = new ArrayList<>();
+        ammo.add(bin0);
+        when(entity.getAmmo()).thenReturn(ammo);
+        int bayEquipmentNum = 18;
+        Mounted bay = mock(Mounted.class);
+        doReturn(bay).when(entity).getBayByAmmo(eq(bin0));
+        doReturn(bayEquipmentNum).when(entity).getEquipmentNum(eq(bay));
+        when(unit.getEntity()).thenReturn(entity);
+        AmmoBin otherAmmoBin = mock(AmmoBin.class);
+        when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { otherAmmoBin }));
+        // Handle parts being added to units having their unit set
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+
+        AdjustLargeCraftAmmoAction action = new AdjustLargeCraftAmmoAction();
+
+        action.execute(campaign, unit);
+
+        ArgumentCaptor<Part> partCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(unit, times(1)).addPart(partCaptor.capture());
+
+        Part addedPart = partCaptor.getValue();
+        verify(quartermaster, times(1)).addPart(eq(addedPart), eq(0));
+
+        assertNotNull(addedPart instanceof LargeCraftAmmoBin);
+
+        LargeCraftAmmoBin ammoBin = (LargeCraftAmmoBin) addedPart;
+        assertEquals(ammoType0, ammoBin.getType());
+        assertEquals(equipmentNum, ammoBin.getEquipmentNum());
+        assertEquals((double) capacity, ammoBin.getCapacity(), 0.001);
+        assertEquals((capacity - onHand) * ammoType0.getShots(), ammoBin.getShotsNeeded());
+        assertEquals(bayEquipmentNum, ammoBin.getBayEqNum());
+        assertEquals(bay, ammoBin.getBay());
+    }
+
+    @Test
+    public void updatesExistingBayToMatchTypeSkipsNonLargeCraftBins() {
+        Campaign campaign = mock(Campaign.class);
+        Quartermaster quartermaster = mock(Quartermaster.class);
+        when(campaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Put together a unit with 1 bay, 1 ammo type, and 1 bin on the unit already
+        Unit unit = mock(Unit.class);
+        when(unit.getCampaign()).thenReturn(campaign);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(entity.getWeight()).thenReturn(500.0);
+        int equipmentNum = 11;
+        Mounted bin0 = mock(Mounted.class);
+        doReturn(equipmentNum).when(entity).getEquipmentNum(eq(bin0));
+        AmmoType ammoType0 = getAmmoType("ISLRM20 Ammo");
+        when(bin0.getType()).thenReturn(ammoType0);
+        ArrayList<Mounted> ammo = new ArrayList<>();
+        ammo.add(bin0);
+        when(entity.getAmmo()).thenReturn(ammo);
+        when(unit.getEntity()).thenReturn(entity);
+        LargeCraftAmmoBin ammoBin = mock(LargeCraftAmmoBin.class);
+        when(ammoBin.getEquipmentNum()).thenReturn(equipmentNum);
+        AmmoBin otherAmmoBin = mock(AmmoBin.class);
+        when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { otherAmmoBin, ammoBin }));
 
         AdjustLargeCraftAmmoAction action = new AdjustLargeCraftAmmoAction();
 

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/AdjustLargeCraftAmmoActionTest.java
@@ -1,0 +1,157 @@
+package mekhq.campaign.unit.actions;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static mekhq.campaign.parts.AmmoUtilities.*;
+
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.Mounted;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
+import mekhq.campaign.unit.Unit;
+
+public class AdjustLargeCraftAmmoActionTest {
+    @Test
+    public void onlyAcceptsEntitiesUsingBayWeapons() {
+        Campaign campaign = mock(Campaign.class);
+        Quartermaster quartermaster = mock(Quartermaster.class);
+        when(campaign.getQuartermaster()).thenReturn(quartermaster);
+        Unit unit = mock(Unit.class);
+        when(unit.getCampaign()).thenReturn(campaign);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(false);
+        when(unit.getEntity()).thenReturn(entity);
+
+        AdjustLargeCraftAmmoAction action = new AdjustLargeCraftAmmoAction();
+
+        action.execute(campaign, unit);
+
+        verify(unit, times(0)).addPart(any());
+        verify(quartermaster, times(0)).addPart(any(), anyInt());
+    }
+
+    @Test
+    public void doesNothingWithNoAmmoBays() {
+        Campaign campaign = mock(Campaign.class);
+        Quartermaster quartermaster = mock(Quartermaster.class);
+        when(campaign.getQuartermaster()).thenReturn(quartermaster);
+        Unit unit = mock(Unit.class);
+        when(unit.getCampaign()).thenReturn(campaign);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(entity.getAmmo()).thenReturn(new ArrayList<>());
+        when(unit.getEntity()).thenReturn(entity);
+
+        AdjustLargeCraftAmmoAction action = new AdjustLargeCraftAmmoAction();
+
+        action.execute(campaign, unit);
+
+        verify(unit, times(0)).addPart(any());
+        verify(quartermaster, times(0)).addPart(any(), anyInt());
+    }
+
+    @Test
+    public void addsMissingBins() {
+        Campaign campaign = mock(Campaign.class);
+        Quartermaster quartermaster = mock(Quartermaster.class);
+        when(campaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Put together a unit with 1 bay, with 1 ammo type
+        Unit unit = mock(Unit.class);
+        when(unit.getCampaign()).thenReturn(campaign);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(entity.getWeight()).thenReturn(500.0);
+        int equipmentNum = 11;
+        Mounted bin0 = mock(Mounted.class);
+        doReturn(equipmentNum).when(entity).getEquipmentNum(eq(bin0));
+        AmmoType ammoType0 = getAmmoType("ISLRM20 Ammo");
+        when(bin0.getType()).thenReturn(ammoType0);
+        int capacity = 10;
+        when(bin0.getSize()).thenReturn((double) capacity);
+        when(bin0.getOriginalShots()).thenReturn(capacity * ammoType0.getShots());
+        int onHand = capacity - 1;
+        when(bin0.getBaseShotsLeft()).thenReturn(onHand * ammoType0.getShots());
+        ArrayList<Mounted> ammo = new ArrayList<>();
+        ammo.add(bin0);
+        when(entity.getAmmo()).thenReturn(ammo);
+        int bayEquipmentNum = 18;
+        Mounted bay = mock(Mounted.class);
+        doReturn(bay).when(entity).getBayByAmmo(eq(bin0));
+        doReturn(bayEquipmentNum).when(entity).getEquipmentNum(eq(bay));
+        when(unit.getEntity()).thenReturn(entity);
+        // Handle parts being added to units having their unit set
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+
+        AdjustLargeCraftAmmoAction action = new AdjustLargeCraftAmmoAction();
+
+        action.execute(campaign, unit);
+
+        ArgumentCaptor<Part> partCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(unit, times(1)).addPart(partCaptor.capture());
+
+        Part addedPart = partCaptor.getValue();
+        verify(quartermaster, times(1)).addPart(eq(addedPart), eq(0));
+
+        assertNotNull(addedPart instanceof LargeCraftAmmoBin);
+
+        LargeCraftAmmoBin ammoBin = (LargeCraftAmmoBin) addedPart;
+        assertEquals(ammoType0, ammoBin.getType());
+        assertEquals(equipmentNum, ammoBin.getEquipmentNum());
+        assertEquals((double) capacity, ammoBin.getCapacity(), 0.001);
+        assertEquals((capacity - onHand) * ammoType0.getShots(), ammoBin.getShotsNeeded());
+        assertEquals(bayEquipmentNum, ammoBin.getBayEqNum());
+        assertEquals(bay, ammoBin.getBay());
+    }
+
+    @Test
+    public void updatesExistingBayToMatchType() {
+        Campaign campaign = mock(Campaign.class);
+        Quartermaster quartermaster = mock(Quartermaster.class);
+        when(campaign.getQuartermaster()).thenReturn(quartermaster);
+
+        // Put together a unit with 1 bay, 1 ammo type, and 1 bin on the unit already
+        Unit unit = mock(Unit.class);
+        when(unit.getCampaign()).thenReturn(campaign);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(entity.getWeight()).thenReturn(500.0);
+        int equipmentNum = 11;
+        Mounted bin0 = mock(Mounted.class);
+        doReturn(equipmentNum).when(entity).getEquipmentNum(eq(bin0));
+        AmmoType ammoType0 = getAmmoType("ISLRM20 Ammo");
+        when(bin0.getType()).thenReturn(ammoType0);
+        ArrayList<Mounted> ammo = new ArrayList<>();
+        ammo.add(bin0);
+        when(entity.getAmmo()).thenReturn(ammo);
+        when(unit.getEntity()).thenReturn(entity);
+        LargeCraftAmmoBin ammoBin = mock(LargeCraftAmmoBin.class);
+        when(ammoBin.getEquipmentNum()).thenReturn(equipmentNum);
+        when(unit.getParts()).thenReturn(Arrays.asList(new Part[] { ammoBin }));
+
+        AdjustLargeCraftAmmoAction action = new AdjustLargeCraftAmmoAction();
+
+        action.execute(campaign, unit);
+
+        // Ensure we didn't add any new parts
+        verify(unit, times(0)).addPart(any());
+        verify(quartermaster, times(0)).addPart(any(), anyInt());
+
+        // Ensure we updated the part's type
+        verify(ammoBin, times(1)).changeMunition(eq(ammoType0));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/HirePersonnelUnitActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/HirePersonnelUnitActionTest.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package mekhq.campaign.unit.actions;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 
-import megamek.common.Crew;
 import megamek.common.Entity;
 import megamek.common.Jumpship;
 import megamek.common.LandAirMech;
@@ -13,7 +30,6 @@ import megamek.common.Mech;
 import megamek.common.SmallCraft;
 import megamek.common.SupportTank;
 import megamek.common.Tank;
-import megamek.common.TankTrailerHitch;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/SwapAmmoTypeActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/SwapAmmoTypeActionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.unit.actions;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.AmmoUtilities.*;
+
+import org.junit.Test;
+
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.Mounted;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.equipment.AmmoBin;
+import mekhq.campaign.unit.Unit;
+
+public class SwapAmmoTypeActionTest {
+    @Test
+    public void swapAmmoTypeSwapsMunitions() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType currentType = getAmmoType("ISSRM6 Ammo");
+        AmmoType newAmmoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create a full ammo bin on a unit.
+        int equipmentNum = 18;
+        AmmoBin currentBin = new AmmoBin(0, currentType, equipmentNum, 0, false, false, mockCampaign);
+
+        Unit unit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(currentType);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        currentBin.setUnit(unit);
+
+        // Ensure the ammo bin is full.
+        assertEquals(0, currentBin.getShotsNeeded());
+
+        SwapAmmoTypeAction action = new SwapAmmoTypeAction(currentBin, newAmmoType);
+
+        // Swap the ammo types.
+        action.execute(mockCampaign, unit);
+
+        // Ensure the action swapped the ammo type ...
+        assertEquals(newAmmoType, currentBin.getType());
+
+        // ... and left us needing to reload the bin.
+        assertEquals(newAmmoType.getShots(), currentBin.getShotsNeeded());
+    }
+
+    @Test
+    public void swapAmmoTypeSwapsMunitionsOnlyForSelectedUnit() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        AmmoType currentType = getAmmoType("ISSRM6 Ammo");
+        AmmoType newAmmoType = getAmmoType("ISSRM6 Inferno Ammo");
+
+        // Create a full ammo bin on a unit.
+        int equipmentNum = 18;
+        AmmoBin currentBin = new AmmoBin(0, currentType, equipmentNum, 0, false, false, mockCampaign);
+
+        Unit unit = mock(Unit.class);
+        Entity mockEntity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(mockEntity);
+        Mounted mockMounted = mock(Mounted.class);
+        when(mockMounted.getType()).thenReturn(currentType);
+        when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn(mockMounted);
+        currentBin.setUnit(unit);
+
+        // Ensure the ammo bin is full.
+        assertEquals(0, currentBin.getShotsNeeded());
+
+        // Create some other unit.
+        Unit otherUnit = mock(Unit.class);
+
+        SwapAmmoTypeAction action = new SwapAmmoTypeAction(currentBin, newAmmoType);
+
+        // Try swapping the ammo types for the wrong unit.
+        action.execute(mockCampaign, otherUnit);
+
+        // Ensure the action DID NOT swap the ammo type ...
+        assertEquals(currentType, currentBin.getType());
+
+        // ... and left us with a FULL bin.
+        assertEquals(0, currentBin.getShotsNeeded());
+    }
+}


### PR DESCRIPTION
Consolidate and simplify ammo additions and removals from Campaigns. Follow on to #2227.

- Fixes #2268
- Fixes #2267
- Fixes #2253
- Fixes #2142
- Fixes #1807 
- Implements #2243 

TODO:
- [x] fix
- [x] loadBin
- [x] amountAvailable
- [x] changeAmountAvailable
- [x] Infantry Ammo
    - [x] InfantryAmmoBin::changeCapacity
- [x] getNewPart
- [x] MissingAmmoBins
- [x] LargeCraftAmmoBins
- [x] Expand test coverage (7k LOC of tests added)