### PR TITLE
Issue #2166: NRE in Money::plus/Money::minus

### DIFF
--- a/MekHQ/src/mekhq/campaign/finances/Money.java
+++ b/MekHQ/src/mekhq/campaign/finances/Money.java
@@ -102,6 +102,10 @@ public class Money implements Comparable<Money> {
     }
 
     public Money plus(Money amount) {
+        if (amount == null) {
+            return plus(0L);
+        }
+
         return new Money(getWrapped().plus(amount.getWrapped()));
     }
 
@@ -114,6 +118,10 @@ public class Money implements Comparable<Money> {
     }
 
     public Money minus(Money amount) {
+        if (amount == null) {
+            return minus(0L);
+        }
+
         return new Money(getWrapped().minus(amount.getWrapped()));
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -235,7 +235,7 @@ public class BattleArmorSuit extends Part {
         //if there are no linked parts and the unit is null,
         //then use the pre-recorded alternate costs
         if ((null == unit) && !hasChildParts()) {
-            return alternateCost;
+            return (alternateCost != null) ? alternateCost : Money.zero();
         }
         Money cost = Money.zero();
         switch(weightClass) {


### PR DESCRIPTION
We have seen more than a handful of null exceptions in `Money::plus`, most of the calling code however, has been fixed. There are a few places that may or may not have been fixed, but I couldn't find any issues with `Part::getStickerPrice` in my search today.

Instead, I've gone ahead and null protected `Money::plus` and `Money::minus`, and ensured that `BattleArmorSuit` does not return a `null` value for `alternateCost`. This fixes #2166, albeit in a defensive way we may not need anymore.