### PR TITLE
Issue #2248: Fix various ContractMarket exceptions when operating at the bounds of MekHQ data

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -208,7 +208,7 @@ public class ContractMarket implements Serializable {
             } else {
                 MekHQ.getLogger().warning(
                         "Unable to find any factions around "
-                            + campaign.getCurrentSystem()
+                            + campaign.getCurrentSystem().getName(campaign.getLocalDate())
                             + " on "
                             + campaign.getLocalDate());
             }

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -390,25 +390,19 @@ public class ContractMarket implements Serializable {
         if (contract.getSystem() == null) {
 		    MekHQ.getLogger().warning("Could not find contract location for "
 		                    + contract.getEmployerCode() + " vs. " + contract.getEnemyCode());
-			if (retries > 0) {
-				return generateAtBContract(campaign, employer, unitRatingMod, retries - 1);
-			} else {
-				return null;
-			}
+			return generateAtBContract(campaign, employer, unitRatingMod, retries - 1);
 		}
 		JumpPath jp = null;
 		try {
 			jp = contract.getJumpPath(campaign);
 		} catch (NullPointerException ex) {
 			// could not calculate jump path; leave jp null
+            MekHQ.getLogger().warning("Could not calculate jump path to contract location: "
+		                    + contract.getSystem().getName(campaign.getLocalDate()), ex);
 		}
 
 		if (jp == null) {
-			if (retries > 0) {
-				return generateAtBContract(campaign, employer, unitRatingMod, retries - 1);
-			} else {
-				return null;
-			}
+			return generateAtBContract(campaign, employer, unitRatingMod, retries - 1);
 		}
 
 		setAllyRating(contract, isAttacker, campaign.getGameYear());


### PR DESCRIPTION
The AtB Contract Market does not enjoy being at the bounds of playable data. This PR just adds a few checks to have it more gracefully fail instead of throwing exceptions and blocking the campaign's forward progress. This sort of fixes #2248 at a wishy-washy level.