### PR TITLE
Issues #2255 #2258: Fix Warehouse::removePart StackOverflowException with child parts

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1615,9 +1615,9 @@ public class Campaign implements Serializable, ITechManager {
      * Sets the Warehouse which stores parts for the campaign.
      * @param warehouse The warehouse in which to store parts.
      */
-	public void setWarehouse(Warehouse warehouse) {
+    public void setWarehouse(Warehouse warehouse) {
         parts = Objects.requireNonNull(warehouse);
-	}
+    }
 
     public Quartermaster getQuartermaster() {
         return quartermaster;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1611,6 +1611,14 @@ public class Campaign implements Serializable, ITechManager {
         return parts;
     }
 
+    /**
+     * Sets the Warehouse which stores parts for the campaign.
+     * @param warehouse The warehouse in which to store parts.
+     */
+	public void setWarehouse(Warehouse warehouse) {
+        parts = Objects.requireNonNull(warehouse);
+	}
+
     public Quartermaster getQuartermaster() {
         return quartermaster;
     }

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -147,9 +147,11 @@ public class Warehouse {
         // Clear the part's ID
         part.setId(-1);
 
-        // Remove child parts as well
-        for (Part childPart : part.getChildParts()) {
-            removePart(childPart);
+        if (didRemove) {
+            // Remove child parts as well
+            for (Part childPart : part.getChildParts()) {
+                removePart(childPart);
+            }
         }
 
         return didRemove;

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -147,9 +147,10 @@ public class Warehouse {
         // Clear the part's ID
         part.setId(-1);
 
-        if (didRemove) {
+        if (didRemove && !part.getChildParts().isEmpty()) {
             // Remove child parts as well
-            for (Part childPart : part.getChildParts()) {
+            List<Part> childParts = new ArrayList<>(part.getChildParts());
+            for (Part childPart : childParts) {
                 part.removeChildPart(childPart);
 
                 removePart(childPart);

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -150,6 +150,8 @@ public class Warehouse {
         if (didRemove) {
             // Remove child parts as well
             for (Part childPart : part.getChildParts()) {
+                part.removeChildPart(childPart);
+
                 removePart(childPart);
             }
         }

--- a/MekHQ/src/mekhq/campaign/parts/BayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BayDoor.java
@@ -88,6 +88,9 @@ public class BayDoor extends Part {
 
     @Override
     public void remove(boolean salvage) {
+        // Grab a reference to our parent part so that we don't accidentally NRE
+        // when we remove the parent part reference.
+        Part parentPart = getParentPart();
         if (null != parentPart) {
             Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {

--- a/MekHQ/src/mekhq/campaign/parts/Cubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/Cubicle.java
@@ -83,6 +83,9 @@ public class Cubicle extends Part {
 
     @Override
     public void remove(boolean salvage) {
+        // Grab a reference to our parent part so that we don't accidentally NRE
+        // when we remove the parent part reference.
+        Part parentPart = getParentPart();
         if (null != parentPart) {
             Part spare = campaign.getWarehouse().checkForExistingSparePart(this);
             if (!salvage) {

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -152,6 +152,10 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
             unit.removePart(this);
         }
         setUnit(null);
+
+        // Grab a reference to our parent part so that we don't accidentally NRE
+        // when we remove the parent part reference.
+        Part parentPart = getParentPart();
         if (null != parentPart) {
             parentPart.removeChildPart(this);
         }

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -96,6 +97,7 @@ public class WarehouseTest {
         // Create a mock part without an ID
         Part mockPart = mock(Part.class, RETURNS_DEEP_STUBS);
         when(mockPart.getId()).thenCallRealMethod();
+        when(mockPart.getChildParts()).thenReturn(Collections.emptyList());
         doCallRealMethod().when(mockPart).setId(anyInt());
 
         // Add the mock part to our warehouse

--- a/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
+++ b/MekHQ/unittests/mekhq/campaign/WarehouseTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -267,6 +268,49 @@ public class WarehouseTest {
                             .count());
 
             // And the three events should correlate to the child parts being removed
+            assertNotNull(eventSpy.findEvent(PartRemovedEvent.class, e -> mockParentPart == e.getPart()));
+            for (Part mockChildPart : mockChildParts) {
+                assertNotNull(eventSpy.findEvent(PartRemovedEvent.class, e -> mockChildPart == e.getPart()));
+            }
+        }
+    }
+
+    @Test
+    public void testWarehouseRemoveRecursiveChildParts() {
+        Warehouse warehouse = new Warehouse();
+
+        // Add a parent part to the warehouse
+        Part mockParentPart = createMockPart(1);
+        warehouse.addPart(mockParentPart);
+
+        // Create child parts for the parent part
+        List<Part> mockChildParts = new ArrayList<>();
+        mockChildParts.add(createMockPart(2));
+        mockChildParts.add(createMockPart(3));
+        Part mockRecursiveChildPart = createMockPart(4);
+        when(mockRecursiveChildPart.getChildParts()).thenReturn(Arrays.asList(new Part[] { mockParentPart }));
+        mockChildParts.add(mockRecursiveChildPart);
+        when(mockParentPart.getChildParts()).thenReturn(mockChildParts);
+
+        for (Part mockChildPart : mockChildParts) {
+            when(mockChildPart.getParentPart()).thenReturn(mockParentPart);
+            when(mockChildPart.hasParentPart()).thenReturn(true);
+
+            warehouse.addPart(mockChildPart);
+        }
+
+        try (EventSpy eventSpy = new EventSpy()) {
+            // Ensure we can then remove the part
+            assertTrue(warehouse.removePart(mockParentPart));
+
+            // There should be four events where we removed parts
+            assertEquals(4,
+                    eventSpy.getEvents()
+                            .stream()
+                            .filter(e -> e instanceof PartRemovedEvent)
+                            .count());
+
+            // And the four events should correlate to the child parts being removed
             assertNotNull(eventSpy.findEvent(PartRemovedEvent.class, e -> mockParentPart == e.getPart()));
             for (Part mockChildPart : mockChildParts) {
                 assertNotNull(eventSpy.findEvent(PartRemovedEvent.class, e -> mockChildPart == e.getPart()));


### PR DESCRIPTION
This fixes _the result of_ an interesting bug, namely that some Part-Child trees are actually cyclic graphs. I don't know why, just that it seems to happen. We've seen it with `getStickerPrice` on `BattleArmorSuit` and added logic to avoid following the cycles.

This fixes the symptoms of #2255 by:
1. Only recursing to remove child parts if we removed the parent part.
2. Breaking the parent-child relationship before we remove the child part.

This also cleans up CampaignXmlParser by having it use the basic logic within Warehouse to consolidate parts. Basically, after we post-process the parts and reach a stable set of parts to keep, we just load them into a brand new warehouse, which will merge any spares. The campaign then uses this new cleaned up warehouse, and we keep one set of tested logic to merge spare parts.

Separately I had to make changes to the `DataLoadingDialog` to even begin to test this problem, but that is another PR for another day.