### PR TITLE
Remove XPath/XQuery usage from AtBScenario CPNX load

### DIFF
--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -32,8 +32,6 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathFactory;
 
 import megamek.common.icons.Camouflage;
 import megamek.utils.MegaMekXmlUtil;
@@ -55,16 +53,6 @@ import megamek.common.Tank;
 
 public class MekHqXmlUtil extends MegaMekXmlUtil {
     private static DocumentBuilderFactory UNSAFE_DOCUMENT_BUILDER_FACTORY;
-    private static XPath XPATH_INSTANCE;
-
-    public static XPath getXPathInstance() {
-        if (XPATH_INSTANCE == null) {
-            XPathFactory xpf = XPathFactory.newInstance();
-            XPATH_INSTANCE = xpf.newXPath();
-        }
-
-        return XPATH_INSTANCE;
-    }
 
     /**
      * USE WITH CARE. Creates a DocumentBuilder safe from XML external entities


### PR DESCRIPTION
Removes usage of XPath/XQuery to improves performance of CPNX loads with transport linkages in AtB scenarios. A 15mb CPNX went from 13 secs to load transport linkages, to 4 secs to load the entire CPNX.