### PR TITLE
Bug: Ensure GM Acquire Instantly acquires the correct quantity

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
@@ -539,7 +539,11 @@ public class AcquisitionsDialog extends JDialog {
                         actualWork = ((AmmoBin) targetWork).getAcquisitionWork();
                     }
 
-                    campaignGUI.getCampaign().addReport(actualWork.find(0));
+                    // GM find the actual number required
+                    for (int count = 0; count < partCountInfo.getMissingCount(); ++count) {
+                        campaignGUI.getCampaign().addReport(actualWork.find(0));
+                    }
+
                     Unit unit = actualWork.getUnit();
                     if (unit != null) {
                         MekHQ.triggerEvent(new UnitChangedEvent(unit));


### PR DESCRIPTION
While research #1720 I noticed that _GM Acquire Instantly_ only found one of the part. This has it find the exact quantity that were missing.