### PR TITLE
Issue #2278: Ensure skill prefs are saved to the campaign on creation

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -4982,6 +4982,7 @@ public class CampaignOptionsDialog extends JDialog {
         rSkillPrefs.setSpecialAbilBonus(SkillType.EXP_REGULAR, (Integer) spnAbilReg.getModel().getValue());
         rSkillPrefs.setSpecialAbilBonus(SkillType.EXP_VETERAN, (Integer) spnAbilVet.getModel().getValue());
         rSkillPrefs.setSpecialAbilBonus(SkillType.EXP_ELITE, (Integer) spnAbilElite.getModel().getValue());
+        campaign.setRandomSkillPreferences(rSkillPrefs);
 
         for (int i = 0; i < phenotypeSpinners.length; i++) {
             options.setPhenotypeProbability(i, (Integer) phenotypeSpinners[i].getValue());


### PR DESCRIPTION
When we update the Random Skill Prefs there is logic to use any pre-existing options on a Campaign. However, once the Campaign is loaded the options are never saved back to the Campaign. Changes to the options made during the Campaign are persisted, but only because they are the same reference. This PR simply assigns the Campaign's `RandomSkillPreferences` property every time the options dialog updates the values, fixing #2278.