### PR TITLE
Issue #2280: GM Restore skips parts

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020 The Megamek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.unit.actions;
+
+import java.util.*;
+
+import megamek.common.*;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.event.UnitChangedEvent;
+import mekhq.campaign.parts.*;
+import mekhq.campaign.parts.equipment.*;
+import mekhq.campaign.unit.Unit;
+
+/**
+ * Restores a unit to an undamaged state.
+ */
+public class RestoreUnitAction implements IUnitAction {
+
+    @Override
+    public void execute(Campaign campaign, Unit unit) {
+        unit.setSalvage(false);
+
+        boolean needsCheck = true;
+        while (unit.isAvailable() && needsCheck) {
+            needsCheck = false;
+            List<Part> parts = new ArrayList<>(unit.getParts());
+            for (Part part : parts) {
+                if (part instanceof MissingPart) {
+                    //Make sure we restore both left and right thrusters
+                    if (part instanceof MissingThrusters) {
+                        if (((Aero) unit.getEntity()).getLeftThrustHits() > 0) {
+                            ((MissingThrusters) part).setLeftThrusters(true);
+                        }
+                    }
+                    // We magically acquire a replacement part, then fix the missing one.
+                    part.getCampaign().getQuartermaster().addPart(((MissingPart) part).getNewPart(), 0);
+                    part.fix();
+                    part.resetTimeSpent();
+                    part.resetOvertime();
+                    part.setTech(null);
+                    part.cancelReservation();
+                    part.remove(false);
+                    needsCheck = true;
+                } else {
+                    if (part.needsFixing()) {
+                        needsCheck = true;
+                        part.fix();
+                    } else {
+                        part.resetRepairSettings();
+                    }
+                    part.resetTimeSpent();
+                    part.resetOvertime();
+                    part.setTech(null);
+                    part.cancelReservation();
+                }
+
+                // replace damaged armor and reload ammo bins after fixing their respective locations
+                if (part instanceof Armor) {
+                    final Armor armor = (Armor) part;
+                    armor.setAmount(armor.getTotalAmount());
+                } else if (part instanceof AmmoBin) {
+                    final AmmoBin ammoBin = (AmmoBin) part;
+
+                    // we magically find the ammo we need, then load the bin
+                    // we only want to get the amount of ammo the bin actually needs
+                    if (ammoBin.getShotsNeeded() > 0) {
+                        ammoBin.setShotsNeeded(0);
+                        ammoBin.updateConditionFromPart();
+                    }
+                }
+
+            }
+
+            // TODO: Make this less painful. We just want to fix hips and shoulders.
+            Entity entity = unit.getEntity();
+            if (entity instanceof Mech) {
+                for (int loc : new int[] {
+                    Mech.LOC_CLEG, Mech.LOC_LLEG, Mech.LOC_RLEG, Mech.LOC_LARM, Mech.LOC_RARM}) {
+                    int numberOfCriticals = entity.getNumberOfCriticals(loc);
+                    for (int crit = 0; crit < numberOfCriticals; ++ crit) {
+                        CriticalSlot slot = entity.getCritical(loc, crit);
+                        if (null != slot) {
+                            slot.setHit(false);
+                            slot.setDestroyed(false);
+                        }
+                    }
+                }
+            }
+        }
+
+        MekHQ.triggerEvent(new UnitChangedEvent(unit));
+    }
+}

--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -51,7 +51,7 @@ public class RestoreUnitAction implements IUnitAction {
                         }
                     }
                     // We magically acquire a replacement part, then fix the missing one.
-                    part.getCampaign().getQuartermaster().addPart(((MissingPart) part).getNewPart(), 0);
+                    campaign.getQuartermaster().addPart(((MissingPart) part).getNewPart(), 0);
                     part.fix();
                     part.resetTimeSpent();
                     part.resetOvertime();

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -54,9 +54,6 @@ import mekhq.campaign.event.RepairStatusChangedEvent;
 import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.Transaction;
-import mekhq.campaign.parts.Armor;
-import mekhq.campaign.parts.MissingPart;
-import mekhq.campaign.parts.MissingThrusters;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.parts.equipment.AmmoBin;
@@ -68,6 +65,7 @@ import mekhq.campaign.unit.actions.CancelMothballUnitAction;
 import mekhq.campaign.unit.actions.HirePersonnelUnitAction;
 import mekhq.campaign.unit.actions.IUnitAction;
 import mekhq.campaign.unit.actions.MothballUnitAction;
+import mekhq.campaign.unit.actions.RestoreUnitAction;
 import mekhq.campaign.unit.actions.ShowUnitBvAction;
 import mekhq.campaign.unit.actions.StripUnitAction;
 import mekhq.gui.CampaignGUI;
@@ -464,77 +462,9 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionLi
             IUnitAction showUnitBvAction = new ShowUnitBvAction();
             showUnitBvAction.execute(gui.getCampaign(), selectedUnit);
         } else if (command.equals(COMMAND_RESTORE_UNIT)) {
-            for (Unit unit : units) {
-                unit.setSalvage(false);
-
-                boolean needsCheck = true;
-                while (unit.isAvailable() && needsCheck) {
-                    needsCheck = false;
-                    List<Part> parts = new ArrayList<>(unit.getParts());
-                    for (Part part : parts) {
-                        if (part instanceof MissingPart) {
-                            //Make sure we restore both left and right thrusters
-                            if (part instanceof MissingThrusters) {
-                                if (((Aero) unit.getEntity()).getLeftThrustHits() > 0) {
-                                    ((MissingThrusters) part).setLeftThrusters(true);
-                                }
-                            }
-                            // We magically acquire a replacement part, then fix the missing one.
-                            part.getCampaign().getQuartermaster().addPart(((MissingPart) part).getNewPart(), 0);
-                            part.fix();
-                            part.resetTimeSpent();
-                            part.resetOvertime();
-                            part.setTech(null);
-                            part.cancelReservation();
-                            part.remove(false);
-                            needsCheck = true;
-                        } else {
-                            if (part.needsFixing()) {
-                                needsCheck = true;
-                                part.fix();
-                            } else {
-                                part.resetRepairSettings();
-                            }
-                            part.resetTimeSpent();
-                            part.resetOvertime();
-                            part.setTech(null);
-                            part.cancelReservation();
-                        }
-
-                        // replace damaged armor and reload ammo bins after fixing their respective locations
-                        if (part instanceof Armor) {
-                            final Armor armor = (Armor) part;
-                            armor.setAmount(armor.getTotalAmount());
-                        } else if (part instanceof AmmoBin) {
-                            final AmmoBin ammoBin = (AmmoBin) part;
-
-                            // we magically find the ammo we need, then load the bin
-                            // we only want to get the amount of ammo the bin actually needs
-                            if (ammoBin.getShotsNeeded() > 0) {
-                                ammoBin.setShotsNeeded(0);
-                                ammoBin.updateConditionFromPart();
-                            }
-                        }
-
-                    }
-
-                    // TODO: Make this less painful. We just want to fix hips and shoulders.
-                    Entity entity = unit.getEntity();
-                    if (entity instanceof Mech) {
-                        for (int loc : new int[] {
-                            Mech.LOC_CLEG, Mech.LOC_LLEG, Mech.LOC_RLEG, Mech.LOC_LARM, Mech.LOC_RARM}) {
-                            int numberOfCriticals = entity.getNumberOfCriticals(loc);
-                            for (int crit = 0; crit < numberOfCriticals; ++ crit) {
-                                CriticalSlot slot = entity.getCritical(loc, crit);
-                                if (null != slot) {
-                                    slot.setHit(false);
-                                    slot.setDestroyed(false);
-                                }
-                            }
-                        }
-                    }
-                }
-                MekHQ.triggerEvent(new UnitChangedEvent(unit));
+            IUnitAction restoreUnitAction = new RestoreUnitAction();
+            for (Unit u : units) {
+                restoreUnitAction.execute(gui.getCampaign(), u);
             }
         } else if (command.equals(COMMAND_STRIP_UNIT)) {
             IUnitAction stripUnitAction = new StripUnitAction();

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -470,8 +470,8 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionLi
                 boolean needsCheck = true;
                 while (unit.isAvailable() && needsCheck) {
                     needsCheck = false;
-                    for (int x = 0; x < unit.getParts().size(); x++) {
-                        Part part = unit.getParts().get(x);
+                    List<Part> parts = new ArrayList<>(unit.getParts());
+                    for (Part part : parts) {
                         if (part instanceof MissingPart) {
                             //Make sure we restore both left and right thrusters
                             if (part instanceof MissingThrusters) {

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/RestoreUnitActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/RestoreUnitActionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.unit.actions;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.parts.MissingMekLocation;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.equipment.EquipmentPart;
+import mekhq.campaign.parts.equipment.MissingEquipmentPart;
+import mekhq.campaign.unit.Unit;
+
+import org.junit.Test;
+
+import megamek.common.Entity;
+
+public class RestoreUnitActionTest {
+    @Test
+    public void restoreUnitDoesNotSkipPartsAfterRepairingMissingParts() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        Entity mockEntity = mock(Entity.class);
+        Unit unit = new Unit(mockEntity, mockCampaign);
+
+        Part part0 = mock(Part.class);
+        when(part0.getUnit()).thenReturn(unit);
+        when(part0.getCampaign()).thenReturn(mockCampaign);
+        EquipmentPart part1 = mock(EquipmentPart.class);
+        when(part1.getUnit()).thenReturn(unit);
+        when(part1.getCampaign()).thenReturn(mockCampaign);
+        MissingMekLocation missing0 = mock(MissingMekLocation.class);
+        when(missing0.getUnit()).thenReturn(unit);
+        when(missing0.getCampaign()).thenReturn(mockCampaign);
+        doAnswer(inv -> {
+            // Simulate MissingPart::fix calling remove(false)
+            unit.removePart(missing0);
+            return null;
+        }).when(missing0).fix();
+        MissingEquipmentPart missing1 = mock(MissingEquipmentPart.class);
+        when(missing1.getUnit()).thenReturn(unit);
+        when(missing1.getCampaign()).thenReturn(mockCampaign);
+        doAnswer(inv -> {
+            // Simulate MissingPart::fix calling remove(false)
+            unit.removePart(missing1);
+            return null;
+        }).when(missing1).fix();
+
+        unit.addPart(part0);
+        unit.addPart(missing0);
+        unit.addPart(missing1);
+        unit.addPart(part1);
+
+        RestoreUnitAction action = new RestoreUnitAction();
+
+        action.execute(mockCampaign, unit);
+
+        verify(part0, atLeastOnce()).needsFixing();
+        verify(missing0, times(1)).fix();
+        verify(missing1, times(1)).fix();
+        verify(part1, atLeastOnce()).needsFixing();
+    }
+}


### PR DESCRIPTION
GM Restore was not making a copy of the parts list before iterating to restore the unit. When it encountered a missing part, the new part would be added and the missing part would be removed. Because the iteration was by index, whichever part was immediately after the missing part in the original list would assume the index of the missing part and it would be skipped. This fixes #2280 (found during investigation of #2266).

- The fix is in https://github.com/MegaMek/mekhq/commit/56659f62978edac307cf7ac0bf629de73a739e21
- The second commit just pulls this out of UnitTableMouseAdapter and puts it into its own file.
- The third commit tests for this bug