### PR TITLE
AbstractIcon: Null Protection for ImageIcons and Separating Dialogs out from the Choosers beneath

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -30,8 +30,8 @@ import java.util.stream.Collectors;
 import javax.swing.*;
 import javax.swing.event.MouseInputAdapter;
 
-import megamek.client.ui.swing.dialog.imageChooser.AbstractIconChooser;
-import megamek.client.ui.swing.dialog.imageChooser.PortraitChooser;
+import megamek.client.ui.swing.dialog.imageChooser.AbstractIconChooserDialog;
+import megamek.client.ui.swing.dialog.imageChooser.PortraitChooserDialog;
 import megamek.client.ui.swing.util.MenuScroller;
 import megamek.common.*;
 import megamek.common.options.IOption;
@@ -793,7 +793,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                 break;
             }
             case CMD_EDIT_PORTRAIT: {
-                AbstractIconChooser portraitDialog = new PortraitChooser(gui.getFrame(),
+                AbstractIconChooserDialog portraitDialog = new PortraitChooserDialog(gui.getFrame(),
                         selectedPerson.getPortrait());
                 int result = portraitDialog.showDialog();
                 if ((result == JOptionPane.OK_OPTION) && (portraitDialog.getSelectedItem() != null)) {

--- a/MekHQ/src/mekhq/gui/dialog/NewRecruitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewRecruitDialog.java
@@ -23,11 +23,10 @@ import java.util.ResourceBundle;
 import javax.swing.*;
 
 import megamek.client.generator.RandomNameGenerator;
-import megamek.client.ui.swing.dialog.imageChooser.AbstractIconChooser;
-import megamek.client.ui.swing.dialog.imageChooser.PortraitChooser;
+import megamek.client.ui.swing.dialog.imageChooser.AbstractIconChooserDialog;
+import megamek.client.ui.swing.dialog.imageChooser.PortraitChooserDialog;
 import megamek.common.enums.Gender;
 import megamek.common.util.EncodeControl;
-import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Ranks;
@@ -37,17 +36,15 @@ import mekhq.gui.view.PersonViewPanel;
 import mekhq.preferences.PreferencesNode;
 
 public class NewRecruitDialog extends javax.swing.JDialog {
-
     /**
      * This dialog is used to both hire new pilots and to edit existing ones
-     *
      */
     private static final long serialVersionUID = -6265589976779860566L;
     private Person person;
 
     private CampaignGUI hqView;
 
-    private javax.swing.JComboBox<String> choiceRanks;
+    private JComboBox<String> choiceRanks;
 
     private JScrollPane scrollView;
 
@@ -231,7 +228,7 @@ public class NewRecruitDialog extends javax.swing.JDialog {
     }
 
     private void choosePortrait() {
-        AbstractIconChooser portraitDialog = new PortraitChooser(hqView.getFrame(), person.getPortrait());
+        AbstractIconChooserDialog portraitDialog = new PortraitChooserDialog(hqView.getFrame(), person.getPortrait());
         int result = portraitDialog.showDialog();
         if ((result == JOptionPane.OK_OPTION) && (portraitDialog.getSelectedItem() != null)) {
             person.setPortrait(portraitDialog.getSelectedItem());


### PR DESCRIPTION
This is the MHQ-side of https://github.com/MegaMek/megamek/pull/2509 , and MUST be merged at the same time.