### PR TITLE
2287: Prisoner Filter Should Include Bondsmen

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -287,7 +287,7 @@ public enum PersonnelFilter {
             case FOUNDER:
                 return person.isFounder();
             case PRISONER:
-                return person.getPrisonerStatus().isPrisoner();
+                return person.getPrisonerStatus().isPrisoner() || person.getPrisonerStatus().isBondsman();
             case INACTIVE:
                 return !person.getStatus().isActive();
             case RETIRED:


### PR DESCRIPTION
This fixes #2287: Prisoner Filter now properly includes bondsmen.