### PR TITLE
Remove old migration code

### DIFF
--- a/MekHQ/src/mekhq/campaign/Kill.java
+++ b/MekHQ/src/mekhq/campaign/Kill.java
@@ -24,7 +24,6 @@ package mekhq.campaign;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.Map;
 import java.util.UUID;
 
 import org.w3c.dom.Node;
@@ -45,9 +44,6 @@ public class Kill implements Serializable {
     private LocalDate date;
     private String killed;
     private String killer;
-
-    //reverse compatibility
-    private int oldPilotId = -1;
 
     public Kill() {
     }
@@ -92,8 +88,6 @@ public class Kill implements Serializable {
     }
 
     public static Kill generateInstanceFromXML(Node wn, Version version) {
-        final String METHOD_NAME = "generateInstanceFromXML(Node,Version)";
-
         Kill retVal = null;
         try {
             retVal = new Kill();
@@ -104,13 +98,9 @@ public class Kill implements Serializable {
                 if (wn2.getNodeName().equalsIgnoreCase("killed")) {
                     retVal.killed = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("pilotId")) {
-                    if(version.getMajorVersion() == 0 && version.getMinorVersion() < 2 && version.getSnapshot() < 14) {
-                        retVal.oldPilotId = Integer.parseInt(wn2.getTextContent());
-                    } else {
-                        retVal.pilotId = UUID.fromString(wn2.getTextContent());
-                    }
+                    retVal.pilotId = UUID.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("killer")) {
-                    retVal.killer = (wn2.getTextContent());
+                    retVal.killer = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("date")) {
                     retVal.date = MekHqXmlUtil.parseDate(wn2.getTextContent().trim());
                 }
@@ -119,22 +109,18 @@ public class Kill implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(Kill.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(ex);
         }
         return retVal;
     }
 
     public void writeToXml(PrintWriter pw1, int indent) {
         MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent++, "kill");
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "pilotId", pilotId.toString());
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "pilotId", pilotId);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "killed", killed);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "killer", killer);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "date", MekHqXmlUtil.saveFormattedDate(date));
         MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, --indent, "kill");
-    }
-
-    public void fixIdReferences(Map<Integer, UUID> pHash) {
-        pilotId = pHash.get(oldPilotId);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -480,11 +480,7 @@ public class Force implements Serializable {
             NamedNodeMap attrs = wn2.getAttributes();
             Node classNameNode = attrs.getNamedItem("id");
             String idString = classNameNode.getTextContent();
-            if (version.getMajorVersion() == 0 && version.getMinorVersion() < 2 && version.getSnapshot() < 14) {
-                retVal.oldUnits.add(Integer.parseInt(idString));
-            } else {
-                retVal.addUnit(UUID.fromString(idString));
-            }
+            retVal.addUnit(UUID.fromString(idString));
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -594,7 +594,6 @@ public class CampaignXmlParser {
 
         String rankNames = null;
         int officerCut = 0;
-        int rankSystem = -1;
 
         // Okay, lets iterate through the children, eh?
         for (int x = 0; x < nl.getLength(); x++) {
@@ -727,10 +726,6 @@ public class CampaignXmlParser {
         if (null != rankNames) {
             //backwards compatibility
             retVal.getRanks().setRanksFromList(rankNames, officerCut);
-        }
-        if (rankSystem != -1) {
-            retVal.setRanks(Ranks.getRanksFromSystem(rankSystem));
-            retVal.getRanks().setOldRankSystem(rankSystem);
         }
 
         // TODO: this could probably be better

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -292,10 +292,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
         OTHER_RANSOM_VALUES.put(SkillType.EXP_ELITE, Money.of(50000));
     }
 
-    //region Reverse Compatibility
-    // Unknown version
-    private int oldId;
-    //endregion Reverse Compatibility
     //endregion Variable Declarations
 
     //region Constructors
@@ -1960,11 +1956,7 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("idleMonths")) {
                     retVal.idleMonths = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("id")) {
-                    if (version.getMajorVersion() == 0 && version.getMinorVersion() < 2 && version.getSnapshot() < 14) {
-                        retVal.oldId = Integer.parseInt(wn2.getTextContent());
-                    } else {
-                        retVal.id = UUID.fromString(wn2.getTextContent());
-                    }
+                    retVal.id = UUID.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("ancestors")) { // legacy - 0.47.6 removal
                     CampaignXmlParser.addToAncestryMigrationMap(UUID.fromString(wn2.getTextContent().trim()), retVal);
                 } else if (wn2.getNodeName().equalsIgnoreCase("spouse")) { // legacy - 0.47.6 removal
@@ -2181,72 +2173,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
             if (version.isLowerThan("0.47.5") && (retVal.getExpectedDueDate() == null)
                     && (retVal.getDueDate() != null)) {
                 retVal.setExpectedDueDate(retVal.getDueDate());
-            }
-
-            //versions before 0.3.4 did not have proper clan phenotypes
-            if (version.isLowerThan("0.3.4") && c.getFaction().isClan()) {
-                //assume personnel are clan and trueborn if the right role
-                retVal.setClanner(true);
-                switch (retVal.getPrimaryRole()) {
-                    case Person.T_MECHWARRIOR:
-                        retVal.setPhenotype(Phenotype.MECHWARRIOR);
-                        break;
-                    case Person.T_AERO_PILOT:
-                    case Person.T_CONV_PILOT:
-                        retVal.setPhenotype(Phenotype.AEROSPACE);
-                        break;
-                    case Person.T_BA:
-                        retVal.setPhenotype(Phenotype.ELEMENTAL);
-                        break;
-                    case Person.T_VEE_GUNNER:
-                    case Person.T_GVEE_DRIVER:
-                    case Person.T_NVEE_DRIVER:
-                    case Person.T_VTOL_PILOT:
-                        retVal.setPhenotype(Phenotype.VEHICLE);
-                        break;
-                    case Person.T_PROTO_PILOT:
-                        retVal.setPhenotype(Phenotype.PROTOMECH);
-                        break;
-                    default:
-                        retVal.setPhenotype(Phenotype.NONE);
-                        break;
-                }
-            }
-
-            if (version.getMajorVersion() == 0 && version.getMinorVersion() < 2 && version.getSnapshot() < 13) {
-                if (retVal.primaryRole > T_INFANTRY) {
-                    retVal.primaryRole += 4;
-
-                }
-                if (retVal.secondaryRole > T_INFANTRY) {
-                    retVal.secondaryRole += 4;
-                }
-            }
-
-            if (version.getMajorVersion() == 0 && version.getMinorVersion() == 2) {
-                //adjust for conventional fighter pilots
-                if (retVal.primaryRole >= T_CONV_PILOT) {
-                    retVal.primaryRole += 1;
-                }
-                if (retVal.secondaryRole >= T_CONV_PILOT) {
-                    retVal.secondaryRole += 1;
-                }
-            }
-
-            if (version.getMajorVersion() == 0 && version.getMinorVersion() == 3 && version.getSnapshot() < 1) {
-                //adjust for conventional fighter pilots
-                if (retVal.primaryRole == T_CONV_PILOT && retVal.hasSkill(SkillType.S_PILOT_SPACE) && !retVal.hasSkill(SkillType.S_PILOT_JET)) {
-                    retVal.primaryRole += 1;
-                }
-                if (retVal.secondaryRole == T_CONV_PILOT && retVal.hasSkill(SkillType.S_PILOT_SPACE) && !retVal.hasSkill(SkillType.S_PILOT_JET)) {
-                    retVal.secondaryRole += 1;
-                }
-                if (retVal.primaryRole == T_AERO_PILOT && !retVal.hasSkill(SkillType.S_PILOT_SPACE) && retVal.hasSkill(SkillType.S_PILOT_JET)) {
-                    retVal.primaryRole += 8;
-                }
-                if (retVal.secondaryRole == T_AERO_PILOT && !retVal.hasSkill(SkillType.S_PILOT_SPACE) && retVal.hasSkill(SkillType.S_PILOT_JET)) {
-                    retVal.secondaryRole += 8;
-                }
             }
 
             if ((null != advantages) && (advantages.trim().length() > 0)) {
@@ -3576,10 +3502,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
         for (Skill s : skills.getSkills()) {
             s.updateType();
         }
-    }
-
-    public int getOldId() {
-        return oldId;
     }
 
     public int getNTasks() {

--- a/MekHQ/src/mekhq/campaign/personnel/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillType.java
@@ -395,8 +395,6 @@ public class SkillType implements Serializable {
     }
 
     public static void generateInstanceFromXML(Node wn, Version version) {
-        final String METHOD_NAME = "generateInstanceFromXML(Node,Version)";
-
         try {
             SkillType retVal = new SkillType();
             NodeList nl = wn.getChildNodes();
@@ -425,20 +423,12 @@ public class SkillType implements Serializable {
                 }
             }
 
-            if (version.getMinorVersion() < 3) {
-                //need to change negotiation and scrounge to be countUp=false with
-                //TNs of 10
-                if (retVal.name.equals(SkillType.S_NEG) || retVal.name.equals(SkillType.S_SCROUNGE)) {
-                    retVal.countUp = false;
-                    retVal.target = 10;
-                }
-            }
             lookupHash.put(retVal.name, retVal);
         } catch (Exception ex) {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(SkillType.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(ex);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -329,8 +329,6 @@ public class SpecialAbility implements MekHqXmlSerializable {
 
     @SuppressWarnings("unchecked")
     public static void generateInstanceFromXML(Node wn, PilotOptions options, Version v) {
-        final String METHOD_NAME = "generateInstanceFromXML(Node,PilotOptions,Version)"; //$NON-NLS-1$
-
         try {
             SpecialAbility retVal = new SpecialAbility();
             NodeList nl = wn.getChildNodes();
@@ -381,14 +379,6 @@ public class SpecialAbility implements MekHqXmlSerializable {
                     retVal.desc = option.getDescription();
                 }
             }
-            if (v != null) {
-                if (defaultSpecialAbilities != null && v.isLowerThan("0.3.6-r1965")) {
-                    if (defaultSpecialAbilities.get(retVal.lookupName) != null
-                            && defaultSpecialAbilities.get(retVal.lookupName).getPrereqSkills() != null) {
-                        retVal.prereqSkills = (Vector<SkillPrereq>) defaultSpecialAbilities.get(retVal.lookupName).getPrereqSkills().clone();
-                    }
-                }
-            }
 
             if (wn.getNodeName().equalsIgnoreCase("edgetrigger")) {
                 edgeTriggers.put(retVal.lookupName, retVal);
@@ -401,7 +391,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(SpecialAbility.class, METHOD_NAME, ex);
+            MekHQ.getLogger().error(ex);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
@@ -25,7 +25,6 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.StringJoiner;
@@ -424,7 +423,6 @@ public class Ranks {
                     if (retVal.oldRankSystem == 7) {
                         showMessage = true;
                     }
-
                     if ((version == null) || (retVal.rankSystem == RS_CUSTOM)) {
                         retVal.ranks.add(Rank.generateInstanceFromXML(wn2));
                     } else {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -87,7 +87,6 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     private int site;
     private boolean salvaged;
     private UUID id;
-    private int oldId;
     private String fluffName;
     // This is the large craft assigned to transport this unit
     private TransportShipAssignment transportShipAssignment;
@@ -1870,11 +1869,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         Unit retVal = new Unit();
         NamedNodeMap attrs = wn.getAttributes();
         Node idNode = attrs.getNamedItem("id");
-        if (version.getMajorVersion() == 0 && version.getMinorVersion() < 2 && version.getSnapshot() < 14) {
-            retVal.oldId = Integer.parseInt(idNode.getTextContent());
-        } else {
-            retVal.id = UUID.fromString(idNode.getTextContent());
-        }
+
+        retVal.id = UUID.fromString(idNode.getTextContent());
 
         //Temp storage for used bay capacities
         boolean needsBayInitialization = true;
@@ -4644,10 +4640,6 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
     public Person getEngineer() {
         return engineer;
-    }
-
-    public int getOldId() {
-        return oldId;
     }
 
     public Part getPartForEquipmentNum(int index, int loc) {


### PR DESCRIPTION
This removes all migration code older than the 0.4X series. Right now the remaining migrations are pretty generous and captures all of the relevant migrations in that series. Migrations from 0.2.X or 0.3.X would require using 0.46.1, then moving to 0.48+.

This is also pretty conservative, in that I did not remove any of the code in the XML parser that "upgraded" certain types of old parts to their newer variants. I wasn't quite sure what versions they came from so I erred on the side of safety. Once 0.48 lands I'll work to remove those as well.

Going forward, I believe the strategy offered by @neoancient should be adopted: _we support upgrading from the N-1 stable version._ That would capture all of the relevant upgrades without much of a burden for folks lagging behind (for whatever reason).