### PR TITLE
Issue #2266: For LAMs check Landing Gear and Avionics when considering repairable slots

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingAvionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingAvionics.java
@@ -30,6 +30,7 @@ import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.Jumpship;
 import megamek.common.LandAirMech;
+import megamek.common.Mech;
 import megamek.common.TechAdvancement;
 import mekhq.campaign.Campaign;
 
@@ -75,6 +76,24 @@ public class MissingAvionics extends MissingPart {
 
     @Override
     public String checkFixable() {
+        if ((unit != null) && (unit.getEntity() instanceof LandAirMech)) {
+            // Avionics are installed in the Head and both Torsos,
+            // make sure they're not missing.
+            for (Part part : unit.getParts()) {
+                if (part instanceof MissingMekLocation) {
+                    switch (part.getLocation()) {
+                        case Mech.LOC_HEAD:
+                            return "Cannot reinstall avionics with a missing Head.";
+                        case Mech.LOC_LT:
+                            return "Cannot reinstall avionics with a missing Left Torso.";
+                        case Mech.LOC_RT:
+                            return "Cannot reinstall avionics with a missing Right Torso.";
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
         return null;
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/MissingLandingGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingLandingGear.java
@@ -28,6 +28,7 @@ import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.Jumpship;
 import megamek.common.LandAirMech;
+import megamek.common.Mech;
 import megamek.common.TechAdvancement;
 import mekhq.campaign.Campaign;
 
@@ -75,6 +76,23 @@ public class MissingLandingGear extends MissingPart {
 
     @Override
     public String checkFixable() {
+        if ((unit != null) && (unit.getEntity() instanceof LandAirMech)) {
+            // Landing Gear is installed in the CT and both Side Torsos,
+            // make sure they're not missing.
+            for (Part part : unit.getParts()) {
+                if (part instanceof MissingMekLocation) {
+                    // The CT cannot be scrapped, so that check is elided.
+                    switch (part.getLocation()) {
+                        case Mech.LOC_LT:
+                            return "Cannot reinstall landing gear with a missing Left Torso.";
+                        case Mech.LOC_RT:
+                            return "Cannot reinstall landing gear with a missing Right Torso.";
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
         return null;
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import megamek.common.CriticalSlot;
 import megamek.common.EquipmentType;
 import megamek.common.IArmorState;
+import megamek.common.LandAirMech;
 import megamek.common.Mech;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
@@ -241,10 +242,29 @@ public class MissingMekLocation extends MissingPart {
             }
 
             //certain other specific crits need to be left out (uggh, must be a better way to do this!)
-            if (slot.getType() == CriticalSlot.TYPE_SYSTEM
-                    && (slot.getIndex() == Mech.ACTUATOR_HIP
-                          || slot.getIndex() == Mech.ACTUATOR_SHOULDER)) {
-                continue;
+            if (slot.getType() == CriticalSlot.TYPE_SYSTEM) {
+                // Skip Hip and Shoulder actuators
+                if ((slot.getIndex() == Mech.ACTUATOR_HIP
+                        || slot.getIndex() == Mech.ACTUATOR_SHOULDER)) {
+                    continue;
+                }
+                if (unit.getEntity() instanceof LandAirMech) {
+                    // Skip Landing Gear if already gone
+                    if (slot.getIndex() == LandAirMech.LAM_LANDING_GEAR) {
+                        if (unit.findPart(p -> p instanceof MissingLandingGear) != null) {
+                            continue;
+                        } else {
+                            return "Landing gear in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first. They can then be re-installed.";
+                        }
+                    // Skip Avionics if already gone
+                    } else if (slot.getIndex() == LandAirMech.LAM_AVIONICS) {
+                        if (unit.findPart(p -> p instanceof MissingAvionics) != null) {
+                            continue;
+                        } else {
+                            return "Avionics in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first. They can then be re-installed.";
+                        }
+                    }
+                }
             }
             if (slot.isRepairable()) {
                 return "Repairable parts in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first. They can then be re-installed.";
@@ -353,7 +373,6 @@ public class MissingMekLocation extends MissingPart {
     public TechAdvancement getTechAdvancement() {
         return EquipmentType.getStructureTechAdvancement(structureType, clan);
     }
-
 
     @Override
     public PartRepairType getMassRepairOptionType() {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -24,6 +24,7 @@ package mekhq.campaign.unit;
 import java.io.PrintWriter;
 import java.math.BigInteger;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import megamek.common.*;
@@ -3224,6 +3225,21 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
     public List<Part> getParts() {
         return parts;
+    }
+
+    /**
+     * Find a part on a unit.
+     * @param predicate A predicate to apply to each part on the unit.
+     * @return The first part which matched the predicate, otherwise null.
+     */
+    public @Nullable Part findPart(Predicate<Part> predicate) {
+        for (Part part : parts) {
+            if (predicate.test(part)) {
+                return part;
+            }
+        }
+
+        return null;
     }
 
     public void setParts(ArrayList<Part> newParts) {

--- a/MekHQ/unittests/mekhq/campaign/parts/MissingAvionicsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MissingAvionicsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import megamek.common.LandAirMech;
+import megamek.common.Mech;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+
+public class MissingAvionicsTest {
+    @Test
+    public void missingLAMAvionicsRepairableOnlyWithBothTorsosAndHead() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+        LandAirMech entity = mock(LandAirMech.class);
+        when(unit.getEntity()).thenReturn(entity);
+        when(entity.getWeight()).thenReturn(30.0);
+        doCallRealMethod().when(entity).getLocationName(any());
+
+        MissingAvionics missing = new MissingAvionics(30, mockCampaign);
+        missing.setUnit(unit);
+
+        final MissingMekLocation rightTorso = mock(MissingMekLocation.class);
+        when(rightTorso.getLocation()).thenReturn(Mech.LOC_RT);
+
+        final MissingMekLocation leftTorso = mock(MissingMekLocation.class);
+        when(leftTorso.getLocation()).thenReturn(Mech.LOC_LT);
+
+        final MissingMekLocation head = mock(MissingMekLocation.class);
+        when(head.getLocation()).thenReturn(Mech.LOC_HEAD);
+
+        // No missing parts
+        when(unit.getParts()).thenReturn(new ArrayList<>());
+
+        // We can repair the avionics if both torsos and head are available
+        assertNull(missing.checkFixable());
+
+        // Missing both side torsos and head
+        when(unit.getParts()).thenReturn(Arrays.asList(rightTorso, head, leftTorso));
+
+        // We cannot repair the avionics
+        assertNotNull(missing.checkFixable());
+
+        // Only missing the head
+        when(unit.getParts()).thenReturn(Arrays.asList(head));
+
+        // We cannot repair the avionics
+        assertNotNull(missing.checkFixable());
+
+        // Only missing the left torso
+        when(unit.getParts()).thenReturn(Arrays.asList(leftTorso));
+
+        // We cannot repair the avionics
+        assertNotNull(missing.checkFixable());
+
+        // Only missing the right torso
+        when(unit.getParts()).thenReturn(Arrays.asList(rightTorso));
+
+        // We cannot repair the avionics
+        assertNotNull(missing.checkFixable());
+
+        // Missing an arm
+        final MissingMekLocation arm = mock(MissingMekLocation.class);
+        when(arm.getLocation()).thenReturn(Mech.LOC_RARM);
+        when(unit.getParts()).thenReturn(Arrays.asList(arm));
+
+        // We CAN repair the avionics with just a missing arm
+        assertNull(missing.checkFixable());
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/MissingLandingGearTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MissingLandingGearTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import megamek.common.LandAirMech;
+import megamek.common.Mech;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+
+public class MissingLandingGearTest {
+    @Test
+    public void missingLAMLandingGearRepairableOnlyWithBothTorsos() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+        LandAirMech entity = mock(LandAirMech.class);
+        when(unit.getEntity()).thenReturn(entity);
+        when(entity.getWeight()).thenReturn(30.0);
+        doCallRealMethod().when(entity).getLocationName(any());
+
+        MissingLandingGear missing = new MissingLandingGear(30, mockCampaign);
+        missing.setUnit(unit);
+
+        final MissingMekLocation rightTorso = mock(MissingMekLocation.class);
+        when(rightTorso.getLocation()).thenReturn(Mech.LOC_RT);
+
+        final MissingMekLocation leftTorso = mock(MissingMekLocation.class);
+        when(leftTorso.getLocation()).thenReturn(Mech.LOC_LT);
+
+        // No missing parts
+        when(unit.getParts()).thenReturn(new ArrayList<>());
+
+        // We can repair the landing gear if both torsos are available
+        assertNull(missing.checkFixable());
+
+        // Missing both side torsos
+        when(unit.getParts()).thenReturn(Arrays.asList(rightTorso, leftTorso));
+
+        // We cannot repair the landing gear
+        assertNotNull(missing.checkFixable());
+
+        // Only missing the left torso
+        when(unit.getParts()).thenReturn(Arrays.asList(leftTorso));
+
+        // We cannot repair the landing gear
+        assertNotNull(missing.checkFixable());
+
+        // Only missing the right torso
+        when(unit.getParts()).thenReturn(Arrays.asList(rightTorso));
+
+        // We cannot repair the landing gear
+        assertNotNull(missing.checkFixable());
+
+        // Missing an arm
+        final MissingMekLocation arm = mock(MissingMekLocation.class);
+        when(arm.getLocation()).thenReturn(Mech.LOC_RARM);
+        when(unit.getParts()).thenReturn(Arrays.asList(arm));
+
+        // We CAN repair the landing gear with just a missing arm
+        assertNull(missing.checkFixable());
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/MissingMekLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MissingMekLocationTest.java
@@ -1,0 +1,131 @@
+package mekhq.campaign.parts;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import megamek.common.CriticalSlot;
+import megamek.common.LandAirMech;
+import megamek.common.Mech;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+
+public class MissingMekLocationTest {
+    @Test
+    public void missingLAMTorsoRepairableOnlyWithMissingAvionicsAndLandingGear() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+        LandAirMech entity = mock(LandAirMech.class);
+        when(unit.getEntity()).thenReturn(entity);
+        when(entity.getWeight()).thenReturn(30.0);
+        doCallRealMethod().when(entity).getLocationName(any());
+
+        int location = Mech.LOC_RT;
+        MissingMekLocation missing = new MissingMekLocation(location, 30, 0, false, false, false, mockCampaign);
+        missing.setUnit(unit);
+
+        // 2 criticals
+        doReturn(2).when(entity).getNumberOfCriticals(eq(location));
+        CriticalSlot mockLandingGear = mock(CriticalSlot.class);
+        when(mockLandingGear.isEverHittable()).thenReturn(true);
+        when(mockLandingGear.getType()).thenReturn(CriticalSlot.TYPE_SYSTEM);
+        when(mockLandingGear.getIndex()).thenReturn(LandAirMech.LAM_LANDING_GEAR);
+        doReturn(mockLandingGear).when(entity).getCritical(eq(location), eq(0));
+        CriticalSlot mockAvionics = mock(CriticalSlot.class);
+        when(mockAvionics.isEverHittable()).thenReturn(true);
+        when(mockAvionics.getType()).thenReturn(CriticalSlot.TYPE_SYSTEM);
+        when(mockAvionics.getIndex()).thenReturn(LandAirMech.LAM_AVIONICS);
+        doReturn(mockAvionics).when(entity).getCritical(eq(location), eq(1));
+
+        // No missing parts
+        doAnswer(inv -> {
+            return null;
+        }).when(unit).findPart(any());
+
+        // We cannot repair this torso
+        assertNotNull(missing.checkFixable());
+
+        // Only missing landing gear, avionics are still good
+        doAnswer(inv -> {
+            Predicate<Part> predicate = inv.getArgument(0);
+            MissingLandingGear missingLandingGear = mock(MissingLandingGear.class);
+            return predicate.test(missingLandingGear) ? missingLandingGear : null;
+        }).when(unit).findPart(any());
+
+        // We cannot repair this torso
+        assertNotNull(missing.checkFixable());
+
+        // Only missing avionics, landing gear is still good
+        doAnswer(inv -> {
+            Predicate<Part> predicate = inv.getArgument(0);
+            MissingAvionics missingAvionics = mock(MissingAvionics.class);
+            return predicate.test(missingAvionics) ? missingAvionics : null;
+        }).when(unit).findPart(any());
+
+        // We cannot repair this torso
+        assertNotNull(missing.checkFixable());
+
+        // Missing both Landing Gear and Avionics
+        doAnswer(inv -> {
+            Predicate<Part> predicate = inv.getArgument(0);
+            MissingLandingGear missingLandingGear = mock(MissingLandingGear.class);
+            if (predicate.test(missingLandingGear)) {
+                return missingLandingGear;
+            }
+
+            MissingAvionics missingAvionics = mock(MissingAvionics.class);
+            return predicate.test(missingAvionics) ? missingAvionics : null;
+        }).when(unit).findPart(any());
+
+        // We CAN repair this torso
+        assertNull(missing.checkFixable());
+    }
+
+    @Test
+    public void missingLAMHeadRepairableOnlyWithMissingAvionics() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+        LandAirMech entity = mock(LandAirMech.class);
+        when(unit.getEntity()).thenReturn(entity);
+        when(entity.getWeight()).thenReturn(30.0);
+        doCallRealMethod().when(entity).getLocationName(any());
+
+        int location = Mech.LOC_HEAD;
+        MissingMekLocation missing = new MissingMekLocation(location, 30, 0, false, false, false, mockCampaign);
+        missing.setUnit(unit);
+
+        // 1 critical
+        doReturn(1).when(entity).getNumberOfCriticals(eq(location));
+        CriticalSlot mockAvionics = mock(CriticalSlot.class);
+        when(mockAvionics.isEverHittable()).thenReturn(true);
+        when(mockAvionics.getType()).thenReturn(CriticalSlot.TYPE_SYSTEM);
+        when(mockAvionics.getIndex()).thenReturn(LandAirMech.LAM_AVIONICS);
+        doReturn(mockAvionics).when(entity).getCritical(eq(location), eq(0));
+
+        // No missing parts
+        doAnswer(inv -> {
+            return null;
+        }).when(unit).findPart(any());
+
+        // We cannot repair this head
+        assertNotNull(missing.checkFixable());
+
+        // Missing avionics
+        doAnswer(inv -> {
+            Predicate<Part> predicate = inv.getArgument(0);
+            MissingLandingGear missingLandingGear = mock(MissingLandingGear.class);
+            if (predicate.test(missingLandingGear)) {
+                return missingLandingGear;
+            }
+
+            MissingAvionics missingAvionics = mock(MissingAvionics.class);
+            return predicate.test(missingAvionics) ? missingAvionics : null;
+        }).when(unit).findPart(any());
+
+        // We CAN repair this head
+        assertNull(missing.checkFixable());
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/MissingMekLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MissingMekLocationTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package mekhq.campaign.parts;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
This adds checks for Landing Gear and Avionics on LAMs when trying to fix missing parts. This fixes #2266.

I handle the following situations in this PR:
- Missing HD, RT, or LT: ensure that Avionics and Landing Gear (RT/LT only) have been removed first before replacing.
- Missing Avionics: ensure that the HD, RT, and LT are all present before replacing.
- Missing Landing Gear: ensure that the RT and LT are present before replacing.

TODO:
- [x] Unit tests

Missing RT and working Landing Gear:
![image](https://user-images.githubusercontent.com/8238690/102271492-7c638400-3eed-11eb-993e-189da07d7fd5.png)
![image](https://user-images.githubusercontent.com/8238690/102271993-13304080-3eee-11eb-875b-d42788abe625.png)

Missing RT, missing Landing Gear, missing Avionics:
![image](https://user-images.githubusercontent.com/8238690/102272504-dadd3200-3eee-11eb-8bb7-9b68dcf17882.png)
![image](https://user-images.githubusercontent.com/8238690/102272520-e16ba980-3eee-11eb-90ee-858eee3a4f5c.png)

Replaced RT:
![image](https://user-images.githubusercontent.com/8238690/102272561-f21c1f80-3eee-11eb-98b9-d875a50aa5b0.png)
