### PR TITLE
Issues #2296 #2299: Support older campaign dropship and jumpship ammo bin sizes in XML file

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -187,7 +187,10 @@ public class LargeCraftAmmoBin extends AmmoBin {
 
         for (int x=0; x<nl.getLength(); x++) {
             Node wn2 = nl.item(x);
-            if (wn2.getNodeName().equalsIgnoreCase("bayEqNum")) {
+            // CAW: campaigns prior to 0.47.15 stored `size` in `capacity`
+            if (wn2.getNodeName().equalsIgnoreCase("capacity")) {
+                size = Double.parseDouble(wn2.getTextContent().trim());
+            } else if (wn2.getNodeName().equalsIgnoreCase("bayEqNum")) {
                 bayEqNum = Integer.parseInt(wn2.getTextContent());
             }
         }


### PR DESCRIPTION
When consolidating logic shared between ammo bins and other equipment parts, I missed that we renamed `size` to `capacity` in `LargeCraftAmmoBin`. This causes campaigns older than 0.47.15 to be loaded with zero ton ammo bins that you cannot refill with ammo. This adds back support for loading LargeCraftAmmoBin's older than 0.47.15.

Fixes #2296.
Fixes #2299.