### PR TITLE
2270: Scenarios Respect Sort Order

### DIFF
--- a/MekHQ/resources/mekhq/resources/ScenarioTableModel.properties
+++ b/MekHQ/resources/mekhq/resources/ScenarioTableModel.properties
@@ -1,0 +1,5 @@
+col_name.text=Scenario Name
+col_status.text=Resolution
+col_date.text=Date
+col_assign.text=Units Assigned
+col_unknown.text=?

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1136,14 +1136,13 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
             }
             int row = personnelTable.getSelectedRow();
             boolean oneSelected = personnelTable.getSelectedRowCount() == 1;
-            Person person = personnelModel.getPerson(personnelTable
-                    .convertRowIndexToModel(row));
+            Person person = personnelModel.getPerson(personnelTable.convertRowIndexToModel(row));
             JMenuItem menuItem;
             JMenu menu;
             JMenu submenu;
             JCheckBoxMenuItem cbMenuItem;
             Person[] selected = getSelectedPeople();
-            // **lets fill the pop up menu**//
+            // lets fill the pop up menu
             if (StaticChecks.areAllEligible(selected, true)) {
                 menu = new JMenu(resourceMap.getString("changeRank.text"));
                 Ranks ranks = person.getRanks();
@@ -1151,8 +1150,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                     Rank rank = ranks.getAllRanks().get(rankOrder);
                     int profession = person.getProfession();
 
-                    // Empty professions need swapped before the
-                    // continuation
+                    // Empty professions need swapped before the continuation
                     while (ranks.isEmptyProfession(profession) && (profession != Ranks.RPROF_MW)) {
                         profession = ranks.getAlternateProfession(profession);
                     }

--- a/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright (c) 2014-2020 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
 package mekhq.gui.adapter;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 
-import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
@@ -20,39 +35,18 @@ import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.CustomizeScenarioDialog;
 import mekhq.gui.model.ScenarioTableModel;
 
-public class ScenarioTableMouseAdapter extends MouseInputAdapter implements
-        ActionListener {
-
+public class ScenarioTableMouseAdapter extends MouseInputAdapter {
+    //region Variable Declarations
     private CampaignGUI gui;
     private JTable scenarioTable;
     private ScenarioTableModel scenarioModel;
+    //endregion Variable Declarations
 
-    public ScenarioTableMouseAdapter(CampaignGUI gui, JTable scenarioTable,
-            ScenarioTableModel scenarioModel) {
+    public ScenarioTableMouseAdapter(CampaignGUI gui, JTable scenarioTable, ScenarioTableModel scenarioModel) {
         super();
         this.gui = gui;
         this.scenarioTable = scenarioTable;
         this.scenarioModel = scenarioModel;
-    }
-
-    public void actionPerformed(ActionEvent action) {
-        String command = action.getActionCommand();
-        Scenario scenario = scenarioModel.getScenario(scenarioTable.getSelectedRow());
-        if (command.equalsIgnoreCase("EDIT")) {
-            Mission mission = gui.getCampaign().getMission(scenario.getMissionId());
-            if (null != mission) {
-                CustomizeScenarioDialog csd = new CustomizeScenarioDialog(
-                    gui.getFrame(), true, scenario, mission, gui.getCampaign());
-                csd.setVisible(true);
-                MekHQ.triggerEvent(new ScenarioChangedEvent(scenario));
-            }
-        } else if (command.equalsIgnoreCase("REMOVE")) {
-            if (0 == JOptionPane.showConfirmDialog(null,
-                    "Do you really want to delete the scenario?",
-                    "Delete Scenario?", JOptionPane.YES_NO_OPTION)) {
-                gui.getCampaign().removeScenario(scenario.getId());
-            }
-        }
     }
 
     @Override
@@ -67,36 +61,52 @@ public class ScenarioTableMouseAdapter extends MouseInputAdapter implements
 
     private void maybeShowPopup(MouseEvent e) {
         JPopupMenu popup = new JPopupMenu();
-        if (e.isPopupTrigger()) {
+        if (e.isPopupTrigger() && (scenarioTable.getSelectedRowCount() > 0)) {
             int row = scenarioTable.getSelectedRow();
             if (row < 0) {
                 return;
             }
-            @SuppressWarnings("unused")
-            // FIXME
             Scenario scenario = scenarioModel.getScenario(row);
-            JMenuItem menuItem = null;
-            JMenu menu = null;
-            @SuppressWarnings("unused")
-            // Placeholder for future expansion
-            JCheckBoxMenuItem cbMenuItem = null;
-            // **lets fill the pop up menu**//
+            JMenuItem menuItem;
+            JMenu menu;
+
+            // lets fill the pop up menu
             menuItem = new JMenuItem("Edit...");
-            menuItem.setActionCommand("EDIT");
-            menuItem.addActionListener(this);
+            menuItem.addActionListener(evt -> editScenario(scenario));
             popup.add(menuItem);
-            // GM mode
-            menu = new JMenu("GM Mode");
-            // remove scenario
-            menuItem = new JMenuItem("Remove Scenario");
-            menuItem.setActionCommand("REMOVE");
-            menuItem.addActionListener(this);
-            menuItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(menuItem);
-            // end
-            popup.addSeparator();
-            popup.add(menu);
+
+            //region GM mode
+            if (gui.getCampaign().isGM()) {
+                popup.addSeparator();
+
+                menu = new JMenu("GM Mode");
+                // remove scenario
+                menuItem = new JMenuItem("Remove Scenario");
+                menuItem.addActionListener(evt -> removeScenario(scenario));
+                menu.add(menuItem);
+
+                popup.add(menu);
+            }
+
             popup.show(e.getComponent(), e.getX(), e.getY());
+        }
+    }
+
+    private void editScenario(Scenario scenario) {
+        Mission mission = gui.getCampaign().getMission(scenario.getMissionId());
+        if (mission != null) {
+            CustomizeScenarioDialog csd = new CustomizeScenarioDialog(gui.getFrame(), true,
+                    scenario, mission, gui.getCampaign());
+            csd.setVisible(true);
+            MekHQ.triggerEvent(new ScenarioChangedEvent(scenario));
+        }
+    }
+
+    private void removeScenario(Scenario scenario) {
+        if (0 == JOptionPane.showConfirmDialog(null,
+                "Do you really want to delete the scenario?",
+                "Delete Scenario?", JOptionPane.YES_NO_OPTION)) {
+            gui.getCampaign().removeScenario(scenario.getId());
         }
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
@@ -66,7 +66,7 @@ public class ScenarioTableMouseAdapter extends MouseInputAdapter {
             if (row < 0) {
                 return;
             }
-            Scenario scenario = scenarioModel.getScenario(row);
+            Scenario scenario = scenarioModel.getScenario(scenarioTable.convertRowIndexToModel(row));
             JMenuItem menuItem;
             JMenu menu;
 

--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -325,18 +325,8 @@ public class PersonnelTableModel extends DataTableModel {
         }
     }
 
-    @Override
-    public Class<?> getColumnClass(int c) {
-        return getValueAt(0, c).getClass();
-    }
-
-    @Override
-    public boolean isCellEditable(int row, int col) {
-        return false;
-    }
-
     public Person getPerson(int i) {
-        return (i < data.size()) ? (Person) data.get(i) : null;
+        return (i < getRowCount()) ? (Person) data.get(i) : null;
     }
 
     public boolean isDeployed(int row) {
@@ -345,13 +335,13 @@ public class PersonnelTableModel extends DataTableModel {
 
     @Override
     public Object getValueAt(int row, int col) {
-        Person p;
         if (data.isEmpty()) {
             return "";
-        } else {
-            p = getPerson(row);
         }
-
+        Person p = getPerson(row);
+        if (p == null) {
+            return "?";
+        }
         String toReturn = "";
 
         switch (col) {

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -19,9 +19,11 @@
 package mekhq.gui.model;
 
 import java.util.ArrayList;
+import java.util.ResourceBundle;
 
 import javax.swing.SwingConstants;
 
+import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Scenario;
@@ -30,6 +32,7 @@ import mekhq.campaign.mission.Scenario;
  * A table model for displaying scenarios
  */
 public class ScenarioTableModel extends DataTableModel {
+    //region Variable Declarations
     private static final long serialVersionUID = 534443424190075264L;
 
     private Campaign campaign;
@@ -38,11 +41,37 @@ public class ScenarioTableModel extends DataTableModel {
     public final static int COL_STATUS     = 1;
     public final static int COL_DATE       = 2;
     public final static int COL_ASSIGN     = 3;
+    public final static int N_COL          = 4;
 
+    private ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.ScenarioTableModel", new EncodeControl());
+    //endregion Variable Declarations
+
+    //region Constructors
     public ScenarioTableModel(Campaign c) {
-        columnNames = new String[] { "Scenario Name", "Resolution", "Date", "# Units Assigned" };
         data = new ArrayList<Scenario>();
         campaign = c;
+    }
+    //endregion Constructors
+
+    @Override
+    public int getColumnCount() {
+        return N_COL;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        switch (column) {
+            case COL_NAME:
+                return resources.getString("col_name.text");
+            case COL_STATUS:
+                return resources.getString("col_status.text");
+            case COL_DATE:
+                return resources.getString("col_date.text");
+            case COL_ASSIGN:
+                return resources.getString("col_assign.text");
+            default:
+                return resources.getString("col_unknown.text");
+        }
     }
 
     public int getColumnWidth(int c) {
@@ -65,11 +94,7 @@ public class ScenarioTableModel extends DataTableModel {
     }
 
     public Scenario getScenario(int row) {
-        if (row >= getRowCount()) {
-            return null;
-        } else {
-            return (Scenario) data.get(row);
-        }
+        return (row < getRowCount()) ? (Scenario) data.get(row) : null;
     }
 
     @Override


### PR DESCRIPTION
This fixes #2270.

The first commit cleans up the scenario table mouse adapter and some minor related things in the Personnel and Scenario Tables, the second fixes the bug.