### PR TITLE
Add EquipmentPart unit tests

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -35,6 +35,7 @@ import megamek.common.annotations.Nullable;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.equipment.EquipmentPart;
+import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.work.IAcquisitionWork;
 
@@ -184,7 +185,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
     @Override
-    public MissingPart getMissingPart() {
+    public MissingEquipmentPart getMissingPart() {
         //nothing to do here
         return null;
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -28,6 +28,7 @@ import megamek.common.TargetRoll;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.WorkTime;
 
@@ -146,16 +147,19 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
 
     @Override
     public void remove(boolean salvage) {
+        final Unit unit = getUnit();
+
         campaign.getWarehouse().removePart(this);
-        if(null != unit) {
+        if (unit != null) {
             unit.removePart(this);
         }
+
         setUnit(null);
 
         // Grab a reference to our parent part so that we don't accidentally NRE
         // when we remove the parent part reference.
         Part parentPart = getParentPart();
-        if (null != parentPart) {
+        if (parentPart != null) {
             parentPart.removeChildPart(this);
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -404,8 +404,23 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
         return toReturn;
     }
 
+    /**
+     * Gets the number of hits on the part.
+     */
     public int getHits() {
         return hits;
+    }
+
+    /**
+     * Sets the number of hits on the part.
+     * 
+     * NOTE: It is the caller's responsibilty to update the condition
+     * of the part and any attached unit.
+     * 
+     * @param hits The number of hits on the part.
+     */
+    public void setHits(int hits) {
+        this.hits = Math.max(hits, 0);
     }
 
     public String getDesc() {
@@ -1074,7 +1089,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     @Override
     public void fix() {
-        hits = 0;
+        setHits(0);
         resetRepairSettings();
     }
 
@@ -1396,7 +1411,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
     }
 
     public void doMaintenanceDamage(int d) {
-        hits += d;
+        setHits(getHits() + d);
         updateConditionFromPart();
         updateConditionFromEntity(false);
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -286,6 +286,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
      * @return The {@code Mounted} or {@code null} if no valid
      *         piece of equipment exists on the {@code Unit}.
      */
+    @Override
     protected @Nullable Mounted getMounted() {
         if ((getUnit() != null) && (getUnit().getEntity() != null)) {
             Mounted mounted = getUnit().getEntity().getEquipment(getEquipmentNum());

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
@@ -223,7 +223,7 @@ public class BattleArmorEquipmentPart extends EquipmentPart {
 	}
 
     @Override
-    public MissingPart getMissingPart() {
+    public MissingBattleArmorEquipmentPart getMissingPart() {
         return new MissingBattleArmorEquipmentPart(getUnitTonnage(), type, equipmentNum, size, trooper,
                 campaign, equipTonnage);
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -2,6 +2,7 @@
  * EquipmentPart.java
  *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
+ * Copyright (C) 2020 MegaMek team
  *
  * This file is part of MekHQ.
  *
@@ -34,11 +35,11 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.TechAdvancement;
 import megamek.common.WeaponType;
+import megamek.common.annotations.Nullable;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
 
@@ -76,7 +77,7 @@ public class EquipmentPart extends Part {
     }
 
     public EquipmentPart() {
-        this(0, null, -1, 1.0, false, null);
+        this(0, null, Entity.LOC_NONE, 1.0, false, null);
     }
 
     public EquipmentPart(int tonnage, EquipmentType et, int equipNum, double size, Campaign c) {
@@ -92,6 +93,7 @@ public class EquipmentPart extends Part {
         }
 
         this.equipmentNum = equipNum;
+        this.size = size;
 
         if (null != type) {
             try {
@@ -117,9 +119,7 @@ public class EquipmentPart extends Part {
     public EquipmentPart clone() {
         EquipmentPart clone = new EquipmentPart(getUnitTonnage(), type, equipmentNum, size, omniPodded, campaign);
         clone.copyBaseData(this);
-        if (hasVariableTonnage(type)) {
-            clone.setEquipTonnage(equipTonnage);
-        }
+        clone.setEquipTonnage(equipTonnage);
         return clone;
     }
 
@@ -197,28 +197,29 @@ public class EquipmentPart extends Part {
     @Override
     public void fix() {
         super.fix();
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted) {
-                mounted.setHit(false);
-                mounted.setMissing(false);
-                mounted.setDestroyed(false);
-                unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
-            }
-            checkWeaponBay();
+
+        final Mounted mounted = getMounted();
+        if (mounted != null) {
+            mounted.setHit(false);
+            mounted.setMissing(false);
+            mounted.setDestroyed(false);
+            unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
         }
+
+        checkWeaponBay(getUnit(), getType(), getEquipmentNum());
     }
 
     @Override
-    public MissingPart getMissingPart() {
+    public MissingEquipmentPart getMissingPart() {
         return new MissingEquipmentPart(getUnitTonnage(), type, equipmentNum, campaign, equipTonnage, size, omniPodded);
     }
 
     @Override
     public void remove(boolean salvage) {
-        Unit unit = getUnit();
+        final int equipmentNum = getEquipmentNum();
+        final Unit unit = getUnit();
         if (unit != null) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
+            final Mounted mounted = getMounted();
             if (null != mounted) {
                 mounted.setHit(true);
                 mounted.setDestroyed(true);
@@ -226,7 +227,7 @@ public class EquipmentPart extends Part {
                 unit.destroySystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
             }
 
-            Part missing = getMissingPart();
+            MissingEquipmentPart missing = getMissingPart();
             if (null != missing) {
                 unit.addPart(missing);
                 campaign.getQuartermaster().addPart(missing, 0);
@@ -243,31 +244,41 @@ public class EquipmentPart extends Part {
                 // to merge us with any other parts of the same type
                 campaign.getQuartermaster().addPart(this, 0);
             }
+
+            checkWeaponBay(unit, getType(), equipmentNum);
         }
     }
 
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {
-        if (null != unit) {
-            int priorHits = hits;
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted) {
-                if (mounted.isMissing()) {
-                    remove(false);
-                    return;
-                }
-                hits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT, equipmentNum,
-                        mounted.getLocation());
-                if (mounted.isSplit()) {
-                    hits += unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT, equipmentNum,
-                            mounted.getSecondLocation());
-                }
-                omniPodded = mounted.isOmniPodMounted();
-            }
-            if (checkForDestruction && hits > priorHits
-                    && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
-                remove(false);
-            }
+        final Unit unit = getUnit();
+        final Mounted mounted = getMounted();
+        if ((unit == null) || (mounted == null)) {
+            return;
+        }
+
+        if (mounted.isMissing()) {
+            remove(false);
+            return;
+        }
+
+        int priorHits = getHits();
+
+        int newHits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum(),
+                mounted.getLocation());
+        if (mounted.isSplit()) {
+            newHits += unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum(),
+                    mounted.getSecondLocation());
+        }
+
+        setHits(newHits);
+
+        omniPodded = mounted.isOmniPodMounted();
+
+        if (checkForDestruction && (getHits() > priorHits)
+                && (Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget())) {
+            remove(false);
+            return;
         }
     }
 
@@ -276,10 +287,13 @@ public class EquipmentPart extends Part {
         if (isSalvaging()) {
             return isOmniPodded() ? 30 : 120;
         }
-        // LAM bomb bays only take 60 minutes to repair.
+
+        final int hits = getHits();
         if ((type instanceof MiscType) && type.hasFlag(MiscType.F_BOMB_BAY)) {
-            return 60;
+            // LAM bomb bays only take 60 minutes to repair.
+            return (hits > 0) ? 60 : 0;
         }
+
         if (hits == 1) {
             return 100;
         } else if (hits == 2) {
@@ -289,6 +303,7 @@ public class EquipmentPart extends Part {
         } else if (hits > 3) {
             return 250;
         }
+
         return 0;
     }
 
@@ -318,14 +333,24 @@ public class EquipmentPart extends Part {
         return hits > 0;
     }
 
-    public int getLocation() {
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted) {
-                return mounted.getLocation();
+    protected @Nullable Mounted getMounted() {
+        final Unit unit = getUnit();
+        if ((unit != null) && (unit.getEntity() != null) && (getEquipmentNum() >= 0)) {
+            final Mounted mounted = unit.getEntity().getEquipment(getEquipmentNum());
+            if (mounted != null) {
+                return mounted;
             }
+
+            MekHQ.getLogger().warning("Missing valid equipment for " + getName() + " on unit " + getUnit().getName());
         }
-        return -1;
+
+        return null;
+    }
+
+    @Override
+    public int getLocation() {
+        final Mounted mounted = getMounted();
+        return (mounted != null) ? mounted.getLocation() : Entity.LOC_NONE;
     }
 
     public double getSize() {
@@ -333,119 +358,93 @@ public class EquipmentPart extends Part {
     }
 
     public boolean isRearFacing() {
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted) {
-                return mounted.isRearMounted();
-            }
-        }
-        return false;
+        final Mounted mounted = getMounted();
+        return (mounted != null) && mounted.isRearMounted();
     }
 
     @Override
     public void updateConditionFromPart() {
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted) {
-                mounted.setMissing(false);
-                if (hits >= 1) {
-                    mounted.setDestroyed(true);
-                    mounted.setHit(true);
-                    mounted.setRepairable(true);
-                    unit.damageSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum, hits);
-                } else {
-                    mounted.setHit(false);
-                    mounted.setDestroyed(false);
-                    mounted.setRepairable(true);
-                    unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, equipmentNum);
-                }
-                setOmniPodded(mounted.isOmniPodMounted());
-            }
-            checkWeaponBay();
+        final Unit unit = getUnit();
+        if (unit == null) {
+            return;
         }
+
+        final Mounted mounted = getMounted();
+        if (mounted != null) {
+            mounted.setMissing(false);
+            if (getHits() > 0) {
+                mounted.setDestroyed(true);
+                mounted.setHit(true);
+                mounted.setRepairable(true);
+                unit.damageSystem(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum(), getHits());
+            } else {
+                mounted.setHit(false);
+                mounted.setDestroyed(false);
+                mounted.setRepairable(true);
+                unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum());
+            }
+
+            setOmniPodded(mounted.isOmniPodMounted());
+        }
+
+        checkWeaponBay(unit, getType(), getEquipmentNum());
     }
 
     @Override
     public String checkFixable() {
-        if (isSalvaging()) {
+        final Unit unit = getUnit();
+        if ((unit != null) && (unit.isSalvage() || isTeamSalvaging())) {
             return null;
         }
+
         // The part is only fixable if the location is not destroyed.
         // be sure to check location and second location
-        if (null != unit) {
-            Mounted m = unit.getEntity().getEquipment(equipmentNum);
-            if (null != m) {
-                int loc = m.getLocation();
+        final Mounted m = getMounted();
+        if ((unit != null) && (m != null)) {
+            int loc = m.getLocation();
+            if (unit.isLocationBreached(loc)) {
+                return unit.getEntity().getLocationName(loc) + " is breached.";
+            }
+    
+            if (unit.isLocationDestroyed(loc)) {
+                return unit.getEntity().getLocationName(loc) + " is destroyed.";
+            }
+
+            if (m.isSplit()) {
+                loc = m.getSecondLocation();
                 if (unit.isLocationBreached(loc)) {
                     return unit.getEntity().getLocationName(loc) + " is breached.";
                 }
                 if (unit.isLocationDestroyed(loc)) {
                     return unit.getEntity().getLocationName(loc) + " is destroyed.";
                 }
-                loc = m.getSecondLocation();
-                if (loc != Entity.LOC_NONE) {
-                    if (unit.isLocationBreached(loc)) {
-                        return unit.getEntity().getLocationName(loc) + " is breached.";
-                    }
-                    if (unit.isLocationDestroyed(loc)) {
-                        return unit.getEntity().getLocationName(loc) + " is destroyed.";
-                    }
-                }
             }
         }
+
         return null;
     }
 
     @Override
     public boolean isMountedOnDestroyedLocation() {
-        // This should do the exact same as the big loop commented out below - Dylan
-        try {
-            return unit != null && unit.getEntity() != null && unit.getEntity().getEquipment(equipmentNum) != null
-                    && unit.isLocationDestroyed(unit.getEntity().getEquipment(equipmentNum).getLocation());
-        } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+        final Unit unit = getUnit();
+        final Mounted mounted = getMounted();
+        if ((unit != null) && (mounted != null)) {
+            return unit.isLocationDestroyed(mounted.getLocation())
+                    || (mounted.isSplit() && unit.isLocationDestroyed(mounted.getSecondLocation()));
         }
+
         return false;
-        /*
-         * if(null == unit) { return false; } for(int loc = 0; loc <
-         * unit.getEntity().locations(); loc++) { for (int i = 0; i <
-         * unit.getEntity().getNumberOfCriticals(loc); i++) { CriticalSlot slot =
-         * unit.getEntity().getCritical(loc, i);
-         *
-         * // ignore empty & system slots if ((slot == null) || (slot.getType() !=
-         * CriticalSlot.TYPE_EQUIPMENT)) { continue; } Mounted equip =
-         * unit.getEntity().getEquipment(equipmentNum); Mounted m1 = slot.getMount();
-         * Mounted m2 = slot.getMount2(); if (m1 == null && m2 == null) { continue; } if
-         * (slot.getIndex() == equipmentNum || (equip.equals(m1) || equip.equals(m2))) {
-         * return unit.isLocationDestroyed(loc); } } } return false;
-         */
     }
 
     @Override
     public boolean onBadHipOrShoulder() {
-        if (null != unit) {
-            for (int loc = 0; loc < unit.getEntity().locations(); loc++) {
-                for (int i = 0; i < unit.getEntity().getNumberOfCriticals(loc); i++) {
-                    CriticalSlot slot = unit.getEntity().getCritical(loc, i);
-
-                    // ignore empty & system slots
-                    if ((slot == null) || (slot.getType() != CriticalSlot.TYPE_EQUIPMENT)) {
-                        continue;
-                    }
-                    Mounted equip = unit.getEntity().getEquipment(equipmentNum);
-                    Mounted m1 = slot.getMount();
-                    Mounted m2 = slot.getMount2();
-                    if (m1 == null && m2 == null) {
-                        continue;
-                    }
-                    if ((equip.equals(m1)) || (equip.equals(m2))) {
-                        if (unit.hasBadHipOrShoulder(loc)) {
-                            return true;
-                        }
-                    }
-                }
-            }
+        final Unit unit = getUnit();
+        final Mounted mounted = getMounted();
+        if ((unit != null) && (mounted != null)) {
+            return unit.hasBadHipOrShoulder(mounted.getLocation())
+                    || (mounted.isSplit() && unit.hasBadHipOrShoulder(mounted.getSecondLocation()));
         }
+
         return false;
     }
 
@@ -577,8 +576,9 @@ public class EquipmentPart extends Part {
      * item tonnage
      */
     public static boolean hasVariableTonnage(EquipmentType type) {
-        return (type instanceof MiscType && (type.hasFlag(MiscType.F_TARGCOMP) || type.hasFlag(MiscType.F_CLUB)
-                || type.hasFlag(MiscType.F_TALON)));
+        return (type instanceof MiscType)
+                && (type.hasFlag(MiscType.F_TARGCOMP) || type.hasFlag(MiscType.F_CLUB)
+                        || type.hasFlag(MiscType.F_TALON));
     }
 
     public static double getStartingTonnage(EquipmentType type) {
@@ -613,7 +613,7 @@ public class EquipmentPart extends Part {
 
     @Override
     public boolean isPartForEquipmentNum(int index, int loc) {
-        return equipmentNum == index && loc == getLocation();
+        return (getEquipmentNum() == index) && (getLocation() == loc);
     }
 
     @Override
@@ -633,46 +633,24 @@ public class EquipmentPart extends Part {
 
     @Override
     public String getLocationName() {
-        if (null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if (null != mounted && mounted.getLocation() != -1) {
-                return unit.getEntity().getLocationName(mounted.getLocation());
-            }
+        final Mounted mounted = getMounted();
+        if ((mounted != null) && (mounted.getLocation() != Entity.LOC_NONE)) {
+            return getUnit().getEntity().getLocationName(mounted.getLocation());
         }
+
         return null;
     }
 
     @Override
     public boolean isInLocation(String loc) {
-        if (null == unit || null == unit.getEntity() || null == unit.getEntity().getEquipment(equipmentNum)) {
+        final Mounted mounted = getMounted();
+        if (mounted == null) {
             return false;
         }
 
-        Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-        if (null == mounted) {
-            return false;
-        }
         int location = unit.getEntity().getLocationFromAbbr(loc);
-        for (int i = 0; i < unit.getEntity().getNumberOfCriticals(location); i++) {
-            CriticalSlot slot = unit.getEntity().getCritical(location, i);
-            // ignore empty & non-hittable slots
-            if ((slot == null) || !slot.isEverHittable() || slot.getType() != CriticalSlot.TYPE_EQUIPMENT
-                    || null == slot.getMount()) {
-                continue;
-            }
-            if (unit.getEntity().getEquipmentNum(slot.getMount()) == equipmentNum) {
-                return true;
-            }
-        }
-        // if we are still here, lets just double check by the mounted's location and
-        // secondary location
-        if (mounted.getLocation() == location) {
-            return true;
-        }
-        if (location != Entity.LOC_NONE && mounted.getSecondLocation() == location) {
-            return true;
-        }
-        return false;
+        return (mounted.getLocation() == location)
+                || (mounted.isSplit() && (mounted.getSecondLocation() == location));
     }
 
     /**
@@ -684,59 +662,65 @@ public class EquipmentPart extends Part {
      * designed to be used only by the fix and remove methods contained here in
      * order to properly update weapon bay mounts on the entity
      */
-    private void checkWeaponBay() {
+    private static void checkWeaponBay(Unit unit, EquipmentType type, int equipmentNum) {
+        if ((unit == null) || (unit.getEntity() == null)
+                || !unit.getEntity().usesWeaponBays()
+                || !(type instanceof WeaponType)) {
+            return;
+        }
 
-        if (type instanceof WeaponType && null != unit && null != unit.getEntity()
-                && unit.getEntity().usesWeaponBays()) {
-            Mounted weapon = unit.getEntity().getEquipment(equipmentNum);
-            if (null == weapon) {
-                return;
+        final Mounted weapon = unit.getEntity().getEquipment(equipmentNum);
+        if (weapon == null) {
+            return;
+        }
+
+        Mounted weaponBay = null;
+        for (Mounted m : unit.getEntity().getWeaponBayList()) {
+            if (m.getLocation() != weapon.getLocation()) {
+                continue;
             }
-            Mounted weaponBay = null;
-            for (Mounted m : unit.getEntity().getWeaponBayList()) {
-                if (m.getLocation() != weapon.getLocation()) {
-                    continue;
-                }
-                if (m.getType() instanceof BayWeapon && m.getBayWeapons().contains(equipmentNum)) {
-                    weaponBay = m;
-                    break;
-                }
+            if ((m.getType() instanceof BayWeapon) && m.getBayWeapons().contains(equipmentNum)) {
+                weaponBay = m;
+                break;
             }
-            if (null == weaponBay) {
-                return;
+        }
+
+        if (weaponBay == null) {
+            return;
+        }
+
+        int wBayIndex = unit.getEntity().getEquipmentNum(weaponBay);
+        // ok we found the weapons bay, now lets check first to see if the current
+        // weapon is fixed
+        if (!weapon.isDestroyed()) {
+            weaponBay.setHit(false);
+            weaponBay.setMissing(false);
+            weaponBay.setDestroyed(false);
+            unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, wBayIndex);
+            return;
+        }
+
+        // if we are still here then we need to check the other weapons, if any of them
+        // are usable then we should do the same thing. Otherwise all weapons are destroyed 
+        // and we should mark the bay as unusuable.
+        for (int wId : weaponBay.getBayWeapons()) {
+            final Mounted m = unit.getEntity().getEquipment(wId);
+            if (m == null) {
+                continue;
             }
-            int wBayIndex = unit.getEntity().getEquipmentNum(weaponBay);
-            // ok we found the weapons bay, now lets check first to see if the current
-            // weapon is fixed
-            if (!weapon.isDestroyed()) {
+
+            if (!m.isDestroyed()) {
                 weaponBay.setHit(false);
                 weaponBay.setMissing(false);
                 weaponBay.setDestroyed(false);
                 unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, wBayIndex);
                 return;
             }
-            // if we are still here then we need to check the other weapons, if any of them
-            // are usable
-            // then we should do the same thing. Otherwise all weapons are destroyed and we
-            // should mark
-            // the bay as unusuable
-            for (int wId : weaponBay.getBayWeapons()) {
-                Mounted m = unit.getEntity().getEquipment(wId);
-                if (null == m) {
-                    continue;
-                }
-                if (!m.isDestroyed()) {
-                    weaponBay.setHit(false);
-                    weaponBay.setMissing(false);
-                    weaponBay.setDestroyed(false);
-                    unit.repairSystem(CriticalSlot.TYPE_EQUIPMENT, wBayIndex);
-                    return;
-                }
-            }
-            weaponBay.setHit(true);
-            weaponBay.setDestroyed(true);
-            weaponBay.setRepairable(true);
-            unit.destroySystem(CriticalSlot.TYPE_EQUIPMENT, wBayIndex);
         }
+
+        weaponBay.setHit(true);
+        weaponBay.setDestroyed(true);
+        weaponBay.setRepairable(true);
+        unit.destroySystem(CriticalSlot.TYPE_EQUIPMENT, wBayIndex);
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/HeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/HeatSink.java
@@ -63,10 +63,10 @@ public class HeatSink extends EquipmentPart {
         }
     }
 
-    @Override
-    public MissingPart getMissingPart() {
-        return new MissingHeatSink(getUnitTonnage(), type, equipmentNum, omniPodded, campaign);
-    }
+	@Override
+	public MissingHeatSink getMissingPart() {
+		return new MissingHeatSink(getUnitTonnage(), type, equipmentNum, omniPodded, campaign);
+	}
 
     @Override
     public void updateConditionFromEntity(boolean checkForDestruction) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryWeaponPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryWeaponPart.java
@@ -55,11 +55,11 @@ public class InfantryWeaponPart extends EquipmentPart {
         return clone;
     }
 
-    @Override
-    public MissingPart getMissingPart() {
-        //shouldn't get here, but ok
-        return new MissingEquipmentPart(getUnitTonnage(), type, equipmentNum, size, campaign, getTonnage());
-    }
+	@Override
+	public MissingEquipmentPart getMissingPart() {
+		//shouldn't get here, but ok
+		return new MissingEquipmentPart(getUnitTonnage(), type, equipmentNum, size, campaign, getTonnage());
+	}
 
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {

--- a/MekHQ/src/mekhq/campaign/parts/equipment/JumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/JumpJet.java
@@ -108,7 +108,7 @@ public class JumpJet extends EquipmentPart {
     }
 
 	@Override
-	public MissingPart getMissingPart() {
+	public MissingJumpJet getMissingPart() {
 		return new MissingJumpJet(getUnitTonnage(), type, equipmentNum, omniPodded, campaign);
 	}
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
@@ -153,7 +153,7 @@ public class MASC extends EquipmentPart {
 	}
 
 	@Override
-	public MissingPart getMissingPart() {
+	public MissingMASC getMissingPart() {
 		return new MissingMASC(getUnitTonnage(), type, equipmentNum, campaign, equipTonnage, engineRating,
 		        omniPodded);
 	}

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingBattleArmorEquipmentPart.java
@@ -175,7 +175,7 @@ public class MissingBattleArmorEquipmentPart extends MissingEquipmentPart {
     }
 
     @Override
-    public Part getNewPart() {
+    public BattleArmorEquipmentPart getNewPart() {
         BattleArmorEquipmentPart epart = new BattleArmorEquipmentPart(getUnitTonnage(), type, -1, size, -1, campaign);
         epart.setEquipTonnage(equipTonnage);
         return epart;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
@@ -2,6 +2,7 @@
  * MissingEquipmentPart.java
  *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
+ * Copyright (C) 2020 MegaMek team
  *
  * This file is part of MekHQ.
  *
@@ -34,6 +35,7 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.TechAdvancement;
 import megamek.common.WeaponType;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.MissingPart;
@@ -81,8 +83,8 @@ public class MissingEquipmentPart extends MissingPart {
         // on which it would have a different price (only tonnage is taken into
         // account for compatibility)
         super(tonnage, c);
-        this.type =et;
-        if(null != type) {
+        this.type = et;
+        if (type != null) {
             this.name = type.getName(size);
             this.typeName = type.getInternalName();
         }
@@ -93,8 +95,14 @@ public class MissingEquipmentPart extends MissingPart {
     }
 
     @Override
+    public MissingEquipmentPart clone() {
+        return new MissingEquipmentPart(getUnitTonnage(), getType(), getEquipmentNum(), getCampaign(),
+                getTonnage(), getSize(), isOmniPodded());
+    }
+
+    @Override
     public int getBaseTime() {
-        return isOmniPodded()? 30 : 120;
+        return isOmniPodded() ? 30 : 120;
     }
 
     @Override
@@ -113,8 +121,7 @@ public class MissingEquipmentPart extends MissingPart {
         }
 
         if (type == null) {
-            MekHQ.getLogger().error(getClass(), "restore",
-                    "Mounted.restore: could not restore equipment type \"" + name + "\"");
+            MekHQ.getLogger().error("Mounted.restore: could not restore equipment type \"" + name + "\"");
         }
     }
 
@@ -160,14 +167,17 @@ public class MissingEquipmentPart extends MissingPart {
     @Override
     public void fix() {
         Part replacement = findReplacement(false);
-        if(null != replacement) {
+        if (replacement != null) {
             Part actualReplacement = replacement.clone();
             unit.addPart(actualReplacement);
+            
             campaign.getQuartermaster().addPart(actualReplacement, 0);
             replacement.decrementQuantity();
+            
             ((EquipmentPart)actualReplacement).setEquipmentNum(equipmentNum);
+            
             remove(false);
-            //assign the replacement part to the unit
+
             actualReplacement.updateConditionFromPart();
         }
     }
@@ -178,123 +188,93 @@ public class MissingEquipmentPart extends MissingPart {
         //they are not acceptable substitutes, so we need to check for that as
         //well
         //http://bg.battletech.com/forums/strategic-operations/(answered)-can-a-lance-for-a-35-ton-mech-be-used-on-a-40-ton-mech-and-so-on/
-        Part newPart = getNewPart();
-        newPart.setUnit(unit);
-        if(part instanceof EquipmentPart) {
-            EquipmentPart eqpart = (EquipmentPart)part;
-            EquipmentType et = eqpart.getType();
-            return (type.equals(et) && getTonnage() == part.getTonnage())
-                    && (size == eqpart.getSize())
-                    && part.getStickerPrice().equals(newPart.getStickerPrice());
+        EquipmentPart newPart = getNewPart();
+        newPart.setEquipmentNum(getEquipmentNum());
+        newPart.setUnit(unit); // CAW: find a way to do this without setting a unit
+        return (type.equals(newPart.getType()) && getTonnage() == part.getTonnage())
+                && (size == newPart.getSize())
+                && part.getStickerPrice().equals(newPart.getStickerPrice());
+    }
+
+    protected @Nullable Mounted getMounted() {
+        final Unit unit = getUnit();
+        if ((unit != null) && (unit.getEntity() != null) && (getEquipmentNum() >= 0)) {
+            final Mounted mounted = unit.getEntity().getEquipment(getEquipmentNum());
+            if (mounted != null) {
+                return mounted;
+            }
+
+            MekHQ.getLogger().warning("Missing valid equipment for " + getName() + " on unit " + getUnit().getName());
         }
-        return false;
+
+        return null;
     }
 
     @Override
     public String checkFixable() {
+        final Unit unit = getUnit();
+        if ((unit != null) && (unit.isSalvage() || isTeamSalvaging())) {
+            return null;
+        }
+
         // The part is only fixable if the location is not destroyed.
         // be sure to check location and second location
-        if(null != unit) {
-            Mounted m = unit.getEntity().getEquipment(equipmentNum);
-            if(null != m) {
-                int loc = m.getLocation();
-                if(loc != Entity.LOC_NONE) {
-                    if (unit.isLocationBreached(loc)) {
-                        return unit.getEntity().getLocationName(loc) + " is breached.";
-                    }
-                    if (unit.isLocationDestroyed(loc)) {
-                        return unit.getEntity().getLocationName(loc) + " is destroyed.";
-                    }
-                }
+        final Mounted m = getMounted();
+        if ((unit != null) && (m != null)) {
+            int loc = m.getLocation();
+            if (unit.isLocationBreached(loc)) {
+                return unit.getEntity().getLocationName(loc) + " is breached.";
+            }
+    
+            if (unit.isLocationDestroyed(loc)) {
+                return unit.getEntity().getLocationName(loc) + " is destroyed.";
+            }
+
+            if (m.isSplit()) {
                 loc = m.getSecondLocation();
-                if(loc != Entity.LOC_NONE) {
-                    if (unit.isLocationBreached(loc)) {
-                        return unit.getEntity().getLocationName(loc) + " is breached.";
-                    }
-                    if (unit.isLocationDestroyed(loc)) {
-                        return unit.getEntity().getLocationName(loc) + " is destroyed.";
-                    }
+                if (unit.isLocationBreached(loc)) {
+                    return unit.getEntity().getLocationName(loc) + " is breached.";
+                }
+                if (unit.isLocationDestroyed(loc)) {
+                    return unit.getEntity().getLocationName(loc) + " is destroyed.";
                 }
             }
         }
+
         return null;
     }
 
     @Override
     public boolean onBadHipOrShoulder() {
-        if(null != unit) {
-            for(int loc = 0; loc < unit.getEntity().locations(); loc++) {
-                for (int i = 0; i < unit.getEntity().getNumberOfCriticals(loc); i++) {
-                    CriticalSlot slot = unit.getEntity().getCritical(loc, i);
-
-                    // ignore empty & system slots
-                    if ((slot == null) || (slot.getType() != CriticalSlot.TYPE_EQUIPMENT)) {
-                        continue;
-                    }
-                    Mounted equip = unit.getEntity().getEquipment(equipmentNum);
-                    Mounted m1 = slot.getMount();
-                    Mounted m2 = slot.getMount2();
-                    if (m1 == null && m2 == null) {
-                        continue;
-                    }
-                    if ((equip.equals(m1)) || (equip.equals(m2))) {
-                        if (unit.hasBadHipOrShoulder(loc)) {
-                            return true;
-                        }
-                    }
-                }
-            }
+        final Unit unit = getUnit();
+        final Mounted mounted = getMounted();
+        if ((unit != null) && (mounted != null)) {
+            return unit.hasBadHipOrShoulder(mounted.getLocation())
+                    || (mounted.isSplit() && unit.hasBadHipOrShoulder(mounted.getSecondLocation()));
         }
+
         return false;
     }
 
     @Override
     public void setUnit(Unit u) {
         super.setUnit(u);
-        if(null != unit) {
-            equipTonnage = type.getTonnage(unit.getEntity());
+        if (unit != null) {
+            equipTonnage = type.getTonnage(unit.getEntity(), getSize());
         }
     }
 
     @Override
-    public Part getNewPart() {
+    public EquipmentPart getNewPart() {
         EquipmentPart epart = new EquipmentPart(getUnitTonnage(), type, -1, size, omniPodded, campaign);
         epart.setEquipTonnage(equipTonnage);
         return epart;
     }
-/*
-    private boolean hasReallyCheckedToday() {
-        return checkedToday;
-    }
 
     @Override
-    public boolean hasCheckedToday() {
-        //if this unit has been checked for any other equipment of this same type
-        //then return false, regardless of whether this one has been checked
-        if(null != unit) {
-            for(Part part : unit.getParts()) {
-                if(part.getId() == getId()) {
-                    continue;
-                }
-                if(part instanceof MissingEquipmentPart
-                        && ((MissingEquipmentPart)part).getType().equals(type)
-                        && ((MissingEquipmentPart)part).hasReallyCheckedToday()) {
-                    return true;
-                }
-            }
-        }
-        return super.hasCheckedToday();
-    }
-*/
-
     public int getLocation() {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                return mounted.getLocation();
-            }
-        }
-        return -1;
+        final Mounted mounted = getMounted();
+        return (mounted != null) ? mounted.getLocation() : Entity.LOC_NONE;
     }
 
     public double getSize() {
@@ -302,25 +282,24 @@ public class MissingEquipmentPart extends MissingPart {
     }
 
     public boolean isRearFacing() {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                return mounted.isRearMounted();
-            }
-        }
-        return false;
+        final Mounted mounted = getMounted();
+        return (mounted != null) && mounted.isRearMounted();
+    }
+
+    @Override
+    public boolean isPartForEquipmentNum(int index, int loc) {
+        return (getEquipmentNum() == index) && (getLocation() == loc);
     }
 
     @Override
     public void updateConditionFromPart() {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted) {
-                mounted.setHit(true);
-                mounted.setDestroyed(true);
-                mounted.setRepairable(false);
-                unit.destroySystem(CriticalSlot.TYPE_EQUIPMENT, unit.getEntity().getEquipmentNum(mounted));
-            }
+        final Unit unit = getUnit();
+        final Mounted mounted = getMounted();
+        if ((unit != null) && (mounted != null)) {
+            mounted.setHit(true);
+            mounted.setDestroyed(true);
+            mounted.setRepairable(false);
+            unit.destroySystem(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum());
         }
     }
 
@@ -344,44 +323,23 @@ public class MissingEquipmentPart extends MissingPart {
 
     @Override
     public String getLocationName() {
-        if(null != unit) {
-            Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-            if(null != mounted && mounted.getLocation() != -1) {
-                return unit.getEntity().getLocationName(mounted.getLocation());
-            }
+        final Mounted mounted = getMounted();
+        if ((mounted != null) && (mounted.getLocation() != Entity.LOC_NONE)) {
+            return getUnit().getEntity().getLocationName(mounted.getLocation());
         }
+
         return null;
     }
 
     @Override
     public boolean isInLocation(String loc) {
-        if(null == unit || null == unit.getEntity() || null == unit.getEntity().getEquipment(equipmentNum)) {
+        final Mounted mounted = getMounted();
+        if (mounted == null) {
             return false;
         }
 
-        Mounted mounted = unit.getEntity().getEquipment(equipmentNum);
-        if(null == mounted) {
-            return false;
-        }
         int location = unit.getEntity().getLocationFromAbbr(loc);
-        for (int i = 0; i < unit.getEntity().getNumberOfCriticals(location); i++) {
-                CriticalSlot slot = unit.getEntity().getCritical(location, i);
-                // ignore empty & non-hittable slots
-                if ((slot == null) || !slot.isEverHittable() || slot.getType()!=CriticalSlot.TYPE_EQUIPMENT
-                        || null == slot.getMount()) {
-                    continue;
-                }
-                if(unit.getEntity().getEquipmentNum(slot.getMount()) == equipmentNum) {
-                    return true;
-                }
-        }
-        //if we are still here, lets just double check by the mounted's location and secondary location
-        if(mounted.getLocation() == location) {
-            return true;
-        }
-        if(mounted.getSecondLocation() == location) {
-            return true;
-        }
-        return false;
+        return (mounted.getLocation() == location)
+                || (mounted.isSplit() && (mounted.getSecondLocation() == location));
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingHeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingHeatSink.java
@@ -22,7 +22,6 @@ package mekhq.campaign.parts.equipment;
 
 import megamek.common.EquipmentType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.enums.PartRepairType;
 
 /**
@@ -50,7 +49,7 @@ public class MissingHeatSink extends MissingEquipmentPart {
     }
 
     @Override
-    public Part getNewPart() {
+    public HeatSink getNewPart() {
         return new HeatSink(getUnitTonnage(), type, -1, omniPodded, campaign);
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingJumpJet.java
@@ -24,7 +24,6 @@ package mekhq.campaign.parts.equipment;
 import megamek.common.EquipmentType;
 import megamek.common.MiscType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.parts.Part;
 
 /**
  *
@@ -52,7 +51,7 @@ public class MissingJumpJet extends MissingEquipmentPart {
 	}
 
     @Override
-	public Part getNewPart() {
+	public JumpJet getNewPart() {
 		return new JumpJet(getUnitTonnage(), type, -1, omniPodded, campaign);
 	}
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingMASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingMASC.java
@@ -133,7 +133,7 @@ public class MissingMASC extends MissingEquipmentPart {
 	}
 
 	@Override
-	public Part getNewPart() {
+	public MASC getNewPart() {
 		MASC epart = new MASC(getUnitTonnage(), type, -1, campaign, engineRating, omniPodded);
 		epart.setEquipTonnage(equipTonnage);
 		return epart;

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentPartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentPartTest.java
@@ -1,0 +1,1758 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts.equipment;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.equipment.EquipmentUtilities.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Vector;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.Aero;
+import megamek.common.Compute;
+import megamek.common.CriticalSlot;
+import megamek.common.Entity;
+import megamek.common.EquipmentType;
+import megamek.common.EquipmentTypeLookup;
+import megamek.common.MMRandom;
+import megamek.common.MMRoll;
+import megamek.common.Mech;
+import megamek.common.MiscType;
+import megamek.common.Mounted;
+import megamek.common.SmallCraft;
+import megamek.common.WeaponType;
+import megamek.common.weapons.bayweapons.BayWeapon;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
+
+public class EquipmentPartTest {
+    @Test
+    public void deserializationCtorTest() {
+        EquipmentPart equipmentPart = new EquipmentPart();
+        assertNotNull(equipmentPart);
+    }
+
+    @Test
+    public void equipmentPartCtorTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int tonnage = 75;
+        double size = 5.0;
+        double equipTonnage = 3.0;
+        int equipmentNum = 7;
+        boolean isOmniPodded = false;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), eq(size));
+        
+        EquipmentPart equipmentPart = new EquipmentPart(tonnage, type, equipmentNum, size, isOmniPodded, mockCampaign);
+        
+        assertEquals(tonnage, equipmentPart.getUnitTonnage());
+        assertEquals(type, equipmentPart.getType());
+        assertEquals(equipmentNum, equipmentPart.getEquipmentNum());
+        assertEquals(size, equipmentPart.getSize(), 0.001);
+        assertEquals(isOmniPodded, equipmentPart.isOmniPodded());
+        assertEquals(equipTonnage, equipmentPart.getTonnage(), 0.001);
+        assertEquals(mockCampaign, equipmentPart.getCampaign());
+
+        isOmniPodded = true;
+        equipmentPart = new EquipmentPart(tonnage, type, equipmentNum, size, isOmniPodded, mockCampaign);
+        
+        assertEquals(tonnage, equipmentPart.getUnitTonnage());
+        assertEquals(type, equipmentPart.getType());
+        assertEquals(equipmentNum, equipmentPart.getEquipmentNum());
+        assertEquals(size, equipmentPart.getSize(), 0.001);
+        assertEquals(isOmniPodded, equipmentPart.isOmniPodded());
+        assertEquals(equipTonnage, equipmentPart.getTonnage(), 0.001);
+        assertEquals(mockCampaign, equipmentPart.getCampaign());
+    }
+    
+    @Test
+    public void cloneTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int tonnage = 75;
+        double size = 5.0;
+        double equipTonnage = 3.0;
+        int equipmentNum = 7;
+        boolean isOmniPodded = false;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), eq(size));
+        
+        EquipmentPart equipmentPart = new EquipmentPart(tonnage, type, equipmentNum, size, isOmniPodded, mockCampaign);
+        
+        EquipmentPart clone = equipmentPart.clone();
+
+        assertEquals(equipmentPart.getUnitTonnage(), clone.getUnitTonnage());
+        assertEquals(equipmentPart.getType(), clone.getType());
+        assertEquals(equipmentPart.getEquipmentNum(), clone.getEquipmentNum());
+        assertEquals(equipmentPart.getSize(), clone.getSize(), 0.001);
+        assertEquals(equipmentPart.getTonnage(), clone.getTonnage(), 0.001);
+        assertEquals(equipmentPart.isOmniPodded(), clone.isOmniPodded());
+        assertEquals(equipmentPart.getCampaign(), clone.getCampaign());
+
+        isOmniPodded = true;
+        equipmentPart = new EquipmentPart(tonnage, type, equipmentNum, size, isOmniPodded, mockCampaign);
+
+        clone = equipmentPart.clone();
+        
+        assertEquals(equipmentPart.getUnitTonnage(), clone.getUnitTonnage());
+        assertEquals(equipmentPart.getType(), clone.getType());
+        assertEquals(equipmentPart.getEquipmentNum(), clone.getEquipmentNum());
+        assertEquals(equipmentPart.getSize(), clone.getSize(), 0.001);
+        assertEquals(equipmentPart.getTonnage(), clone.getTonnage(), 0.001);
+        assertEquals(equipmentPart.isOmniPodded(), clone.isOmniPodded());
+        assertEquals(equipmentPart.getCampaign(), clone.getCampaign());
+    }
+
+    @Test
+    public void getMissingPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int tonnage = 75;
+        double size = 5.0;
+        double equipTonnage = 3.0;
+        int equipmentNum = 7;
+        boolean isOmniPodded = false;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), eq(size));
+        
+        EquipmentPart equipmentPart = new EquipmentPart(tonnage, type, equipmentNum, size, isOmniPodded, mockCampaign);
+
+        MissingEquipmentPart missingPart = equipmentPart.getMissingPart();
+        assertNotNull(missingPart);
+
+        assertEquals(equipmentPart.getUnitTonnage(), missingPart.getUnitTonnage());
+        assertEquals(equipmentPart.getType(), missingPart.getType());
+        assertEquals(equipmentPart.getEquipmentNum(), missingPart.getEquipmentNum());
+        assertEquals(equipmentPart.getSize(), missingPart.getSize(), 0.001);
+        assertEquals(equipmentPart.getTonnage(), missingPart.getTonnage(), 0.001);
+        assertEquals(equipmentPart.isOmniPodded(), missingPart.isOmniPodded());
+        assertEquals(equipmentPart.getCampaign(), missingPart.getCampaign());
+
+        isOmniPodded = true;
+        equipmentPart = new EquipmentPart(tonnage, type, equipmentNum, size, isOmniPodded, mockCampaign);
+
+        missingPart = equipmentPart.getMissingPart();
+        assertNotNull(missingPart);
+
+        assertEquals(equipmentPart.getUnitTonnage(), missingPart.getUnitTonnage());
+        assertEquals(equipmentPart.getType(), missingPart.getType());
+        assertEquals(equipmentPart.getEquipmentNum(), missingPart.getEquipmentNum());
+        assertEquals(equipmentPart.getSize(), missingPart.getSize(), 0.001);
+        assertEquals(equipmentPart.getTonnage(), missingPart.getTonnage(), 0.001);
+        assertEquals(equipmentPart.isOmniPodded(), missingPart.isOmniPodded());
+        assertEquals(equipmentPart.getCampaign(), missingPart.getCampaign());
+    }
+
+    @Test
+    public void isPartForEquipmentTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        int location = Aero.LOC_NOSE;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setUnit(unit);
+
+        assertTrue(equipmentPart.isPartForEquipmentNum(equipmentNum, location));
+        assertFalse(equipmentPart.isPartForEquipmentNum(equipmentNum, Aero.LOC_RWING));
+        assertFalse(equipmentPart.isPartForEquipmentNum(equipmentNum - 1, location));
+    }
+    
+    @Test
+    public void isOmniPoddableTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        // Not MiscType or WeaponType
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, 16, size, false, mockCampaign);
+        assertTrue(equipmentPart.isOmniPoddable());
+
+        // If fixed only, then we're not omnipoddable
+        when(type.isOmniFixedOnly()).thenReturn(true);
+        assertFalse(equipmentPart.isOmniPoddable());
+
+        // MiscType
+        MiscType miscType = mock(MiscType.class);
+        doReturn(1.0).when(miscType).getTonnage(any(), anyDouble());
+        equipmentPart = new EquipmentPart(75, miscType, 16, size, false, mockCampaign);
+
+        // Just because we're MiscType doesn't mean we're omnipoddable ...
+        assertFalse(equipmentPart.isOmniPoddable());
+
+        // ... we need to be Mech Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return MiscType.F_MECH_EQUIPMENT.equals(flag);
+        }).when(miscType).hasFlag(any());
+        assertTrue(equipmentPart.isOmniPoddable());
+
+        // ... or Tank Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return MiscType.F_TANK_EQUIPMENT.equals(flag);
+        }).when(miscType).hasFlag(any());
+        assertTrue(equipmentPart.isOmniPoddable());
+
+        // ... or Aero Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return MiscType.F_FIGHTER_EQUIPMENT.equals(flag);
+        }).when(miscType).hasFlag(any());
+        assertTrue(equipmentPart.isOmniPoddable());
+
+        // WeaponType
+        WeaponType weaponType = mock(WeaponType.class);
+        doReturn(1.0).when(weaponType).getTonnage(any(), anyDouble());
+        equipmentPart = new EquipmentPart(75, weaponType, 16, size, false, mockCampaign);
+
+        // Just because we're WeaponType doesn't mean we're omnipoddable ...
+        assertFalse(equipmentPart.isOmniPoddable());
+
+        // ... we need to be Mech Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return WeaponType.F_MECH_WEAPON.equals(flag);
+        }).when(weaponType).hasFlag(any());
+        assertTrue(equipmentPart.isOmniPoddable());
+
+        // ... or Tank Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return WeaponType.F_TANK_WEAPON.equals(flag);
+        }).when(weaponType).hasFlag(any());
+        assertTrue(equipmentPart.isOmniPoddable());
+
+        // ... or Fighter Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return WeaponType.F_AERO_WEAPON.equals(flag);
+        }).when(weaponType).hasFlag(any());
+        assertTrue(equipmentPart.isOmniPoddable());
+
+        // ... but not Capital scale.
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return WeaponType.F_AERO_WEAPON.equals(flag);
+        }).when(weaponType).hasFlag(any());
+        when(weaponType.isCapital()).thenReturn(true);
+        assertFalse(equipmentPart.isOmniPoddable());
+    }
+
+    @Test
+    public void setUnitUpdatesEquipmentTonnage() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, 6, size, false, mockCampaign);
+
+        equipmentPart.setUnit(unit);
+
+        // Ensure we update the equipment tonnage for variable sized equipment
+        verify(type, times(1)).getTonnage(eq(entity), eq(size));
+    }
+
+    @Test
+    public void getLocationTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // No unit
+        assertEquals(Entity.LOC_NONE, equipmentPart.getLocation());
+
+        // Assign to a unit
+        equipmentPart.setUnit(unit);
+
+        // No equipment at the equipment num
+        assertEquals(Entity.LOC_NONE, equipmentPart.getLocation());
+
+        // Put a mount behind the equipment on the unit
+        Mounted mounted = mock(Mounted.class);
+        int location = Mech.LOC_RT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Our location should match up
+        assertEquals(location, equipmentPart.getLocation());
+    }
+
+    @Test
+    public void getLocationNameTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // No unit
+        assertNull(equipmentPart.getLocationName());
+
+        // Assign to a unit
+        equipmentPart.setUnit(unit);
+
+        // No equipment at the equipment num
+        assertNull(equipmentPart.getLocationName());
+
+        // Put a mount behind the equipment on the unit
+        Mounted mounted = mock(Mounted.class);
+        String locationName = "Mech Right Torso";
+        int location = Mech.LOC_RT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(locationName).when(entity).getLocationName(eq(location));
+
+        // Our location should match up
+        assertEquals(locationName, equipmentPart.getLocationName());
+
+        // The mount has no named location
+        when(mounted.getLocation()).thenReturn(Entity.LOC_NONE);
+        assertNull(equipmentPart.getLocationName());
+    }
+
+    @Test
+    public void isInLocationTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        String locationName = "Mech Right Torso";
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // No unit
+        assertFalse(equipmentPart.isInLocation(locationName));
+
+        // Assign to a unit
+        equipmentPart.setUnit(unit);
+
+        // No equipment at the equipment num
+        assertFalse(equipmentPart.isInLocation(locationName));
+
+        // Put a mount behind the equipment on the unit
+        Mounted mounted = mock(Mounted.class);
+        int location = Mech.LOC_RT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        
+        doReturn(location).when(entity).getLocationFromAbbr(eq(locationName));
+
+        // Our location should match up
+        assertTrue(equipmentPart.isInLocation(locationName));
+
+        // The mount has no named location
+        when(mounted.getLocation()).thenReturn(Entity.LOC_NONE);
+        assertFalse(equipmentPart.isInLocation(locationName));
+
+        // Split the mount and have the second location be the one we want
+        when(mounted.getLocation()).thenReturn(Mech.LOC_RLEG);
+        when(mounted.isSplit()).thenReturn(true);
+        when(mounted.getSecondLocation()).thenReturn(location);
+
+        assertTrue(equipmentPart.isInLocation(locationName));
+    }
+
+    @Test
+    public void isRearFacingTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // No unit
+        assertFalse(equipmentPart.isRearFacing());
+
+        // Assign to a unit
+        equipmentPart.setUnit(unit);
+
+        // No equipment at the equipment num
+        assertFalse(equipmentPart.isRearFacing());
+
+        // Put a mount behind the equipment on the unit
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.isRearMounted()).thenReturn(true);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Our facing should match up
+        assertTrue(equipmentPart.isRearFacing());
+
+        when(mounted.isRearMounted()).thenReturn(false);
+
+        // Our facing should match up
+        assertFalse(equipmentPart.isRearFacing());
+    }
+
+    @Test
+    public void equipmentPartWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        EquipmentType type = getEquipmentType(EquipmentTypeLookup.JUMP_JET);
+        Campaign mockCampaign = mock(Campaign.class);
+        EquipmentPart equipmentPart = new EquipmentPart(65, type, 42, 18.0, false, mockCampaign);
+        equipmentPart.setId(25);
+
+        // Write the EquipmentPart XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        equipmentPart.writeToXml(pw, 0);
+
+        // Get the EquipmentPart XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the EquipmentPart
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof EquipmentPart);
+
+        EquipmentPart deserialized = (EquipmentPart) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(equipmentPart.getId(), deserialized.getId());
+        assertEquals(equipmentPart.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(equipmentPart.getType(), deserialized.getType());
+        assertEquals(equipmentPart.getName(), deserialized.getName());
+        assertEquals(equipmentPart.getSize(), deserialized.getSize(), 0.001);
+        assertEquals(equipmentPart.getTonnage(), deserialized.getTonnage(), 0.001);
+    }
+    
+    @Test
+    public void removeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.setUnit(unit);
+
+        // Add the part to the warehouse
+        warehouse.addPart(equipmentPart);
+
+        // Remove the part (not salvage)
+        equipmentPart.remove(false);
+
+        assertTrue(equipmentPart.getId() < 0);
+        assertTrue(equipmentPart.getEquipmentNum() < 0);
+        assertNull(equipmentPart.getUnit());
+        assertFalse(warehouse.getParts().contains(equipmentPart));
+
+        verify(mounted, times(1)).setHit(eq(true));
+        verify(mounted, times(1)).setDestroyed(eq(true));
+        verify(mounted, times(1)).setRepairable(eq(false));
+
+        verify(unit, times(1)).destroySystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum));
+        verify(unit, times(1)).removePart(eq(equipmentPart));
+        
+        ArgumentCaptor<Part> missingPartCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(unit, times(1)).addPart(missingPartCaptor.capture());
+
+        Part missingPart = missingPartCaptor.getValue();
+        assertTrue(missingPart instanceof MissingEquipmentPart);
+
+        MissingEquipmentPart missingEquipmentPart = (MissingEquipmentPart) missingPart;
+        assertTrue(missingEquipmentPart.getId() > 0);
+        assertEquals(equipmentNum, missingEquipmentPart.getEquipmentNum());
+        assertEquals(unit, missingEquipmentPart.getUnit());
+        assertTrue(warehouse.getParts().contains(missingEquipmentPart));
+    }
+    
+    @Test
+    public void salvageTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.setUnit(unit);
+
+        // Add the part to the warehouse
+        warehouse.addPart(equipmentPart);
+
+        // Salvage the part
+        equipmentPart.remove(true);
+
+        assertTrue(equipmentPart.getId() > 0);
+        assertTrue(equipmentPart.getEquipmentNum() < 0);
+        assertNull(equipmentPart.getUnit());
+        assertTrue(warehouse.getParts().contains(equipmentPart));
+
+        verify(mounted, times(1)).setHit(eq(true));
+        verify(mounted, times(1)).setDestroyed(eq(true));
+        verify(mounted, times(1)).setRepairable(eq(false));
+
+        verify(unit, times(1)).destroySystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum));
+        verify(unit, times(1)).removePart(eq(equipmentPart));
+        
+        ArgumentCaptor<Part> missingPartCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(unit, times(1)).addPart(missingPartCaptor.capture());
+
+        Part missingPart = missingPartCaptor.getValue();
+        assertTrue(missingPart instanceof MissingEquipmentPart);
+
+        MissingEquipmentPart missingEquipmentPart = (MissingEquipmentPart) missingPart;
+        assertTrue(missingEquipmentPart.getId() > 0);
+        assertEquals(equipmentNum, missingEquipmentPart.getEquipmentNum());
+        assertEquals(unit, missingEquipmentPart.getUnit());
+        assertTrue(warehouse.getParts().contains(missingEquipmentPart));
+    }
+    
+    @Test
+    public void needsFixingTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, 6, size, false, mockCampaign);
+        
+        assertFalse(equipmentPart.needsFixing());
+
+        equipmentPart.setHits(1);
+        assertTrue(equipmentPart.needsFixing());
+
+        equipmentPart.setHits(7);
+        assertTrue(equipmentPart.needsFixing());
+
+        equipmentPart.setHits(0);
+        assertFalse(equipmentPart.needsFixing());
+    }
+
+    @Test
+    public void isMountedOnDestroyedLocationTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // No unit ...
+        assertFalse(equipmentPart.isMountedOnDestroyedLocation());
+
+        equipmentPart.setUnit(unit);
+
+        // No mount ....
+        assertFalse(equipmentPart.isMountedOnDestroyedLocation());
+
+        // add the equipment
+        Mounted mounted = mock(Mounted.class);
+        int location = Aero.LOC_LWING;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Destroy the location ...
+        doReturn(true).when(unit).isLocationDestroyed(eq(location));
+        assertTrue(equipmentPart.isMountedOnDestroyedLocation());
+
+        // Fix the location ...
+        doReturn(false).when(unit).isLocationDestroyed(eq(location));
+        assertFalse(equipmentPart.isMountedOnDestroyedLocation());
+
+        // Destroy the secondary location ...
+        int secondLocation = Aero.LOC_FUSELAGE;
+        when(mounted.getSecondLocation()).thenReturn(secondLocation);
+        when(mounted.isSplit()).thenReturn(true);
+        doReturn(true).when(unit).isLocationDestroyed(eq(secondLocation));
+        assertTrue(equipmentPart.isMountedOnDestroyedLocation());
+
+        // Fix them both
+        doReturn(false).when(unit).isLocationDestroyed(eq(location));
+        doReturn(false).when(unit).isLocationDestroyed(eq(secondLocation));
+        assertFalse(equipmentPart.isMountedOnDestroyedLocation());
+    }
+
+    @Test
+    public void onBadHipOrShoulderTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // Not on unit
+        assertFalse(equipmentPart.onBadHipOrShoulder());
+
+        // No equipment mounted at that index
+        equipmentPart.setUnit(unit);
+        assertFalse(equipmentPart.onBadHipOrShoulder());
+
+        // Mount equipment at the index
+        Mounted mounted = mock(Mounted.class);
+        int location = Mech.LOC_LARM;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Just because we've got the correct mount, doesn't mean we're
+        // on a bad hip or shoulder
+        assertFalse(equipmentPart.onBadHipOrShoulder());
+
+        // Bust the shoulder/hip
+        doReturn(true).when(unit).hasBadHipOrShoulder(eq(location));
+        assertTrue(equipmentPart.onBadHipOrShoulder());
+
+        // Swap over to the secondary location
+        doReturn(false).when(unit).hasBadHipOrShoulder(eq(location));
+        int secondLocation = Mech.LOC_LT;
+        when(mounted.getSecondLocation()).thenReturn(secondLocation);
+        when(mounted.isSplit()).thenReturn(true);
+        doReturn(true).when(unit).hasBadHipOrShoulder(eq(secondLocation));
+
+        // Still busted
+        assertTrue(equipmentPart.onBadHipOrShoulder());
+
+        // But wait, fixed again
+        doReturn(false).when(unit).hasBadHipOrShoulder(eq(location));
+        doReturn(false).when(unit).hasBadHipOrShoulder(eq(secondLocation));
+        assertFalse(equipmentPart.onBadHipOrShoulder());
+    }
+
+    @Test
+    public void checkFixableTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // Not on unit
+        assertNull(equipmentPart.checkFixable());
+
+        // No equipment mounted at that index
+        equipmentPart.setUnit(unit);
+        assertNull(equipmentPart.checkFixable());
+
+        // Salvaging
+        when(unit.isSalvage()).thenReturn(true);
+        assertNull(equipmentPart.checkFixable());
+
+        // Turn off salvaging
+        when(unit.isSalvage()).thenReturn(false);
+
+        // Mount equipment at the index
+        Mounted mounted = mock(Mounted.class);
+        String locationName = "Mech Left Torso";
+        int location = Mech.LOC_LT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(locationName).when(entity).getLocationName(eq(location));
+
+        // Nothing wrong with the mount
+        assertNull(equipmentPart.checkFixable());
+
+        // Location breached
+        doReturn(true).when(unit).isLocationBreached(eq(location));
+        doReturn(false).when(unit).isLocationDestroyed(eq(location));
+        assertNotNull(equipmentPart.checkFixable());
+
+        // Location destroyed
+        doReturn(false).when(unit).isLocationBreached(eq(location));
+        doReturn(true).when(unit).isLocationDestroyed(eq(location));
+        assertNotNull(equipmentPart.checkFixable());
+
+        String secondaryLocationName = "Mech Left Arm";
+        int secondaryLocation = Mech.LOC_LARM;
+        when(mounted.getSecondLocation()).thenReturn(secondaryLocation);
+        when(mounted.isSplit()).thenReturn(true);
+        doReturn(secondaryLocationName).when(entity).getLocationName(secondaryLocation);
+
+        // Restore the first location
+        doReturn(false).when(unit).isLocationBreached(eq(location));
+        doReturn(false).when(unit).isLocationDestroyed(eq(location));
+
+        // Secondary Location breached
+        doReturn(true).when(unit).isLocationBreached(eq(secondaryLocation));
+        doReturn(false).when(unit).isLocationDestroyed(eq(secondaryLocation));
+        assertNotNull(equipmentPart.checkFixable());
+
+        // Location destroyed
+        doReturn(false).when(unit).isLocationBreached(eq(secondaryLocation));
+        doReturn(true).when(unit).isLocationDestroyed(eq(secondaryLocation));
+        assertNotNull(equipmentPart.checkFixable());
+
+        // Restore both locations
+        doReturn(false).when(unit).isLocationBreached(eq(location));
+        doReturn(false).when(unit).isLocationDestroyed(eq(location));
+        doReturn(false).when(unit).isLocationBreached(eq(secondaryLocation));
+        doReturn(false).when(unit).isLocationDestroyed(eq(secondaryLocation));
+
+        assertNull(equipmentPart.checkFixable());
+    }
+
+    @Test
+    public void fixTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.setUnit(unit);
+
+        // Damage the part
+        equipmentPart.setHits(3);
+
+        // Fix the part
+        equipmentPart.fix();
+
+        assertEquals(0, equipmentPart.getHits());
+        assertFalse(equipmentPart.needsFixing());
+
+        verify(mounted, times(1)).setHit(eq(false));
+        verify(mounted, times(1)).setMissing(eq(false));
+        verify(mounted, times(1)).setDestroyed(eq(false));
+
+        verify(unit, times(1)).repairSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum));
+    }
+
+    @Test
+    public void updateConditionFromPartWorkingTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // No unit? This is a no-op
+        equipmentPart.updateConditionFromPart();
+
+        equipmentPart.setUnit(unit);
+
+        // No equipment mounted at equipmentNum? This is a no-op
+        equipmentPart.updateConditionFromPart();
+
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Functional equipment mounted
+        equipmentPart.updateConditionFromPart();
+
+        verify(mounted, times(1)).setMissing(eq(false));
+        verify(mounted, times(1)).setHit(eq(false));
+        verify(mounted, times(1)).setDestroyed(eq(false));
+        verify(mounted, times(1)).setRepairable(eq(true));
+        verify(unit, times(1)).repairSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum));
+    }
+
+    @Test
+    public void updateConditionFromPartHitTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setUnit(unit);
+
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Hit the part
+        int hits = 3;
+        equipmentPart.setHits(hits);
+
+        equipmentPart.updateConditionFromPart();
+
+        verify(mounted, times(1)).setMissing(eq(false));
+        verify(mounted, times(1)).setHit(eq(true));
+        verify(mounted, times(1)).setDestroyed(eq(true));
+        verify(mounted, times(1)).setRepairable(eq(true));
+        verify(unit, times(1)).damageSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(hits));
+    }
+
+    @Test
+    public void updateConditionFromEntityNoUnitOrMountedTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, true, mockCampaign);
+
+        // No unit? This is a no-op
+        equipmentPart.updateConditionFromEntity(false);
+
+        assertTrue(equipmentPart.isOmniPodded());
+        assertEquals(0, equipmentPart.getHits());
+
+        equipmentPart.updateConditionFromEntity(true);
+
+        assertTrue(equipmentPart.isOmniPodded());
+        assertEquals(0, equipmentPart.getHits());
+
+        equipmentPart.setUnit(unit);
+
+        // No equipment mounted at equipmentNum? This is a no-op
+        equipmentPart.updateConditionFromEntity(false);
+
+        assertTrue(equipmentPart.isOmniPodded());
+        assertEquals(0, equipmentPart.getHits());
+
+        equipmentPart.updateConditionFromEntity(true);
+
+        assertTrue(equipmentPart.isOmniPodded());
+        assertEquals(0, equipmentPart.getHits());
+    }
+
+    @Test
+    public void updateConditionFromEntityResetsHitsTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.isMissing()).thenReturn(false);
+        int location = Mech.LOC_LLEG;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(1).when(entity).getDamagedCriticals(anyInt(), anyInt(), anyInt()); // Setup damage everywhere else
+        doReturn(0).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(location));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, true, mockCampaign);
+        equipmentPart.setUnit(unit);
+
+        int hits = 3;
+        equipmentPart.setHits(hits);
+
+        // The underlying equipment is fine so this should restore the part
+        equipmentPart.updateConditionFromEntity(false);
+
+        assertEquals(0, equipmentPart.getHits());
+
+        // ... and it should learn that the mount is not on an omnipod.
+        assertFalse(equipmentPart.isOmniPodded());
+
+        // If the part is split it should also take those hits into account
+        when(mounted.isSplit()).thenReturn(true);
+        int secondLocation = Mech.LOC_LT;
+        when(mounted.getSecondLocation()).thenReturn(secondLocation);
+        doReturn(0).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(secondLocation));
+
+        // Break the part again
+        equipmentPart.setHits(hits);
+
+        // The underlying equipment in both locations is fine so this should restore the part
+        equipmentPart.updateConditionFromEntity(false);
+
+        assertEquals(0, equipmentPart.getHits());
+    }
+
+    @Test
+    public void updateConditionFromEntityTakesHitsTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.isMissing()).thenReturn(false);
+        int location = Mech.LOC_LLEG;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(0).when(entity).getDamagedCriticals(anyInt(), anyInt(), anyInt()); // Setup damage everywhere else
+        doReturn(1).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(location));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, true, mockCampaign);
+        equipmentPart.setUnit(unit);
+
+        // The underlying equipment has a hit so this should hit the part
+        equipmentPart.updateConditionFromEntity(false);
+
+        assertEquals(1, equipmentPart.getHits());
+
+        // If the part is split it should also take those hits into account
+        when(mounted.isSplit()).thenReturn(true);
+        int secondLocation = Mech.LOC_LT;
+        when(mounted.getSecondLocation()).thenReturn(secondLocation);
+        doReturn(2).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(secondLocation));
+
+        // Fix the part from our side
+        equipmentPart.setHits(0);
+
+        // The underlying equipment in both locations has hits so this should hit the part
+        equipmentPart.updateConditionFromEntity(false);
+
+        assertEquals(3, equipmentPart.getHits());
+    }
+
+    @Test
+    public void updateConditionFromEntityTakesHitsChecksDestructionTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(campaignOptions);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.isMissing()).thenReturn(false);
+        int location = Mech.LOC_LLEG;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(0).when(entity).getDamagedCriticals(anyInt(), anyInt(), anyInt()); // Setup damage everywhere else
+        doReturn(1).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(location));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, true, mockCampaign);
+        equipmentPart.setId(16);
+        equipmentPart.setUnit(unit);
+
+        warehouse.addPart(equipmentPart);
+
+        MMRandom rng = mock(MMRandom.class);
+        try {
+            Compute.setRNG(rng);
+
+            // Setup two rolls: PASS and FAIL
+            MMRoll roll = mock(MMRoll.class);
+            when(roll.getIntValue()).thenReturn(12, 2);
+            doReturn(roll).when(rng).d6(eq(2));
+            when(campaignOptions.getDestroyPartTarget()).thenReturn(6);
+
+            // The underlying equipment has a hit so this should hit the part
+            equipmentPart.updateConditionFromEntity(true);
+
+            // Because we rolled a 12, we should have a hit, but not be destroyed
+            assertEquals(1, equipmentPart.getHits());
+            assertTrue(warehouse.getParts().contains(equipmentPart));
+
+            // Restore thte first location
+            doReturn(0).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(location));
+
+            // Split the mount and bust the second location ...
+            when(mounted.isSplit()).thenReturn(true);
+            int secondLocation = Mech.LOC_LT;
+            when(mounted.getSecondLocation()).thenReturn(secondLocation);
+            doReturn(1).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(secondLocation));
+
+            // The underlying equipment has a hit so this should hit the part
+            equipmentPart.updateConditionFromEntity(true);
+
+            // Because we did not accrue any additional hits, we should have a hit, but not be destroyed
+            assertEquals(1, equipmentPart.getHits());
+            assertTrue(warehouse.getParts().contains(equipmentPart));
+
+            // Now, hit both locations hard, triggering a roll we'll fail
+            doReturn(2).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(location));
+            doReturn(3).when(entity).getDamagedCriticals(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum), eq(secondLocation));
+
+            // The underlying equipment has a hit so this should hit the part
+            equipmentPart.updateConditionFromEntity(true);
+
+            // Because we failed the roll, we'll be removed and destroyed
+            assertEquals(5, equipmentPart.getHits());
+            assertFalse(warehouse.getParts().contains(equipmentPart));
+        } finally {
+            // Restore the RNG for other tests
+            Compute.setRNG(MMRandom.R_DEFAULT);
+        }
+    }
+
+    @Test
+    public void updateConditionFromEntityMissingTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.isMissing()).thenReturn(true);
+        int location = Mech.LOC_LLEG;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setId(19);
+        equipmentPart.setUnit(unit);
+
+        warehouse.addPart(equipmentPart);
+
+        // The mounted is missing, this should remove the part
+        equipmentPart.updateConditionFromEntity(false);
+
+        assertTrue(equipmentPart.getId() < 0);
+        assertNull(equipmentPart.getUnit());
+        assertFalse(warehouse.getParts().contains(equipmentPart));
+    }
+
+    @Test
+    public void getBaseTimeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        MiscType type = mock(MiscType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, 42, size, false, mockCampaign);
+        equipmentPart.setUnit(unit);
+
+        // Salvaging is 120 minutes ...
+        when(unit.isSalvage()).thenReturn(true);
+        assertEquals(120, equipmentPart.getBaseTime());
+
+        // ... except when omni-podded.
+        equipmentPart.setOmniPodded(true);
+        assertEquals(30, equipmentPart.getBaseTime());
+
+        when(unit.isSalvage()).thenReturn(false);
+
+        // If not salvaging, go by hits ...
+
+        // ... no hits, no time.
+        assertEquals(0, equipmentPart.getBaseTime());
+
+        // Hits go 100, 150, 200, 250 (>3)
+        equipmentPart.setHits(1);
+        assertEquals(100, equipmentPart.getBaseTime());
+        equipmentPart.setHits(2);
+        assertEquals(150, equipmentPart.getBaseTime());
+        equipmentPart.setHits(3);
+        assertEquals(200, equipmentPart.getBaseTime());
+        equipmentPart.setHits(4);
+        assertEquals(250, equipmentPart.getBaseTime());
+        equipmentPart.setHits(10);
+        assertEquals(250, equipmentPart.getBaseTime());
+
+        // Finally, bomb bays on LAMs take 60 minutes
+        doReturn(true).when(type).hasFlag(MiscType.F_BOMB_BAY);
+
+        // No hits, no time on the bomb bay.
+        equipmentPart.setHits(0);
+        assertEquals(0, equipmentPart.getBaseTime());
+
+        // Otherwise, its always 60 minutes
+        equipmentPart.setHits(3);
+        assertEquals(60, equipmentPart.getBaseTime());
+    }
+
+    @Test
+    public void getDifficultyTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double size = 3.0;
+        MiscType type = mock(MiscType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, 42, size, false, mockCampaign);
+        equipmentPart.setUnit(unit);
+
+        // Salvaging is +0
+        when(unit.isSalvage()).thenReturn(true);
+        assertEquals(0, equipmentPart.getDifficulty());
+
+        // ... even when omni-podded.
+        equipmentPart.setOmniPodded(true);
+        assertEquals(0, equipmentPart.getDifficulty());
+
+        when(unit.isSalvage()).thenReturn(false);
+
+        // If not salvaging, go by hits ...
+
+        // ... no hits, no difficulty mod.
+        assertEquals(0, equipmentPart.getDifficulty());
+
+        // Hits go -3, -2, 0, +2 (>3)
+        equipmentPart.setHits(1);
+        assertEquals(-3, equipmentPart.getDifficulty());
+        equipmentPart.setHits(2);
+        assertEquals(-2, equipmentPart.getDifficulty());
+        equipmentPart.setHits(3);
+        assertEquals(0, equipmentPart.getDifficulty());
+        equipmentPart.setHits(4);
+        assertEquals(2, equipmentPart.getDifficulty());
+        equipmentPart.setHits(10);
+        assertEquals(2, equipmentPart.getDifficulty());
+
+        // Finally, bomb bays on LAMs have a fixed -1 difficulty
+        doReturn(true).when(type).hasFlag(MiscType.F_BOMB_BAY);
+
+        equipmentPart.setHits(0);
+        assertEquals(-1, equipmentPart.getDifficulty());
+
+        equipmentPart.setHits(3);
+        assertEquals(-1, equipmentPart.getDifficulty());
+    }
+
+    @Test
+    public void isSamePartTypeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        int equipmentNum = 42;
+        double size = 3.0;
+        double cost = 12.0;
+        MiscType type = mock(MiscType.class);
+        when(type.getRawCost()).thenReturn(cost);
+        doReturn(1.0).when(type).getTonnage(any(), eq(size));
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+
+        // We're the same as ourselves
+        assertTrue(equipmentPart.isSamePartType(equipmentPart));
+
+        // We're the same as our clone
+        Part otherPart = equipmentPart.clone();
+        assertTrue(equipmentPart.isSamePartType(otherPart));
+        assertTrue(otherPart.isSamePartType(equipmentPart));
+
+        // We're the same even if unit tonnage differs, as long as our
+        // equipment tonnage is the same.
+        otherPart = new EquipmentPart(65, type, 42, size, false, mockCampaign);
+        assertTrue(equipmentPart.isSamePartType(otherPart));
+        assertTrue(otherPart.isSamePartType(equipmentPart));
+
+        // We're not the same if types differ
+        MiscType otherType = mock(MiscType.class);
+        otherPart = new EquipmentPart(75, otherType, 42, size, false, mockCampaign);
+        assertFalse(equipmentPart.isSamePartType(otherPart));
+        assertFalse(otherPart.isSamePartType(equipmentPart));
+
+        // We're not the same if sizes differ
+        double otherSize = 2.0;
+        doReturn(1.75).when(type).getTonnage(any(), eq(otherSize));
+        otherPart = new EquipmentPart(75, type, 42, otherSize, false, mockCampaign);
+        assertFalse(equipmentPart.isSamePartType(otherPart));
+        assertFalse(otherPart.isSamePartType(equipmentPart));
+
+        // We're not the same if one is omni-podded and the other isn't
+        otherPart = new EquipmentPart(75, type, 42, size, true, mockCampaign);
+        assertFalse(equipmentPart.isSamePartType(otherPart));
+        assertFalse(otherPart.isSamePartType(equipmentPart));
+
+        // We're not the same if our sticker prices differ;
+
+        // Setup a type with variable costs
+        doReturn(true).when(type).hasFlag(eq(MiscType.F_OFF_ROAD));
+        doReturn((double) EquipmentType.COST_VARIABLE).when(type).getRawCost();
+
+        // They're both variable cost, but the same misc type (and not on units)
+        equipmentPart.setUnit(null);
+        otherPart = new EquipmentPart(75, type, 42, size, false, mockCampaign);
+        assertTrue(equipmentPart.isSamePartType(otherPart));
+        assertTrue(otherPart.isSamePartType(equipmentPart));
+
+        // Put the variable cost part back on a unit
+        Mounted mounted = mock(Mounted.class);
+        int location = Mech.LOC_CT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(cost * 10.0).when(type).getCost(eq(entity), anyBoolean(), eq(location), eq(size));
+        equipmentPart.setUnit(unit);
+
+        // And now the other part is not on a unit, so no location hence different cost
+        otherPart = new EquipmentPart(75, type, 42, size, false, mockCampaign);
+        assertFalse(equipmentPart.isSamePartType(otherPart));
+        assertFalse(otherPart.isSamePartType(equipmentPart));
+    }
+
+    @Test
+    public void checkWeaponBayOnlyWeaponRemovedTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double size = 3.0;
+        WeaponType type = mock(WeaponType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int location = SmallCraft.LOC_HULL;
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getLocation()).thenReturn(location);
+        doAnswer(inv -> {
+            when(mounted.isDestroyed()).thenReturn(true);
+            return null;
+        }).when(mounted).setDestroyed(eq(true));
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        int bayEqNum = 12;
+        BayWeapon bayWeaponType = mock(BayWeapon.class);
+        Mounted weaponBay = mock(Mounted.class);
+        when(weaponBay.getLocation()).thenReturn(location);
+        when(weaponBay.getType()).thenReturn(bayWeaponType);
+        Vector<Integer> bayWeapons = new Vector<>();
+        bayWeapons.addElement(33);
+        bayWeapons.addElement(equipmentNum);
+        when(weaponBay.getBayWeapons()).thenReturn(bayWeapons);
+        doReturn(weaponBay).when(entity).getEquipment(eq(bayEqNum));
+        doReturn(bayEqNum).when(entity).getEquipmentNum(eq(weaponBay));
+
+        Mounted notOurBay = mock(Mounted.class);
+        when(notOurBay.getLocation()).thenReturn(location);
+        when(notOurBay.getType()).thenReturn(bayWeaponType);
+        when(notOurBay.getBayWeapons()).thenReturn(new Vector<Integer>());
+
+        Mounted notABayWeapon = mock(Mounted.class);
+        when(notABayWeapon.getLocation()).thenReturn(location);
+        when(notABayWeapon.getType()).thenReturn(mock(MiscType.class));
+
+        ArrayList<Mounted> bayList = new ArrayList<>();
+        bayList.add(mock(Mounted.class));
+        bayList.add(notOurBay);
+        bayList.add(notABayWeapon);
+        bayList.add(weaponBay);
+
+        when(entity.getWeaponBayList()).thenReturn(bayList);
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.setUnit(unit);
+
+        // Add the part to the warehouse
+        warehouse.addPart(equipmentPart);
+
+        // Remove the part (not salvage), its the only weapon in the bay
+        equipmentPart.remove(false);
+
+        // Ensure we destroyed the bay
+        verify(weaponBay, times(1)).setHit(eq(true));
+        verify(weaponBay, times(1)).setDestroyed(eq(true));
+        verify(weaponBay, times(1)).setRepairable(eq(true));
+        verify(unit, times(1)).destroySystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(bayEqNum));
+    }
+    
+    @Test
+    public void checkWeaponBayWeaponRemovedOthersOkayTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double size = 3.0;
+        WeaponType type = mock(WeaponType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int location = SmallCraft.LOC_HULL;
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getLocation()).thenReturn(location);
+        doAnswer(inv -> {
+            when(mounted.isDestroyed()).thenReturn(true);
+            return null;
+        }).when(mounted).setDestroyed(eq(true));
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        int otherEqNum = 33;
+        Mounted otherMounted = mock(Mounted.class);
+        when(otherMounted.getLocation()).thenReturn(location);
+        doReturn(otherMounted).when(entity).getEquipment(eq(otherEqNum));
+
+        int bayEqNum = 12;
+        BayWeapon bayWeaponType = mock(BayWeapon.class);
+        Mounted weaponBay = mock(Mounted.class);
+        when(weaponBay.getLocation()).thenReturn(location);
+        when(weaponBay.getType()).thenReturn(bayWeaponType);
+        Vector<Integer> bayWeapons = new Vector<>();
+        bayWeapons.addElement(otherEqNum);
+        bayWeapons.addElement(equipmentNum);
+        when(weaponBay.getBayWeapons()).thenReturn(bayWeapons);
+        doReturn(weaponBay).when(entity).getEquipment(eq(bayEqNum));
+        doReturn(bayEqNum).when(entity).getEquipmentNum(eq(weaponBay));
+
+        Mounted notOurBay = mock(Mounted.class);
+        when(notOurBay.getLocation()).thenReturn(location);
+        when(notOurBay.getType()).thenReturn(bayWeaponType);
+        when(notOurBay.getBayWeapons()).thenReturn(new Vector<Integer>());
+
+        Mounted notABayWeapon = mock(Mounted.class);
+        when(notABayWeapon.getLocation()).thenReturn(location);
+        when(notABayWeapon.getType()).thenReturn(mock(MiscType.class));
+
+        ArrayList<Mounted> bayList = new ArrayList<>();
+        bayList.add(mock(Mounted.class));
+        bayList.add(notOurBay);
+        bayList.add(notABayWeapon);
+        bayList.add(weaponBay);
+
+        when(entity.getWeaponBayList()).thenReturn(bayList);
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.setUnit(unit);
+
+        // Add the part to the warehouse
+        warehouse.addPart(equipmentPart);
+
+        // Remove the part (not salvage), but there is another weapon in the bay
+        equipmentPart.remove(false);
+
+        // Ensure we kept the bay alive
+        verify(weaponBay, times(1)).setHit(eq(false));
+        verify(weaponBay, times(1)).setMissing(eq(false));
+        verify(weaponBay, times(1)).setDestroyed(eq(false));
+        verify(unit, times(1)).repairSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(bayEqNum));
+    }
+
+    @Test
+    public void checkWeaponBayWeaponRemovedOthersDestroyedTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double size = 3.0;
+        WeaponType type = mock(WeaponType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int location = SmallCraft.LOC_HULL;
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getLocation()).thenReturn(location);
+        doAnswer(inv -> {
+            when(mounted.isDestroyed()).thenReturn(true);
+            return null;
+        }).when(mounted).setDestroyed(eq(true));
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        int otherEqNum = 33;
+        Mounted otherMounted = mock(Mounted.class);
+        when(otherMounted.getLocation()).thenReturn(location);
+        when(otherMounted.isDestroyed()).thenReturn(true);
+        doReturn(otherMounted).when(entity).getEquipment(eq(otherEqNum));
+
+        int bayEqNum = 12;
+        BayWeapon bayWeaponType = mock(BayWeapon.class);
+        Mounted weaponBay = mock(Mounted.class);
+        when(weaponBay.getLocation()).thenReturn(location);
+        when(weaponBay.getType()).thenReturn(bayWeaponType);
+        Vector<Integer> bayWeapons = new Vector<>();
+        bayWeapons.addElement(otherEqNum);
+        bayWeapons.addElement(equipmentNum);
+        when(weaponBay.getBayWeapons()).thenReturn(bayWeapons);
+        doReturn(weaponBay).when(entity).getEquipment(eq(bayEqNum));
+        doReturn(bayEqNum).when(entity).getEquipmentNum(eq(weaponBay));
+
+        Mounted notOurBay = mock(Mounted.class);
+        when(notOurBay.getLocation()).thenReturn(location);
+        when(notOurBay.getType()).thenReturn(bayWeaponType);
+        when(notOurBay.getBayWeapons()).thenReturn(new Vector<Integer>());
+
+        Mounted notABayWeapon = mock(Mounted.class);
+        when(notABayWeapon.getLocation()).thenReturn(location);
+        when(notABayWeapon.getType()).thenReturn(mock(MiscType.class));
+
+        ArrayList<Mounted> bayList = new ArrayList<>();
+        bayList.add(mock(Mounted.class));
+        bayList.add(notOurBay);
+        bayList.add(notABayWeapon);
+        bayList.add(weaponBay);
+
+        when(entity.getWeaponBayList()).thenReturn(bayList);
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.setUnit(unit);
+
+        // Add the part to the warehouse
+        warehouse.addPart(equipmentPart);
+
+        // Remove the part (not salvage), and there is another weapon in the bay that is destroyed
+        equipmentPart.remove(false);
+
+        // Ensure we destroyed the bay
+        verify(weaponBay, times(1)).setHit(eq(true));
+        verify(weaponBay, times(1)).setDestroyed(eq(true));
+        verify(weaponBay, times(1)).setRepairable(eq(true));
+        verify(unit, times(1)).destroySystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(bayEqNum));
+    }
+
+    @Test
+    public void checkWeaponBayUpdateConditionFromPartGoodWeaponTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(entity.usesWeaponBays()).thenReturn(true);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double size = 3.0;
+        WeaponType type = mock(WeaponType.class);
+        doReturn(1.0).when(type).getTonnage(any(), anyDouble());
+
+        int location = SmallCraft.LOC_HULL;
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        int otherEqNum = 33;
+        Mounted otherMounted = mock(Mounted.class);
+        when(otherMounted.getLocation()).thenReturn(location);
+        doReturn(otherMounted).when(entity).getEquipment(eq(otherEqNum));
+
+        int bayEqNum = 12;
+        BayWeapon bayWeaponType = mock(BayWeapon.class);
+        Mounted weaponBay = mock(Mounted.class);
+        when(weaponBay.getLocation()).thenReturn(location);
+        when(weaponBay.getType()).thenReturn(bayWeaponType);
+        Vector<Integer> bayWeapons = new Vector<>();
+        bayWeapons.addElement(otherEqNum);
+        bayWeapons.addElement(equipmentNum);
+        when(weaponBay.getBayWeapons()).thenReturn(bayWeapons);
+        doReturn(weaponBay).when(entity).getEquipment(eq(bayEqNum));
+        doReturn(bayEqNum).when(entity).getEquipmentNum(eq(weaponBay));
+
+        Mounted notOurBay = mock(Mounted.class);
+        when(notOurBay.getLocation()).thenReturn(location);
+        when(notOurBay.getType()).thenReturn(bayWeaponType);
+        when(notOurBay.getBayWeapons()).thenReturn(new Vector<Integer>());
+
+        Mounted notABayWeapon = mock(Mounted.class);
+        when(notABayWeapon.getLocation()).thenReturn(location);
+        when(notABayWeapon.getType()).thenReturn(mock(MiscType.class));
+
+        ArrayList<Mounted> bayList = new ArrayList<>();
+        bayList.add(mock(Mounted.class));
+        bayList.add(notOurBay);
+        bayList.add(notABayWeapon);
+        bayList.add(weaponBay);
+
+        when(entity.getWeaponBayList()).thenReturn(bayList);
+
+        EquipmentPart equipmentPart = new EquipmentPart(75, type, equipmentNum, size, false, mockCampaign);
+        equipmentPart.setId(25);
+        equipmentPart.setUnit(unit);
+
+        // Add the part to the warehouse
+        warehouse.addPart(equipmentPart);
+
+        // Update the condition of the entity from the part
+        equipmentPart.updateConditionFromPart();
+
+        // Ensure we destroyed the bay
+        verify(weaponBay, times(1)).setHit(eq(false));
+        verify(weaponBay, times(1)).setMissing(eq(false));
+        verify(weaponBay, times(1)).setDestroyed(eq(false));
+        verify(unit, times(1)).repairSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(bayEqNum));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentUtilities.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentUtilities.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts.equipment;
+
+import static org.junit.Assert.assertNotNull;
+
+import megamek.common.EquipmentType;
+
+public class EquipmentUtilities {
+    /**
+     * Gets an EquipmentType by name (performing any initialization required
+     * on the MM side).
+     * @param name The lookup name for the EquipmentType.
+     * @return The equipment type for the given name.
+     */
+    public synchronized static EquipmentType getEquipmentType(String name) {
+        EquipmentType equipmentType = EquipmentType.get(name);
+        assertNotNull(equipmentType);
+
+        return equipmentType;
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingEquipmentPartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingEquipmentPartTest.java
@@ -1,0 +1,1116 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts.equipment;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static mekhq.campaign.parts.equipment.EquipmentUtilities.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.math.BigInteger;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import megamek.common.Aero;
+import megamek.common.CriticalSlot;
+import megamek.common.Entity;
+import megamek.common.EquipmentType;
+import megamek.common.EquipmentTypeLookup;
+import megamek.common.Mech;
+import megamek.common.MiscType;
+import megamek.common.Mounted;
+import megamek.common.WeaponType;
+import mekhq.MekHqXmlUtil;
+import mekhq.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
+
+public class MissingEquipmentPartTest {
+    @Test
+    public void deserializationCtorTest() {
+        MissingEquipmentPart missingPart = new MissingEquipmentPart();
+        assertNotNull(missingPart);
+    }
+
+    @Test
+    public void equipmentPartCtorTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int tonnage = 75;
+        double size = 5.0;
+        double equipTonnage = 3.0;
+        int equipmentNum = 7;
+        boolean isOmniPodded = false;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), eq(size));
+        
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(tonnage, type, equipmentNum, mockCampaign, equipTonnage, size, isOmniPodded);
+        
+        assertEquals(tonnage, missingPart.getUnitTonnage());
+        assertEquals(type, missingPart.getType());
+        assertEquals(equipmentNum, missingPart.getEquipmentNum());
+        assertEquals(size, missingPart.getSize(), 0.001);
+        assertEquals(isOmniPodded, missingPart.isOmniPodded());
+        assertEquals(equipTonnage, missingPart.getTonnage(), 0.001);
+        assertEquals(mockCampaign, missingPart.getCampaign());
+
+        isOmniPodded = true;
+        missingPart = new MissingEquipmentPart(tonnage, type, equipmentNum, mockCampaign, equipTonnage, size, isOmniPodded);
+        
+        assertEquals(tonnage, missingPart.getUnitTonnage());
+        assertEquals(type, missingPart.getType());
+        assertEquals(equipmentNum, missingPart.getEquipmentNum());
+        assertEquals(size, missingPart.getSize(), 0.001);
+        assertEquals(isOmniPodded, missingPart.isOmniPodded());
+        assertEquals(equipTonnage, missingPart.getTonnage(), 0.001);
+        assertEquals(mockCampaign, missingPart.getCampaign());
+    }
+    
+    @Test
+    public void cloneTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int tonnage = 75;
+        double size = 5.0;
+        double equipTonnage = 3.0;
+        int equipmentNum = 7;
+        boolean isOmniPodded = false;
+        EquipmentType type = mock(EquipmentType.class);
+        
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(tonnage, type, equipmentNum, mockCampaign, equipTonnage, size, isOmniPodded);
+        
+        MissingEquipmentPart clone = missingPart.clone();
+
+        assertEquals(missingPart.getUnitTonnage(), clone.getUnitTonnage());
+        assertEquals(missingPart.getType(), clone.getType());
+        assertEquals(missingPart.getEquipmentNum(), clone.getEquipmentNum());
+        assertEquals(missingPart.getSize(), clone.getSize(), 0.001);
+        assertEquals(missingPart.getTonnage(), clone.getTonnage(), 0.001);
+        assertEquals(missingPart.isOmniPodded(), clone.isOmniPodded());
+        assertEquals(missingPart.getCampaign(), clone.getCampaign());
+
+        isOmniPodded = true;
+        missingPart = new MissingEquipmentPart(tonnage, type, equipmentNum, mockCampaign, equipTonnage, size, isOmniPodded);
+
+        clone = missingPart.clone();
+        
+        assertEquals(missingPart.getUnitTonnage(), clone.getUnitTonnage());
+        assertEquals(missingPart.getType(), clone.getType());
+        assertEquals(missingPart.getEquipmentNum(), clone.getEquipmentNum());
+        assertEquals(missingPart.getSize(), clone.getSize(), 0.001);
+        assertEquals(missingPart.getTonnage(), clone.getTonnage(), 0.001);
+        assertEquals(missingPart.isOmniPodded(), clone.isOmniPodded());
+        assertEquals(missingPart.getCampaign(), clone.getCampaign());
+    }
+
+    @Test
+    public void getNewPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        int tonnage = 75;
+        double size = 5.0;
+        double equipTonnage = 3.0;
+        int equipmentNum = 7;
+        boolean isOmniPodded = false;
+        EquipmentType type = mock(EquipmentType.class);
+        
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(tonnage, type, equipmentNum, mockCampaign, equipTonnage, size, isOmniPodded);
+
+        EquipmentPart equipmentPart = missingPart.getNewPart();
+        assertNotNull(equipmentPart);
+
+        assertEquals(missingPart.getUnitTonnage(), equipmentPart.getUnitTonnage());
+        assertEquals(missingPart.getType(), equipmentPart.getType());
+        assertTrue(equipmentPart.getEquipmentNum() < 0);
+        assertEquals(missingPart.getSize(), equipmentPart.getSize(), 0.001);
+        assertEquals(missingPart.getTonnage(), equipmentPart.getTonnage(), 0.001);
+        assertEquals(missingPart.isOmniPodded(), equipmentPart.isOmniPodded());
+        assertEquals(missingPart.getCampaign(), equipmentPart.getCampaign());
+
+        isOmniPodded = true;
+        missingPart = new MissingEquipmentPart(tonnage, type, equipmentNum, mockCampaign, equipTonnage, size, isOmniPodded);
+
+        equipmentPart = missingPart.getNewPart();
+        assertNotNull(missingPart);
+
+        assertEquals(missingPart.getUnitTonnage(), equipmentPart.getUnitTonnage());
+        assertEquals(missingPart.getType(), equipmentPart.getType());
+        assertTrue(equipmentPart.getEquipmentNum() < 0);
+        assertEquals(missingPart.getSize(), equipmentPart.getSize(), 0.001);
+        assertEquals(missingPart.getTonnage(), equipmentPart.getTonnage(), 0.001);
+        assertEquals(missingPart.isOmniPodded(), equipmentPart.isOmniPodded());
+        assertEquals(missingPart.getCampaign(), equipmentPart.getCampaign());
+    }
+
+    @Test
+    public void isPartForEquipmentTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+
+        int equipmentNum = 42;
+        int location = Aero.LOC_NOSE;
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+        missingPart.setUnit(unit);
+
+        assertTrue(missingPart.isPartForEquipmentNum(equipmentNum, location));
+        assertFalse(missingPart.isPartForEquipmentNum(equipmentNum, Aero.LOC_RWING));
+        assertFalse(missingPart.isPartForEquipmentNum(equipmentNum - 1, location));
+    }
+    
+    @Test
+    public void isOmniPoddableTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+
+        // Not MiscType or WeaponType
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, 16, mockCampaign, equipTonnage, size, false);
+        assertTrue(missingPart.isOmniPoddable());
+
+        // If fixed only, then we're not omnipoddable
+        when(type.isOmniFixedOnly()).thenReturn(true);
+        assertFalse(missingPart.isOmniPoddable());
+
+        // MiscType
+        MiscType miscType = mock(MiscType.class);
+        doReturn(1.0).when(miscType).getTonnage(any(), anyDouble());
+        missingPart = new MissingEquipmentPart(75, miscType, 16, mockCampaign, equipTonnage, size, false);
+
+        // Just because we're MiscType doesn't mean we're omnipoddable ...
+        assertFalse(missingPart.isOmniPoddable());
+
+        // ... we need to be Mech Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return MiscType.F_MECH_EQUIPMENT.equals(flag);
+        }).when(miscType).hasFlag(any());
+        assertTrue(missingPart.isOmniPoddable());
+
+        // ... or Tank Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return MiscType.F_TANK_EQUIPMENT.equals(flag);
+        }).when(miscType).hasFlag(any());
+        assertTrue(missingPart.isOmniPoddable());
+
+        // ... or Aero Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return MiscType.F_FIGHTER_EQUIPMENT.equals(flag);
+        }).when(miscType).hasFlag(any());
+        assertTrue(missingPart.isOmniPoddable());
+
+        // WeaponType
+        WeaponType weaponType = mock(WeaponType.class);
+        doReturn(1.0).when(weaponType).getTonnage(any(), anyDouble());
+        missingPart = new MissingEquipmentPart(75, weaponType, 16, mockCampaign, equipTonnage, size, false);
+
+        // Just because we're WeaponType doesn't mean we're omnipoddable ...
+        assertFalse(missingPart.isOmniPoddable());
+
+        // ... we need to be Mech Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return WeaponType.F_MECH_WEAPON.equals(flag);
+        }).when(weaponType).hasFlag(any());
+        assertTrue(missingPart.isOmniPoddable());
+
+        // ... or Tank Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return WeaponType.F_TANK_WEAPON.equals(flag);
+        }).when(weaponType).hasFlag(any());
+        assertTrue(missingPart.isOmniPoddable());
+
+        // ... or Fighter Equipment ...
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return WeaponType.F_AERO_WEAPON.equals(flag);
+        }).when(weaponType).hasFlag(any());
+        assertTrue(missingPart.isOmniPoddable());
+
+        // ... but not Capital scale.
+        doAnswer(inv -> {
+            BigInteger flag = inv.getArgument(0);
+            return WeaponType.F_AERO_WEAPON.equals(flag);
+        }).when(weaponType).hasFlag(any());
+        when(weaponType.isCapital()).thenReturn(true);
+        assertFalse(missingPart.isOmniPoddable());
+    }
+
+    @Test
+    public void setUnitUpdatesEquipmentTonnage() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        double unitEquipTonnage = 1.0;
+        doReturn(unitEquipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, 6, mockCampaign, equipTonnage, size, false);
+
+        missingPart.setUnit(unit);
+
+        // Ensure we update the equipment tonnage for variable sized equipment
+        verify(type, times(1)).getTonnage(eq(entity), eq(size));
+
+        assertEquals(unitEquipTonnage, missingPart.getTonnage(), 0.001);
+    }
+
+    @Test
+    public void getLocationTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+
+        // No unit
+        assertEquals(Entity.LOC_NONE, missingPart.getLocation());
+
+        // Assign to a unit
+        missingPart.setUnit(unit);
+
+        // No equipment at the equipment num
+        assertEquals(Entity.LOC_NONE, missingPart.getLocation());
+
+        // Put a mount behind the equipment on the unit
+        Mounted mounted = mock(Mounted.class);
+        int location = Mech.LOC_RT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Our location should match up
+        assertEquals(location, missingPart.getLocation());
+    }
+
+    @Test
+    public void getLocationNameTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+
+        // No unit
+        assertNull(missingPart.getLocationName());
+
+        // Assign to a unit
+        missingPart.setUnit(unit);
+
+        // No equipment at the equipment num
+        assertNull(missingPart.getLocationName());
+
+        // Put a mount behind the equipment on the unit
+        Mounted mounted = mock(Mounted.class);
+        String locationName = "Mech Right Torso";
+        int location = Mech.LOC_RT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(locationName).when(entity).getLocationName(eq(location));
+
+        // Our location should match up
+        assertEquals(locationName, missingPart.getLocationName());
+
+        // The mount has no named location
+        when(mounted.getLocation()).thenReturn(Entity.LOC_NONE);
+        assertNull(missingPart.getLocationName());
+    }
+
+    @Test
+    public void isInLocationTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        String locationName = "Mech Right Torso";
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+
+        // No unit
+        assertFalse(missingPart.isInLocation(locationName));
+
+        // Assign to a unit
+        missingPart.setUnit(unit);
+
+        // No equipment at the equipment num
+        assertFalse(missingPart.isInLocation(locationName));
+
+        // Put a mount behind the equipment on the unit
+        Mounted mounted = mock(Mounted.class);
+        int location = Mech.LOC_RT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        
+        doReturn(location).when(entity).getLocationFromAbbr(eq(locationName));
+
+        // Our location should match up
+        assertTrue(missingPart.isInLocation(locationName));
+
+        // The mount has no named location
+        when(mounted.getLocation()).thenReturn(Entity.LOC_NONE);
+        assertFalse(missingPart.isInLocation(locationName));
+
+        // Split the mount and have the second location be the one we want
+        when(mounted.getLocation()).thenReturn(Mech.LOC_RLEG);
+        when(mounted.isSplit()).thenReturn(true);
+        when(mounted.getSecondLocation()).thenReturn(location);
+
+        assertTrue(missingPart.isInLocation(locationName));
+    }
+
+    @Test
+    public void isRearFacingTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+
+        // No unit
+        assertFalse(missingPart.isRearFacing());
+
+        // Assign to a unit
+        missingPart.setUnit(unit);
+
+        // No equipment at the equipment num
+        assertFalse(missingPart.isRearFacing());
+
+        // Put a mount behind the equipment on the unit
+        Mounted mounted = mock(Mounted.class);
+        when(mounted.isRearMounted()).thenReturn(true);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Our facing should match up
+        assertTrue(missingPart.isRearFacing());
+
+        when(mounted.isRearMounted()).thenReturn(false);
+
+        // Our facing should match up
+        assertFalse(missingPart.isRearFacing());
+    }
+
+    @Test
+    public void equipmentPartWriteToXmlTest() throws ParserConfigurationException, SAXException, IOException {
+        EquipmentType type = getEquipmentType(EquipmentTypeLookup.JUMP_JET);
+        Campaign mockCampaign = mock(Campaign.class);
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(65, type, 42, mockCampaign, 14.0, 18.0, false);
+        missingPart.setId(25);
+
+        // Write the MissingEquipmentPart XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        missingPart.writeToXml(pw, 0);
+
+        // Get the MissingEquipmentPart XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
+
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+        Element partElt = xmlDoc.getDocumentElement();
+        assertEquals("part", partElt.getNodeName());
+
+        // Deserialize the MissingEquipmentPart
+        Part deserializedPart = Part.generateInstanceFromXML(partElt, new Version("1.0.0"));
+        assertNotNull(deserializedPart);
+        assertTrue(deserializedPart instanceof MissingEquipmentPart);
+
+        MissingEquipmentPart deserialized = (MissingEquipmentPart) deserializedPart;
+
+        // Check that we deserialized the part correctly.
+        assertEquals(missingPart.getId(), deserialized.getId());
+        assertEquals(missingPart.getEquipmentNum(), deserialized.getEquipmentNum());
+        assertEquals(missingPart.getType(), deserialized.getType());
+        assertEquals(missingPart.getName(), deserialized.getName());
+        assertEquals(missingPart.getSize(), deserialized.getSize(), 0.001);
+        assertEquals(missingPart.getTonnage(), deserialized.getTonnage(), 0.001);
+    }
+    
+    @Test
+    public void removeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+        missingPart.setId(25);
+        missingPart.setUnit(unit);
+
+        // Add the part to the warehouse
+        warehouse.addPart(missingPart);
+
+        // Remove the part (not salvage)
+        missingPart.remove(false);
+
+        assertTrue(missingPart.getId() < 0);
+        assertNull(missingPart.getUnit());
+        assertTrue(warehouse.getParts().isEmpty());
+
+        verify(unit, times(1)).removePart(eq(missingPart));
+    }
+    
+    @Test
+    public void salvageTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+        missingPart.setId(25);
+        missingPart.setUnit(unit);
+
+        // Add the part to the warehouse
+        warehouse.addPart(missingPart);
+
+        // Salvage the part ... (does nothing but remove the part)
+        missingPart.remove(true);
+
+        assertTrue(missingPart.getId() < 0);
+        assertNull(missingPart.getUnit());
+        assertTrue(warehouse.getParts().isEmpty());
+
+        verify(unit, times(1)).removePart(eq(missingPart));
+    }
+    
+    @Test
+    public void needsFixingTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, 6, mockCampaign, equipTonnage, size, false);
+        
+        // Not on a unit
+        assertFalse(missingPart.needsFixing());
+
+        missingPart.setUnit(unit);
+
+        // Unit is not repairable
+        assertFalse(missingPart.needsFixing());
+
+        when(unit.isRepairable()).thenReturn(true);
+
+        // Unit is repairable
+        assertTrue(missingPart.needsFixing());
+
+        when(unit.isSalvage()).thenReturn(true);
+        
+        // On a unit being salvaged, we need a tech
+        assertFalse(missingPart.needsFixing());
+
+        missingPart.setTech(mock(Person.class));
+        
+        // Salvaging with a tech
+        assertTrue(missingPart.needsFixing());
+    }
+
+    @Test
+    public void onBadHipOrShoulderTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+
+        // Not on unit
+        assertFalse(missingPart.onBadHipOrShoulder());
+
+        // No equipment mounted at that index
+        missingPart.setUnit(unit);
+        assertFalse(missingPart.onBadHipOrShoulder());
+
+        // Mount equipment at the index
+        Mounted mounted = mock(Mounted.class);
+        int location = Mech.LOC_LARM;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Just because we've got the correct mount, doesn't mean we're
+        // on a bad hip or shoulder
+        assertFalse(missingPart.onBadHipOrShoulder());
+
+        // Bust the shoulder/hip
+        doReturn(true).when(unit).hasBadHipOrShoulder(eq(location));
+        assertTrue(missingPart.onBadHipOrShoulder());
+
+        // Swap over to the secondary location
+        doReturn(false).when(unit).hasBadHipOrShoulder(eq(location));
+        int secondLocation = Mech.LOC_LT;
+        when(mounted.getSecondLocation()).thenReturn(secondLocation);
+        when(mounted.isSplit()).thenReturn(true);
+        doReturn(true).when(unit).hasBadHipOrShoulder(eq(secondLocation));
+
+        // Still busted
+        assertTrue(missingPart.onBadHipOrShoulder());
+
+        // But wait, fixed again
+        doReturn(false).when(unit).hasBadHipOrShoulder(eq(location));
+        doReturn(false).when(unit).hasBadHipOrShoulder(eq(secondLocation));
+        assertFalse(missingPart.onBadHipOrShoulder());
+    }
+
+    @Test
+    public void checkFixableTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+
+        // Not on unit
+        assertNull(missingPart.checkFixable());
+
+        // No equipment mounted at that index
+        missingPart.setUnit(unit);
+        assertNull(missingPart.checkFixable());
+
+        // Salvaging
+        when(unit.isSalvage()).thenReturn(true);
+        assertNull(missingPart.checkFixable());
+
+        // Turn off salvaging
+        when(unit.isSalvage()).thenReturn(false);
+
+        // Mount equipment at the index
+        Mounted mounted = mock(Mounted.class);
+        String locationName = "Mech Left Torso";
+        int location = Mech.LOC_LT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(locationName).when(entity).getLocationName(eq(location));
+
+        // Nothing wrong with the mount
+        assertNull(missingPart.checkFixable());
+
+        // Location breached
+        doReturn(true).when(unit).isLocationBreached(eq(location));
+        doReturn(false).when(unit).isLocationDestroyed(eq(location));
+        assertNotNull(missingPart.checkFixable());
+
+        // Location destroyed
+        doReturn(false).when(unit).isLocationBreached(eq(location));
+        doReturn(true).when(unit).isLocationDestroyed(eq(location));
+        assertNotNull(missingPart.checkFixable());
+
+        String secondaryLocationName = "Mech Left Arm";
+        int secondaryLocation = Mech.LOC_LARM;
+        when(mounted.getSecondLocation()).thenReturn(secondaryLocation);
+        when(mounted.isSplit()).thenReturn(true);
+        doReturn(secondaryLocationName).when(entity).getLocationName(secondaryLocation);
+
+        // Restore the first location
+        doReturn(false).when(unit).isLocationBreached(eq(location));
+        doReturn(false).when(unit).isLocationDestroyed(eq(location));
+
+        // Secondary Location breached
+        doReturn(true).when(unit).isLocationBreached(eq(secondaryLocation));
+        doReturn(false).when(unit).isLocationDestroyed(eq(secondaryLocation));
+        assertNotNull(missingPart.checkFixable());
+
+        // Location destroyed
+        doReturn(false).when(unit).isLocationBreached(eq(secondaryLocation));
+        doReturn(true).when(unit).isLocationDestroyed(eq(secondaryLocation));
+        assertNotNull(missingPart.checkFixable());
+
+        // Restore both locations
+        doReturn(false).when(unit).isLocationBreached(eq(location));
+        doReturn(false).when(unit).isLocationDestroyed(eq(location));
+        doReturn(false).when(unit).isLocationBreached(eq(secondaryLocation));
+        doReturn(false).when(unit).isLocationDestroyed(eq(secondaryLocation));
+
+        assertNull(missingPart.checkFixable());
+    }
+
+    @Test
+    public void fixWithoutSparePartsTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+        missingPart.setId(25);
+        missingPart.setUnit(unit);
+
+        warehouse.addPart(missingPart);
+
+        // Try fixing the part without a spare
+        missingPart.fix();
+
+        assertTrue(warehouse.getParts().contains(missingPart));
+        assertEquals(unit, missingPart.getUnit());
+    }
+
+    @Test
+    public void fixWithOneSparePartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+        missingPart.setId(25);
+        missingPart.setUnit(unit);
+
+        EquipmentPart sparePart = missingPart.getNewPart();
+        sparePart.setId(21);
+
+        warehouse.addPart(sparePart);
+        warehouse.addPart(missingPart);
+
+        // Try fixing the part with a spare
+        missingPart.fix();
+
+        assertFalse(warehouse.getParts().contains(missingPart));
+        assertTrue(missingPart.getId() < 0);
+        assertNull(missingPart.getUnit());
+
+        // Ensure we used up the spare part
+        assertFalse(warehouse.getParts().contains(sparePart));
+        assertTrue(sparePart.getId() < 0);
+
+        ArgumentCaptor<Part> replacementCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(unit, times(1)).addPart(replacementCaptor.capture());
+
+        Part replacement = replacementCaptor.getValue();
+        assertTrue(replacement instanceof EquipmentPart);
+
+        EquipmentPart replacementEquipmentPart = (EquipmentPart) replacement;
+        assertTrue(replacementEquipmentPart.getId() > 0);
+        assertEquals(equipmentNum, replacementEquipmentPart.getEquipmentNum());
+        assertEquals(unit, replacementEquipmentPart.getUnit());
+        assertTrue(warehouse.getParts().contains(replacementEquipmentPart));
+
+        verify(mounted, times(1)).setMissing(eq(false));
+        verify(mounted, times(1)).setHit(eq(false));
+        verify(mounted, times(1)).setDestroyed(eq(false));
+        verify(mounted, times(1)).setRepairable(eq(true));
+        verify(unit, times(1)).repairSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum));
+    }
+
+    @Test
+    public void fixWithManySparePartsTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse warehouse = new Warehouse();
+        when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+        Quartermaster quartermaster = new Quartermaster(mockCampaign);
+        when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(unit);
+            return null;
+        }).when(unit).addPart(any());
+        doAnswer(inv -> {
+            Part part = inv.getArgument(0);
+            part.setUnit(null);
+            return null;
+        }).when(unit).removePart(any());
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+        missingPart.setId(25);
+        missingPart.setUnit(unit);
+
+        int onHand = 27;
+        EquipmentPart sparePart = missingPart.getNewPart();
+        sparePart.setId(21);
+        sparePart.setQuantity(onHand);
+
+        warehouse.addPart(sparePart);
+        warehouse.addPart(missingPart);
+
+        // Try fixing the part with a spare
+        missingPart.fix();
+
+        assertFalse(warehouse.getParts().contains(missingPart));
+        assertTrue(missingPart.getId() < 0);
+        assertNull(missingPart.getUnit());
+
+        // Ensure we used only one of the spare parts
+        assertTrue(warehouse.getParts().contains(sparePart));
+        assertEquals(onHand - 1, sparePart.getQuantity());
+
+        ArgumentCaptor<Part> replacementCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(unit, times(1)).addPart(replacementCaptor.capture());
+
+        Part replacement = replacementCaptor.getValue();
+        assertTrue(replacement instanceof EquipmentPart);
+
+        EquipmentPart replacementEquipmentPart = (EquipmentPart) replacement;
+        assertTrue(replacementEquipmentPart.getId() > 0);
+        assertEquals(equipmentNum, replacementEquipmentPart.getEquipmentNum());
+        assertEquals(unit, replacementEquipmentPart.getUnit());
+        assertTrue(warehouse.getParts().contains(replacementEquipmentPart));
+
+        verify(mounted, times(1)).setMissing(eq(false));
+        verify(mounted, times(1)).setHit(eq(false));
+        verify(mounted, times(1)).setDestroyed(eq(false));
+        verify(mounted, times(1)).setRepairable(eq(true));
+        verify(unit, times(1)).repairSystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum));
+    }
+
+    @Test
+    public void updateConditionFromPartTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        int equipmentNum = 42;
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+
+        // No unit? This is a no-op
+        missingPart.updateConditionFromPart();
+
+        missingPart.setUnit(unit);
+
+        // No equipment mounted at equipmentNum? This is a no-op
+        missingPart.updateConditionFromPart();
+
+        Mounted mounted = mock(Mounted.class);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+
+        // Equipment mounted at the location
+        missingPart.updateConditionFromPart();
+
+        verify(mounted, times(1)).setHit(eq(true));
+        verify(mounted, times(1)).setDestroyed(eq(true));
+        verify(mounted, times(1)).setRepairable(eq(false));
+        verify(unit, times(1)).destroySystem(eq(CriticalSlot.TYPE_EQUIPMENT), eq(equipmentNum));
+    }
+
+    @Test
+    public void getBaseTimeTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, 42, mockCampaign, equipTonnage, size, false);
+        missingPart.setUnit(unit);
+
+        // Missing parts are 120 minutes ...
+        assertEquals(120, missingPart.getBaseTime());
+
+        // ... except when omni-podded.
+        missingPart.setOmniPodded(true);
+        assertEquals(30, missingPart.getBaseTime());
+    }
+
+    @Test
+    public void getDifficultyTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        EquipmentType type = mock(EquipmentType.class);
+        doReturn(equipTonnage).when(type).getTonnage(any(), anyDouble());
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, 42, mockCampaign, equipTonnage, size, false);
+        missingPart.setUnit(unit);
+
+        // Missing parts are +0
+        assertEquals(0, missingPart.getDifficulty());
+    }
+
+    @Test
+    public void isAcceptableReplacementTest() {
+        Campaign mockCampaign = mock(Campaign.class);
+
+        Unit unit = mock(Unit.class);
+        Entity entity = mock(Entity.class);
+        when(unit.getEntity()).thenReturn(entity);
+
+        int equipmentNum = 42;
+        double equipTonnage = 2.0;
+        double size = 3.0;
+        double cost = 12.0;
+        MiscType type = mock(MiscType.class);
+        when(type.getRawCost()).thenReturn(cost);
+        doReturn(equipTonnage).when(type).getTonnage(any(), eq(size));
+
+        MissingEquipmentPart missingPart = new MissingEquipmentPart(75, type, equipmentNum, mockCampaign, equipTonnage, size, false);
+
+        // We can't replace ourselves with ourselves
+        assertFalse(missingPart.isAcceptableReplacement(missingPart, false));
+
+        // We can't replace ourselves with another missing part
+        Part otherPart = missingPart.clone();
+        assertFalse(missingPart.isAcceptableReplacement(otherPart, false));
+
+        // We're the same even if unit tonnage differs, as long as our
+        // equipment tonnage is the same.
+        otherPart = new EquipmentPart(65, type, 42, size, false, mockCampaign);
+        assertTrue(missingPart.isAcceptableReplacement(otherPart, false));
+
+        // We're not the same if types differ
+        MiscType otherType = mock(MiscType.class);
+        otherPart = new EquipmentPart(75, otherType, 42, size, false, mockCampaign);
+        assertFalse(missingPart.isAcceptableReplacement(otherPart, false));
+
+        // We're not the same if sizes differ
+        double otherSize = 2.0;
+        doReturn(1.75).when(type).getTonnage(any(), eq(otherSize));
+        otherPart = new EquipmentPart(75, type, 42, otherSize, false, mockCampaign);
+        assertFalse(missingPart.isAcceptableReplacement(otherPart, false));
+
+        // We're not the same if one is omni-podded and the other isn't
+        otherPart = new EquipmentPart(75, type, 42, size, true, mockCampaign);
+        assertFalse(missingPart.isAcceptableReplacement(otherPart, false));
+
+        // We're not the same if our sticker prices differ;
+
+        // Setup a type with variable costs
+        doReturn(true).when(type).hasFlag(eq(MiscType.F_OFF_ROAD));
+        doReturn((double) EquipmentType.COST_VARIABLE).when(type).getRawCost();
+
+        // Put the variable cost part back on a unit
+        Mounted mounted = mock(Mounted.class);
+        int location = Mech.LOC_CT;
+        when(mounted.getLocation()).thenReturn(location);
+        doReturn(mounted).when(entity).getEquipment(eq(equipmentNum));
+        doReturn(cost * 10.0).when(type).getCost(eq(entity), anyBoolean(), eq(location), eq(size));
+
+        // And now the other part is not on a unit, so no location hence different cost
+        otherPart = new EquipmentPart(75, type, 42, size, false, mockCampaign);
+        assertTrue(missingPart.isAcceptableReplacement(otherPart, false));
+    }
+}


### PR DESCRIPTION
This PR adds EquipmentPart unit tests and fixes five bugs found along the way:
1. Variable weight sizes were not saved in some circumstances.
2. Weapon Bays weren't checked for destruction in remove. Well, they weren't before due to a bug, then removed as a "dead code path". This restores it.
3. LAM bomb bays always reported 60 minutes to fix, even when not broken.
4. MissingEquipmentPart's did not apply variable sized sticker prices correctly
5. MissingEquipmentPart did not override MissingPart::clone

TODO:
- [x] EquipmentPart::checkWeaponBay Test
- [X] MissingEquipmentPart tests