### PR TITLE
Issue #2310: Avoid procurement popup exceptions due to race condition

### DIFF
--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -382,7 +382,8 @@ public final class CommandCenterTab extends CampaignGuiTab {
                 }
                 if (procurementModel
                         .getAcquisition(procurementTable.convertRowIndexToModel(procurementTable.getSelectedRow()))
-                        .getQuantity() > 0) {
+                        .map(a -> a.getQuantity())
+                        .orElse(0) > 0) {
                     procurementModel.decrementItem(
                             procurementTable.convertRowIndexToModel(procurementTable.getSelectedRow()));
                 }

--- a/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
@@ -54,7 +54,9 @@ public class ProcurementTableMouseAdapter extends MouseInputAdapter {
                 .convertRowIndexToModel(table.getSelectedRow());
         final int[] rows = table.getSelectedRows();
         final boolean oneSelected = table.getSelectedRowCount() == 1;
-        if (e.isPopupTrigger()) {
+        
+        // GM Only (for now)
+        if (e.isPopupTrigger() && gui.getCampaign().isGM()) {
             // **lets fill the pop up menu**//
             // GM mode
             menu = new JMenu("GM Mode");
@@ -67,109 +69,15 @@ public class ProcurementTableMouseAdapter extends MouseInputAdapter {
                         return;
                     }
                     if (oneSelected) {
-                        IAcquisitionWork acquisition = model
-                                .getAcquisition(row);
-                        Object equipment = acquisition.getNewEquipment();
-                        if (equipment instanceof Part) {
-                            if (gui.getCampaign()
-                                    .getQuartermaster()
-                                    .buyPart(
-                                            (Part) equipment,
-                                            gui.getCampaign().calculatePartTransitTime(0))) {
-                                gui.getCampaign()
-                                        .addReport(
-                                                "<font color='Green'><b>"
-                                                        + acquisition
-                                                                .getAcquisitionName()
-                                                        + " found.</b></font>");
-                                acquisition.decrementQuantity();
-                            } else {
-                                gui.getCampaign()
-                                        .addReport(
-                                                "<font color='red'><b>You cannot afford to purchase "
-                                                        + acquisition
-                                                                .getAcquisitionName()
-                                                        + "</b></font>");
-                            }
-                        } else if (equipment instanceof Entity) {
-                            if (gui.getCampaign()
-                                    .getQuartermaster()
-                                    .buyUnit(
-                                            (Entity) equipment,
-                                            gui.getCampaign().calculatePartTransitTime(0))) {
-                                gui.getCampaign()
-                                        .addReport(
-                                                "<font color='Green'><b>"
-                                                        + acquisition
-                                                                .getAcquisitionName()
-                                                        + " found.</b></font>");
-                                acquisition.decrementQuantity();
-                            } else {
-                                gui.getCampaign()
-                                        .addReport(
-                                                "<font color='red'><b>You cannot afford to purchase "
-                                                        + acquisition
-                                                                .getAcquisitionName()
-                                                        + "</b></font>");
-                            }
-                        }
+                        model.getAcquisition(row)
+                                .ifPresent(ProcurementTableMouseAdapter.this::tryProcureOneItem);
                     } else {
                         for (int curRow : rows) {
                             if (curRow < 0) {
                                 continue;
                             }
-                            int row = table.convertRowIndexToModel(curRow);
-                            IAcquisitionWork acquisition = model
-                                    .getAcquisition(row);
-                            Object equipment = acquisition
-                                    .getNewEquipment();
-                            if (equipment instanceof Part) {
-                                if (gui.getCampaign()
-                                        .getQuartermaster()
-                                        .buyPart(
-                                                (Part) equipment,
-                                                gui.getCampaign()
-                                                        .calculatePartTransitTime(
-                                                                0))) {
-                                    gui.getCampaign()
-                                            .addReport(
-                                                    "<font color='Green'><b>"
-                                                            + acquisition
-                                                                    .getAcquisitionName()
-                                                            + " found.</b></font>");
-                                    acquisition.decrementQuantity();
-                                } else {
-                                    gui.getCampaign()
-                                            .addReport(
-                                                    "<font color='red'><b>You cannot afford to purchase "
-                                                            + acquisition
-                                                                    .getAcquisitionName()
-                                                            + "</b></font>");
-                                }
-                            } else if (equipment instanceof Entity) {
-                                if (gui.getCampaign()
-                                        .getQuartermaster()
-                                        .buyUnit(
-                                                (Entity) equipment,
-                                                gui.getCampaign()
-                                                        .calculatePartTransitTime(
-                                                                0))) {
-                                    gui.getCampaign()
-                                            .addReport(
-                                                    "<font color='Green'><b>"
-                                                            + acquisition
-                                                                    .getAcquisitionName()
-                                                            + " found.</b></font>");
-                                    acquisition.decrementQuantity();
-                                } else {
-                                    gui.getCampaign()
-                                            .addReport(
-                                                    "<font color='red'><b>You cannot afford to purchase "
-                                                            + acquisition
-                                                                    .getAcquisitionName()
-                                                            + "</b></font>");
-                                }
-                            }
+                            model.getAcquisition(table.convertRowIndexToModel(curRow))
+                                    .ifPresent(ProcurementTableMouseAdapter.this::tryProcureOneItem);
                         }
                     }
                 }
@@ -184,125 +92,15 @@ public class ProcurementTableMouseAdapter extends MouseInputAdapter {
                         return;
                     }
                     if (oneSelected) {
-                        IAcquisitionWork acquisition = model
-                                .getAcquisition(row);
-                        boolean canAfford = true;
-                        while (canAfford && acquisition.getQuantity() > 0) {
-                            Object equipment = acquisition
-                                    .getNewEquipment();
-                            if (equipment instanceof Part) {
-                                if (gui.getCampaign()
-                                        .getQuartermaster()
-                                        .buyPart(
-                                                (Part) equipment,
-                                                gui.getCampaign()
-                                                        .calculatePartTransitTime(
-                                                                0))) {
-                                    gui.getCampaign()
-                                            .addReport(
-                                                    "<font color='Green'><b>"
-                                                            + acquisition
-                                                                    .getAcquisitionName()
-                                                            + " found.</b></font>");
-                                    acquisition.decrementQuantity();
-                                } else {
-                                    gui.getCampaign()
-                                            .addReport(
-                                                    "<font color='red'><b>You cannot afford to purchase "
-                                                            + acquisition
-                                                                    .getAcquisitionName()
-                                                            + "</b></font>");
-                                    canAfford = false;
-                                }
-                            } else if (equipment instanceof Entity) {
-                                if (gui.getCampaign()
-                                        .getQuartermaster()
-                                        .buyUnit(
-                                                (Entity) equipment,
-                                                gui.getCampaign()
-                                                        .calculatePartTransitTime(
-                                                                0))) {
-                                    gui.getCampaign()
-                                            .addReport(
-                                                    "<font color='Green'><b>"
-                                                            + acquisition
-                                                                    .getAcquisitionName()
-                                                            + " found.</b></font>");
-                                    acquisition.decrementQuantity();
-                                } else {
-                                    gui.getCampaign()
-                                            .addReport(
-                                                    "<font color='red'><b>You cannot afford to purchase "
-                                                            + acquisition
-                                                                    .getAcquisitionName()
-                                                            + "</b></font>");
-                                    canAfford = false;
-                                }
-                            }
-                        }
+                        model.getAcquisition(row)
+                                .ifPresent(ProcurementTableMouseAdapter.this::procureAllItems);
                     } else {
                         for (int curRow : rows) {
                             if (curRow < 0) {
                                 continue;
                             }
-                            int row = table.convertRowIndexToModel(curRow);
-                            IAcquisitionWork acquisition = model
-                                    .getAcquisition(row);
-                            boolean canAfford = true;
-                            while (canAfford
-                                    && acquisition.getQuantity() > 0) {
-                                Object equipment = acquisition
-                                        .getNewEquipment();
-                                if (equipment instanceof Part) {
-                                    if (gui.getCampaign()
-                                            .getQuartermaster()
-                                            .buyPart(
-                                                    (Part) equipment,
-                                                    gui.getCampaign()
-                                                            .calculatePartTransitTime(
-                                                                    0))) {
-                                        gui.getCampaign()
-                                                .addReport(
-                                                        "<font color='Green'><b>"
-                                                                + acquisition
-                                                                        .getAcquisitionName()
-                                                                + " found.</b></font>");
-                                        acquisition.decrementQuantity();
-                                    } else {
-                                        gui.getCampaign()
-                                                .addReport(
-                                                        "<font color='red'><b>You cannot afford to purchase "
-                                                                + acquisition
-                                                                        .getAcquisitionName()
-                                                                + "</b></font>");
-                                        canAfford = false;
-                                    }
-                                } else if (equipment instanceof Entity) {
-                                    if (gui.getCampaign()
-                                            .getQuartermaster()
-                                            .buyUnit(
-                                                    (Entity) equipment,
-                                                    gui.getCampaign()
-                                                            .calculatePartTransitTime(
-                                                                    0))) {
-                                        gui.getCampaign()
-                                                .addReport(
-                                                        "<font color='Green'><b>"
-                                                                + acquisition
-                                                                        .getAcquisitionName()
-                                                                + " found.</b></font>");
-                                        acquisition.decrementQuantity();
-                                    } else {
-                                        gui.getCampaign()
-                                                .addReport(
-                                                        "<font color='red'><b>You cannot afford to purchase "
-                                                                + acquisition
-                                                                        .getAcquisitionName()
-                                                                + "</b></font>");
-                                        canAfford = false;
-                                    }
-                                }
-                            }
+                            model.getAcquisition(table.convertRowIndexToModel(curRow))
+                                    .ifPresent(ProcurementTableMouseAdapter.this::procureAllItems);
                         }
                     }
                 }
@@ -317,20 +115,20 @@ public class ProcurementTableMouseAdapter extends MouseInputAdapter {
                         return;
                     }
                     if (oneSelected) {
-                        IAcquisitionWork acquisition = model
-                                .getAcquisition(row);
-                        model.removeRow(row);
-                        MekHQ.triggerEvent(new ProcurementEvent(acquisition));
+                        model.getAcquisition(row).ifPresent(a -> {
+                            model.removeRow(row);
+                            MekHQ.triggerEvent(new ProcurementEvent(a));
+                        });
                     } else {
                         for (int curRow : rows) {
                             if (curRow < 0) {
                                 continue;
                             }
-                            int row = table.convertRowIndexToModel(curRow);
-                            IAcquisitionWork acquisition = model
-                                    .getAcquisition(row);
-                            model.removeRow(row);
-                            MekHQ.triggerEvent(new ProcurementEvent(acquisition));
+                            model.getAcquisition(table.convertRowIndexToModel(curRow))
+                                    .ifPresent(a -> {
+                                        model.removeRow(row);
+                                        MekHQ.triggerEvent(new ProcurementEvent(a));
+                                    });
                         }
                     }
                 }
@@ -342,5 +140,49 @@ public class ProcurementTableMouseAdapter extends MouseInputAdapter {
             popup.add(menu);
             popup.show(e.getComponent(), e.getX(), e.getY());
         }
+    }
+
+    private void procureAllItems(IAcquisitionWork acquisition) {
+        while (acquisition.getQuantity() > 0) {
+            if (!tryProcureOneItem(acquisition)) {
+                break;
+            }
+        }
+    }
+
+    private boolean tryProcureOneItem(IAcquisitionWork acquisition) {
+        Object equipment = acquisition.getNewEquipment();
+        int transitTime = gui.getCampaign().calculatePartTransitTime(0);
+        if (equipment instanceof Part) {
+            if (gui.getCampaign().getQuartermaster().buyPart((Part) equipment, transitTime)) {
+                reportAcquisitionSuccess(acquisition);
+                acquisition.decrementQuantity();
+                return true;
+            } else {
+                reportAcquisitionFailure(acquisition);
+            }
+        } else if (equipment instanceof Entity) {
+            if (gui.getCampaign().getQuartermaster().buyUnit((Entity) equipment, transitTime)) {
+                reportAcquisitionSuccess(acquisition);
+                acquisition.decrementQuantity();
+                return true;
+            } else {
+                reportAcquisitionFailure(acquisition);
+            }
+        }
+
+        return false;
+    }
+
+    private void reportAcquisitionSuccess(IAcquisitionWork acquisition) {
+        gui.getCampaign()
+                .addReport(String.format("<font color='Green'><b>Procured %s</b></font>",
+                        acquisition.getAcquisitionName()));
+    }
+
+    private void reportAcquisitionFailure(IAcquisitionWork acquisition) {
+        gui.getCampaign()
+                .addReport(String.format("<font color='red'><b>You cannot afford to purchase %s</b></font>",
+                        acquisition.getAcquisitionName()));
     }
 }

--- a/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
@@ -1,6 +1,8 @@
 package mekhq.gui.model;
 
 import java.awt.Component;
+import java.util.Optional;
+
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -65,31 +67,28 @@ public class ProcurementTableModel extends DataTableModel {
     }
 
     public void incrementItem(int row) {
-        ((IAcquisitionWork)data.get(row)).incrementQuantity();
+        getAcquisition(row).ifPresent(IAcquisitionWork::incrementQuantity);
         this.fireTableCellUpdated(row, COL_QUEUE);
     }
 
     public void decrementItem(int row) {
-        ((IAcquisitionWork)data.get(row)).decrementQuantity();
+        getAcquisition(row).ifPresent(IAcquisitionWork::decrementQuantity);
         this.fireTableCellUpdated(row, COL_QUEUE);
     }
 
     public void removeRow(int row) {
-        getCampaign().getShoppingList().removeItem(getNewEquipmentAt(row));
+        getNewEquipmentAt(row).ifPresent(getCampaign().getShoppingList()::removeItem);
     }
 
-    public Object getValueAt(int row, int col) {
-        //Part part;
-        IAcquisitionWork shoppingItem;
-        if(data.isEmpty()) {
+    public Object getValueAt(final int row, final int col) {
+        if (data.isEmpty()) {
             return "";
-        } else {
-            //part = getNewPartAt(row);
-            shoppingItem = getAcquisition(row);
         }
-        if(null == shoppingItem) {
-            return "?";
-        }
+        
+        return getAcquisition(row).map(a -> getValueFor(a, col)).orElse("?");
+    }
+
+    private Object getValueFor(IAcquisitionWork shoppingItem, int col) {
         if(col == COL_NAME) {
             return shoppingItem.getAcquisitionName();
         }
@@ -140,12 +139,16 @@ public class ProcurementTableModel extends DataTableModel {
         return getValueAt(0, c).getClass();
     }
 
-    public Object getNewEquipmentAt(int row) {
-        return ((IAcquisitionWork) data.get(row)).getNewEquipment();
+    public Optional<Object> getNewEquipmentAt(int row) {
+        return getAcquisition(row).map(IAcquisitionWork::getNewEquipment);
     }
 
-    public IAcquisitionWork getAcquisition(int row) {
-        return (IAcquisitionWork) data.get(row);
+    public Optional<IAcquisitionWork> getAcquisition(int row) {
+        if (row >= 0 && row < data.size()) {
+            return Optional.of((IAcquisitionWork) data.get(row));
+        }
+        
+        return Optional.empty();
     }
 
     public int getColumnWidth(int c) {
@@ -177,25 +180,18 @@ public class ProcurementTableModel extends DataTableModel {
         }
     }
 
-    public String getTooltip(int row, int col) {
-        //Part part;
-        IAcquisitionWork shoppingItem;
-        if(data.isEmpty()) {
-            return null;
-        } else {
-            //part = getNewPartAt(row);
-            shoppingItem = getAcquisition(row);
-        }
-        if(null ==shoppingItem) {
-            return null;
-        }
+    public String getTooltip(final int row, final int col) {
+        return getAcquisition(row).map(a -> getTooltipFor(a, col)).orElse(null);
+    }
+
+    private String getTooltipFor(IAcquisitionWork shoppingItem, int col) {
         switch(col) {
-        case COL_TARGET:
-            TargetRoll target = getCampaign().getTargetForAcquisition(shoppingItem, getCampaign().getLogisticsPerson(), false);
-            return target.getDesc();
-        default:
-            return "<html>You can increase or decrease the quantity with the left/right arrows keys or the plus/minus keys.<br>Quantities reduced to zero will remain on the list until the next procurement cycle.</html>";
-        }
+            case COL_TARGET:
+                TargetRoll target = getCampaign().getTargetForAcquisition(shoppingItem, getCampaign().getLogisticsPerson(), false);
+                return target.getDesc();
+            default:
+                return "<html>You can increase or decrease the quantity with the left/right arrows keys or the plus/minus keys.<br>Quantities reduced to zero will remain on the list until the next procurement cycle.</html>";
+            }
     }
 
     private Campaign getCampaign() {

--- a/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
@@ -80,6 +80,7 @@ public class ProcurementTableModel extends DataTableModel {
         getNewEquipmentAt(row).ifPresent(getCampaign().getShoppingList()::removeItem);
     }
 
+    @Override
     public Object getValueAt(final int row, final int col) {
         if (data.isEmpty()) {
             return "";
@@ -206,6 +207,7 @@ public class ProcurementTableModel extends DataTableModel {
 
         private static final long serialVersionUID = 9054581142945717303L;
 
+        @Override
         public Component getTableCellRendererComponent(JTable table,
                 Object value, boolean isSelected, boolean hasFocus,
                 int row, int column) {


### PR DESCRIPTION
When clearing the procurement list, a race condition occurs when other areas of the GUI are updating as the underlying list gets out of sync. Attempts at synchronizing the list did not meet with success, however, moving to a model where failure is expected we can defensively avoid these exceptions.

- Use `Optional<>` to describe data in the table
- Use `Optional<>::ifPresent` to take conditional actions
- Refactor `ProcumentTableMouseAdapter` to be cleaner and more maintainable
- Improve the campaign report message when you actually procure an item

Fixes #2310.