### PR TITLE
Issue #2298: Do not display unknown armor types in the Parts In Use report

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1647,11 +1647,14 @@ public class Campaign implements Serializable, ITechManager {
         if (p instanceof StructuralIntegrity) {
             return null;
         }
+        // Skip out on "not armor" (as in 0 point armer on men or field guns)
+        if ((p instanceof Armor) && ((Armor) p).getType() == EquipmentType.T_ARMOR_UNKNOWN) {
+            return null;
+        }
         // Makes no sense buying those separately from the chasis
         if((p instanceof EquipmentPart)
                 && ((EquipmentPart) p).getType() != null
-                && (((EquipmentPart) p).getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION)))
-        {
+                && (((EquipmentPart) p).getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION))) {
             return null;
         }
         // Replace a "missing" part with a corresponding "new" one.


### PR DESCRIPTION
This filters out armor which has an unknown type, as seen on some infantry units in the campaign. There may be a more elegant solution to this, but I'm not exactly sure how these units ended up this way in the first place (by design? error?). You can't buy this armor, nor sell it, so it might as well not show up.

Fixes #2298.