### PR TITLE
Issue #2317: Ensure Person::idleMonths defaults to 0

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -349,7 +349,6 @@ public class Person implements Serializable, MekHqXmlSerializable {
         phenotype = Phenotype.NONE;
         bloodname = "";
         biography = "";
-        idleMonths = -1;
         genealogy = new Genealogy(getId());
         tryingToMarry = true;
         tryingToConceive = true;


### PR DESCRIPTION
When serializing `Person::idleMonths`, as a performance tweak we do not save the value if it is zero. This performance tweak is only applicable if the default value for the field is used (`0`), however, in this case the existing code defaulted the value to `-1`. This meant if you saved the campaign when there were zero idle months for your crew and reloaded the campaign, they would instead be at `-1` idle months from the default ctor during deserialization. They'd end up having to work an extra month for the same XP gain.

This removes the default value for `idleMonths`, leaving it to be set by the JVM. Fixes #2317.