### PR TITLE
Restrict removing, salvaging, or scrapping certain locations on LAMs

### DIFF
--- a/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2020 MegaMek team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import megamek.common.CriticalSlot;
+import megamek.common.LandAirMech;
+import megamek.common.Mech;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+
+public class MekLocationTest {
+    @Test
+    public void lamTorsoRemovableOnlyWithMissingAvionicsAndLandingGear() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+        LandAirMech entity = mock(LandAirMech.class);
+        when(unit.getEntity()).thenReturn(entity);
+        when(entity.getWeight()).thenReturn(30.0);
+        doCallRealMethod().when(entity).getLocationName(any());
+
+        int location = Mech.LOC_RT;
+        MekLocation torso = new MekLocation(location, 30, 0, false, false, false, false, false, mockCampaign);
+        torso.setUnit(unit);
+
+        // Mark that we're salvaging the part
+        when(unit.isSalvage()).thenReturn(true);
+
+        // Blow off the right arm
+        doReturn(true).when(entity).isLocationBad(Mech.LOC_RARM);
+
+        // 2 criticals
+        doReturn(2).when(entity).getNumberOfCriticals(eq(location));
+        CriticalSlot mockLandingGear = mock(CriticalSlot.class);
+        when(mockLandingGear.isEverHittable()).thenReturn(true);
+        when(mockLandingGear.getType()).thenReturn(CriticalSlot.TYPE_SYSTEM);
+        when(mockLandingGear.getIndex()).thenReturn(LandAirMech.LAM_LANDING_GEAR);
+        doReturn(mockLandingGear).when(entity).getCritical(eq(location), eq(0));
+        CriticalSlot mockAvionics = mock(CriticalSlot.class);
+        when(mockAvionics.isEverHittable()).thenReturn(true);
+        when(mockAvionics.getType()).thenReturn(CriticalSlot.TYPE_SYSTEM);
+        when(mockAvionics.getIndex()).thenReturn(LandAirMech.LAM_AVIONICS);
+        doReturn(mockAvionics).when(entity).getCritical(eq(location), eq(1));
+
+        // No missing parts
+        doAnswer(inv -> {
+            return null;
+        }).when(unit).findPart(any());
+
+        // We cannot remove this torso
+        assertNotNull(torso.checkFixable());
+        assertNotNull(torso.checkSalvagable());
+        assertNotNull(torso.checkScrappable());
+
+        // Only missing landing gear, avionics are still good
+        doAnswer(inv -> {
+            Predicate<Part> predicate = inv.getArgument(0);
+            MissingLandingGear missingLandingGear = mock(MissingLandingGear.class);
+            return predicate.test(missingLandingGear) ? missingLandingGear : null;
+        }).when(unit).findPart(any());
+
+        // We cannot remove this torso
+        assertNotNull(torso.checkFixable());
+        assertNotNull(torso.checkSalvagable());
+        assertNotNull(torso.checkScrappable());
+
+        // Only missing avionics, landing gear is still good
+        doAnswer(inv -> {
+            Predicate<Part> predicate = inv.getArgument(0);
+            MissingAvionics missingAvionics = mock(MissingAvionics.class);
+            return predicate.test(missingAvionics) ? missingAvionics : null;
+        }).when(unit).findPart(any());
+
+        // We cannot remove this torso
+        assertNotNull(torso.checkFixable());
+        assertNotNull(torso.checkSalvagable());
+        assertNotNull(torso.checkScrappable());
+
+        // Missing both Landing Gear and Avionics
+        doAnswer(inv -> {
+            Predicate<Part> predicate = inv.getArgument(0);
+            MissingLandingGear missingLandingGear = mock(MissingLandingGear.class);
+            if (predicate.test(missingLandingGear)) {
+                return missingLandingGear;
+            }
+
+            MissingAvionics missingAvionics = mock(MissingAvionics.class);
+            return predicate.test(missingAvionics) ? missingAvionics : null;
+        }).when(unit).findPart(any());
+
+        // We CAN remove this torso
+        assertNull(torso.checkFixable());
+        assertNull(torso.checkSalvagable());
+        assertNull(torso.checkScrappable());
+    }
+
+    @Test
+    public void lamHeadRemovableOnlyWithMissingAvionics() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Unit unit = mock(Unit.class);
+        LandAirMech entity = mock(LandAirMech.class);
+        when(unit.getEntity()).thenReturn(entity);
+        when(entity.getWeight()).thenReturn(30.0);
+        doCallRealMethod().when(entity).getLocationName(any());
+
+        int location = Mech.LOC_HEAD;
+        MekLocation head = new MekLocation(location, 30, 0, false, false, false, false, false, mockCampaign);
+        head.setUnit(unit);
+
+        // Mark that we're salvaging the part
+        when(unit.isSalvage()).thenReturn(true);
+
+        // 1 critical
+        doReturn(1).when(entity).getNumberOfCriticals(eq(location));
+        CriticalSlot mockAvionics = mock(CriticalSlot.class);
+        when(mockAvionics.isEverHittable()).thenReturn(true);
+        when(mockAvionics.getType()).thenReturn(CriticalSlot.TYPE_SYSTEM);
+        when(mockAvionics.getIndex()).thenReturn(LandAirMech.LAM_AVIONICS);
+        doReturn(mockAvionics).when(entity).getCritical(eq(location), eq(0));
+
+        // No missing parts
+        doAnswer(inv -> {
+            return null;
+        }).when(unit).findPart(any());
+
+        // We cannot remove this head
+        assertNotNull(head.checkFixable());
+        assertNotNull(head.checkSalvagable());
+        assertNotNull(head.checkScrappable());
+
+        // Missing avionics
+        doAnswer(inv -> {
+            Predicate<Part> predicate = inv.getArgument(0);
+            MissingLandingGear missingLandingGear = mock(MissingLandingGear.class);
+            if (predicate.test(missingLandingGear)) {
+                return missingLandingGear;
+            }
+
+            MissingAvionics missingAvionics = mock(MissingAvionics.class);
+            return predicate.test(missingAvionics) ? missingAvionics : null;
+        }).when(unit).findPart(any());
+
+        // We CAN remove this head
+        assertNull(head.checkFixable());
+        assertNull(head.checkSalvagable());
+        assertNull(head.checkScrappable());
+    }
+}


### PR DESCRIPTION
This is the follow-up to #2290 and restricts removing, salvaging, and scrapping the head and side torsos on LAMs until their Avionics and Landing Gear have been removed/salvaged/scrapped.