### PR TITLE
Issue #2325: Do not throw NPE on missing equipment when unscrambling equipment numbers

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -1169,13 +1169,15 @@ public class Utilities {
                 eqnum = ((MissingEquipmentPart) part).getEquipmentNum();
                 etype = ((MissingEquipmentPart) part).getType();
             }
-            if (null != etype) {
+            if (etype != null) {
                 Mounted mounted = unit.getEntity().getEquipment(eqnum);
                 if (equipNums.contains(eqnum)
+                        && (mounted != null)
                         && etype.equals(mounted.getType())) {
                     equipNums.remove((Integer) eqnum);
                 } else if ((part instanceof AmmoBin)
                         && (etype instanceof AmmoType)
+                        && (mounted != null)
                         && (mounted.getType() instanceof AmmoType)) {
                     // Handle AmmoBins which had their AmmoType changed
                     // but did not get reloaded yet.

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -62,682 +62,682 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitTestUtilities;
 
 public class RefitTest {
-        @Test
-        public void deserializationCtor() {
-                Refit refit = new Refit();
-                assertNotNull(refit);
+    @Test
+    public void deserializationCtor() {
+        Refit refit = new Refit();
+        assertNotNull(refit);
+    }
+
+    @Test
+    public void newRefitCtor() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+
+        // Create the original entity backing the unit
+        Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
+        IPlayer mockPlayer = mock(IPlayer.class);
+        when(mockPlayer.getName()).thenReturn("Test Player");
+        oldEntity.setOwner(mockPlayer);
+
+        // Create the entity we're going to refit to
+        Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+
+        // Create the unit which will be refit
+        Unit oldUnit = new Unit(oldEntity, mockCampaign);
+        oldUnit.initializeParts(false);
+
+        // Create the Refit
+        Refit refit = new Refit(oldUnit, newEntity, false, false);
+        assertEquals(mockCampaign, refit.getCampaign());
+
+        // Should be old parts...
+        assertFalse(refit.getOldUnitParts().isEmpty());
+
+        // ... and new parts.
+        assertFalse(refit.getNewUnitParts().isEmpty());
+
+        // ... and we'll need to buy some parts
+        assertFalse(refit.getShoppingList().isEmpty());
+    }
+
+    @Test
+    public void locust1Vto1ETest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+
+        // Create the original entity backing the unit
+        Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
+        IPlayer mockPlayer = mock(IPlayer.class);
+        when(mockPlayer.getName()).thenReturn("Test Player");
+        oldEntity.setOwner(mockPlayer);
+
+        // Create the entity we're going to refit to
+        Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+
+        // Create the unit which will be refit
+        Unit oldUnit = new Unit(oldEntity, mockCampaign);
+        oldUnit.setId(UUID.randomUUID());
+        oldUnit.initializeParts(false);
+
+        // Create the Refit
+        Refit refit = new Refit(oldUnit, newEntity, false, false);
+        assertEquals(mockCampaign, refit.getCampaign());
+
+        //
+        // Locust 1V to 1E Class D refit steps (in no particular order):
+        // 1. Remove excess Machine Gun (LA) [120 mins]
+        // 2. Remove excess Machine Gun (RA) [120 mins]
+        // 3. Remove Machine Gun Ammo Bin (CT) [120 mins]
+        // 4. Move Medium Laser (CT) to (RA) [120 mins]
+        // 5. Add Medium Laser to (LA) [120 mins]
+        // 6. Add Small Laser to (RA) [120 mins]
+        // 7. Add Small Laser to (LA) [120 mins]
+        //
+        // Everything else is the same.
+        //
+
+        // Per SO p188:
+        // "This kit permits players to install a new item
+        // where previously there was none..."
+        assertEquals(Refit.CLASS_D, refit.getRefitClass());
+
+        // Time?
+        // + 3 removals @ 120 mins ea
+        // + 1 move @ 120 mins ea
+        // + 3 adds @ 120 mins ea
+        // x 3 (Class D)
+        assertEquals((120.0 * 7.0) * 3.0, refit.getActualTime(), 0.1);
+
+        // Cost?
+        // + 1 Medium Laser @ 40,000 ea
+        // + 2 Small Lasers @ 11,250 ea
+        // x 1.1 (Refit Kit cost, SO p188)
+        assertEquals(Money.of((40000 + 11250 + 11250) * 1.1), refit.getCost());
+
+        // We're removing 2 machine guns and an ammo bin
+        List<Part> removedParts = refit.getOldUnitParts();
+        assertEquals(3, removedParts.size());
+        assertEquals(2, removedParts.stream()
+                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("Machine Gun"))
+                .count());
+        assertEquals(1, removedParts.stream()
+                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("Machine Gun Ammo Bin"))
+                .count());
+
+        // All of the new parts should be from the old unit
+        List<Part> newParts = refit.getNewUnitParts();
+        assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
+
+        // We need to buy one Medium Laser and two Small Lasers
+        List<Part> shoppingCart = refit.getShoppingList();
+        assertEquals(1, shoppingCart.stream()
+                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Medium Laser"))
+                .count());
+        assertEquals(2, shoppingCart.stream()
+                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Small Laser"))
+                .count());
+    }
+
+    @Test
+    public void testLocust1Vto1EWriteToXml() throws ParserConfigurationException, SAXException, IOException {
+        Campaign mockCampaign = mock(Campaign.class);
+        when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+
+        // Create the original entity backing the unit
+        Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
+        IPlayer mockPlayer = mock(IPlayer.class);
+        when(mockPlayer.getName()).thenReturn("Test Player");
+        oldEntity.setOwner(mockPlayer);
+
+        // Create the entity we're going to refit to
+        Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+
+        // Create the unit which will be refit
+        Unit oldUnit = new Unit(oldEntity, mockCampaign);
+        oldUnit.setId(UUID.randomUUID());
+        oldUnit.initializeParts(false);
+
+        // Make sure the unit parts have an ID before we serialize them
+        int partId = 1;
+        for (Part part : oldUnit.getParts()) {
+            part.setId(partId++);
         }
 
-        @Test
-        public void newRefitCtor() {
-                Campaign mockCampaign = mock(Campaign.class);
-                Warehouse mockWarehouse = mock(Warehouse.class);
-                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-                Quartermaster mockQuartermaster = mock(Quartermaster.class);
-                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        // Create the Refit
+        Refit refit = new Refit(oldUnit, newEntity, false, false);
 
-                // Create the original entity backing the unit
-                Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
-                IPlayer mockPlayer = mock(IPlayer.class);
-                when(mockPlayer.getName()).thenReturn("Test Player");
-                oldEntity.setOwner(mockPlayer);
+        // Write the Refit XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        refit.writeToXml(pw, 0);
 
-                // Create the entity we're going to refit to
-                Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+        // Get the Refit XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
 
-                // Create the unit which will be refit
-                Unit oldUnit = new Unit(oldEntity, mockCampaign);
-                oldUnit.initializeParts(false);
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
-                // Create the Refit
-                Refit refit = new Refit(oldUnit, newEntity, false, false);
-                assertEquals(mockCampaign, refit.getCampaign());
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
 
-                // Should be old parts...
-                assertFalse(refit.getOldUnitParts().isEmpty());
+        Element refitElt = xmlDoc.getDocumentElement();
+        assertEquals("refit", refitElt.getNodeName());
 
-                // ... and new parts.
-                assertFalse(refit.getNewUnitParts().isEmpty());
+        // Deserialize the refit
+        Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
+        assertNotNull(deserialized);
 
-                // ... and we'll need to buy some parts
-                assertFalse(refit.getShoppingList().isEmpty());
+        // Spot check the values
+        assertEquals(refit.getTime(), deserialized.getTime());
+        assertEquals(refit.getActualTime(), deserialized.getActualTime());
+        assertEquals(refit.getCost(), deserialized.getCost());
+        assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
+        assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
+        assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
+        assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
+        assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
+        assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
+        assertEquals(refit.kitFound(), deserialized.kitFound());
+        assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
+        assertEquals(refit.getTech(), deserialized.getTech());
+
+        // Check that we got all the correct old parts in the XML
+        Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        assertEquals(oldUnitParts, serializedOldParts);
+
+        // Check that we got all the correct new parts in the XML
+        Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        assertEquals(newUnitParts, serializedNewParts);
+
+        // Check that we got all the shopping list entries (by name, not amazing but
+        // reasonable)
+        List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
+                .collect(Collectors.toList());
+        List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
+                .collect(Collectors.toList());
+
+        // Make sure they're the same length first...
+        assertEquals(shoppingList.size(), serializedShoppingList.size());
+
+        // ... then make sure they're the "same" by removing them one by one...
+        for (String partName : shoppingList) {
+            assertTrue(serializedShoppingList.remove(partName));
         }
 
-        @Test
-        public void locust1Vto1ETest() {
-                Campaign mockCampaign = mock(Campaign.class);
-                Warehouse mockWarehouse = mock(Warehouse.class);
-                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-                Quartermaster mockQuartermaster = mock(Quartermaster.class);
-                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        // ... and ensuring nothing is left.
+        assertTrue(serializedShoppingList.isEmpty());
 
-                // Create the original entity backing the unit
-                Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
-                IPlayer mockPlayer = mock(IPlayer.class);
-                when(mockPlayer.getName()).thenReturn("Test Player");
-                oldEntity.setOwner(mockPlayer);
+        // Do the same for their descriptions, which include the quantities...
+        List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
+        // ... except the second list needs to be mutable.
+        List<String> serializedShoppingListDescs = new ArrayList<>(
+                Arrays.asList(deserialized.getShoppingListDescription()));
 
-                // Create the entity we're going to refit to
-                Entity newEntity = UnitTestUtilities.getLocustLCT1E();
-
-                // Create the unit which will be refit
-                Unit oldUnit = new Unit(oldEntity, mockCampaign);
-                oldUnit.setId(UUID.randomUUID());
-                oldUnit.initializeParts(false);
-
-                // Create the Refit
-                Refit refit = new Refit(oldUnit, newEntity, false, false);
-                assertEquals(mockCampaign, refit.getCampaign());
-
-                //
-                // Locust 1V to 1E Class D refit steps (in no particular order):
-                // 1. Remove excess Machine Gun (LA) [120 mins]
-                // 2. Remove excess Machine Gun (RA) [120 mins]
-                // 3. Remove Machine Gun Ammo Bin (CT) [120 mins]
-                // 4. Move Medium Laser (CT) to (RA) [120 mins]
-                // 5. Add Medium Laser to (LA) [120 mins]
-                // 6. Add Small Laser to (RA) [120 mins]
-                // 7. Add Small Laser to (LA) [120 mins]
-                //
-                // Everything else is the same.
-                //
-
-                // Per SO p188:
-                // "This kit permits players to install a new item
-                // where previously there was none..."
-                assertEquals(Refit.CLASS_D, refit.getRefitClass());
-
-                // Time?
-                // + 3 removals @ 120 mins ea
-                // + 1 move @ 120 mins ea
-                // + 3 adds @ 120 mins ea
-                // x 3 (Class D)
-                assertEquals((120.0 * 7.0) * 3.0, refit.getActualTime(), 0.1);
-
-                // Cost?
-                // + 1 Medium Laser @ 40,000 ea
-                // + 2 Small Lasers @ 11,250 ea
-                // x 1.1 (Refit Kit cost, SO p188)
-                assertEquals(Money.of((40000 + 11250 + 11250) * 1.1), refit.getCost());
-
-                // We're removing 2 machine guns and an ammo bin
-                List<Part> removedParts = refit.getOldUnitParts();
-                assertEquals(3, removedParts.size());
-                assertEquals(2, removedParts.stream()
-                                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("Machine Gun"))
-                                .count());
-                assertEquals(1, removedParts.stream()
-                                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("Machine Gun Ammo Bin"))
-                                .count());
-
-                // All of the new parts should be from the old unit
-                List<Part> newParts = refit.getNewUnitParts();
-                assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
-
-                // We need to buy one Medium Laser and two Small Lasers
-                List<Part> shoppingCart = refit.getShoppingList();
-                assertEquals(1, shoppingCart.stream()
-                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Medium Laser"))
-                                .count());
-                assertEquals(2, shoppingCart.stream()
-                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Small Laser"))
-                                .count());
+        assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
+        for (String desc : shoppingListDescs) {
+            assertTrue(serializedShoppingListDescs.remove(desc));
         }
 
-        @Test
-        public void testLocust1Vto1EWriteToXml() throws ParserConfigurationException, SAXException, IOException {
-                Campaign mockCampaign = mock(Campaign.class);
-                when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
-                Warehouse mockWarehouse = mock(Warehouse.class);
-                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-                Quartermaster mockQuartermaster = mock(Quartermaster.class);
-                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        assertTrue(serializedShoppingListDescs.isEmpty());
+    }
 
-                // Create the original entity backing the unit
-                Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
-                IPlayer mockPlayer = mock(IPlayer.class);
-                when(mockPlayer.getName()).thenReturn("Test Player");
-                oldEntity.setOwner(mockPlayer);
+    @Test
+    public void javelinJVN10Nto10ATest() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
 
-                // Create the entity we're going to refit to
-                Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+        // Create the original entity backing the unit
+        Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
+        IPlayer mockPlayer = mock(IPlayer.class);
+        when(mockPlayer.getName()).thenReturn("Test Player");
+        oldEntity.setOwner(mockPlayer);
 
-                // Create the unit which will be refit
-                Unit oldUnit = new Unit(oldEntity, mockCampaign);
-                oldUnit.setId(UUID.randomUUID());
-                oldUnit.initializeParts(false);
+        // Create the entity we're going to refit to
+        Entity newEntity = UnitTestUtilities.getJavelinJVN10A();
 
-                // Make sure the unit parts have an ID before we serialize them
-                int partId = 1;
-                for (Part part : oldUnit.getParts()) {
-                        part.setId(partId++);
-                }
+        // Create the unit which will be refit
+        Unit oldUnit = new Unit(oldEntity, mockCampaign);
+        oldUnit.setId(UUID.randomUUID());
+        oldUnit.initializeParts(false);
 
-                // Create the Refit
-                Refit refit = new Refit(oldUnit, newEntity, false, false);
+        // Create the Refit
+        Refit refit = new Refit(oldUnit, newEntity, false, false);
+        assertEquals(mockCampaign, refit.getCampaign());
 
-                // Write the Refit XML
-                StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);
-                refit.writeToXml(pw, 0);
+        //
+        // Javelin 10N to 10A Class C refit steps (in no particular order):
+        // 1. Remove excess SRM 6 (LT) [120 mins]
+        // 2. Remove excess SRM 6 (RT) [120 mins]
+        // 3. Remove SRM 6 Ammo Bin (LT) [120 mins]
+        // 4. Remove SRM 6 Ammo Bin (RT) [120 mins]
+        // 5. Add LRM 15 to (RT) [120 mins]
+        // 6. Add LRM 15 Ammo Bin to (RT) [120 mins]
+        //
+        // Everything else is the same.
+        //
 
-                // Get the Refit XML
-                String xml = sw.toString();
-                assertFalse(xml.trim().isEmpty());
+        // Per SO p188:
+        // "A Class C kit also enables replacement of a weapon
+        // or item of equipment with any other, even if it is
+        // larger than the item(s) being replaced; for example,
+        // replacing an ER large laser with an LRM-10 launcher
+        // and ammunition."
+        assertEquals(Refit.CLASS_C, refit.getRefitClass());
 
-                // Using factory get an instance of document builder
-                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+        // Time?
+        // + 4 removals @ 120 mins ea
+        // + 2 adds @ 120 mins ea
+        // x 2 (Class C)
+        assertEquals((120.0 * 6.0) * 2.0, refit.getActualTime(), 0.1);
 
-                // Parse using builder to get DOM representation of the XML file
-                Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+        // Cost?
+        // + 1 LRM 15 @ 175,000 ea
+        // + 1 ton LRM 15 Ammo @ 30,000 ea
+        // x 1.1 (Refit Kit cost, SO p188)
+        assertEquals(Money.of(175000.0 + 30000.0).multipliedBy(1.1), refit.getCost());
 
-                Element refitElt = xmlDoc.getDocumentElement();
-                assertEquals("refit", refitElt.getNodeName());
+        // We're removing 2 SRM 6s and two ammo bins
+        List<Part> removedParts = refit.getOldUnitParts();
+        assertEquals(4, removedParts.size());
+        assertEquals(2, removedParts.stream()
+                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("SRM 6")).count());
+        assertEquals(2, removedParts.stream()
+                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("SRM 6 Ammo Bin")).count());
 
-                // Deserialize the refit
-                Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
-                assertNotNull(deserialized);
+        // All of the new parts should be from the old unit
+        List<Part> newParts = refit.getNewUnitParts();
+        assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
 
-                // Spot check the values
-                assertEquals(refit.getTime(), deserialized.getTime());
-                assertEquals(refit.getActualTime(), deserialized.getActualTime());
-                assertEquals(refit.getCost(), deserialized.getCost());
-                assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
-                assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
-                assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
-                assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
-                assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
-                assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
-                assertEquals(refit.kitFound(), deserialized.kitFound());
-                assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
-                assertEquals(refit.getTech(), deserialized.getTech());
+        // We need to buy one LRM 15 and one LRM 15 Ammo Bin
+        List<Part> shoppingCart = refit.getShoppingList();
+        assertEquals(1, shoppingCart.stream()
+                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("LRM 15"))
+                .count());
+        assertEquals(1, shoppingCart.stream()
+                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("LRM 15 Ammo Bin")).count());
+    }
 
-                // Check that we got all the correct old parts in the XML
-                Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                assertEquals(oldUnitParts, serializedOldParts);
+    @Test
+    public void testJavelinJVN10Nto10AWriteToXml() throws ParserConfigurationException, SAXException, IOException {
+        Campaign mockCampaign = mock(Campaign.class);
+        when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        Person mockTech = mock(Person.class);
+        UUID techId = UUID.randomUUID();
+        when(mockTech.getId()).thenReturn(techId);
 
-                // Check that we got all the correct new parts in the XML
-                Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                assertEquals(newUnitParts, serializedNewParts);
+        // Create the original entity backing the unit
+        Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
+        IPlayer mockPlayer = mock(IPlayer.class);
+        when(mockPlayer.getName()).thenReturn("Test Player");
+        oldEntity.setOwner(mockPlayer);
 
-                // Check that we got all the shopping list entries (by name, not amazing but
-                // reasonable)
-                List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
-                                .collect(Collectors.toList());
-                List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
-                                .collect(Collectors.toList());
+        // Create the entity we're going to refit to
+        Entity newEntity = UnitTestUtilities.getJavelinJVN10A();
 
-                // Make sure they're the same length first...
-                assertEquals(shoppingList.size(), serializedShoppingList.size());
+        // Create the unit which will be refit
+        Unit oldUnit = new Unit(oldEntity, mockCampaign);
+        oldUnit.setId(UUID.randomUUID());
+        oldUnit.initializeParts(false);
 
-                // ... then make sure they're the "same" by removing them one by one...
-                for (String partName : shoppingList) {
-                        assertTrue(serializedShoppingList.remove(partName));
-                }
-
-                // ... and ensuring nothing is left.
-                assertTrue(serializedShoppingList.isEmpty());
-
-                // Do the same for their descriptions, which include the quantities...
-                List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
-                // ... except the second list needs to be mutable.
-                List<String> serializedShoppingListDescs = new ArrayList<>(
-                                Arrays.asList(deserialized.getShoppingListDescription()));
-
-                assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
-                for (String desc : shoppingListDescs) {
-                        assertTrue(serializedShoppingListDescs.remove(desc));
-                }
-
-                assertTrue(serializedShoppingListDescs.isEmpty());
+        // Make sure the unit parts have an ID before we serialize them
+        int partId = 1;
+        for (Part part : oldUnit.getParts()) {
+            part.setId(partId++);
         }
 
-        @Test
-        public void javelinJVN10Nto10ATest() {
-                Campaign mockCampaign = mock(Campaign.class);
-                CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-                when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-                Warehouse mockWarehouse = mock(Warehouse.class);
-                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-                Quartermaster mockQuartermaster = mock(Quartermaster.class);
-                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        // Create the Refit
+        Refit refit = new Refit(oldUnit, newEntity, false, false);
+        refit.setTech(mockTech);
+        refit.addTimeSpent(60); // 1 hour of work!
 
-                // Create the original entity backing the unit
-                Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
-                IPlayer mockPlayer = mock(IPlayer.class);
-                when(mockPlayer.getName()).thenReturn("Test Player");
-                oldEntity.setOwner(mockPlayer);
+        // Write the Refit XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        refit.writeToXml(pw, 0);
 
-                // Create the entity we're going to refit to
-                Entity newEntity = UnitTestUtilities.getJavelinJVN10A();
+        // Get the Refit XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
 
-                // Create the unit which will be refit
-                Unit oldUnit = new Unit(oldEntity, mockCampaign);
-                oldUnit.setId(UUID.randomUUID());
-                oldUnit.initializeParts(false);
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
-                // Create the Refit
-                Refit refit = new Refit(oldUnit, newEntity, false, false);
-                assertEquals(mockCampaign, refit.getCampaign());
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
 
-                //
-                // Javelin 10N to 10A Class C refit steps (in no particular order):
-                // 1. Remove excess SRM 6 (LT) [120 mins]
-                // 2. Remove excess SRM 6 (RT) [120 mins]
-                // 3. Remove SRM 6 Ammo Bin (LT) [120 mins]
-                // 4. Remove SRM 6 Ammo Bin (RT) [120 mins]
-                // 5. Add LRM 15 to (RT) [120 mins]
-                // 6. Add LRM 15 Ammo Bin to (RT) [120 mins]
-                //
-                // Everything else is the same.
-                //
+        Element refitElt = xmlDoc.getDocumentElement();
+        assertEquals("refit", refitElt.getNodeName());
 
-                // Per SO p188:
-                // "A Class C kit also enables replacement of a weapon
-                // or item of equipment with any other, even if it is
-                // larger than the item(s) being replaced; for example,
-                // replacing an ER large laser with an LRM-10 launcher
-                // and ammunition."
-                assertEquals(Refit.CLASS_C, refit.getRefitClass());
+        // Deserialize the refit
+        Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
+        assertNotNull(deserialized);
 
-                // Time?
-                // + 4 removals @ 120 mins ea
-                // + 2 adds @ 120 mins ea
-                // x 2 (Class C)
-                assertEquals((120.0 * 6.0) * 2.0, refit.getActualTime(), 0.1);
+        // Spot check the values
+        assertEquals(refit.getTime(), deserialized.getTime());
+        assertEquals(refit.getActualTime(), deserialized.getActualTime());
+        assertEquals(refit.getCost(), deserialized.getCost());
+        assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
+        assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
+        assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
+        assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
+        assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
+        assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
+        assertEquals(refit.kitFound(), deserialized.kitFound());
+        assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
+        assertEquals(refit.getTech().getId(), deserialized.getTech().getId());
 
-                // Cost?
-                // + 1 LRM 15 @ 175,000 ea
-                // + 1 ton LRM 15 Ammo @ 30,000 ea
-                // x 1.1 (Refit Kit cost, SO p188)
-                assertEquals(Money.of(175000.0 + 30000.0).multipliedBy(1.1), refit.getCost());
+        // Check that we got all the correct old parts in the XML
+        Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        assertEquals(oldUnitParts, serializedOldParts);
 
-                // We're removing 2 SRM 6s and two ammo bins
-                List<Part> removedParts = refit.getOldUnitParts();
-                assertEquals(4, removedParts.size());
-                assertEquals(2, removedParts.stream()
-                                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("SRM 6")).count());
-                assertEquals(2, removedParts.stream()
-                                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("SRM 6 Ammo Bin")).count());
+        // Check that we got all the correct new parts in the XML
+        Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        assertEquals(newUnitParts, serializedNewParts);
 
-                // All of the new parts should be from the old unit
-                List<Part> newParts = refit.getNewUnitParts();
-                assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
+        // Check that we got all the shopping list entries (by name, not amazing but
+        // reasonable)
+        List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
+                .collect(Collectors.toList());
+        List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
+                .collect(Collectors.toList());
 
-                // We need to buy one LRM 15 and one LRM 15 Ammo Bin
-                List<Part> shoppingCart = refit.getShoppingList();
-                assertEquals(1, shoppingCart.stream()
-                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("LRM 15"))
-                                .count());
-                assertEquals(1, shoppingCart.stream()
-                                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("LRM 15 Ammo Bin")).count());
+        // Make sure they're the same length first...
+        assertEquals(shoppingList.size(), serializedShoppingList.size());
+
+        // ... then make sure they're the "same" by removing them one by one...
+        for (String partName : shoppingList) {
+            assertTrue(serializedShoppingList.remove(partName));
         }
 
-        @Test
-        public void testJavelinJVN10Nto10AWriteToXml() throws ParserConfigurationException, SAXException, IOException {
-                Campaign mockCampaign = mock(Campaign.class);
-                when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
-                CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-                when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-                Warehouse mockWarehouse = mock(Warehouse.class);
-                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-                Quartermaster mockQuartermaster = mock(Quartermaster.class);
-                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
-                Person mockTech = mock(Person.class);
-                UUID techId = UUID.randomUUID();
-                when(mockTech.getId()).thenReturn(techId);
+        // ... and ensuring nothing is left.
+        assertTrue(serializedShoppingList.isEmpty());
 
-                // Create the original entity backing the unit
-                Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
-                IPlayer mockPlayer = mock(IPlayer.class);
-                when(mockPlayer.getName()).thenReturn("Test Player");
-                oldEntity.setOwner(mockPlayer);
+        // Do the same for their descriptions, which include the quantities...
+        List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
+        // ... except the second list needs to be mutable.
+        List<String> serializedShoppingListDescs = new ArrayList<>(
+                Arrays.asList(deserialized.getShoppingListDescription()));
 
-                // Create the entity we're going to refit to
-                Entity newEntity = UnitTestUtilities.getJavelinJVN10A();
-
-                // Create the unit which will be refit
-                Unit oldUnit = new Unit(oldEntity, mockCampaign);
-                oldUnit.setId(UUID.randomUUID());
-                oldUnit.initializeParts(false);
-
-                // Make sure the unit parts have an ID before we serialize them
-                int partId = 1;
-                for (Part part : oldUnit.getParts()) {
-                        part.setId(partId++);
-                }
-
-                // Create the Refit
-                Refit refit = new Refit(oldUnit, newEntity, false, false);
-                refit.setTech(mockTech);
-                refit.addTimeSpent(60); // 1 hour of work!
-
-                // Write the Refit XML
-                StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);
-                refit.writeToXml(pw, 0);
-
-                // Get the Refit XML
-                String xml = sw.toString();
-                assertFalse(xml.trim().isEmpty());
-
-                // Using factory get an instance of document builder
-                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
-
-                // Parse using builder to get DOM representation of the XML file
-                Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
-
-                Element refitElt = xmlDoc.getDocumentElement();
-                assertEquals("refit", refitElt.getNodeName());
-
-                // Deserialize the refit
-                Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
-                assertNotNull(deserialized);
-
-                // Spot check the values
-                assertEquals(refit.getTime(), deserialized.getTime());
-                assertEquals(refit.getActualTime(), deserialized.getActualTime());
-                assertEquals(refit.getCost(), deserialized.getCost());
-                assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
-                assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
-                assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
-                assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
-                assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
-                assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
-                assertEquals(refit.kitFound(), deserialized.kitFound());
-                assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
-                assertEquals(refit.getTech().getId(), deserialized.getTech().getId());
-
-                // Check that we got all the correct old parts in the XML
-                Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                assertEquals(oldUnitParts, serializedOldParts);
-
-                // Check that we got all the correct new parts in the XML
-                Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                assertEquals(newUnitParts, serializedNewParts);
-
-                // Check that we got all the shopping list entries (by name, not amazing but
-                // reasonable)
-                List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
-                                .collect(Collectors.toList());
-                List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
-                                .collect(Collectors.toList());
-
-                // Make sure they're the same length first...
-                assertEquals(shoppingList.size(), serializedShoppingList.size());
-
-                // ... then make sure they're the "same" by removing them one by one...
-                for (String partName : shoppingList) {
-                        assertTrue(serializedShoppingList.remove(partName));
-                }
-
-                // ... and ensuring nothing is left.
-                assertTrue(serializedShoppingList.isEmpty());
-
-                // Do the same for their descriptions, which include the quantities...
-                List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
-                // ... except the second list needs to be mutable.
-                List<String> serializedShoppingListDescs = new ArrayList<>(
-                                Arrays.asList(deserialized.getShoppingListDescription()));
-
-                assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
-                for (String desc : shoppingListDescs) {
-                        assertTrue(serializedShoppingListDescs.remove(desc));
-                }
-
-                assertTrue(serializedShoppingListDescs.isEmpty());
+        assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
+        for (String desc : shoppingListDescs) {
+            assertTrue(serializedShoppingListDescs.remove(desc));
         }
 
-        @Test
-        public void fleaFLE4toFLE15Test() {
-                Campaign mockCampaign = mock(Campaign.class);
-                CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-                when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-                Warehouse mockWarehouse = mock(Warehouse.class);
-                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-                Quartermaster mockQuartermaster = mock(Quartermaster.class);
-                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        assertTrue(serializedShoppingListDescs.isEmpty());
+    }
 
-                // Create the original entity backing the unit
-                Entity oldEntity = UnitTestUtilities.getFleaFLE4();
-                IPlayer mockPlayer = mock(IPlayer.class);
-                when(mockPlayer.getName()).thenReturn("Test Player");
-                oldEntity.setOwner(mockPlayer);
+    @Test
+    public void fleaFLE4toFLE15Test() {
+        Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
 
-                // Create the entity we're going to refit to
-                Entity newEntity = UnitTestUtilities.getFleaFLE15();
+        // Create the original entity backing the unit
+        Entity oldEntity = UnitTestUtilities.getFleaFLE4();
+        IPlayer mockPlayer = mock(IPlayer.class);
+        when(mockPlayer.getName()).thenReturn("Test Player");
+        oldEntity.setOwner(mockPlayer);
 
-                // Create the unit which will be refit
-                Unit oldUnit = new Unit(oldEntity, mockCampaign);
-                oldUnit.setId(UUID.randomUUID());
-                oldUnit.initializeParts(false);
+        // Create the entity we're going to refit to
+        Entity newEntity = UnitTestUtilities.getFleaFLE15();
 
-                // Create the Refit
-                Refit refit = new Refit(oldUnit, newEntity, false, false);
-                assertEquals(mockCampaign, refit.getCampaign());
+        // Create the unit which will be refit
+        Unit oldUnit = new Unit(oldEntity, mockCampaign);
+        oldUnit.setId(UUID.randomUUID());
+        oldUnit.initializeParts(false);
 
-                //
-                // Flea 4 to 15 Class D refit steps (in no particular order):
-                // 1. Remove excess Large Laser (RA) [120 mins]
-                // 2. Move Small Laser (LA) to (LT)(R) [120 mins]
-                // 3. Move Small Laser (LA) to (RT)(R) [120 mins]
-                // 4. Add Medium Laser (LA) [120 mins]
-                // 5. Add Medium Laser (RA) [120 mins]
-                // 6. Add Machine Gun (LA) [120 mins]
-                // 7. Add Machine Gun (RA) [120 mins]
-                // 8. Add Machine Gun Ammo Bin to (CT) [120 mins]
-                // 9. Add 16 points of armor to 10 locations (except the HD).
-                // a. Add 1 point to (LA) [5 mins]
-                // b. Add 1 point to (RA) [5 mins]
-                // c. Add 2 points to (LT) [10 mins]
-                // d. Add 2 points to (RT) [10 mins]
-                // e. Add 3 points to (CT) [15 mins]
-                // g. Add 1 point to (LL) [5 mins]
-                // h. Add 1 point to (RL) [5 mins]
-                // i. Add 2 points to (RTL) [10 mins]
-                // j. Add 2 points to (RTR) [10 mins]
-                // k. Add 1 point to (RTC) [5 mins]
-                // 10. Switch Flamer (CT) facing to (CT)(R) [120 mins]
-                //
-                // Everything else is the same.
-                //
+        // Create the Refit
+        Refit refit = new Refit(oldUnit, newEntity, false, false);
+        assertEquals(mockCampaign, refit.getCampaign());
 
-                // Per SO p188:
-                // "This kit permits players to install a new item
-                // where previously there was none..."
-                assertEquals(Refit.CLASS_D, refit.getRefitClass());
+        //
+        // Flea 4 to 15 Class D refit steps (in no particular order):
+        // 1. Remove excess Large Laser (RA) [120 mins]
+        // 2. Move Small Laser (LA) to (LT)(R) [120 mins]
+        // 3. Move Small Laser (LA) to (RT)(R) [120 mins]
+        // 4. Add Medium Laser (LA) [120 mins]
+        // 5. Add Medium Laser (RA) [120 mins]
+        // 6. Add Machine Gun (LA) [120 mins]
+        // 7. Add Machine Gun (RA) [120 mins]
+        // 8. Add Machine Gun Ammo Bin to (CT) [120 mins]
+        // 9. Add 16 points of armor to 10 locations (except the HD).
+        // a. Add 1 point to (LA) [5 mins]
+        // b. Add 1 point to (RA) [5 mins]
+        // c. Add 2 points to (LT) [10 mins]
+        // d. Add 2 points to (RT) [10 mins]
+        // e. Add 3 points to (CT) [15 mins]
+        // g. Add 1 point to (LL) [5 mins]
+        // h. Add 1 point to (RL) [5 mins]
+        // i. Add 2 points to (RTL) [10 mins]
+        // j. Add 2 points to (RTR) [10 mins]
+        // k. Add 1 point to (RTC) [5 mins]
+        // 10. Switch Flamer (CT) facing to (CT)(R) [120 mins]
+        //
+        // Everything else is the same.
+        //
 
-                // Time?
-                // + 1 removal @ 120 mins ea
-                // + 2 moves @ 120 mins ea
-                // + 1 facing change @ 120 mins ea
-                // + 5 adds @ 120 mins ea
-                // + 16 armor changes @ 5 mins ea
-                // x 3 (Class D)
-                assertEquals(((120.0 * 9.0) + (5.0 * 16.0)) * 3.0, refit.getActualTime(), 0.1);
+        // Per SO p188:
+        // "This kit permits players to install a new item
+        // where previously there was none..."
+        assertEquals(Refit.CLASS_D, refit.getRefitClass());
 
-                // Cost?
-                // + 2 Medium Lasers @ 40,000 ea
-                // + 2 Machine Guns @ 5,000 ea
-                // + 1 ton Machine Gun Ammo @ 1,000 ea
-                // + 1 ton Armor (Standard) @ 10,000 ea
-                // x 1.1 (Refit Kit cost, SO p188)
-                assertEquals(Money.of(40000.0 + 40000.0 + 5000.0 + 5000.0 + 1000.0 + 10000.0).multipliedBy(1.1),
-                                refit.getCost());
+        // Time?
+        // + 1 removal @ 120 mins ea
+        // + 2 moves @ 120 mins ea
+        // + 1 facing change @ 120 mins ea
+        // + 5 adds @ 120 mins ea
+        // + 16 armor changes @ 5 mins ea
+        // x 3 (Class D)
+        assertEquals(((120.0 * 9.0) + (5.0 * 16.0)) * 3.0, refit.getActualTime(), 0.1);
 
-                // We're removing 1 Large Laser and using existing armor in 10 locations
-                List<Part> removedParts = refit.getOldUnitParts();
-                assertEquals(11, removedParts.size());
-                assertEquals(1, removedParts.stream()
-                                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("Large Laser"))
-                                .count());
-                assertEquals(10, removedParts.stream().filter(p -> (p instanceof Armor)).count());
+        // Cost?
+        // + 2 Medium Lasers @ 40,000 ea
+        // + 2 Machine Guns @ 5,000 ea
+        // + 1 ton Machine Gun Ammo @ 1,000 ea
+        // + 1 ton Armor (Standard) @ 10,000 ea
+        // x 1.1 (Refit Kit cost, SO p188)
+        assertEquals(Money.of(40000.0 + 40000.0 + 5000.0 + 5000.0 + 1000.0 + 10000.0).multipliedBy(1.1),
+                refit.getCost());
 
-                // All of the new parts should be from the old unit
-                List<Part> newParts = refit.getNewUnitParts();
-                assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
+        // We're removing 1 Large Laser and using existing armor in 10 locations
+        List<Part> removedParts = refit.getOldUnitParts();
+        assertEquals(11, removedParts.size());
+        assertEquals(1, removedParts.stream()
+                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("Large Laser"))
+                .count());
+        assertEquals(10, removedParts.stream().filter(p -> (p instanceof Armor)).count());
 
-                // We need to buy two Medium Lasers, two Machine Guns, and Machine Gun Ammo
-                List<Part> shoppingCart = refit.getShoppingList();
-                assertEquals(2, shoppingCart.stream()
-                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Medium Laser"))
-                                .count());
-                assertEquals(2, shoppingCart.stream()
-                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Machine Gun"))
-                                .count());
-                assertEquals(1, shoppingCart.stream()
-                                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("Machine Gun Ammo Bin"))
-                                .count());
+        // All of the new parts should be from the old unit
+        List<Part> newParts = refit.getNewUnitParts();
+        assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
 
-                // We should have 16 points of standard armor on order
-                assertNotNull(refit.getNewArmorSupplies());
-                assertEquals(refit.getNewArmorSupplies().getType(), EquipmentType.T_ARMOR_STANDARD);
-                assertEquals(16, refit.getNewArmorSupplies().getAmountNeeded());
+        // We need to buy two Medium Lasers, two Machine Guns, and Machine Gun Ammo
+        List<Part> shoppingCart = refit.getShoppingList();
+        assertEquals(2, shoppingCart.stream()
+                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Medium Laser"))
+                .count());
+        assertEquals(2, shoppingCart.stream()
+                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Machine Gun"))
+                .count());
+        assertEquals(1, shoppingCart.stream()
+                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("Machine Gun Ammo Bin"))
+                .count());
+
+        // We should have 16 points of standard armor on order
+        assertNotNull(refit.getNewArmorSupplies());
+        assertEquals(refit.getNewArmorSupplies().getType(), EquipmentType.T_ARMOR_STANDARD);
+        assertEquals(16, refit.getNewArmorSupplies().getAmountNeeded());
+    }
+
+    @Test
+    public void testFleaFLE4toFLE15WriteToXml() throws ParserConfigurationException, SAXException, IOException {
+        Campaign mockCampaign = mock(Campaign.class);
+        when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Warehouse mockWarehouse = mock(Warehouse.class);
+        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+        doReturn(null).when(mockWarehouse).findSparePart(any());
+        Quartermaster mockQuartermaster = mock(Quartermaster.class);
+        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        Person mockTech = mock(Person.class);
+        UUID techId = UUID.randomUUID();
+        when(mockTech.getId()).thenReturn(techId);
+
+        // Create the original entity backing the unit
+        Entity oldEntity = UnitTestUtilities.getFleaFLE4();
+        IPlayer mockPlayer = mock(IPlayer.class);
+        when(mockPlayer.getName()).thenReturn("Test Player");
+        oldEntity.setOwner(mockPlayer);
+
+        // Create the entity we're going to refit to
+        Entity newEntity = UnitTestUtilities.getFleaFLE15();
+
+        // Create the unit which will be refit
+        Unit oldUnit = new Unit(oldEntity, mockCampaign);
+        oldUnit.setId(UUID.randomUUID());
+        oldUnit.initializeParts(false);
+
+        // Make sure the unit parts have an ID before we serialize them
+        int partId = 1;
+        for (Part part : oldUnit.getParts()) {
+            part.setId(partId++);
         }
 
-        @Test
-        public void testFleaFLE4toFLE15WriteToXml() throws ParserConfigurationException, SAXException, IOException {
-                Campaign mockCampaign = mock(Campaign.class);
-                when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
-                CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-                when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-                Warehouse mockWarehouse = mock(Warehouse.class);
-                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-                doReturn(null).when(mockWarehouse).findSparePart(any());
-                Quartermaster mockQuartermaster = mock(Quartermaster.class);
-                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
-                Person mockTech = mock(Person.class);
-                UUID techId = UUID.randomUUID();
-                when(mockTech.getId()).thenReturn(techId);
+        // Create the Refit
+        Refit refit = new Refit(oldUnit, newEntity, false, false);
+        refit.setTech(mockTech);
+        refit.addTimeSpent(60); // 1 hour of work!
 
-                // Create the original entity backing the unit
-                Entity oldEntity = UnitTestUtilities.getFleaFLE4();
-                IPlayer mockPlayer = mock(IPlayer.class);
-                when(mockPlayer.getName()).thenReturn("Test Player");
-                oldEntity.setOwner(mockPlayer);
+        // Write the Refit XML
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        refit.writeToXml(pw, 0);
 
-                // Create the entity we're going to refit to
-                Entity newEntity = UnitTestUtilities.getFleaFLE15();
+        // Get the Refit XML
+        String xml = sw.toString();
+        assertFalse(xml.trim().isEmpty());
 
-                // Create the unit which will be refit
-                Unit oldUnit = new Unit(oldEntity, mockCampaign);
-                oldUnit.setId(UUID.randomUUID());
-                oldUnit.initializeParts(false);
+        // Using factory get an instance of document builder
+        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
 
-                // Make sure the unit parts have an ID before we serialize them
-                int partId = 1;
-                for (Part part : oldUnit.getParts()) {
-                        part.setId(partId++);
-                }
+        // Parse using builder to get DOM representation of the XML file
+        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
 
-                // Create the Refit
-                Refit refit = new Refit(oldUnit, newEntity, false, false);
-                refit.setTech(mockTech);
-                refit.addTimeSpent(60); // 1 hour of work!
+        Element refitElt = xmlDoc.getDocumentElement();
+        assertEquals("refit", refitElt.getNodeName());
 
-                // Write the Refit XML
-                StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);
-                refit.writeToXml(pw, 0);
+        // Deserialize the refit
+        Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
+        assertNotNull(deserialized);
+        deserialized.reCalc();
 
-                // Get the Refit XML
-                String xml = sw.toString();
-                assertFalse(xml.trim().isEmpty());
+        // Spot check the values
+        assertEquals(refit.getTime(), deserialized.getTime());
+        assertEquals(refit.getActualTime(), deserialized.getActualTime());
+        assertEquals(refit.getCost(), deserialized.getCost());
+        assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
+        assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
+        assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
+        assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
+        assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
+        assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
+        assertEquals(refit.kitFound(), deserialized.kitFound());
+        assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
+        assertEquals(refit.getTech().getId(), deserialized.getTech().getId());
 
-                // Using factory get an instance of document builder
-                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+        // Check that we got all the correct old parts in the XML
+        Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        assertEquals(oldUnitParts, serializedOldParts);
 
-                // Parse using builder to get DOM representation of the XML file
-                Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+        // Check that we got all the correct new parts in the XML
+        Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
+                .collect(Collectors.toSet());
+        assertEquals(newUnitParts, serializedNewParts);
 
-                Element refitElt = xmlDoc.getDocumentElement();
-                assertEquals("refit", refitElt.getNodeName());
+        // Check that we got all the shopping list entries (by name, not amazing but
+        // reasonable)
+        List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
+                .collect(Collectors.toList());
+        List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
+                .collect(Collectors.toList());
 
-                // Deserialize the refit
-                Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
-                assertNotNull(deserialized);
-                deserialized.reCalc();
+        // Make sure they're the same length first...
+        assertEquals(shoppingList.size(), serializedShoppingList.size());
 
-                // Spot check the values
-                assertEquals(refit.getTime(), deserialized.getTime());
-                assertEquals(refit.getActualTime(), deserialized.getActualTime());
-                assertEquals(refit.getCost(), deserialized.getCost());
-                assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
-                assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
-                assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
-                assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
-                assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
-                assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
-                assertEquals(refit.kitFound(), deserialized.kitFound());
-                assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
-                assertEquals(refit.getTech().getId(), deserialized.getTech().getId());
-
-                // Check that we got all the correct old parts in the XML
-                Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                assertEquals(oldUnitParts, serializedOldParts);
-
-                // Check that we got all the correct new parts in the XML
-                Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
-                                .collect(Collectors.toSet());
-                assertEquals(newUnitParts, serializedNewParts);
-
-                // Check that we got all the shopping list entries (by name, not amazing but
-                // reasonable)
-                List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
-                                .collect(Collectors.toList());
-                List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
-                                .collect(Collectors.toList());
-
-                // Make sure they're the same length first...
-                assertEquals(shoppingList.size(), serializedShoppingList.size());
-
-                // ... then make sure they're the "same" by removing them one by one...
-                for (String partName : shoppingList) {
-                        assertTrue(serializedShoppingList.remove(partName));
-                }
-
-                // ... and ensuring nothing is left.
-                assertTrue(serializedShoppingList.isEmpty());
-
-                // Do the same for their descriptions, which include the quantities...
-                List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
-                // ... except the second list needs to be mutable.
-                List<String> serializedShoppingListDescs = new ArrayList<>(
-                                Arrays.asList(deserialized.getShoppingListDescription()));
-
-                assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
-                for (String desc : shoppingListDescs) {
-                        assertTrue(serializedShoppingListDescs.remove(desc));
-                }
-
-                assertTrue(serializedShoppingListDescs.isEmpty());
-
-                // Make sure the new armor is serialized/deserialized properly
-                assertNotNull(deserialized.getNewArmorSupplies());
-                assertTrue(refit.getNewArmorSupplies().isSameType(deserialized.getNewArmorSupplies()));
-                assertEquals(refit.getNewArmorSupplies().getAmountNeeded(),
-                                deserialized.getNewArmorSupplies().getAmountNeeded());
+        // ... then make sure they're the "same" by removing them one by one...
+        for (String partName : shoppingList) {
+            assertTrue(serializedShoppingList.remove(partName));
         }
 
-        @Test
-        public void heavyTrackedApcMgToStandard() throws EntityLoadingException, IOException {
+        // ... and ensuring nothing is left.
+        assertTrue(serializedShoppingList.isEmpty());
+
+        // Do the same for their descriptions, which include the quantities...
+        List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
+        // ... except the second list needs to be mutable.
+        List<String> serializedShoppingListDescs = new ArrayList<>(
+                Arrays.asList(deserialized.getShoppingListDescription()));
+
+        assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
+        for (String desc : shoppingListDescs) {
+            assertTrue(serializedShoppingListDescs.remove(desc));
+        }
+
+        assertTrue(serializedShoppingListDescs.isEmpty());
+
+        // Make sure the new armor is serialized/deserialized properly
+        assertNotNull(deserialized.getNewArmorSupplies());
+        assertTrue(refit.getNewArmorSupplies().isSameType(deserialized.getNewArmorSupplies()));
+        assertEquals(refit.getNewArmorSupplies().getAmountNeeded(),
+                deserialized.getNewArmorSupplies().getAmountNeeded());
+    }
+
+    @Test
+    public void heavyTrackedApcMgToStandard() throws EntityLoadingException, IOException {
         Campaign mockCampaign = mock(Campaign.class);
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
         when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -44,13 +44,16 @@ import org.xml.sax.SAXException;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.IPlayer;
+import megamek.common.loaders.EntityLoadingException;
 import mekhq.MekHqXmlUtil;
 import mekhq.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Hangar;
 import mekhq.campaign.Quartermaster;
 import mekhq.campaign.Warehouse;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
@@ -59,63 +62,702 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitTestUtilities;
 
 public class RefitTest {
-    @Test
-    public void deserializationCtor() {
-        Refit refit = new Refit();
-        assertNotNull(refit);
-    }
+        @Test
+        public void deserializationCtor() {
+                Refit refit = new Refit();
+                assertNotNull(refit);
+        }
 
-    @Test
-    public void newRefitCtor() {
+        @Test
+        public void newRefitCtor() {
+                Campaign mockCampaign = mock(Campaign.class);
+                Warehouse mockWarehouse = mock(Warehouse.class);
+                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+                Quartermaster mockQuartermaster = mock(Quartermaster.class);
+                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+
+                // Create the original entity backing the unit
+                Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
+                IPlayer mockPlayer = mock(IPlayer.class);
+                when(mockPlayer.getName()).thenReturn("Test Player");
+                oldEntity.setOwner(mockPlayer);
+
+                // Create the entity we're going to refit to
+                Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+
+                // Create the unit which will be refit
+                Unit oldUnit = new Unit(oldEntity, mockCampaign);
+                oldUnit.initializeParts(false);
+
+                // Create the Refit
+                Refit refit = new Refit(oldUnit, newEntity, false, false);
+                assertEquals(mockCampaign, refit.getCampaign());
+
+                // Should be old parts...
+                assertFalse(refit.getOldUnitParts().isEmpty());
+
+                // ... and new parts.
+                assertFalse(refit.getNewUnitParts().isEmpty());
+
+                // ... and we'll need to buy some parts
+                assertFalse(refit.getShoppingList().isEmpty());
+        }
+
+        @Test
+        public void locust1Vto1ETest() {
+                Campaign mockCampaign = mock(Campaign.class);
+                Warehouse mockWarehouse = mock(Warehouse.class);
+                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+                Quartermaster mockQuartermaster = mock(Quartermaster.class);
+                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+
+                // Create the original entity backing the unit
+                Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
+                IPlayer mockPlayer = mock(IPlayer.class);
+                when(mockPlayer.getName()).thenReturn("Test Player");
+                oldEntity.setOwner(mockPlayer);
+
+                // Create the entity we're going to refit to
+                Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+
+                // Create the unit which will be refit
+                Unit oldUnit = new Unit(oldEntity, mockCampaign);
+                oldUnit.setId(UUID.randomUUID());
+                oldUnit.initializeParts(false);
+
+                // Create the Refit
+                Refit refit = new Refit(oldUnit, newEntity, false, false);
+                assertEquals(mockCampaign, refit.getCampaign());
+
+                //
+                // Locust 1V to 1E Class D refit steps (in no particular order):
+                // 1. Remove excess Machine Gun (LA) [120 mins]
+                // 2. Remove excess Machine Gun (RA) [120 mins]
+                // 3. Remove Machine Gun Ammo Bin (CT) [120 mins]
+                // 4. Move Medium Laser (CT) to (RA) [120 mins]
+                // 5. Add Medium Laser to (LA) [120 mins]
+                // 6. Add Small Laser to (RA) [120 mins]
+                // 7. Add Small Laser to (LA) [120 mins]
+                //
+                // Everything else is the same.
+                //
+
+                // Per SO p188:
+                // "This kit permits players to install a new item
+                // where previously there was none..."
+                assertEquals(Refit.CLASS_D, refit.getRefitClass());
+
+                // Time?
+                // + 3 removals @ 120 mins ea
+                // + 1 move @ 120 mins ea
+                // + 3 adds @ 120 mins ea
+                // x 3 (Class D)
+                assertEquals((120.0 * 7.0) * 3.0, refit.getActualTime(), 0.1);
+
+                // Cost?
+                // + 1 Medium Laser @ 40,000 ea
+                // + 2 Small Lasers @ 11,250 ea
+                // x 1.1 (Refit Kit cost, SO p188)
+                assertEquals(Money.of((40000 + 11250 + 11250) * 1.1), refit.getCost());
+
+                // We're removing 2 machine guns and an ammo bin
+                List<Part> removedParts = refit.getOldUnitParts();
+                assertEquals(3, removedParts.size());
+                assertEquals(2, removedParts.stream()
+                                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("Machine Gun"))
+                                .count());
+                assertEquals(1, removedParts.stream()
+                                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("Machine Gun Ammo Bin"))
+                                .count());
+
+                // All of the new parts should be from the old unit
+                List<Part> newParts = refit.getNewUnitParts();
+                assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
+
+                // We need to buy one Medium Laser and two Small Lasers
+                List<Part> shoppingCart = refit.getShoppingList();
+                assertEquals(1, shoppingCart.stream()
+                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Medium Laser"))
+                                .count());
+                assertEquals(2, shoppingCart.stream()
+                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Small Laser"))
+                                .count());
+        }
+
+        @Test
+        public void testLocust1Vto1EWriteToXml() throws ParserConfigurationException, SAXException, IOException {
+                Campaign mockCampaign = mock(Campaign.class);
+                when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
+                Warehouse mockWarehouse = mock(Warehouse.class);
+                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+                Quartermaster mockQuartermaster = mock(Quartermaster.class);
+                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+
+                // Create the original entity backing the unit
+                Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
+                IPlayer mockPlayer = mock(IPlayer.class);
+                when(mockPlayer.getName()).thenReturn("Test Player");
+                oldEntity.setOwner(mockPlayer);
+
+                // Create the entity we're going to refit to
+                Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+
+                // Create the unit which will be refit
+                Unit oldUnit = new Unit(oldEntity, mockCampaign);
+                oldUnit.setId(UUID.randomUUID());
+                oldUnit.initializeParts(false);
+
+                // Make sure the unit parts have an ID before we serialize them
+                int partId = 1;
+                for (Part part : oldUnit.getParts()) {
+                        part.setId(partId++);
+                }
+
+                // Create the Refit
+                Refit refit = new Refit(oldUnit, newEntity, false, false);
+
+                // Write the Refit XML
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                refit.writeToXml(pw, 0);
+
+                // Get the Refit XML
+                String xml = sw.toString();
+                assertFalse(xml.trim().isEmpty());
+
+                // Using factory get an instance of document builder
+                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+                // Parse using builder to get DOM representation of the XML file
+                Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+                Element refitElt = xmlDoc.getDocumentElement();
+                assertEquals("refit", refitElt.getNodeName());
+
+                // Deserialize the refit
+                Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
+                assertNotNull(deserialized);
+
+                // Spot check the values
+                assertEquals(refit.getTime(), deserialized.getTime());
+                assertEquals(refit.getActualTime(), deserialized.getActualTime());
+                assertEquals(refit.getCost(), deserialized.getCost());
+                assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
+                assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
+                assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
+                assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
+                assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
+                assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
+                assertEquals(refit.kitFound(), deserialized.kitFound());
+                assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
+                assertEquals(refit.getTech(), deserialized.getTech());
+
+                // Check that we got all the correct old parts in the XML
+                Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                assertEquals(oldUnitParts, serializedOldParts);
+
+                // Check that we got all the correct new parts in the XML
+                Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                assertEquals(newUnitParts, serializedNewParts);
+
+                // Check that we got all the shopping list entries (by name, not amazing but
+                // reasonable)
+                List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
+                                .collect(Collectors.toList());
+                List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
+                                .collect(Collectors.toList());
+
+                // Make sure they're the same length first...
+                assertEquals(shoppingList.size(), serializedShoppingList.size());
+
+                // ... then make sure they're the "same" by removing them one by one...
+                for (String partName : shoppingList) {
+                        assertTrue(serializedShoppingList.remove(partName));
+                }
+
+                // ... and ensuring nothing is left.
+                assertTrue(serializedShoppingList.isEmpty());
+
+                // Do the same for their descriptions, which include the quantities...
+                List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
+                // ... except the second list needs to be mutable.
+                List<String> serializedShoppingListDescs = new ArrayList<>(
+                                Arrays.asList(deserialized.getShoppingListDescription()));
+
+                assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
+                for (String desc : shoppingListDescs) {
+                        assertTrue(serializedShoppingListDescs.remove(desc));
+                }
+
+                assertTrue(serializedShoppingListDescs.isEmpty());
+        }
+
+        @Test
+        public void javelinJVN10Nto10ATest() {
+                Campaign mockCampaign = mock(Campaign.class);
+                CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+                when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+                Warehouse mockWarehouse = mock(Warehouse.class);
+                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+                Quartermaster mockQuartermaster = mock(Quartermaster.class);
+                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+
+                // Create the original entity backing the unit
+                Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
+                IPlayer mockPlayer = mock(IPlayer.class);
+                when(mockPlayer.getName()).thenReturn("Test Player");
+                oldEntity.setOwner(mockPlayer);
+
+                // Create the entity we're going to refit to
+                Entity newEntity = UnitTestUtilities.getJavelinJVN10A();
+
+                // Create the unit which will be refit
+                Unit oldUnit = new Unit(oldEntity, mockCampaign);
+                oldUnit.setId(UUID.randomUUID());
+                oldUnit.initializeParts(false);
+
+                // Create the Refit
+                Refit refit = new Refit(oldUnit, newEntity, false, false);
+                assertEquals(mockCampaign, refit.getCampaign());
+
+                //
+                // Javelin 10N to 10A Class C refit steps (in no particular order):
+                // 1. Remove excess SRM 6 (LT) [120 mins]
+                // 2. Remove excess SRM 6 (RT) [120 mins]
+                // 3. Remove SRM 6 Ammo Bin (LT) [120 mins]
+                // 4. Remove SRM 6 Ammo Bin (RT) [120 mins]
+                // 5. Add LRM 15 to (RT) [120 mins]
+                // 6. Add LRM 15 Ammo Bin to (RT) [120 mins]
+                //
+                // Everything else is the same.
+                //
+
+                // Per SO p188:
+                // "A Class C kit also enables replacement of a weapon
+                // or item of equipment with any other, even if it is
+                // larger than the item(s) being replaced; for example,
+                // replacing an ER large laser with an LRM-10 launcher
+                // and ammunition."
+                assertEquals(Refit.CLASS_C, refit.getRefitClass());
+
+                // Time?
+                // + 4 removals @ 120 mins ea
+                // + 2 adds @ 120 mins ea
+                // x 2 (Class C)
+                assertEquals((120.0 * 6.0) * 2.0, refit.getActualTime(), 0.1);
+
+                // Cost?
+                // + 1 LRM 15 @ 175,000 ea
+                // + 1 ton LRM 15 Ammo @ 30,000 ea
+                // x 1.1 (Refit Kit cost, SO p188)
+                assertEquals(Money.of(175000.0 + 30000.0).multipliedBy(1.1), refit.getCost());
+
+                // We're removing 2 SRM 6s and two ammo bins
+                List<Part> removedParts = refit.getOldUnitParts();
+                assertEquals(4, removedParts.size());
+                assertEquals(2, removedParts.stream()
+                                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("SRM 6")).count());
+                assertEquals(2, removedParts.stream()
+                                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("SRM 6 Ammo Bin")).count());
+
+                // All of the new parts should be from the old unit
+                List<Part> newParts = refit.getNewUnitParts();
+                assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
+
+                // We need to buy one LRM 15 and one LRM 15 Ammo Bin
+                List<Part> shoppingCart = refit.getShoppingList();
+                assertEquals(1, shoppingCart.stream()
+                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("LRM 15"))
+                                .count());
+                assertEquals(1, shoppingCart.stream()
+                                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("LRM 15 Ammo Bin")).count());
+        }
+
+        @Test
+        public void testJavelinJVN10Nto10AWriteToXml() throws ParserConfigurationException, SAXException, IOException {
+                Campaign mockCampaign = mock(Campaign.class);
+                when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
+                CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+                when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+                Warehouse mockWarehouse = mock(Warehouse.class);
+                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+                Quartermaster mockQuartermaster = mock(Quartermaster.class);
+                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+                Person mockTech = mock(Person.class);
+                UUID techId = UUID.randomUUID();
+                when(mockTech.getId()).thenReturn(techId);
+
+                // Create the original entity backing the unit
+                Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
+                IPlayer mockPlayer = mock(IPlayer.class);
+                when(mockPlayer.getName()).thenReturn("Test Player");
+                oldEntity.setOwner(mockPlayer);
+
+                // Create the entity we're going to refit to
+                Entity newEntity = UnitTestUtilities.getJavelinJVN10A();
+
+                // Create the unit which will be refit
+                Unit oldUnit = new Unit(oldEntity, mockCampaign);
+                oldUnit.setId(UUID.randomUUID());
+                oldUnit.initializeParts(false);
+
+                // Make sure the unit parts have an ID before we serialize them
+                int partId = 1;
+                for (Part part : oldUnit.getParts()) {
+                        part.setId(partId++);
+                }
+
+                // Create the Refit
+                Refit refit = new Refit(oldUnit, newEntity, false, false);
+                refit.setTech(mockTech);
+                refit.addTimeSpent(60); // 1 hour of work!
+
+                // Write the Refit XML
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                refit.writeToXml(pw, 0);
+
+                // Get the Refit XML
+                String xml = sw.toString();
+                assertFalse(xml.trim().isEmpty());
+
+                // Using factory get an instance of document builder
+                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+                // Parse using builder to get DOM representation of the XML file
+                Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+                Element refitElt = xmlDoc.getDocumentElement();
+                assertEquals("refit", refitElt.getNodeName());
+
+                // Deserialize the refit
+                Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
+                assertNotNull(deserialized);
+
+                // Spot check the values
+                assertEquals(refit.getTime(), deserialized.getTime());
+                assertEquals(refit.getActualTime(), deserialized.getActualTime());
+                assertEquals(refit.getCost(), deserialized.getCost());
+                assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
+                assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
+                assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
+                assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
+                assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
+                assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
+                assertEquals(refit.kitFound(), deserialized.kitFound());
+                assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
+                assertEquals(refit.getTech().getId(), deserialized.getTech().getId());
+
+                // Check that we got all the correct old parts in the XML
+                Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                assertEquals(oldUnitParts, serializedOldParts);
+
+                // Check that we got all the correct new parts in the XML
+                Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                assertEquals(newUnitParts, serializedNewParts);
+
+                // Check that we got all the shopping list entries (by name, not amazing but
+                // reasonable)
+                List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
+                                .collect(Collectors.toList());
+                List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
+                                .collect(Collectors.toList());
+
+                // Make sure they're the same length first...
+                assertEquals(shoppingList.size(), serializedShoppingList.size());
+
+                // ... then make sure they're the "same" by removing them one by one...
+                for (String partName : shoppingList) {
+                        assertTrue(serializedShoppingList.remove(partName));
+                }
+
+                // ... and ensuring nothing is left.
+                assertTrue(serializedShoppingList.isEmpty());
+
+                // Do the same for their descriptions, which include the quantities...
+                List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
+                // ... except the second list needs to be mutable.
+                List<String> serializedShoppingListDescs = new ArrayList<>(
+                                Arrays.asList(deserialized.getShoppingListDescription()));
+
+                assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
+                for (String desc : shoppingListDescs) {
+                        assertTrue(serializedShoppingListDescs.remove(desc));
+                }
+
+                assertTrue(serializedShoppingListDescs.isEmpty());
+        }
+
+        @Test
+        public void fleaFLE4toFLE15Test() {
+                Campaign mockCampaign = mock(Campaign.class);
+                CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+                when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+                Warehouse mockWarehouse = mock(Warehouse.class);
+                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+                Quartermaster mockQuartermaster = mock(Quartermaster.class);
+                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+
+                // Create the original entity backing the unit
+                Entity oldEntity = UnitTestUtilities.getFleaFLE4();
+                IPlayer mockPlayer = mock(IPlayer.class);
+                when(mockPlayer.getName()).thenReturn("Test Player");
+                oldEntity.setOwner(mockPlayer);
+
+                // Create the entity we're going to refit to
+                Entity newEntity = UnitTestUtilities.getFleaFLE15();
+
+                // Create the unit which will be refit
+                Unit oldUnit = new Unit(oldEntity, mockCampaign);
+                oldUnit.setId(UUID.randomUUID());
+                oldUnit.initializeParts(false);
+
+                // Create the Refit
+                Refit refit = new Refit(oldUnit, newEntity, false, false);
+                assertEquals(mockCampaign, refit.getCampaign());
+
+                //
+                // Flea 4 to 15 Class D refit steps (in no particular order):
+                // 1. Remove excess Large Laser (RA) [120 mins]
+                // 2. Move Small Laser (LA) to (LT)(R) [120 mins]
+                // 3. Move Small Laser (LA) to (RT)(R) [120 mins]
+                // 4. Add Medium Laser (LA) [120 mins]
+                // 5. Add Medium Laser (RA) [120 mins]
+                // 6. Add Machine Gun (LA) [120 mins]
+                // 7. Add Machine Gun (RA) [120 mins]
+                // 8. Add Machine Gun Ammo Bin to (CT) [120 mins]
+                // 9. Add 16 points of armor to 10 locations (except the HD).
+                // a. Add 1 point to (LA) [5 mins]
+                // b. Add 1 point to (RA) [5 mins]
+                // c. Add 2 points to (LT) [10 mins]
+                // d. Add 2 points to (RT) [10 mins]
+                // e. Add 3 points to (CT) [15 mins]
+                // g. Add 1 point to (LL) [5 mins]
+                // h. Add 1 point to (RL) [5 mins]
+                // i. Add 2 points to (RTL) [10 mins]
+                // j. Add 2 points to (RTR) [10 mins]
+                // k. Add 1 point to (RTC) [5 mins]
+                // 10. Switch Flamer (CT) facing to (CT)(R) [120 mins]
+                //
+                // Everything else is the same.
+                //
+
+                // Per SO p188:
+                // "This kit permits players to install a new item
+                // where previously there was none..."
+                assertEquals(Refit.CLASS_D, refit.getRefitClass());
+
+                // Time?
+                // + 1 removal @ 120 mins ea
+                // + 2 moves @ 120 mins ea
+                // + 1 facing change @ 120 mins ea
+                // + 5 adds @ 120 mins ea
+                // + 16 armor changes @ 5 mins ea
+                // x 3 (Class D)
+                assertEquals(((120.0 * 9.0) + (5.0 * 16.0)) * 3.0, refit.getActualTime(), 0.1);
+
+                // Cost?
+                // + 2 Medium Lasers @ 40,000 ea
+                // + 2 Machine Guns @ 5,000 ea
+                // + 1 ton Machine Gun Ammo @ 1,000 ea
+                // + 1 ton Armor (Standard) @ 10,000 ea
+                // x 1.1 (Refit Kit cost, SO p188)
+                assertEquals(Money.of(40000.0 + 40000.0 + 5000.0 + 5000.0 + 1000.0 + 10000.0).multipliedBy(1.1),
+                                refit.getCost());
+
+                // We're removing 1 Large Laser and using existing armor in 10 locations
+                List<Part> removedParts = refit.getOldUnitParts();
+                assertEquals(11, removedParts.size());
+                assertEquals(1, removedParts.stream()
+                                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("Large Laser"))
+                                .count());
+                assertEquals(10, removedParts.stream().filter(p -> (p instanceof Armor)).count());
+
+                // All of the new parts should be from the old unit
+                List<Part> newParts = refit.getNewUnitParts();
+                assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
+
+                // We need to buy two Medium Lasers, two Machine Guns, and Machine Gun Ammo
+                List<Part> shoppingCart = refit.getShoppingList();
+                assertEquals(2, shoppingCart.stream()
+                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Medium Laser"))
+                                .count());
+                assertEquals(2, shoppingCart.stream()
+                                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Machine Gun"))
+                                .count());
+                assertEquals(1, shoppingCart.stream()
+                                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("Machine Gun Ammo Bin"))
+                                .count());
+
+                // We should have 16 points of standard armor on order
+                assertNotNull(refit.getNewArmorSupplies());
+                assertEquals(refit.getNewArmorSupplies().getType(), EquipmentType.T_ARMOR_STANDARD);
+                assertEquals(16, refit.getNewArmorSupplies().getAmountNeeded());
+        }
+
+        @Test
+        public void testFleaFLE4toFLE15WriteToXml() throws ParserConfigurationException, SAXException, IOException {
+                Campaign mockCampaign = mock(Campaign.class);
+                when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
+                CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+                when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+                Warehouse mockWarehouse = mock(Warehouse.class);
+                when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
+                doReturn(null).when(mockWarehouse).findSparePart(any());
+                Quartermaster mockQuartermaster = mock(Quartermaster.class);
+                when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+                Person mockTech = mock(Person.class);
+                UUID techId = UUID.randomUUID();
+                when(mockTech.getId()).thenReturn(techId);
+
+                // Create the original entity backing the unit
+                Entity oldEntity = UnitTestUtilities.getFleaFLE4();
+                IPlayer mockPlayer = mock(IPlayer.class);
+                when(mockPlayer.getName()).thenReturn("Test Player");
+                oldEntity.setOwner(mockPlayer);
+
+                // Create the entity we're going to refit to
+                Entity newEntity = UnitTestUtilities.getFleaFLE15();
+
+                // Create the unit which will be refit
+                Unit oldUnit = new Unit(oldEntity, mockCampaign);
+                oldUnit.setId(UUID.randomUUID());
+                oldUnit.initializeParts(false);
+
+                // Make sure the unit parts have an ID before we serialize them
+                int partId = 1;
+                for (Part part : oldUnit.getParts()) {
+                        part.setId(partId++);
+                }
+
+                // Create the Refit
+                Refit refit = new Refit(oldUnit, newEntity, false, false);
+                refit.setTech(mockTech);
+                refit.addTimeSpent(60); // 1 hour of work!
+
+                // Write the Refit XML
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                refit.writeToXml(pw, 0);
+
+                // Get the Refit XML
+                String xml = sw.toString();
+                assertFalse(xml.trim().isEmpty());
+
+                // Using factory get an instance of document builder
+                DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
+
+                // Parse using builder to get DOM representation of the XML file
+                Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
+
+                Element refitElt = xmlDoc.getDocumentElement();
+                assertEquals("refit", refitElt.getNodeName());
+
+                // Deserialize the refit
+                Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
+                assertNotNull(deserialized);
+                deserialized.reCalc();
+
+                // Spot check the values
+                assertEquals(refit.getTime(), deserialized.getTime());
+                assertEquals(refit.getActualTime(), deserialized.getActualTime());
+                assertEquals(refit.getCost(), deserialized.getCost());
+                assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
+                assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
+                assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
+                assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
+                assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
+                assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
+                assertEquals(refit.kitFound(), deserialized.kitFound());
+                assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
+                assertEquals(refit.getTech().getId(), deserialized.getTech().getId());
+
+                // Check that we got all the correct old parts in the XML
+                Set<Integer> oldUnitParts = refit.getOldUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                Set<Integer> serializedOldParts = deserialized.getOldUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                assertEquals(oldUnitParts, serializedOldParts);
+
+                // Check that we got all the correct new parts in the XML
+                Set<Integer> newUnitParts = refit.getNewUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                Set<Integer> serializedNewParts = deserialized.getNewUnitParts().stream().map(p -> p.getId())
+                                .collect(Collectors.toSet());
+                assertEquals(newUnitParts, serializedNewParts);
+
+                // Check that we got all the shopping list entries (by name, not amazing but
+                // reasonable)
+                List<String> shoppingList = refit.getShoppingList().stream().map(p -> p.getName())
+                                .collect(Collectors.toList());
+                List<String> serializedShoppingList = deserialized.getShoppingList().stream().map(p -> p.getName())
+                                .collect(Collectors.toList());
+
+                // Make sure they're the same length first...
+                assertEquals(shoppingList.size(), serializedShoppingList.size());
+
+                // ... then make sure they're the "same" by removing them one by one...
+                for (String partName : shoppingList) {
+                        assertTrue(serializedShoppingList.remove(partName));
+                }
+
+                // ... and ensuring nothing is left.
+                assertTrue(serializedShoppingList.isEmpty());
+
+                // Do the same for their descriptions, which include the quantities...
+                List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
+                // ... except the second list needs to be mutable.
+                List<String> serializedShoppingListDescs = new ArrayList<>(
+                                Arrays.asList(deserialized.getShoppingListDescription()));
+
+                assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
+                for (String desc : shoppingListDescs) {
+                        assertTrue(serializedShoppingListDescs.remove(desc));
+                }
+
+                assertTrue(serializedShoppingListDescs.isEmpty());
+
+                // Make sure the new armor is serialized/deserialized properly
+                assertNotNull(deserialized.getNewArmorSupplies());
+                assertTrue(refit.getNewArmorSupplies().isSameType(deserialized.getNewArmorSupplies()));
+                assertEquals(refit.getNewArmorSupplies().getAmountNeeded(),
+                                deserialized.getNewArmorSupplies().getAmountNeeded());
+        }
+
+        @Test
+        public void heavyTrackedApcMgToStandard() throws EntityLoadingException, IOException {
         Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        Hangar mockHangar = mock(Hangar.class);
+        when(mockCampaign.getHangar()).thenReturn(mockHangar);
         Warehouse mockWarehouse = mock(Warehouse.class);
         when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
         Quartermaster mockQuartermaster = mock(Quartermaster.class);
         when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        ShoppingList mockShoppingList = mock(ShoppingList.class);
+        when(mockCampaign.getShoppingList()).thenReturn(mockShoppingList);
 
         // Create the original entity backing the unit
-        Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
+        Entity oldEntity = UnitTestUtilities.getHeavyTrackedApcMg();
         IPlayer mockPlayer = mock(IPlayer.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 
         // Create the entity we're going to refit to
-        Entity newEntity = UnitTestUtilities.getLocustLCT1E();
-
-        // Create the unit which will be refit
-        Unit oldUnit = new Unit(oldEntity, mockCampaign);
-        oldUnit.initializeParts(false);
-
-        // Create the Refit
-        Refit refit = new Refit(oldUnit, newEntity, false, false);
-        assertEquals(mockCampaign, refit.getCampaign());
-
-        // Should be old parts...
-        assertFalse(refit.getOldUnitParts().isEmpty());
-
-        // ... and new parts.
-        assertFalse(refit.getNewUnitParts().isEmpty());
-
-        // ... and we'll need to buy some parts
-        assertFalse(refit.getShoppingList().isEmpty());
-    }
-
-    @Test
-    public void locust1Vto1ETest() {
-        Campaign mockCampaign = mock(Campaign.class);
-        Warehouse mockWarehouse = mock(Warehouse.class);
-        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
-        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
-
-        // Create the original entity backing the unit
-        Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
-        IPlayer mockPlayer = mock(IPlayer.class);
-        when(mockPlayer.getName()).thenReturn("Test Player");
-        oldEntity.setOwner(mockPlayer);
-
-        // Create the entity we're going to refit to
-        Entity newEntity = UnitTestUtilities.getLocustLCT1E();
+        Entity newEntity = UnitTestUtilities.getHeavyTrackedApcStandard();
 
         // Create the unit which will be refit
         Unit oldUnit = new Unit(oldEntity, mockCampaign);
@@ -126,595 +768,30 @@ public class RefitTest {
         Refit refit = new Refit(oldUnit, newEntity, false, false);
         assertEquals(mockCampaign, refit.getCampaign());
 
-        //
-        // Locust 1V to 1E Class D refit steps (in no particular order):
-        //     1. Remove excess Machine Gun (LA) [120 mins]
-        //     2. Remove excess Machine Gun (RA) [120 mins]
-        //     3. Remove Machine Gun Ammo Bin (CT) [120 mins]
-        //     4. Move Medium Laser (CT) to (RA) [120 mins]
-        //     5. Add Medium Laser to (LA) [120 mins]
-        //     6. Add Small Laser to (RA) [120 mins]
-        //     7. Add Small Laser to (LA) [120 mins]
-        //
-        // Everything else is the same.
-        //
-
-        // Per SO p188:
-        //     "This kit permits players to install a new item
-        //      where previously there was none..."
-        assertEquals(Refit.CLASS_D, refit.getRefitClass());
-
-        // Time?
-        //     + 3 removals @ 120 mins ea
-        //     + 1 move @ 120 mins ea
-        //     + 3 adds @ 120 mins ea
-        //     x 3 (Class D)
-        assertEquals((120.0 * 7.0) * 3.0, refit.getActualTime(), 0.1);
-
-        // Cost?
-        //    + 1 Medium Laser @ 40,000 ea
-        //    + 2 Small Lasers @ 11,250 ea
-        //    x 1.1 (Refit Kit cost, SO p188)
-        assertEquals(Money.of((40000 + 11250 + 11250) * 1.1), refit.getCost());
-
-        // We're removing 2 machine guns and an ammo bin
+        // We're removing 4 Machine Guns and a Full Bin of Machine Gun Ammo
         List<Part> removedParts = refit.getOldUnitParts();
-        assertEquals(3, removedParts.size());
-        assertEquals(2, removedParts.stream()
+        assertEquals(5, removedParts.size());
+        assertEquals(4, removedParts.stream()
                 .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("Machine Gun")).count());
         assertEquals(1, removedParts.stream()
                 .filter(p -> (p instanceof AmmoBin) && p.getName().equals("Machine Gun Ammo Bin")).count());
 
-        // All of the new parts should be from the old unit
+        // All of the new parts (except ammo bins) should be from the old unit
         List<Part> newParts = refit.getNewUnitParts();
-        assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
+        assertTrue(newParts.stream().filter(p -> !(p instanceof AmmoBin)).allMatch(p -> p.getUnit().equals(oldUnit)));
 
-        // We need to buy one Medium Laser and two Small Lasers
+        // We we have nothing we need to buy
         List<Part> shoppingCart = refit.getShoppingList();
-        assertEquals(1, shoppingCart.stream()
-                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Medium Laser")).count());
-        assertEquals(2, shoppingCart.stream()
-                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Small Laser")).count());
-    }
+        assertTrue(shoppingCart.isEmpty());
 
-    @Test
-    public void testLocust1Vto1EWriteToXml() throws ParserConfigurationException, SAXException, IOException {
-        Campaign mockCampaign = mock(Campaign.class);
-        when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
-        Warehouse mockWarehouse = mock(Warehouse.class);
-        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
-        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
+        // We should not have any ammo needed
+        assertNull(refit.getNewArmorSupplies());
 
-        // Create the original entity backing the unit
-        Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
-        IPlayer mockPlayer = mock(IPlayer.class);
-        when(mockPlayer.getName()).thenReturn("Test Player");
-        oldEntity.setOwner(mockPlayer);
+        // Begin the refit
+        refit.begin();
 
-        // Create the entity we're going to refit to
-        Entity newEntity = UnitTestUtilities.getLocustLCT1E();
-
-        // Create the unit which will be refit
-        Unit oldUnit = new Unit(oldEntity, mockCampaign);
-        oldUnit.setId(UUID.randomUUID());
-        oldUnit.initializeParts(false);
-
-        // Make sure the unit parts have an ID before we serialize them
-        int partId = 1;
-        for (Part part : oldUnit.getParts()) {
-            part.setId(partId++);
-        }
-
-        // Create the Refit
-        Refit refit = new Refit(oldUnit, newEntity, false, false);
-
-        // Write the Refit XML
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        refit.writeToXml(pw, 0);
-
-        // Get the Refit XML
-        String xml = sw.toString();
-        assertFalse(xml.trim().isEmpty());
-
-        // Using factory get an instance of document builder
-        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
-
-        // Parse using builder to get DOM representation of the XML file
-        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
-
-        Element refitElt = xmlDoc.getDocumentElement();
-        assertEquals("refit", refitElt.getNodeName());
-
-        // Deserialize the refit
-        Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
-        assertNotNull(deserialized);
-
-        // Spot check the values
-        assertEquals(refit.getTime(), deserialized.getTime());
-        assertEquals(refit.getActualTime(), deserialized.getActualTime());
-        assertEquals(refit.getCost(), deserialized.getCost());
-        assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
-        assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
-        assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
-        assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
-        assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
-        assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
-        assertEquals(refit.kitFound(), deserialized.kitFound());
-        assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
-        assertEquals(refit.getTech(), deserialized.getTech());
-
-        // Check that we got all the correct old parts in the XML
-        Set<Integer> oldUnitParts = refit.getOldUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        Set<Integer> serializedOldParts = deserialized.getOldUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        assertEquals(oldUnitParts, serializedOldParts);
-
-        // Check that we got all the correct new parts in the XML
-        Set<Integer> newUnitParts = refit.getNewUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        Set<Integer> serializedNewParts = deserialized.getNewUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        assertEquals(newUnitParts, serializedNewParts);
-
-        // Check that we got all the shopping list entries (by name, not amazing but reasonable)
-        List<String> shoppingList = refit.getShoppingList()
-                .stream().map(p -> p.getName()).collect(Collectors.toList());
-        List<String> serializedShoppingList = deserialized.getShoppingList()
-                .stream().map(p -> p.getName()).collect(Collectors.toList());
-
-        // Make sure they're the same length first...
-        assertEquals(shoppingList.size(), serializedShoppingList.size());
-
-        // ... then make sure they're the "same" by removing them one by one...
-        for (String partName : shoppingList) {
-            assertTrue(serializedShoppingList.remove(partName));
-        }
-
-        // ... and ensuring nothing is left.
-        assertTrue(serializedShoppingList.isEmpty());
-
-        // Do the same for their descriptions, which include the quantities...
-        List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
-        // ... except the second list needs to be mutable.
-        List<String> serializedShoppingListDescs = new ArrayList<>(Arrays.asList(deserialized.getShoppingListDescription()));
-
-        assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
-        for (String desc : shoppingListDescs) {
-            assertTrue(serializedShoppingListDescs.remove(desc));
-        }
-
-        assertTrue(serializedShoppingListDescs.isEmpty());
-    }
-
-    @Test
-    public void javelinJVN10Nto10ATest() {
-        Campaign mockCampaign = mock(Campaign.class);
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
-        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
-        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
-
-        // Create the original entity backing the unit
-        Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
-        IPlayer mockPlayer = mock(IPlayer.class);
-        when(mockPlayer.getName()).thenReturn("Test Player");
-        oldEntity.setOwner(mockPlayer);
-
-        // Create the entity we're going to refit to
-        Entity newEntity = UnitTestUtilities.getJavelinJVN10A();
-
-        // Create the unit which will be refit
-        Unit oldUnit = new Unit(oldEntity, mockCampaign);
-        oldUnit.setId(UUID.randomUUID());
-        oldUnit.initializeParts(false);
-
-        // Create the Refit
-        Refit refit = new Refit(oldUnit, newEntity, false, false);
-        assertEquals(mockCampaign, refit.getCampaign());
-
-        //
-        // Javelin 10N to 10A Class C refit steps (in no particular order):
-        //     1. Remove excess SRM 6 (LT) [120 mins]
-        //     2. Remove excess SRM 6 (RT) [120 mins]
-        //     3. Remove SRM 6 Ammo Bin (LT) [120 mins]
-        //     4. Remove SRM 6 Ammo Bin (RT) [120 mins]
-        //     5. Add LRM 15 to (RT) [120 mins]
-        //     6. Add LRM 15 Ammo Bin to (RT) [120 mins]
-        //
-        // Everything else is the same.
-        //
-
-        // Per SO p188:
-        //     "A Class C kit also enables replacement of a weapon
-        //      or item of equipment with any other, even if it is
-        //      larger than the item(s) being replaced; for example,
-        //      replacing an ER large laser with an LRM-10 launcher
-        //      and ammunition."
-        assertEquals(Refit.CLASS_C, refit.getRefitClass());
-
-        // Time?
-        //     + 4 removals @ 120 mins ea
-        //     + 2 adds @ 120 mins ea
-        //     x 2 (Class C)
-        assertEquals((120.0 * 6.0) * 2.0, refit.getActualTime(), 0.1);
-
-        // Cost?
-        //    + 1 LRM 15 @ 175,000 ea
-        //    + 1 ton LRM 15 Ammo @ 30,000 ea
-        //    x 1.1 (Refit Kit cost, SO p188)
-        assertEquals(Money.of(175000.0 + 30000.0).multipliedBy(1.1), refit.getCost());
-
-        // We're removing 2 SRM 6s and two ammo bins
-        List<Part> removedParts = refit.getOldUnitParts();
-        assertEquals(4, removedParts.size());
-        assertEquals(2, removedParts.stream()
-                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("SRM 6")).count());
-        assertEquals(2, removedParts.stream()
-                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("SRM 6 Ammo Bin")).count());
-
-        // All of the new parts should be from the old unit
-        List<Part> newParts = refit.getNewUnitParts();
-        assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
-
-        // We need to buy one LRM 15 and one LRM 15 Ammo Bin
-        List<Part> shoppingCart = refit.getShoppingList();
-        assertEquals(1, shoppingCart.stream()
-                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("LRM 15")).count());
-        assertEquals(1, shoppingCart.stream()
-                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("LRM 15 Ammo Bin")).count());
-    }
-
-    @Test
-    public void testJavelinJVN10Nto10AWriteToXml() throws ParserConfigurationException, SAXException, IOException {
-        Campaign mockCampaign = mock(Campaign.class);
-        when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
-        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
-        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
-        Person mockTech = mock(Person.class);
-        UUID techId = UUID.randomUUID();
-        when(mockTech.getId()).thenReturn(techId);
-
-        // Create the original entity backing the unit
-        Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
-        IPlayer mockPlayer = mock(IPlayer.class);
-        when(mockPlayer.getName()).thenReturn("Test Player");
-        oldEntity.setOwner(mockPlayer);
-
-        // Create the entity we're going to refit to
-        Entity newEntity = UnitTestUtilities.getJavelinJVN10A();
-
-        // Create the unit which will be refit
-        Unit oldUnit = new Unit(oldEntity, mockCampaign);
-        oldUnit.setId(UUID.randomUUID());
-        oldUnit.initializeParts(false);
-
-        // Make sure the unit parts have an ID before we serialize them
-        int partId = 1;
-        for (Part part : oldUnit.getParts()) {
-            part.setId(partId++);
-        }
-
-        // Create the Refit
-        Refit refit = new Refit(oldUnit, newEntity, false, false);
-        refit.setTech(mockTech);
-        refit.addTimeSpent(60); // 1 hour of work!
-
-        // Write the Refit XML
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        refit.writeToXml(pw, 0);
-
-        // Get the Refit XML
-        String xml = sw.toString();
-        assertFalse(xml.trim().isEmpty());
-
-        // Using factory get an instance of document builder
-        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
-
-        // Parse using builder to get DOM representation of the XML file
-        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
-
-        Element refitElt = xmlDoc.getDocumentElement();
-        assertEquals("refit", refitElt.getNodeName());
-
-        // Deserialize the refit
-        Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
-        assertNotNull(deserialized);
-
-        // Spot check the values
-        assertEquals(refit.getTime(), deserialized.getTime());
-        assertEquals(refit.getActualTime(), deserialized.getActualTime());
-        assertEquals(refit.getCost(), deserialized.getCost());
-        assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
-        assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
-        assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
-        assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
-        assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
-        assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
-        assertEquals(refit.kitFound(), deserialized.kitFound());
-        assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
-        assertEquals(refit.getTech().getId(), deserialized.getTech().getId());
-
-        // Check that we got all the correct old parts in the XML
-        Set<Integer> oldUnitParts = refit.getOldUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        Set<Integer> serializedOldParts = deserialized.getOldUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        assertEquals(oldUnitParts, serializedOldParts);
-
-        // Check that we got all the correct new parts in the XML
-        Set<Integer> newUnitParts = refit.getNewUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        Set<Integer> serializedNewParts = deserialized.getNewUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        assertEquals(newUnitParts, serializedNewParts);
-
-        // Check that we got all the shopping list entries (by name, not amazing but reasonable)
-        List<String> shoppingList = refit.getShoppingList()
-                .stream().map(p -> p.getName()).collect(Collectors.toList());
-        List<String> serializedShoppingList = deserialized.getShoppingList()
-                .stream().map(p -> p.getName()).collect(Collectors.toList());
-
-        // Make sure they're the same length first...
-        assertEquals(shoppingList.size(), serializedShoppingList.size());
-
-        // ... then make sure they're the "same" by removing them one by one...
-        for (String partName : shoppingList) {
-            assertTrue(serializedShoppingList.remove(partName));
-        }
-
-        // ... and ensuring nothing is left.
-        assertTrue(serializedShoppingList.isEmpty());
-
-        // Do the same for their descriptions, which include the quantities...
-        List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
-        // ... except the second list needs to be mutable.
-        List<String> serializedShoppingListDescs = new ArrayList<>(Arrays.asList(deserialized.getShoppingListDescription()));
-
-        assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
-        for (String desc : shoppingListDescs) {
-            assertTrue(serializedShoppingListDescs.remove(desc));
-        }
-
-        assertTrue(serializedShoppingListDescs.isEmpty());
-    }
-
-    @Test
-    public void fleaFLE4toFLE15Test() {
-        Campaign mockCampaign = mock(Campaign.class);
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
-        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
-        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
-
-        // Create the original entity backing the unit
-        Entity oldEntity = UnitTestUtilities.getFleaFLE4();
-        IPlayer mockPlayer = mock(IPlayer.class);
-        when(mockPlayer.getName()).thenReturn("Test Player");
-        oldEntity.setOwner(mockPlayer);
-
-        // Create the entity we're going to refit to
-        Entity newEntity = UnitTestUtilities.getFleaFLE15();
-
-        // Create the unit which will be refit
-        Unit oldUnit = new Unit(oldEntity, mockCampaign);
-        oldUnit.setId(UUID.randomUUID());
-        oldUnit.initializeParts(false);
-
-        // Create the Refit
-        Refit refit = new Refit(oldUnit, newEntity, false, false);
-        assertEquals(mockCampaign, refit.getCampaign());
-
-        //
-        // Flea 4 to 15 Class D refit steps (in no particular order):
-        //     1. Remove excess Large Laser (RA) [120 mins]
-        //     2. Move Small Laser (LA) to (LT)(R) [120 mins]
-        //     3. Move Small Laser (LA) to (RT)(R) [120 mins]
-        //     4. Add Medium Laser (LA) [120 mins]
-        //     5. Add Medium Laser (RA) [120 mins]
-        //     6. Add Machine Gun (LA) [120 mins]
-        //     7. Add Machine Gun (RA) [120 mins]
-        //     8. Add Machine Gun Ammo Bin to (CT) [120 mins]
-        //     9. Add 16 points of armor to 10 locations (except the HD).
-        //        a. Add 1 point to (LA) [5 mins]
-        //        b. Add 1 point to (RA) [5 mins]
-        //        c. Add 2 points to (LT) [10 mins]
-        //        d. Add 2 points to (RT) [10 mins]
-        //        e. Add 3 points to (CT) [15 mins]
-        //        g. Add 1 point to (LL) [5 mins]
-        //        h. Add 1 point to (RL) [5 mins]
-        //        i. Add 2 points to (RTL) [10 mins]
-        //        j. Add 2 points to (RTR) [10 mins]
-        //        k. Add 1 point to (RTC) [5 mins]
-        //    10. Switch Flamer (CT) facing to (CT)(R) [120 mins]
-        //
-        // Everything else is the same.
-        //
-
-        // Per SO p188:
-        //     "This kit permits players to install a new item
-        //      where previously there was none..."
-        assertEquals(Refit.CLASS_D, refit.getRefitClass());
-
-        // Time?
-        //     + 1 removal @ 120 mins ea
-        //     + 2 moves @ 120 mins ea
-        //     + 1 facing change @ 120 mins ea
-        //     + 5 adds @ 120 mins ea
-        //     + 16 armor changes @ 5 mins ea
-        //     x 3 (Class D)
-        assertEquals(((120.0 * 9.0) + (5.0 * 16.0)) * 3.0, refit.getActualTime(), 0.1);
-
-        // Cost?
-        //    + 2 Medium Lasers @ 40,000 ea
-        //    + 2 Machine Guns @ 5,000 ea
-        //    + 1 ton Machine Gun Ammo @ 1,000 ea
-        //    + 1 ton Armor (Standard) @ 10,000 ea
-        //    x 1.1 (Refit Kit cost, SO p188)
-        assertEquals(Money.of(40000.0 + 40000.0 + 5000.0 + 5000.0 + 1000.0 + 10000.0).multipliedBy(1.1), refit.getCost());
-
-        // We're removing 1 Large Laser and using existing armor in 10 locations
-        List<Part> removedParts = refit.getOldUnitParts();
-        assertEquals(11, removedParts.size());
-        assertEquals(1, removedParts.stream()
-                .filter(p -> (p instanceof EquipmentPart) && p.getName().equals("Large Laser")).count());
-        assertEquals(10, removedParts.stream()
-                .filter(p -> (p instanceof Armor)).count());
-
-        // All of the new parts should be from the old unit
-        List<Part> newParts = refit.getNewUnitParts();
-        assertTrue(newParts.stream().allMatch(p -> p.getUnit().equals(oldUnit)));
-
-        // We need to buy two Medium Lasers, two Machine Guns, and Machine Gun Ammo
-        List<Part> shoppingCart = refit.getShoppingList();
-        assertEquals(2, shoppingCart.stream()
-                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Medium Laser")).count());
-        assertEquals(2, shoppingCart.stream()
-                .filter(p -> (p instanceof MissingEquipmentPart) && p.getName().equals("Machine Gun")).count());
-        assertEquals(1, shoppingCart.stream()
-                .filter(p -> (p instanceof AmmoBin) && p.getName().equals("Machine Gun Ammo Bin")).count());
-
-        // We should have 16 points of standard armor on order
-        assertNotNull(refit.getNewArmorSupplies());
-        assertEquals(refit.getNewArmorSupplies().getType(), EquipmentType.T_ARMOR_STANDARD);
-        assertEquals(16, refit.getNewArmorSupplies().getAmountNeeded());
-    }
-
-    @Test
-    public void testFleaFLE4toFLE15WriteToXml() throws ParserConfigurationException, SAXException, IOException {
-        Campaign mockCampaign = mock(Campaign.class);
-        when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
-        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
-        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
-        Warehouse mockWarehouse = mock(Warehouse.class);
-        when(mockCampaign.getWarehouse()).thenReturn(mockWarehouse);
-        doReturn(null).when(mockWarehouse).findSparePart(any());
-        Quartermaster mockQuartermaster = mock(Quartermaster.class);
-        when(mockCampaign.getQuartermaster()).thenReturn(mockQuartermaster);
-        Person mockTech = mock(Person.class);
-        UUID techId = UUID.randomUUID();
-        when(mockTech.getId()).thenReturn(techId);
-
-        // Create the original entity backing the unit
-        Entity oldEntity = UnitTestUtilities.getFleaFLE4();
-        IPlayer mockPlayer = mock(IPlayer.class);
-        when(mockPlayer.getName()).thenReturn("Test Player");
-        oldEntity.setOwner(mockPlayer);
-
-        // Create the entity we're going to refit to
-        Entity newEntity = UnitTestUtilities.getFleaFLE15();
-
-        // Create the unit which will be refit
-        Unit oldUnit = new Unit(oldEntity, mockCampaign);
-        oldUnit.setId(UUID.randomUUID());
-        oldUnit.initializeParts(false);
-
-        // Make sure the unit parts have an ID before we serialize them
-        int partId = 1;
-        for (Part part : oldUnit.getParts()) {
-            part.setId(partId++);
-        }
-
-        // Create the Refit
-        Refit refit = new Refit(oldUnit, newEntity, false, false);
-        refit.setTech(mockTech);
-        refit.addTimeSpent(60); // 1 hour of work!
-
-        // Write the Refit XML
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        refit.writeToXml(pw, 0);
-
-        // Get the Refit XML
-        String xml = sw.toString();
-        assertFalse(xml.trim().isEmpty());
-
-        // Using factory get an instance of document builder
-        DocumentBuilder db = MekHqXmlUtil.newSafeDocumentBuilder();
-
-        // Parse using builder to get DOM representation of the XML file
-        Document xmlDoc = db.parse(new ByteArrayInputStream(xml.getBytes()));
-
-        Element refitElt = xmlDoc.getDocumentElement();
-        assertEquals("refit", refitElt.getNodeName());
-
-        // Deserialize the refit
-        Refit deserialized = Refit.generateInstanceFromXML(refitElt, oldUnit, new Version("1.0.0"));
-        assertNotNull(deserialized);
-        deserialized.reCalc();
-
-        // Spot check the values
-        assertEquals(refit.getTime(), deserialized.getTime());
-        assertEquals(refit.getActualTime(), deserialized.getActualTime());
-        assertEquals(refit.getCost(), deserialized.getCost());
-        assertEquals(refit.isSameArmorType(), deserialized.isSameArmorType());
-        assertEquals(refit.hasFailedCheck(), deserialized.hasFailedCheck());
-        assertEquals(refit.getRefitClass(), deserialized.getRefitClass());
-        assertEquals(refit.getTimeSpent(), deserialized.getTimeSpent());
-        assertEquals(refit.getTimeLeft(), deserialized.getTimeLeft());
-        assertEquals(refit.isCustomJob(), deserialized.isCustomJob());
-        assertEquals(refit.kitFound(), deserialized.kitFound());
-        assertEquals(refit.isBeingRefurbished(), deserialized.isBeingRefurbished());
-        assertEquals(refit.getTech().getId(), deserialized.getTech().getId());
-
-        // Check that we got all the correct old parts in the XML
-        Set<Integer> oldUnitParts = refit.getOldUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        Set<Integer> serializedOldParts = deserialized.getOldUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        assertEquals(oldUnitParts, serializedOldParts);
-
-        // Check that we got all the correct new parts in the XML
-        Set<Integer> newUnitParts = refit.getNewUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        Set<Integer> serializedNewParts = deserialized.getNewUnitParts()
-                .stream().map(p -> p.getId()).collect(Collectors.toSet());
-        assertEquals(newUnitParts, serializedNewParts);
-
-        // Check that we got all the shopping list entries (by name, not amazing but reasonable)
-        List<String> shoppingList = refit.getShoppingList()
-                .stream().map(p -> p.getName()).collect(Collectors.toList());
-        List<String> serializedShoppingList = deserialized.getShoppingList()
-                .stream().map(p -> p.getName()).collect(Collectors.toList());
-
-        // Make sure they're the same length first...
-        assertEquals(shoppingList.size(), serializedShoppingList.size());
-
-        // ... then make sure they're the "same" by removing them one by one...
-        for (String partName : shoppingList) {
-            assertTrue(serializedShoppingList.remove(partName));
-        }
-
-        // ... and ensuring nothing is left.
-        assertTrue(serializedShoppingList.isEmpty());
-
-        // Do the same for their descriptions, which include the quantities...
-        List<String> shoppingListDescs = Arrays.asList(refit.getShoppingListDescription());
-        // ... except the second list needs to be mutable.
-        List<String> serializedShoppingListDescs = new ArrayList<>(Arrays.asList(deserialized.getShoppingListDescription()));
-
-        assertEquals(shoppingListDescs.size(), serializedShoppingListDescs.size());
-        for (String desc : shoppingListDescs) {
-            assertTrue(serializedShoppingListDescs.remove(desc));
-        }
-
-        assertTrue(serializedShoppingListDescs.isEmpty());
-
-        // Make sure the new armor is serialized/deserialized properly
-        assertNotNull(deserialized.getNewArmorSupplies());
-        assertTrue(refit.getNewArmorSupplies().isSameType(deserialized.getNewArmorSupplies()));
-        assertEquals(refit.getNewArmorSupplies().getAmountNeeded(),
-                deserialized.getNewArmorSupplies().getAmountNeeded());
+        // Complete the refit!
+        String report = refit.succeed();
+        assertNotNull(report);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTestUtilities.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTestUtilities.java
@@ -21,8 +21,8 @@
 
 package mekhq.campaign.unit;
 
-import megamek.common.loaders.EntityLoadingException;
-import megamek.common.loaders.MtfFile;
+import megamek.common.loaders.*;
+import megamek.common.util.BuildingBlock;
 import mekhq.TestUtilities;
 import org.junit.Assert;
 
@@ -50,6 +50,67 @@ public final class UnitTestUtilities {
             MtfFile parser = new MtfFile(in);
 
             return parser.getEntity();
+        } catch (EntityLoadingException e) {
+            Assert.fail(e.toString());
+        }
+
+        return null;
+    }
+
+    public static Entity parseBase64BlkFile(String base64) {
+        try {
+            InputStream in = new ByteArrayInputStream(TestUtilities.Decode(base64));
+            IMechLoader loader;
+            
+            BuildingBlock bb = new BuildingBlock(in);
+            if (bb.exists("UnitType")) {
+                String sType = bb.getDataAsString("UnitType")[0];
+                if (sType.equals("Tank") || sType.equals("Naval")
+                        || sType.equals("Surface") || sType.equals("Hydrofoil")) {
+                    loader = new BLKTankFile(bb);
+                } else if (sType.equals("Infantry")) {
+                    loader = new BLKInfantryFile(bb);
+                } else if (sType.equals("BattleArmor")) {
+                    loader = new BLKBattleArmorFile(bb);
+                } else if (sType.equals("ProtoMech")) {
+                    loader = new BLKProtoFile(bb);
+                } else if (sType.equals("Mech")) {
+                    loader = new BLKMechFile(bb);
+                } else if (sType.equals("VTOL")) {
+                    loader = new BLKVTOLFile(bb);
+                } else if (sType.equals("GunEmplacement")) {
+                    loader = new BLKGunEmplacementFile(bb);
+                } else if (sType.equals("SupportTank")) {
+                    loader = new BLKSupportTankFile(bb);
+                } else if (sType.equals("LargeSupportTank")) {
+                    loader = new BLKLargeSupportTankFile(bb);
+                } else if (sType.equals("SupportVTOL")) {
+                    loader = new BLKSupportVTOLFile(bb);
+                } else if (sType.equals("Aero")) {
+                    loader = new BLKAeroFile(bb);
+                } else if (sType.equals("FixedWingSupport")) {
+                    loader = new BLKFixedWingSupportFile(bb);
+                } else if (sType.equals("ConvFighter")) {
+                    loader = new BLKConvFighterFile(bb);
+                } else if (sType.equals("SmallCraft")) {
+                    loader = new BLKSmallCraftFile(bb);
+                } else if (sType.equals("Dropship")) {
+                    loader = new BLKDropshipFile(bb);
+                } else if (sType.equals("Jumpship")) {
+                    loader = new BLKJumpshipFile(bb);
+                } else if (sType.equals("Warship")) {
+                    loader = new BLKWarshipFile(bb);
+                } else if (sType.equals("SpaceStation")) {
+                    loader = new BLKSpaceStationFile(bb);
+                } else {
+                    throw new EntityLoadingException("Unknown UnitType: "
+                            + sType);
+                }
+            } else {
+                loader = new BLKMechFile(bb);
+            }
+
+            return loader.getEntity();
         } catch (EntityLoadingException e) {
             Assert.fail(e.toString());
         }
@@ -475,5 +536,38 @@ public final class UnitTestUtilities {
             + "Q0FUSU9OUzpOZWlsDQpzeXN0ZW1tb2RlOkNPTU1VTklDQVRJT05TOjIwMDANCnN5c3RlbW1hbnVm"
             + "YWN0dXJlcjpUQVJHRVRJTkc6RGFsYmFuDQpzeXN0ZW1tb2RlOlRBUkdFVElORzpIaVJlei1CDQo="
         );
+    }
+
+    public static Entity getHeavyTrackedApcStandard() {
+        return parseBase64BlkFile("I2J1aWxkaW5nIGJsb2NrIGRhdGEgZmlsZQo8QmxvY2tWZXJzaW9uPgoxCjwvQmxvY2tWZXJzaW9u"
+            + "PgojV3JpdGUgdGhlIHZlcnNpb24gbnVtYmVyIGp1c3QgaW4gY2FzZS4uLgo8VmVyc2lvbj4KTUFN"
+            + "MAo8L1ZlcnNpb24+CjxVbml0VHlwZT4KVGFuawo8L1VuaXRUeXBlPgo8TmFtZT4KSGVhdnkgVHJh"
+            + "Y2tlZCBBUEMKPC9OYW1lPgo8TW9kZWw+CihTdGFuZGFyZCkKPC9Nb2RlbD4KPFRvbm5hZ2U+CjIw"
+            + "CjwvVG9ubmFnZT4KPGNydWlzZU1QPgo1CjwvY3J1aXNlTVA+CjxBcm1vcj4KMjAKMTMKMTMKMTAK"
+            + "PC9Bcm1vcj4KPEZyb250IEVxdWlwbWVudD4KSVNNYWNoaW5lIEd1bgpJU01hY2hpbmUgR3VuCjwv"
+            + "RnJvbnQgRXF1aXBtZW50Pgo8dHJhbnNwb3J0ZXJzPgpUcm9vcFNwYWNlOjYKPC90cmFuc3BvcnRl"
+            + "cnM+CjxCb2R5IEVxdWlwbWVudD4KSVNNRyBBbW1vICgxMDApCjwvQm9keSBFcXVpcG1lbnQ+Cjx0"
+            + "eXBlPgpJUyBMZXZlbCAxCjwvdHlwZT4KPHllYXI+CjI0NzAKPC95ZWFyPgo8aW50ZXJuYWxfdHlw"
+            + "ZT4KMAo8L2ludGVybmFsX3R5cGU+Cjxhcm1vcl90eXBlPgowCjwvYXJtb3JfdHlwZT4KPGVuZ2lu"
+            + "ZV90eXBlPgoxCjwvZW5naW5lX3R5cGU+Cjxtb3Rpb25fdHlwZT4KVHJhY2tlZAo8L21vdGlvbl90"
+            + "eXBlPgo8c291cmNlPgpTdGFyIExlYWd1ZQo8L3NvdXJjZT4K");
+    }
+
+    public static Entity getHeavyTrackedApcMg() {
+        return parseBase64BlkFile("I2J1aWxkaW5nIGJsb2NrIGRhdGEgZmlsZQo8QmxvY2tWZXJzaW9uPgoxCjwvQmxvY2tWZXJzaW9u"
+            + "PgojV3JpdGUgdGhlIHZlcnNpb24gbnVtYmVyIGp1c3QgaW4gY2FzZS4uLgo8VmVyc2lvbj4KTUFN"
+            + "MAo8L1ZlcnNpb24+CjxVbml0VHlwZT4KVGFuawo8L1VuaXRUeXBlPgo8TmFtZT4KSGVhdnkgVHJh"
+            + "Y2tlZCBBUEMKPC9OYW1lPgo8TW9kZWw+CihNRykKPC9Nb2RlbD4KPFRvbm5hZ2U+CjIwCjwvVG9u"
+            + "bmFnZT4KPGNydWlzZU1QPgo1CjwvY3J1aXNlTVA+CjxBcm1vcj4KMjAKMTMKMTMKMTAKPC9Bcm1v"
+            + "cj4KPEZyb250IEVxdWlwbWVudD4KSVNNYWNoaW5lIEd1bgpJU01hY2hpbmUgR3VuCjwvRnJvbnQg"
+            + "RXF1aXBtZW50Pgo8UmlnaHQgRXF1aXBtZW50PgpJU01hY2hpbmUgR3VuCjwvUmlnaHQgRXF1aXBt"
+            + "ZW50Pgo8TGVmdCBFcXVpcG1lbnQ+CklTTWFjaGluZSBHdW4KPC9MZWZ0IEVxdWlwbWVudD4KPFJl"
+            + "YXIgRXF1aXBtZW50PgpJU01hY2hpbmUgR3VuCklTTWFjaGluZSBHdW4KPC9SZWFyIEVxdWlwbWVu"
+            + "dD4KPHRyYW5zcG9ydGVycz4KVHJvb3BTcGFjZTozCjwvdHJhbnNwb3J0ZXJzPgo8Qm9keSBFcXVp"
+            + "cG1lbnQ+CklTTUcgQW1tbyAoMjAwKQpJU01HIEFtbW8gKDEwMCkKPC9Cb2R5IEVxdWlwbWVudD4K"
+            + "PHR5cGU+CklTIExldmVsIDEKPC90eXBlPgo8eWVhcj4KMjQ3MAo8L3llYXI+CjxpbnRlcm5hbF90"
+            + "eXBlPgowCjwvaW50ZXJuYWxfdHlwZT4KPGFybW9yX3R5cGU+CjAKPC9hcm1vcl90eXBlPgo8ZW5n"
+            + "aW5lX3R5cGU+CjEKPC9lbmdpbmVfdHlwZT4KPG1vdGlvbl90eXBlPgpUcmFja2VkCjwvbW90aW9u"
+            + "X3R5cGU+Cjxzb3VyY2U+ClN0YXIgTGVhZ3VlCjwvc291cmNlPgo=");
     }
 }


### PR DESCRIPTION
The logic to unscramble equipment numbers did not always handle the case where less equipment was found that before, and therefore could throw an NPE when referencing the underlying `Mounted`. This adds an explicit null check for the `Mounted`, and if null the part ends up in the "remaining" bin.

The symptom in this case was a unit with an ammo bin for equipment number 4, when instead the equipments are 0 through 2. Resolving the NPE in a naive fashion led to an additional ammo bin being added for the missing equipment. This PR avoids that case as well (you will end up with _two_ pieces of equipment: the invalid missing part and the replacement part).

Fixes #2325.