### PR TITLE
Issue #2332: Delete refit file if unable to read it back when saving

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1561,7 +1561,7 @@ public class Refit extends Part implements IAcquisitionWork {
         String fileNameCampaign;
         try {
             if (newEntity instanceof Mech) {
-                //if this file already exists then don't overwrite it or we will end up with a bunch of copies
+                // if this file already exists then don't overwrite it or we will end up with a bunch of copies
                 String fileOutName = sCustomsDir + File.separator + fileName + ".mtf";
                 fileNameCampaign = sCustomsDirCampaign + File.separator + fileName + ".mtf";
                 if ((new File(fileOutName)).exists() || (new File(fileNameCampaign)).exists()) {
@@ -1572,7 +1572,7 @@ public class Refit extends Part implements IAcquisitionWork {
                     p.println(((Mech) newEntity).getMtf());
                 }
             } else {
-                //if this file already exists then don't overwrite it or we will end up with a bunch of copies
+                // if this file already exists then don't overwrite it or we will end up with a bunch of copies
                 String fileOutName = sCustomsDir + File.separator + fileName + ".blk";
                 fileNameCampaign = sCustomsDirCampaign + File.separator + fileName + ".blk";
                 if ((new File(fileOutName)).exists() || (new File(fileNameCampaign)).exists()) {
@@ -1590,8 +1590,8 @@ public class Refit extends Part implements IAcquisitionWork {
         try {
             MechSummaryCache.getInstance().loadMechData();
 
-            //I need to change the new entity to the one from the mtf file now, so that equip
-            //numbers will match
+            // I need to change the new entity to the one from the mtf file now, so that equipment numbers will match
+
             MechSummary summary = MechSummaryCache.getInstance().getMech(newEntity.getChassis() + " " + newEntity.getModel());
             if (null == summary) {
                 throw new EntityLoadingException(String.format("Could not load %s %s from the mech cache",

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1558,23 +1558,23 @@ public class Refit extends Part implements IAcquisitionWork {
             }
         }
 
+        String fileNameCampaign;
         try {
             if (newEntity instanceof Mech) {
                 //if this file already exists then don't overwrite it or we will end up with a bunch of copies
                 String fileOutName = sCustomsDir + File.separator + fileName + ".mtf";
-                String fileNameCampaign = sCustomsDirCampaign + File.separator + fileName + ".mtf";
+                fileNameCampaign = sCustomsDirCampaign + File.separator + fileName + ".mtf";
                 if ((new File(fileOutName)).exists() || (new File(fileNameCampaign)).exists()) {
                     throw new IOException("A file already exists with the custom name "+fileNameCampaign+". Please choose a different name. (Unit name and/or model)");
                 }
-                FileOutputStream out = new FileOutputStream(fileNameCampaign);
-                PrintStream p = new PrintStream(out);
-                p.println(((Mech) newEntity).getMtf());
-                p.close();
-                out.close();
+                try (FileOutputStream out = new FileOutputStream(fileNameCampaign);
+                    PrintStream p = new PrintStream(out)) {
+                    p.println(((Mech) newEntity).getMtf());
+                }
             } else {
                 //if this file already exists then don't overwrite it or we will end up with a bunch of copies
                 String fileOutName = sCustomsDir + File.separator + fileName + ".blk";
-                String fileNameCampaign = sCustomsDirCampaign + File.separator + fileName + ".blk";
+                fileNameCampaign = sCustomsDirCampaign + File.separator + fileName + ".blk";
                 if ((new File(fileOutName)).exists() || (new File(fileNameCampaign)).exists()) {
                     throw new IOException("A file already exists with the custom name "+fileNameCampaign+". Please choose a different name. (Unit name and/or model)");
                 }
@@ -1582,17 +1582,43 @@ public class Refit extends Part implements IAcquisitionWork {
             }
         } catch (Exception e) {
             MekHQ.getLogger().error(e);
-        }
-        getCampaign().addCustom(newEntity.getChassis() + " " + newEntity.getModel());
-        MechSummaryCache.getInstance().loadMechData();
-        //I need to change the new entity to the one from the mtf file now, so that equip
-        //numbers will match
-        MechSummary summary = MechSummaryCache.getInstance().getMech(newEntity.getChassis() + " " + newEntity.getModel());
-        if (null == summary) {
-            throw(new EntityLoadingException());
+            fileNameCampaign = null;
         }
 
-        newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
+        getCampaign().addCustom(newEntity.getChassis() + " " + newEntity.getModel());
+
+        try {
+            MechSummaryCache.getInstance().loadMechData();
+
+            //I need to change the new entity to the one from the mtf file now, so that equip
+            //numbers will match
+            MechSummary summary = MechSummaryCache.getInstance().getMech(newEntity.getChassis() + " " + newEntity.getModel());
+            if (null == summary) {
+                throw new EntityLoadingException(String.format("Could not load %s %s from the mech cache",
+                        newEntity.getChassis(), newEntity.getModel()));
+            }
+
+            newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
+            MekHQ.getLogger().info(String.format("Saved %s %s to %s",
+                    newEntity.getChassis(), newEntity.getModel(), summary.getSourceFile()));
+        } catch (EntityLoadingException e) {
+            MekHQ.getLogger().error(String.format("Could not read back refit entity %s %s", 
+                    newEntity.getChassis(), newEntity.getModel()), e);
+
+            if (fileNameCampaign != null) {
+                MekHQ.getLogger().warning("Deleting invalid refit file " + fileNameCampaign);
+                try {
+                    new File(fileNameCampaign).delete();
+                } catch (SecurityException se) {
+                    MekHQ.getLogger().warning("Could not clean up bad refit file " + fileNameCampaign, se);
+                }
+            }
+
+            // Reload the mech cache if we had to delete the file
+            MechSummaryCache.getInstance().loadMechData();
+
+            throw e;
+        }
     }
 
     private int getTimeMultiplier() {


### PR DESCRIPTION
When we begin a custom refit, we save the file to disk and then load it back into the cache. However, if we encounter a fatal error at this point and cannot read the file we simply alert the user. The file itself is never removed from disk. This causes an odd situation where you are allowed to make a mech with the same name, but it won't save it back to disk and each attempt at fixing or recreating the mech will fail unless you rename it.

This changes the behavior of Refit::saveCustomization slightly, in that if the refit file cannot be read back by MHQ the file itself is deleted and the cache is refreshed. The downside is that we won't have the files to look back at to see why it failed on load. The upside is that users do not have to take manual actions to restore their campaign.

Fixes part of #2332.