### PR TITLE
Issue #2342: Customs in CPNX with invalid file name chars do not save to disk

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -40,7 +40,7 @@ import mekhq.campaign.personnel.enums.FamilialRelationshipType;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;


### PR DESCRIPTION
Found this while debugging another campaign issue, but basically we were not escaping the name of the custom before writing it to disk. This brings the code over from Refit and unblocks this problem for customs that may not have valid file names for certain operating systems.