### PR TITLE
Issue #2341: Equipment on incorrect mounts is not fixed

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1360,36 +1360,49 @@ public class CampaignXmlParser {
             }
 
             Unit u = prt.getUnit();
-            if (null != u) {
+            if (u != null) {
                 // get rid of any equipmentparts without locations or mounteds
                 if (prt instanceof EquipmentPart) {
-                    Mounted m = u.getEntity().getEquipment(
-                            ((EquipmentPart) prt).getEquipmentNum());
-                    if ((m == null) || (m.getLocation() == Entity.LOC_NONE)) {
-                        // ... don't remove ammo bins as they may not have a location
-                        if (!(prt instanceof AmmoBin)) {
-                            removeParts.add(prt);
-                            continue;
-                        }
+                    EquipmentPart ePart = (EquipmentPart) prt;
+                    Mounted m = u.getEntity().getEquipment(ePart.getEquipmentNum());
+
+                    // Remove equipment parts missing mounts
+                    if (m == null) {
+                        removeParts.add(prt);
+                        continue;
                     }
+
+                    // Remove equipment parts without a valid location, unless they're an ammo bin as they may not have a location
+                    if ((m.getLocation() == Entity.LOC_NONE) && !(prt instanceof AmmoBin)) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+
                     // Remove existing duplicate parts.
-                    Part duplicatePart = u.getPartForEquipmentNum(((EquipmentPart) prt).getEquipmentNum(), prt.getLocation());
+                    Part duplicatePart = u.getPartForEquipmentNum(ePart.getEquipmentNum(), prt.getLocation());
                     if ((duplicatePart instanceof EquipmentPart)
-                            && ((EquipmentPart) prt).getType().equals(((EquipmentPart) duplicatePart).getType())) {
+                            && ePart.getType().equals(((EquipmentPart) duplicatePart).getType())) {
                         removeParts.add(prt);
                         continue;
                     }
                 }
                 if (prt instanceof MissingEquipmentPart) {
-                    Mounted m = u.getEntity().getEquipment(
-                            ((MissingEquipmentPart) prt).getEquipmentNum());
-                    if ((null == m) || (m.getLocation() == Entity.LOC_NONE)) {
+                    Mounted m = u.getEntity().getEquipment(((MissingEquipmentPart) prt).getEquipmentNum());
+
+                    // Remove equipment parts missing mounts
+                    if (m == null) {
+                        removeParts.add(prt);
+                        continue;
+                    }
+
+                    // Remove missing equipment parts without a valid location, unless they're an ammo bin as they may not have a location
+                    if ((m.getLocation() == Entity.LOC_NONE) && !(prt instanceof MissingAmmoBin)) {
                         removeParts.add(prt);
                         continue;
                     }
                 }
 
-                //if the type is a BayWeapon, remove
+                // if the type is a BayWeapon, remove
                 if ((prt instanceof EquipmentPart)
                         && (((EquipmentPart) prt).getType() instanceof BayWeapon)) {
                     removeParts.add(prt);
@@ -1418,8 +1431,7 @@ public class CampaignXmlParser {
                 }
             }
 
-            // deal with true values for sensor and life support on non-Mech
-            // heads
+            // deal with true values for sensor and life support on non-Mech heads
             if ((prt instanceof MekLocation)
                     && (((MekLocation) prt).getLoc() != Mech.LOC_HEAD)) {
                 ((MekLocation) prt).setSensors(false);


### PR DESCRIPTION
In certain cases (refits, entity updates) we get out of sync parts and equipment numbers. In most cases this is _missing_ underlying equipment, but in some cases there is a different type of equipment at the mount. In other cases, there is also a part for that equipment.

This fixes this situation by changing how we unscramble equipment, adding steps 2 and 4 below:
1. Detect exactly correct equipment.
2. Detect approximately correct equipment (AmmoBins with munition type changes not reflected on the entity yet).
3. Find matches on different equipment numbers.
4. Break linkages between equipment parts and mounts if they are incorrect and a part already exists for the mount.

A second issue was noted, which is that AmmoBins were not removed if they had a missing mount due to the boolean logic. The logic has been spread out to make it more obvious what is going on to avoid this issue going forward.

Fixes #2341.