### PR TITLE
Don't skip ComStar as an origin faction

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/RangedFactionSelector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RangedFactionSelector.java
@@ -145,8 +145,13 @@ public class RangedFactionSelector extends AbstractFactionSelector {
             // to affect the 'spread'.
             double delta = Math.log10(pop) / (1 + distance * distanceScale);
             for (Faction faction : planetarySystem.getFactionSet(now)) {
-                if (faction.is(Tag.ABANDONED) || faction.is(Tag.HIDDEN) || faction.is(Tag.INACTIVE)
-                    || faction.is(Tag.MERC)) {
+                if (faction.is(Tag.ABANDONED) || faction.is(Tag.HIDDEN) || faction.is(Tag.SPECIAL)
+                        || faction.is(Tag.MERC)) {
+                    continue;
+                }
+
+                if (faction.is(Tag.INACTIVE) && !faction.isComStar()) {
+                    // Skip INACTIVE factions [excepting ComStar]
                     continue;
                 }
 


### PR DESCRIPTION
I misunderstood the usage of the `INACTIVE` tag when I wrote the random origin code, and this fixes it such that ComStar can be selected as a random origin. This also adds the `SPECIAL` tag to the reject list, otherwise "All Clans" shows up.

I believe this passes the bar of being simple enough for Stable.