### PR TITLE
Issue #2348: Allow Clanner origins

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/RangedFactionSelector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RangedFactionSelector.java
@@ -129,6 +129,7 @@ public class RangedFactionSelector extends AbstractFactionSelector {
         PlanetarySystem currentSystem = campaign.getCurrentSystem();
 
         LocalDate now = campaign.getLocalDate();
+        boolean isClan = campaign.getFaction().isClan();
 
         Map<Faction, Double> weights = new HashMap<>();
         Systems.getInstance().visitNearbySystems(currentSystem, range, planetarySystem -> {
@@ -150,7 +151,7 @@ public class RangedFactionSelector extends AbstractFactionSelector {
                     continue;
                 }
 
-                if (faction.is(Tag.CLAN) && !isAllowClan()) {
+                if (faction.is(Tag.CLAN) && !(isClan || isAllowClan())) {
                     continue;
                 }
 
@@ -163,9 +164,11 @@ public class RangedFactionSelector extends AbstractFactionSelector {
         Faction mercenaries = Factions.getInstance().getFaction("MERC");
         TreeMap<Double, Faction> factions = new TreeMap<>();
         if (weights.isEmpty()) {
-            // If we have no valid factions, we can always
-            // have mercs and the campaign's faction.
-            factions.put(1.0, mercenaries);
+            // If we have no valid factions use the campaign's faction ...
+            if (!isClan) {
+                // ... and if we're not a clan faction, we can have mercs too.
+                factions.put(1.0, mercenaries);
+            }
             factions.put(2.0, campaign.getFaction());
 
             cachedDate = now;
@@ -194,14 +197,21 @@ public class RangedFactionSelector extends AbstractFactionSelector {
         }
 
         if (factions.isEmpty()) {
-            // If we have no valid factions, we can always
-            // have mercs and the campaign's faction.
-            factions.put(1.0, mercenaries);
+            // If we have no valid factions use the campaign's faction ...
+            if (!isClan) {
+                // ... and if we're not a clan faction, we can have mercs too.
+                factions.put(1.0, mercenaries);
+            }
             factions.put(2.0, campaign.getFaction());
         } else {
-            // There is a good chance they're a merc!
-            // The 1.0 prevents no weight calculations
-            factions.put((total == 0.0) ? 1.0 : total + total * getFactionWeight(mercenaries), mercenaries);
+            if (!isClan) {
+                // There is a good chance they're a merc if we're not a clan faction!
+                // The 1.0 prevents no weight calculations
+                factions.put((total == 0.0) ? 1.0 : total + total * getFactionWeight(mercenaries), mercenaries);
+            } else {
+                // There is a lopsided chance they're from the campaign faction if it is a clan faction.
+                factions.put((total == 0.0) ? 1.0 : total + (15 * total), campaign.getFaction());
+            }
         }
 
         cachedDate = now;

--- a/MekHQ/src/mekhq/campaign/universe/RangedFactionSelector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RangedFactionSelector.java
@@ -151,7 +151,7 @@ public class RangedFactionSelector extends AbstractFactionSelector {
                     continue;
                 }
 
-                if (faction.is(Tag.CLAN) && !(isClan || isAllowClan())) {
+                if (faction.isClan() && !(isClan || isAllowClan())) {
                     continue;
                 }
 


### PR DESCRIPTION
This fixes a logic bug where the Clans had a hard time getting anyone but Mercs to fight for them.

- Ensures the clans can always generate clan origins
- Ensures the clans don't automatically give a 50:50 split to Mercs
- Ensures the clans are lopsided to favoring their own clan as an origin

Fixes #2348.

This is a nice to have for 0.48.0, but not required.