### PR TITLE
Issue #2358: Add missing lances on CPNX load

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -27,6 +27,7 @@ import java.io.PrintStream;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -355,6 +356,17 @@ public class CampaignXmlParser {
                     if (f.isDeployed()) {
                         u.setScenarioId(f.getScenarioId());
                     }
+                }
+            }
+        }
+
+        // determine if we've missed any lances and add those back into the campaign
+        if (retVal.getCampaignOptions().getUseAtB()) {
+            Hashtable<Integer, Lance> lances = retVal.getLances();
+            for (Force f : retVal.getAllForces()) {
+                if (f.getUnits().size() > 0 && (null == lances.get(f.getId()))) {
+                    lances.put(f.getId(), new Lance(f.getId(), retVal));
+                    MekHQ.getLogger().warning(String.format("Added missing Lance %s to AtB list", f.getName()));
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -364,7 +364,7 @@ public class CampaignXmlParser {
         if (retVal.getCampaignOptions().getUseAtB()) {
             Hashtable<Integer, Lance> lances = retVal.getLances();
             for (Force f : retVal.getAllForces()) {
-                if (f.getUnits().size() > 0 && (null == lances.get(f.getId()))) {
+                if ((f.getUnits().size() > 0) && (null == lances.get(f.getId()))) {
                     lances.put(f.getId(), new Lance(f.getId(), retVal));
                     MekHQ.getLogger().warning(String.format("Added missing Lance %s to AtB list", f.getName()));
                 }


### PR DESCRIPTION
I'm not sure of the root cause, but it appears that sometimes we do not correctly update the AtB lance list in Campaign. On load we now verify that the AtB lance list contains _at least_ the lances that should be there.

Fixes #2358.

Loading the Campaign in question:
```
17:42:55,458 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Command Star to AtB list

17:42:55,458 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Scout Star to AtB list

17:42:55,458 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Striker Star to AtB list

17:42:55,459 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Hover Point I to AtB list

17:42:55,459 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Hover Point II to AtB list

17:42:55,459 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Hover Point III to AtB list

17:42:55,459 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Hover Point IV to AtB list

17:42:55,459 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Hover Point V to AtB list

17:42:55,460 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Track Star to AtB list

17:42:55,463 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Wheel Star to AtB list

17:42:55,464 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance PHawk IIC Point to AtB list

17:42:55,464 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Stinger IIC Point to AtB list

17:42:55,464 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Wasp IIC Point to AtB list

17:42:55,464 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance PHawk Point to AtB list

17:42:55,464 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Osprey Point to AtB list

17:42:55,464 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Sabutai Point to AtB list

17:42:55,465 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Stuka Point to AtB list

17:42:55,465 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Gotha Point to AtB list

17:42:55,465 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Tyre Point to AtB list

17:42:55,465 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Issus Point to AtB list

17:42:55,467 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance DropShip Star II to AtB list

17:42:55,474 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance DropShip Star I to AtB list

17:42:55,475 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance HQ Point to AtB list

17:42:55,475 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Coolant Point to AtB list

17:42:55,475 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance MASH Point to AtB list

17:42:55,475 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Long Tom Point to AtB list

17:42:55,476 WARN [mekhq.campaign.io.CampaignXmlParser] {SwingWorker-pool-1-thread-1} 
parse(), line 373 : Added missing Lance Recovery Point to AtB list
```