### PR TITLE
Infantry Motive Type File I/O Fixes

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/InfantryMotiveType.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryMotiveType.java
@@ -178,25 +178,21 @@ public class InfantryMotiveType extends Part {
 
 	@Override
 	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<moveMode>"
-				+mode
-				+"</moveMode>");
-		writeToXmlEnd(pw1, indent);
+		writeToXmlBegin(pw1, indent++);
+		MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "moveMode", mode.name());
+		writeToXmlEnd(pw1, --indent);
 	}
 
 	@Override
 	protected void loadFieldsFromXmlNode(Node wn) {
 		NodeList nl = wn.getChildNodes();
 
-		for (int x=0; x<nl.getLength(); x++) {
+		for (int x = 0; x < nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
 			if (wn2.getNodeName().equalsIgnoreCase("mode")) {
 				mode = EntityMovementMode.getMode(wn2.getTextContent());
 				assignName();
-			}
-			else if (wn2.getNodeName().equalsIgnoreCase("moveMode")) {
+			} else if (wn2.getNodeName().equalsIgnoreCase("moveMode")) {
 				mode = EntityMovementMode.getMode(wn2.getTextContent());
 				assignName();
 			}

--- a/MekHQ/src/mekhq/campaign/parts/InfantryMotiveType.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryMotiveType.java
@@ -189,10 +189,7 @@ public class InfantryMotiveType extends Part {
 
 		for (int x = 0; x < nl.getLength(); x++) {
 			Node wn2 = nl.item(x);
-			if (wn2.getNodeName().equalsIgnoreCase("mode")) {
-				mode = EntityMovementMode.getMode(wn2.getTextContent());
-				assignName();
-			} else if (wn2.getNodeName().equalsIgnoreCase("moveMode")) {
+            if (wn2.getNodeName().equalsIgnoreCase("moveMode")) {
 				mode = EntityMovementMode.getMode(wn2.getTextContent());
 				assignName();
 			}

--- a/MekHQ/src/mekhq/campaign/parts/MissingInfantryMotiveType.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingInfantryMotiveType.java
@@ -1,20 +1,20 @@
 /*
  * MissingInfantryMotiveType.java
- * 
+ *
  * Copyright (c) 2009 Jay Lawson <jaylawson39 at yahoo.com>. All rights reserved.
- * 
+ *
  * This file is part of MekHQ.
- * 
+ *
  * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -40,7 +40,7 @@ import mekhq.campaign.Campaign;
 public class MissingInfantryMotiveType extends MissingPart {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 2454012279066776500L;
 	private EntityMovementMode mode;
@@ -48,7 +48,7 @@ public class MissingInfantryMotiveType extends MissingPart {
 	public MissingInfantryMotiveType() {
     	this(0, null, null);
     }
-	
+
 	public MissingInfantryMotiveType(int tonnage, Campaign c, EntityMovementMode m) {
 		super(tonnage, c);
 		this.mode = m;
@@ -56,17 +56,17 @@ public class MissingInfantryMotiveType extends MissingPart {
 			assignName();
 		}
 	}
-	
-	@Override 
+
+	@Override
 	public int getBaseTime() {
 		return 0;
 	}
-	
+
 	@Override
 	public int getDifficulty() {
 		return 0;
 	}
-	
+
 	private void assignName() {
 		switch (mode) {
         case INF_UMU:
@@ -91,10 +91,10 @@ public class MissingInfantryMotiveType extends MissingPart {
         	name = "Unknown Motive Type";
 		}
 	}
-	
+
 	@Override
 	public void updateConditionFromPart() {
-		//Do nothing		
+		//Do nothing
 	}
 
 	@Override
@@ -119,22 +119,19 @@ public class MissingInfantryMotiveType extends MissingPart {
 
 	@Override
 	public void writeToXml(PrintWriter pw1, int indent) {
-		writeToXmlBegin(pw1, indent);
-		pw1.println(MekHqXmlUtil.indentStr(indent+1)
-				+"<moveMode>"
-				+mode
-				+"</moveMode>");
-		writeToXmlEnd(pw1, indent);
+		writeToXmlBegin(pw1, indent++);
+		MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "moveMode", mode.name());
+		writeToXmlEnd(pw1, --indent);
 	}
 
 	@Override
 	protected void loadFieldsFromXmlNode(Node wn) {
 		NodeList nl = wn.getChildNodes();
-		
-		for (int x=0; x<nl.getLength(); x++) {
-			Node wn2 = nl.item(x);		
+
+		for (int x = 0; x < nl.getLength(); x++) {
+			Node wn2 = nl.item(x);
 			if (wn2.getNodeName().equalsIgnoreCase("moveMode")) {
-				mode = EntityMovementMode.getMode(wn2.getTextContent());
+				mode = EntityMovementMode.getMode(wn2.getTextContent().trim());
 				assignName();
 			}
 		}
@@ -155,5 +152,5 @@ public class MissingInfantryMotiveType extends MissingPart {
     public TechAdvancement getTechAdvancement() {
         return Infantry.getMotiveTechAdvancement(mode);
     }
-    	
+
 }


### PR DESCRIPTION
This PR fixes the save format for the mode, namely that it should be saving as an enum. This also removes eight year old migration code that ends up causing issues during parsing. I found this issue while working on some modernization and simplifications relating to the EntityMovementMode enum, but thought this issue should be fixed for stable.