### PR TITLE
Moving to fully use isConventionalInfantry

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4851,11 +4851,9 @@ public class Campaign implements Serializable, ITechManager {
             return new TargetRoll(TargetRoll.IMPOSSIBLE, notFixable);
         }
         // if this is an infantry refit, then automatic success
-        if (partWork instanceof Refit && null != partWork.getUnit()
-                && partWork.getUnit().getEntity() instanceof Infantry
-                && !(partWork.getUnit().getEntity() instanceof BattleArmor)) {
-            return new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS,
-                    "infantry refit");
+        if ((partWork instanceof Refit) && (partWork.getUnit() != null)
+                && partWork.getUnit().getEntity().isConventionalInfantry()) {
+            return new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "infantry refit");
         }
 
         //if we are using the MoF rule, then we will ignore mode penalty here

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -603,9 +603,8 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
                                 .multipliedBy(straightSupport)
                                 .dividedBy(100);
         } else {
-            Money maintCosts = c.getHangar().getUnitCosts(
-                u -> !(u.getEntity() instanceof Infantry) || (u.getEntity() instanceof BattleArmor),
-                Unit::getWeeklyMaintenanceCost);
+            Money maintCosts = c.getHangar().getUnitCosts(u -> !u.getEntity().isConventionalInfantry(),
+                    Unit::getWeeklyMaintenanceCost);
             maintCosts = maintCosts.multipliedBy(4);
             supportAmount = maintCosts
                                 .multipliedBy(getLength())

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -971,9 +971,9 @@ public class Refit extends Part implements IAcquisitionWork {
 
         //infantry take zero time to re-organize
         //also check for squad size and number changes
-        if (oldUnit.getEntity() instanceof Infantry && !(oldUnit.getEntity() instanceof BattleArmor)) {
-            if (((Infantry)oldUnit.getEntity()).getSquadN() != ((Infantry)newEntity).getSquadN()
-                    ||((Infantry)oldUnit.getEntity()).getSquadSize() != ((Infantry)newEntity).getSquadSize()) {
+        if (oldUnit.getEntity().isConventionalInfantry()) {
+            if (((Infantry) oldUnit.getEntity()).getSquadN() != ((Infantry) newEntity).getSquadN()
+                    ||((Infantry) oldUnit.getEntity()).getSquadSize() != ((Infantry) newEntity).getSquadSize()) {
                 updateRefitClass(CLASS_A);
             }
             time = 0;
@@ -1489,7 +1489,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 ((AmmoBin) p).loadBin();
             }
         }
-        
+
         if (null != newArmorSupplies) {
             getCampaign().getWarehouse().removePart(newArmorSupplies);
         }
@@ -1602,7 +1602,7 @@ public class Refit extends Part implements IAcquisitionWork {
             MekHQ.getLogger().info(String.format("Saved %s %s to %s",
                     newEntity.getChassis(), newEntity.getModel(), summary.getSourceFile()));
         } catch (EntityLoadingException e) {
-            MekHQ.getLogger().error(String.format("Could not read back refit entity %s %s", 
+            MekHQ.getLogger().error(String.format("Could not read back refit entity %s %s",
                     newEntity.getChassis(), newEntity.getModel()), e);
 
             if (fileNameCampaign != null) {
@@ -2268,8 +2268,8 @@ public class Refit extends Part implements IAcquisitionWork {
     }
 
     public void suggestNewName() {
-        if (newEntity instanceof Infantry && !(newEntity instanceof BattleArmor)) {
-            Infantry infantry = (Infantry)newEntity;
+        if (newEntity.isConventionalInfantry()) {
+            Infantry infantry = (Infantry) newEntity;
             String chassis;
             switch (infantry.getMovementMode()) {
             case INF_UMU:

--- a/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
@@ -387,16 +387,10 @@ public abstract class AbstractUnitRating implements IUnitRating {
      */
     BigDecimal getUnitValue(Unit u) {
         BigDecimal value = BigDecimal.ONE;
-        if (isConventionalInfantry(u) &&
-            (((Infantry) u.getEntity()).getSquadN() == 1)) {
+        if (u.getEntity().isConventionalInfantry() && (((Infantry) u.getEntity()).getSquadN() == 1)) {
             value = new BigDecimal("0.25");
         }
         return value;
-    }
-
-    boolean isConventionalInfantry(Unit u) {
-        return (u.getEntity() instanceof Infantry) &&
-               !(u.getEntity() instanceof BattleArmor);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -962,7 +962,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         if (u.isMothballed()) {
             return;
         }
-        MekHQ.getLogger().debug(this, "Unit " + u.getName() + " updating advanced tech count.");
+        MekHQ.getLogger().debug("Unit " + u.getName() + " updating advanced tech count.");
 
         int unitType = u.getEntity().getUnitType();
         switch (unitType) {
@@ -978,16 +978,16 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             case UnitType.WARSHIP:
             case UnitType.JUMPSHIP:
                 int techLevel = u.getEntity().getTechLevel();
-                MekHQ.getLogger().debug(this, "Unit " + u.getName() + " TL = " + TechConstants.getLevelDisplayableName(techLevel));
+                MekHQ.getLogger().debug("Unit " + u.getName() + " TL = " + TechConstants.getLevelDisplayableName(techLevel));
                 if (techLevel > TechConstants.T_INTRO_BOXSET) {
                     if (TechConstants.isClan(techLevel)) {
                         setNumberClan(getNumberClan().add(value));
-                        if (!isConventionalInfantry(u)) {
+                        if (!u.getEntity().isConventionalInfantry()) {
                             setCountClan(getCountClan() + 1);
                         }
                     } else {
                         setNumberIS2(getNumberIS2().add(value));
-                        if (!isConventionalInfantry(u)) {
+                        if (!u.getEntity().isConventionalInfantry()) {
                             setCountIS2(getCountIS2() + 1);
                         }
                     }
@@ -995,7 +995,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
                 break;
             default:
                 // not counted for tech level purposes.
-                MekHQ.getLogger().debug(this, "Unit " + u.getName() + " not counted for tech level.");
+                MekHQ.getLogger().debug("Unit " + u.getName() + " not counted for tech level.");
                 break;
         }
     }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4880,8 +4880,8 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     }
 
     public boolean isSelfCrewed() {
-        return (getEntity() instanceof Dropship || getEntity() instanceof Jumpship
-                || getEntity() instanceof Infantry && !(getEntity() instanceof BattleArmor));
+        return (getEntity() instanceof Dropship) || (getEntity() instanceof Jumpship)
+                || getEntity().isConventionalInfantry();
     }
 
     public boolean isUnderRepair() {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1614,7 +1614,7 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
                         }
 
                         if (StaticChecks.areAllInfantry(selected)) {
-                            if (!(unit.getEntity() instanceof Infantry) || unit.getEntity() instanceof BattleArmor) {
+                            if (!unit.getEntity().isConventionalInfantry()) {
                                 continue;
                             }
                             if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {

--- a/MekHQ/src/mekhq/gui/dialog/RefitNameDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RefitNameDialog.java
@@ -88,7 +88,7 @@ public class RefitNameDialog extends JDialog {
         txtChassis.setText(refit.getNewEntity().getChassis());
         txtChassis.setMinimumSize(new Dimension(150, 28));
         //only allow chassis renaming for conventional infantry
-        if (refit.getNewEntity().isConventionalInfantry()) {
+        if (!refit.getNewEntity().isConventionalInfantry()) {
         	txtChassis.setEditable(false);
         	txtChassis.setEnabled(false);
         }

--- a/MekHQ/src/mekhq/gui/dialog/RefitNameDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RefitNameDialog.java
@@ -12,26 +12,19 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
-import java.awt.Frame;
+import java.awt.*;
 import java.util.ResourceBundle;
 
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JTextField;
+import javax.swing.*;
 
-import megamek.common.BattleArmor;
-import megamek.common.Infantry;
 import megamek.common.MechSummaryCache;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
@@ -40,7 +33,6 @@ import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
 
 /**
- *
  * @author  Taharqa
  */
 public class RefitNameDialog extends JDialog {
@@ -78,29 +70,29 @@ public class RefitNameDialog extends JDialog {
         btnOK = new JButton();
         btnCancel = new JButton();
 
-        ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.RefitNameDialog", new EncodeControl()); //$NON-NLS-1$
-        setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
-        setName("Form"); // NOI18N
+        ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.RefitNameDialog", new EncodeControl());
+        setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        setName("Form");
         setTitle(resourceMap.getString("Form.title"));
-        getContentPane().setLayout(new java.awt.GridBagLayout());
+        getContentPane().setLayout(new GridBagLayout());
 
-        lblChassis.setText(resourceMap.getString("lblChassis.text")); // NOI18N
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        lblChassis.setText(resourceMap.getString("lblChassis.text"));
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.gridwidth = 1;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
-        gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         getContentPane().add(lblChassis, gridBagConstraints);
 
         txtChassis.setText(refit.getNewEntity().getChassis());
-        txtChassis.setMinimumSize(new java.awt.Dimension(150, 28));
+        txtChassis.setMinimumSize(new Dimension(150, 28));
         //only allow chassis renaming for conventional infantry
-        if(!(refit.getNewEntity() instanceof Infantry) || refit.getNewEntity() instanceof BattleArmor) {
+        if (refit.getNewEntity().isConventionalInfantry()) {
         	txtChassis.setEditable(false);
         	txtChassis.setEnabled(false);
         }
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.gridwidth = 1;


### PR DESCRIPTION
This is the MekHQ part of a full repository swapover from using instanceof to determine if a unit is conventional infantry to the isConventionalInfantry method, which returns true for Infantry and all inheritors outside of BattleArmor and inheritors.

Logic:
(Infantry && !BattleArmor): isConventionalInfantry 
(!Infantry || BattleArmor): !isConventionalInfantry