### PR TITLE
Fixing Baby Prisoner Status Ternary

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1459,8 +1459,8 @@ public class Person implements Serializable, MekHqXmlSerializable {
                 ? Utilities.nonNull(getGenealogy().getSpouseId(), fatherId) : fatherId;
 
         // Determine Prisoner Status
-        PrisonerStatus prisonerStatus = campaign.getCampaignOptions().getPrisonerBabyStatus()
-                ? PrisonerStatus.FREE : getPrisonerStatus();
+        final PrisonerStatus prisonerStatus = campaign.getCampaignOptions().getPrisonerBabyStatus()
+                ? getPrisonerStatus() : PrisonerStatus.FREE;
 
         // Output a specific report to the campaign if they are giving birth to multiple children
         if (PREGNANCY_MULTIPLE_NAMES[size] != null) {


### PR DESCRIPTION
The ternary was flipped, so it worked the exact opposite of how it was supposed to. This fixes that issue.