### PR TITLE
2397: Adding Fall Back SPA check for current SPAs being edited

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/EditSpecialAbilityDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditSpecialAbilityDialog.java
@@ -12,32 +12,20 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.gui.dialog;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Frame;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
+import java.awt.*;
 import java.awt.event.ActionListener;
 import java.util.Hashtable;
 import java.util.Vector;
 
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JSpinner;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.SkillPrereq;
@@ -45,9 +33,7 @@ import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.gui.preferences.JWindowPreference;
 import mekhq.preferences.PreferencesNode;
 
-
 /**
- *
  * @author  Taharqa
  */
 public class EditSpecialAbilityDialog extends JDialog {
@@ -69,33 +55,36 @@ public class EditSpecialAbilityDialog extends JDialog {
     private Vector<String> invalidAbilities;
     private Vector<String> removeAbilities;
 
-    private Hashtable<String, SpecialAbility> allSPA;
+    private Hashtable<String, SpecialAbility> allSPAs;
 
     private JLabel lblPrereqAbil;
     private JLabel lblInvalidAbil;
     private JLabel lblRemoveAbil;
-    
+
     private boolean cancelled;
     private int currentXP;
 
+    //region Constructors
     @SuppressWarnings("unchecked")
-	public EditSpecialAbilityDialog(Frame parent, SpecialAbility spa, Hashtable<String, SpecialAbility> hash) {
+	public EditSpecialAbilityDialog(JFrame parent, SpecialAbility spa, Hashtable<String, SpecialAbility> hash) {
         super(parent, true);
         this.ability = spa;
-        this.allSPA = hash;
-        // FIXME: Java is broken, so we had to supress unchecked warnings for these 4 lines
+        this.allSPAs = hash;
+        // FIXME: Java is broken, so we had to suppress unchecked warnings for these 4 lines
         // Basically, Vector<E>.clone() returns an Object instead of a new Vector<E> - DOH!
-        prereqAbilities = (Vector<String>)ability.getPrereqAbilities().clone();
-        invalidAbilities = (Vector<String>)ability.getInvalidAbilities().clone();
-        removeAbilities = (Vector<String>)ability.getRemovedAbilities().clone();
-        prereqSkills = (Vector<SkillPrereq>)ability.getPrereqSkills().clone();
+        prereqAbilities = (Vector<String>) ability.getPrereqAbilities().clone();
+        invalidAbilities = (Vector<String>) ability.getInvalidAbilities().clone();
+        removeAbilities = (Vector<String>) ability.getRemovedAbilities().clone();
+        prereqSkills = (Vector<SkillPrereq>) ability.getPrereqSkills().clone();
         cancelled = false;
         currentXP = ability.getCost();
         initComponents();
         setLocationRelativeTo(parent);
         setUserPreferences();
     }
+    //endregion Constructors
 
+    //region Initialization
     private void initComponents() {
     	java.awt.GridBagConstraints gridBagConstraints;
 
@@ -133,11 +122,11 @@ public class EditSpecialAbilityDialog extends JDialog {
         btnEditPrereqAbil = new javax.swing.JButton("Edit Prereq Abilities");
         btnEditPrereqAbil.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-            	SelectAbilitiesDialog sad = new SelectAbilitiesDialog(null, prereqAbilities, allSPA);
+            	SelectAbilitiesDialog sad = new SelectAbilitiesDialog(null, prereqAbilities, allSPAs);
                 sad.setVisible(true);
                 if(!sad.wasCancelled()) {
                 	prereqAbilities = sad.getSelected();
-                    lblPrereqAbil.setText("<html>" + getPrereqAbilDesc() + "</html>");
+                    lblPrereqAbil.setText("<html>" + getPrerequisiteAbilityDesc() + "</html>");
                     refreshGUI();
                 }
             }
@@ -154,7 +143,7 @@ public class EditSpecialAbilityDialog extends JDialog {
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.insets = new java.awt.Insets(1, 10, 1, 1);
-        lblPrereqAbil = new JLabel("<html>" + getPrereqAbilDesc() + "</html>");
+        lblPrereqAbil = new JLabel("<html>" + getPrerequisiteAbilityDesc() + "</html>");
         panAbil.add(lblPrereqAbil, gridBagConstraints);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -167,7 +156,7 @@ public class EditSpecialAbilityDialog extends JDialog {
         btnEditInvalid = new javax.swing.JButton("Edit Invalid Abilities");
         btnEditInvalid.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                SelectAbilitiesDialog sad = new SelectAbilitiesDialog(null, invalidAbilities, allSPA);
+                SelectAbilitiesDialog sad = new SelectAbilitiesDialog(null, invalidAbilities, allSPAs);
                 sad.setVisible(true);
                 if(!sad.wasCancelled()) {
                 	invalidAbilities = sad.getSelected();
@@ -201,9 +190,9 @@ public class EditSpecialAbilityDialog extends JDialog {
         btnEditRemove = new javax.swing.JButton("Edit Removed Abilities");
         btnEditRemove.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                SelectAbilitiesDialog sad = new SelectAbilitiesDialog(null, removeAbilities, allSPA);
+                SelectAbilitiesDialog sad = new SelectAbilitiesDialog(null, removeAbilities, allSPAs);
                 sad.setVisible(true);
-                if(!sad.wasCancelled()) {
+                if (!sad.wasCancelled()) {
                 	removeAbilities = sad.getSelected();
                     lblRemoveAbil.setText("<html>" + getRemovedDesc() + "</html>");
                     refreshGUI();
@@ -417,9 +406,44 @@ public class EditSpecialAbilityDialog extends JDialog {
         this.setName("dialog");
         preferences.manage(new JWindowPreference(this));
     }
+    //endregion Initialization
+
+    //region Getters/Setters
+    public Hashtable<String, SpecialAbility> getAllSPAs() {
+        return allSPAs;
+    }
+
+    public void setAllSPAs(Hashtable<String, SpecialAbility> allSPAs) {
+        this.allSPAs = allSPAs;
+    }
+
+    public Vector<String> getPrerequisiteAbilities() {
+        return prereqAbilities;
+    }
+
+    public void setPrerequisiteAbilities(Vector<String> prerequisiteAbilities) {
+        this.prereqAbilities = prerequisiteAbilities;
+    }
+
+    public Vector<String> getInvalidAbilities() {
+        return invalidAbilities;
+    }
+
+    public void setInvalidAbilities(Vector<String> invalidAbilities) {
+        this.invalidAbilities = invalidAbilities;
+    }
+
+    public Vector<String> getRemoveAbilities() {
+        return removeAbilities;
+    }
+
+    public void setRemoveAbilities(Vector<String> removeAbilities) {
+        this.removeAbilities = removeAbilities;
+    }
+    //endregion Getters/Setters
 
     private void edit() {
-    	ability.setCost((Integer)spnXP.getModel().getValue());
+    	ability.setCost((Integer) spnXP.getModel().getValue());
     	ability.setPrereqAbilities(prereqAbilities);
     	ability.setInvalidAbilities(invalidAbilities);
     	ability.setRemovedAbilities(removeAbilities);
@@ -432,41 +456,47 @@ public class EditSpecialAbilityDialog extends JDialog {
         this.setVisible(false);
     }
 
-    private String getPrereqAbilDesc() {
-        String toReturn = "";
-        for(String prereq : prereqAbilities) {
-            toReturn += allSPA.get(prereq).getDisplayName() + "<br>";
+    private String getPrerequisiteAbilityDesc() {
+        StringBuilder toReturn = new StringBuilder();
+        for (String prerequisite : getPrerequisiteAbilities()) {
+            SpecialAbility prerequisiteAbility = getAllSPAs().get(prerequisite);
+            prerequisiteAbility = (prerequisiteAbility == null)
+                    ? SpecialAbility.getOption(prerequisite) : prerequisiteAbility;
+            if (prerequisiteAbility != null) {
+                toReturn.append(prerequisiteAbility.getDisplayName()).append("<br>");
+            }
         }
-        if(toReturn.isEmpty()) {
-        	toReturn = "None";
-        }
-        return toReturn;
+        return (toReturn.length() == 0) ? "None" : toReturn.toString();
     }
 
     private String getInvalidDesc() {
-        String toReturn = "";
-        for(String invalid : invalidAbilities) {
-            toReturn += allSPA.get(invalid).getDisplayName() + "<br>";
+        StringBuilder toReturn = new StringBuilder();
+        for (String invalid : getInvalidAbilities()) {
+            SpecialAbility invalidAbility = getAllSPAs().get(invalid);
+            invalidAbility = (invalidAbility == null)
+                    ? SpecialAbility.getOption(invalid) : invalidAbility;
+            if (invalidAbility != null) {
+                toReturn.append(invalidAbility.getDisplayName()).append("<br>");
+            }
         }
-        if(toReturn.isEmpty()) {
-        	toReturn = "None";
-        }
-        return toReturn;
+        return (toReturn.length() == 0) ? "None" : toReturn.toString();
     }
 
     private String getRemovedDesc() {
-        String toReturn = "";
-        for(String remove : removeAbilities) {
-            toReturn += allSPA.get(remove).getDisplayName() + "<br>";
+        StringBuilder removedDescription = new StringBuilder();
+        for (String remove : getRemoveAbilities()) {
+            SpecialAbility removeAbility = getAllSPAs().get(remove);
+            removeAbility = (removeAbility == null)
+                    ? SpecialAbility.getOption(remove) : removeAbility;
+            if (removeAbility != null) {
+                removedDescription.append(removeAbility.getDisplayName()).append("<br>");
+            }
         }
-        if(toReturn.isEmpty()) {
-        	toReturn = "None";
-        }
-        return toReturn;
+        return (removedDescription.length() == 0) ? "None" : removedDescription.toString();
     }
 
     private void refreshGUI() {
-    	currentXP = (Integer)spnXP.getModel().getValue();
+    	currentXP = (Integer) spnXP.getModel().getValue();
     	getContentPane().removeAll();
     	initComponents();
     	getContentPane().revalidate();
@@ -480,12 +510,12 @@ public class EditSpecialAbilityDialog extends JDialog {
     private void editSkillPrereq(int i) {
     	EditSkillPrereqDialog nspd = new EditSkillPrereqDialog(null, prereqSkills.get(i));
     	nspd.setVisible(true);
-    	if(!nspd.wasCancelled() && !nspd.getPrereq().isEmpty()) {
+    	if (!nspd.wasCancelled() && !nspd.getPrereq().isEmpty()) {
         	prereqSkills.set(i, nspd.getPrereq());
         	refreshGUI();
         }
     }
-    
+
     public boolean wasCancelled() {
     	return cancelled;
     }


### PR DESCRIPTION
This fixes #2397 by adding a fall back value if the SPA being edited isn't in the hash, adding getters and setters for the vectors (which are only partially implemented, I'll finalize that when I swap SPAs to no longer be static).