### PR TITLE
Issue #2396: Resolve Infantry part and other part type bugs

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -22,6 +22,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.Objects;
 
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
@@ -115,11 +116,8 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
 
     @Override
     public boolean isSamePartType(@Nullable Part part) {
-        if ((getType() != null) && (part instanceof AmmoStorage)) {
-            return getType().equals(((AmmoStorage) part).getType());
-        }
-
-        return false;
+        return getClass().equals(part.getClass())
+                && Objects.equals(getType(), ((AmmoStorage) part).getType());
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -227,7 +227,7 @@ public class Armor extends Part implements IAcquisitionWork {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return (part instanceof Armor)
+        return getClass().equals(part.getClass())
                 && Objects.equals(getRefitUnit(), part.getRefitUnit())
                 && isSameType((Armor)part);
     }

--- a/MekHQ/src/mekhq/campaign/parts/BaArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BaArmor.java
@@ -128,7 +128,7 @@ public class BaArmor extends Armor implements IAcquisitionWork {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return (part instanceof BaArmor)
+        return getClass().equals(part.getClass())
                 && (isClanTechBase() == part.isClanTechBase())
                 && Objects.equals(getRefitUnit(), part.getRefitUnit())
                 && (((BaArmor) part).getType() == getType());

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -97,7 +97,7 @@ public class InfantryAmmoStorage extends AmmoStorage {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return (part instanceof InfantryAmmoStorage)
+        return getClass().equals(part.getClass())
                 && isSameAmmoType(((InfantryAmmoStorage) part).getType(), ((InfantryAmmoStorage) part).getWeaponType());
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/InfantryArmorPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryArmorPart.java
@@ -214,7 +214,7 @@ public class InfantryArmorPart extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof InfantryArmorPart
+        return getClass().equals(part.getClass())
                 && damageDivisor == ((InfantryArmorPart)part).getDamageDivisor()
                 && dest == ((InfantryArmorPart)part).isDest()
                 && encumbering == ((InfantryArmorPart)part).isEncumbering()

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmor.java
@@ -87,7 +87,7 @@ public class ProtomekArmor extends Armor implements IAcquisitionWork {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof ProtomekArmor
+        return getClass().equals(part.getClass())
                 && getType() == ((ProtomekArmor) part).getType()
                 && isClanTechBase() == part.isClanTechBase()
                 && Objects.equals(getRefitUnit(), part.getRefitUnit());

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -107,7 +107,7 @@ public class SVArmor extends Armor {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof SVArmor
+        return getClass().equals(part.getClass())
                 && bar == ((SVArmor) part).bar
                 && techRating == ((SVArmor) part).techRating;
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -459,8 +459,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         // AmmoBins are the same type of part if they can hold the same
         // AmmoType and number of rounds of ammo (i.e. they are the same
         // irrespective of "munition type" or "bomb type").
-        return (part instanceof AmmoBin)
-                && !(part instanceof LargeCraftAmmoBin)
+        return getClass().equals(part.getClass())
                 && getType().isCompatibleWith(((AmmoBin) part).getType())
                 && ((AmmoBin) part).getFullShots() == getFullShots();
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
@@ -230,7 +230,7 @@ public class BattleArmorEquipmentPart extends EquipmentPart {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return part instanceof BattleArmorEquipmentPart
+        return getClass().equals(part.getClass())
                 && getType().equals(((BattleArmorEquipmentPart) part).getType())
                 && getSize() == ((BattleArmorEquipmentPart) part).getSize()
                 && getTonnage() == part.getTonnage();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -149,7 +149,8 @@ public class EquipmentPart extends Part {
         // they are not acceptable substitutes, so we need to check for that as
         // well
         // http://bg.battletech.com/forums/strategic-operations/(answered)-can-a-lance-for-a-35-ton-mech-be-used-on-a-40-ton-mech-and-so-on/
-        return part instanceof EquipmentPart && getType().equals(((EquipmentPart) part).getType())
+        return getClass().equals(part.getClass())
+                && getType().equals(((EquipmentPart) part).getType())
                 && getTonnage() == part.getTonnage() && getStickerPrice().equals(part.getStickerPrice())
                 && getSize() == ((EquipmentPart) part).getSize()
                 && isOmniPodded() == part.isOmniPodded();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryAmmoBin.java
@@ -250,7 +250,7 @@ public class InfantryAmmoBin extends AmmoBin {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return  (part instanceof InfantryAmmoBin)
+        return getClass().equals(part.getClass())
                 && getType().equals(((InfantryAmmoBin) part).getType())
                 && Objects.equals(getWeaponType(), ((InfantryAmmoBin) part).getWeaponType())
                 && getClips() == ((InfantryAmmoBin) part).getClips();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -321,7 +321,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return (part instanceof LargeCraftAmmoBin)
+        return getClass().equals(part.getClass())
                 && getType().isCompatibleWith(((AmmoBin) part).getType());
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -21,6 +21,7 @@
 package mekhq.campaign.parts.equipment;
 
 import java.io.PrintWriter;
+import java.util.Objects;
 
 import megamek.common.Aero;
 import megamek.common.AmmoType;
@@ -122,12 +123,11 @@ public class MissingAmmoBin extends MissingEquipmentPart {
 
     @Override
     public boolean isAcceptableReplacement(Part part, boolean refit) {
-        return (part instanceof AmmoBin)
-                // Do not try to replace a MissingAmmoBin with anything other
-                // than an AmmoBin. Subclasses should use a similar check, which
-                // breaks Composability to a degree but in this case we've used
-                // subclasses where they're not truly composable.
-                && (part.getClass() == AmmoBin.class)
+        // Do not try to replace a MissingAmmoBin with anything other
+        // than an AmmoBin. Subclasses should use a similar check, which
+        // breaks Composability to a degree but in this case we've used
+        // subclasses where they're not truly composable.
+        return Objects.equals(part.getClass(), AmmoBin.class)
                 && getType().equals(((AmmoBin) part).getType())
                 && (isOneShot() == ((AmmoBin) part).isOneShot());
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
@@ -19,6 +19,7 @@
 package mekhq.campaign.parts.equipment;
 
 import java.io.PrintWriter;
+import java.util.Objects;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -121,7 +122,8 @@ public class MissingLargeCraftAmmoBin extends MissingAmmoBin {
         // than an LargeCraftAmmoBin. Subclasses should use a similar check, which
         // breaks Composability to a degree but in this case we've used
         // subclasses where they're not truly composable.
-        if ((part instanceof LargeCraftAmmoBin) && (part.getClass() == LargeCraftAmmoBin.class)) {
+        if ((part instanceof LargeCraftAmmoBin)
+                && Objects.equals(part.getClass(), LargeCraftAmmoBin.class)) {
             LargeCraftAmmoBin ammoBin = (LargeCraftAmmoBin) part;
             return getType().equals(ammoBin.getType())
                     && (getFullShots() == ammoBin.getFullShots());

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
@@ -122,8 +122,7 @@ public class MissingLargeCraftAmmoBin extends MissingAmmoBin {
         // than an LargeCraftAmmoBin. Subclasses should use a similar check, which
         // breaks Composability to a degree but in this case we've used
         // subclasses where they're not truly composable.
-        if ((part instanceof LargeCraftAmmoBin)
-                && Objects.equals(part.getClass(), LargeCraftAmmoBin.class)) {
+        if (Objects.equals(part.getClass(), LargeCraftAmmoBin.class)) {
             LargeCraftAmmoBin ammoBin = (LargeCraftAmmoBin) part;
             return getType().equals(ammoBin.getType())
                     && (getFullShots() == ammoBin.getFullShots());

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2330,23 +2330,23 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 if (!(entity instanceof BattleArmor)) {
                     partsToRemove.add(part);
                 } else {
-                    Part[] parts = baEquipParts.get(((BattleArmorEquipmentPart)part).getEquipmentNum());
+                    Part[] parts = baEquipParts.get(((BattleArmorEquipmentPart) part).getEquipmentNum());
                     if (null == parts) {
-                        parts = new Part[((BattleArmor)entity).getSquadSize()];
+                        parts = new Part[((BattleArmor) entity).getSquadSize()];
                     }
-                    parts[((BattleArmorEquipmentPart)part).getTrooper()-BattleArmor.LOC_TROOPER_1] = part;
-                    baEquipParts.put(((BattleArmorEquipmentPart)part).getEquipmentNum(), parts);
+                    parts[((BattleArmorEquipmentPart) part).getTrooper() - BattleArmor.LOC_TROOPER_1] = part;
+                    baEquipParts.put(((BattleArmorEquipmentPart) part).getEquipmentNum(), parts);
                 }
             } else if (part instanceof MissingBattleArmorEquipmentPart) {
                 if (!(entity instanceof BattleArmor)) {
                     partsToRemove.add(part);
                 } else {
-                    Part[] parts = baEquipParts.get(((MissingBattleArmorEquipmentPart)part).getEquipmentNum());
+                    Part[] parts = baEquipParts.get(((MissingBattleArmorEquipmentPart) part).getEquipmentNum());
                     if (null == parts) {
-                        parts = new Part[((BattleArmor)entity).getSquadSize()];
+                        parts = new Part[((BattleArmor) entity).getSquadSize()];
                     }
-                    parts[((MissingBattleArmorEquipmentPart)part).getTrooper()-BattleArmor.LOC_TROOPER_1] = part;
-                    baEquipParts.put(((MissingBattleArmorEquipmentPart)part).getEquipmentNum(), parts);
+                    parts[((MissingBattleArmorEquipmentPart) part).getTrooper() - BattleArmor.LOC_TROOPER_1] = part;
+                    baEquipParts.put(((MissingBattleArmorEquipmentPart) part).getEquipmentNum(), parts);
                 }
             } else if (part instanceof EquipmentPart) {
                 equipParts.put(((EquipmentPart)part).getEquipmentNum(), part);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2285,13 +2285,15 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     partsToRemove.add(part);
                 }
             } else if (part instanceof BattleArmorSuit) {
-                if (((BattleArmorSuit) part).getTrooper() < locations.length) {
+                if ((entity instanceof BattleArmor)
+                        && ((BattleArmorSuit) part).getTrooper() < locations.length) {
                     locations[((BattleArmorSuit) part).getTrooper()] = part;
                 } else {
                     partsToRemove.add(part);
                 }
             } else if (part instanceof MissingBattleArmorSuit) {
-                if (((MissingBattleArmorSuit) part).getTrooper() < locations.length) {
+                if ((entity instanceof BattleArmor)
+                        && ((MissingBattleArmorSuit) part).getTrooper() < locations.length) {
                     locations[((MissingBattleArmorSuit) part).getTrooper()] = part;
                 } else {
                     partsToRemove.add(part);
@@ -2325,19 +2327,27 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             } else if (part instanceof MissingJumpJet) {
                 jumpJets.put(((MissingJumpJet)part).getEquipmentNum(), part);
             }  else if (part instanceof BattleArmorEquipmentPart) {
-                Part[] parts = baEquipParts.get(((BattleArmorEquipmentPart)part).getEquipmentNum());
-                if (null == parts) {
-                    parts = new Part[((BattleArmor)entity).getSquadSize()];
+                if (!(entity instanceof BattleArmor)) {
+                    partsToRemove.add(part);
+                } else {
+                    Part[] parts = baEquipParts.get(((BattleArmorEquipmentPart)part).getEquipmentNum());
+                    if (null == parts) {
+                        parts = new Part[((BattleArmor)entity).getSquadSize()];
+                    }
+                    parts[((BattleArmorEquipmentPart)part).getTrooper()-BattleArmor.LOC_TROOPER_1] = part;
+                    baEquipParts.put(((BattleArmorEquipmentPart)part).getEquipmentNum(), parts);
                 }
-                parts[((BattleArmorEquipmentPart)part).getTrooper()-BattleArmor.LOC_TROOPER_1] = part;
-                baEquipParts.put(((BattleArmorEquipmentPart)part).getEquipmentNum(), parts);
             } else if (part instanceof MissingBattleArmorEquipmentPart) {
-                Part[] parts = baEquipParts.get(((MissingBattleArmorEquipmentPart)part).getEquipmentNum());
-                if (null == parts) {
-                    parts = new Part[((BattleArmor)entity).getSquadSize()];
+                if (!(entity instanceof BattleArmor)) {
+                    partsToRemove.add(part);
+                } else {
+                    Part[] parts = baEquipParts.get(((MissingBattleArmorEquipmentPart)part).getEquipmentNum());
+                    if (null == parts) {
+                        parts = new Part[((BattleArmor)entity).getSquadSize()];
+                    }
+                    parts[((MissingBattleArmorEquipmentPart)part).getTrooper()-BattleArmor.LOC_TROOPER_1] = part;
+                    baEquipParts.put(((MissingBattleArmorEquipmentPart)part).getEquipmentNum(), parts);
                 }
-                parts[((MissingBattleArmorEquipmentPart)part).getTrooper()-BattleArmor.LOC_TROOPER_1] = part;
-                baEquipParts.put(((MissingBattleArmorEquipmentPart)part).getEquipmentNum(), parts);
             } else if (part instanceof EquipmentPart) {
                 equipParts.put(((EquipmentPart)part).getEquipmentNum(), part);
             } else if (part instanceof MissingEquipmentPart) {


### PR DESCRIPTION
When we initialize a unit, there are certain assumptions about where a part came from. If a refit went "bad" and picked the wrong type of part, you can end up in a situation where the unit cannot be initialized. Two approaches are taken here to resolve this issue:
1. If the entity type for a BA part isn't BattleArmor, remove the part from the unit.
2. For all of the sub-classes and extendable parts, make `isSamePartType` use strict class equality rather than `instanceof`.

The first approach directly fixes #2396.

The second approach hopes to make this a non-issue going forward. We shot ourselves in the foot a bit where we have base classes that are not abstract. Ideally, EquipmentPart would be abstract (as would Armor and AmmoBin), and the various type or entity specific classes would inherit from them. At that point `instanceof` would be a valid check.