### PR TITLE
Issue #2387: Allow salvaging components on destroyed locations from repair bay

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -393,13 +393,13 @@ public class EquipmentPart extends Part {
 
     @Override
     public String checkFixable() {
-        final Unit unit = getUnit();
-        if ((unit != null) && (unit.isSalvage() || isTeamSalvaging())) {
+        if (isSalvaging()) {
             return null;
         }
 
         // The part is only fixable if the location is not destroyed.
         // be sure to check location and second location
+        final Unit unit = getUnit();
         final Mounted m = getMounted();
         if ((unit != null) && (m != null)) {
             int loc = m.getLocation();

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentPartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/EquipmentPartTest.java
@@ -29,7 +29,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Vector;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -820,7 +819,11 @@ public class EquipmentPartTest {
         // Location destroyed
         doReturn(false).when(unit).isLocationBreached(eq(location));
         doReturn(true).when(unit).isLocationDestroyed(eq(location));
-        assertNotNull(equipmentPart.checkFixable());
+        // CAW: this should be non-null in a perfect world, but because
+        //      MekHQ automagically switches to salvage mode when the
+        //      location is destroyed, this should return null.
+        //      See: https://github.com/MegaMek/mekhq/issues/2387
+        assertNull(equipmentPart.checkFixable());
 
         String secondaryLocationName = "Mech Left Arm";
         int secondaryLocation = Mech.LOC_LARM;
@@ -840,7 +843,11 @@ public class EquipmentPartTest {
         // Location destroyed
         doReturn(false).when(unit).isLocationBreached(eq(secondaryLocation));
         doReturn(true).when(unit).isLocationDestroyed(eq(secondaryLocation));
-        assertNotNull(equipmentPart.checkFixable());
+        // CAW: this should be non-null in a perfect world, but because
+        //      MekHQ automagically switches to salvage mode when the
+        //      location is destroyed, this should return null.
+        //      See: https://github.com/MegaMek/mekhq/issues/2387
+        assertNull(equipmentPart.checkFixable());
 
         // Restore both locations
         doReturn(false).when(unit).isLocationBreached(eq(location));


### PR DESCRIPTION
Partial revert of #2308 to preserve MekHQ behavior. MekHQ automagically switches to salvage on a salvageable part, the previous fix did not apply in practice because of this. Fixes #2387.