### PR TITLE
Fixing BaseDialog Preferences

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BaseDialog.java
@@ -139,7 +139,7 @@ public abstract class BaseDialog extends JDialog implements WindowListener {
     }
 
     private void setPreferences() {
-        PreferencesNode preferences = MekHQ.getPreferences().forClass(BaseDialog.class);
+        PreferencesNode preferences = MekHQ.getPreferences().forClass(getClass());
 
         preferences.manage(new JWindowPreference(this));
         this.setCustomPreferences(preferences);


### PR DESCRIPTION
This should be using getClass, as we want the derived class not the base dialog class.