### PR TITLE
2415: Implementing Unit Weapon SPA Generation and Fixing Tech Level Comparisons

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -18,6 +18,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
 
+import megamek.common.annotations.Nullable;
 import megamek.common.options.AbstractOptionsInfo;
 import megamek.common.options.IBasicOptionGroup;
 import megamek.common.options.IOption;
@@ -139,7 +140,10 @@ public class PersonnelOptions extends PilotOptions {
         return new Vector<IOption>().elements();
     }
 
-    public void acquireAbility(String type, String name, Object value) {
+    public void acquireAbility(final String type, final String name, final @Nullable Object value) {
+        if (value == null) {
+            return;
+        }
         //we might also need to remove some prior abilities
         SpecialAbility spa = SpecialAbility.getAbility(name);
         Vector<String> toRemove = new Vector<>();

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -641,7 +641,6 @@ public class SpecialAbility implements MekHqXmlSerializable {
                 : (weaponTechLevel < CampaignOptions.TECH_ADVANCED) ? 25
                 : (weaponTechLevel < CampaignOptions.TECH_EXPERIMENTAL) ? 5
                 : 1;
-        MekHQ.getLogger().warning(equipmentType.getName() + " has a weight of " + weight + " with weapon tech level " + weaponTechLevel);
         weapons.add(weight, equipmentType);
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -34,6 +34,10 @@ import java.util.Vector;
 
 import javax.xml.parsers.DocumentBuilder;
 
+import megamek.common.Mounted;
+import megamek.common.annotations.Nullable;
+import megamek.common.util.WeightedMap;
+import mekhq.campaign.CampaignOptions;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -568,52 +572,81 @@ public class SpecialAbility implements MekHqXmlSerializable {
         return implants.get(name);
     }
 
-    public static String chooseWeaponSpecialization(final Person person, final int techLvl,
-                                                    final int year, final boolean clusterOnly) {
-        final List<String> candidates = new ArrayList<>();
-        for (Enumeration<EquipmentType> e = EquipmentType.getAllTypes(); e.hasMoreElements();) {
-            final EquipmentType et = e.nextElement();
-
-            if (!isWeaponEligibleForSPA(et, person.getPrimaryRole(), clusterOnly)) {
-                continue;
-            }
-
-            final WeaponType wt = (WeaponType) et;
-
-            if (TechConstants.isClan(wt.getTechLevel(year)) != person.isClanner()) {
-                continue;
-            }
-
-            final int lvl = wt.getTechLevel(year);
-            if (lvl < 0) {
-                continue;
-            }
-
-            if (techLvl < Utilities.getSimpleTechLevel(lvl)) {
-                continue;
-            }
-
-            if (techLvl == TechConstants.T_IS_UNOFFICIAL) {
-                continue;
-            }
-
-            int ntimes = 10;
-            if (techLvl >= TechConstants.T_IS_ADVANCED) {
-                ntimes = 1;
-            }
-
-            while (ntimes > 0) {
-                candidates.add(et.getName());
-                ntimes--;
+    /**
+     * This return a random weapon to specialize in, selected based on weightings. Introtech
+     * weaponry is weighted at 50, standard weaponry at 25, advanced weaponry at 5, while experimental
+     * and unofficial weaponry are both weighted at 1.
+     *
+     * @param person the person to generate the weapon specialization for
+     * @param techLevel the maximum tech level to generate a weapon for
+     * @param year the year to generate the specialization for
+     * @param clusterOnly whether to only consider cluster weapons or not
+     * @return the name of the selected weapon, or null if there are no weapons that can be selected
+     */
+    public static @Nullable String chooseWeaponSpecialization(final Person person, final int techLevel,
+                                                              final int year, final boolean clusterOnly) {
+        final WeightedMap<EquipmentType> weapons = new WeightedMap<>();
+        // First try to generate based on the person's unit
+        if ((person.getUnit() != null) && (person.getUnit().getEntity() != null)) {
+            for (final Mounted mounted : person.getUnit().getEntity().getEquipment()) {
+                addValidWeaponryToMap(mounted.getType(), person, techLevel, year, clusterOnly, weapons);
             }
         }
 
-        return candidates.isEmpty() ? "??" : Utilities.getRandomItem(candidates);
+        // If that doesn't generate a valid weapon, then turn to the wider list
+        if (weapons.isEmpty()) {
+            for (Enumeration<EquipmentType> e = EquipmentType.getAllTypes(); e.hasMoreElements(); ) {
+                final EquipmentType equipmentType = e.nextElement();
+                addValidWeaponryToMap(equipmentType, person, techLevel, year, clusterOnly, weapons);
+            }
+        }
+        return weapons.isEmpty() ? null : weapons.randomItem().getName();
     }
 
     /**
-     * Worker function that determines if a piece of equipment is eligible
-     * for being selected for an SPA.
+     * This is a worker method to add any valid weaponry to the weighted map used to generate a
+     * random weapon specialization
+     *
+     * @param equipmentType the equipment type to test for validity
+     * @param person the person to generate the weapon specialization for
+     * @param techLevel the maximum tech level to generate a weapon for
+     * @param year the year to generate the specialization for
+     * @param clusterOnly whether to only consider cluster weapons or not
+     * @param weapons the weighted map of weaponry to add the equipmentType to if valid
+     */
+    private static void addValidWeaponryToMap(final EquipmentType equipmentType,
+                                              final Person person, final int techLevel,
+                                              final int year, final boolean clusterOnly,
+                                              final WeightedMap<EquipmentType> weapons) {
+        // Ensure it is a weapon eligible for the SPA in question, and the tech level is IS for
+        // IS personnel and Clan for Clan personnel
+        if (!isWeaponEligibleForSPA(equipmentType, person.getPrimaryRole(), clusterOnly)
+                || (TechConstants.isClan(equipmentType.getTechLevel(year)) != person.isClanner())) {
+            return;
+        }
+
+        // Ensure the weapon's tech level is valid (zero or above)
+        int weaponTechLevel = equipmentType.getTechLevel(year);
+        if (weaponTechLevel < 0) {
+            return;
+        }
+        // Ensure that the weapon's tech level is lower than that of the specified tech level
+        weaponTechLevel = Utilities.getSimpleTechLevel(weaponTechLevel);
+        if (techLevel < weaponTechLevel) {
+            return;
+        }
+
+        // Determine the weight based on the tech level
+        final int weight = (weaponTechLevel < CampaignOptions.TECH_STANDARD) ? 50
+                : (weaponTechLevel < CampaignOptions.TECH_ADVANCED) ? 25
+                : (weaponTechLevel < CampaignOptions.TECH_EXPERIMENTAL) ? 5
+                : 1;
+        MekHQ.getLogger().warning(equipmentType.getName() + " has a weight of " + weight + " with weapon tech level " + weaponTechLevel);
+        weapons.add(weight, equipmentType);
+    }
+
+    /**
+     * Worker function that determines if a piece of equipment is eligible for being selected for an SPA.
      * @param et Equipment type to check
      * @param type Person role, e.g. Person.T_MECHWARRIOR. This check is ignored if Person.T_NONE is passed in.
      * @param clusterOnly All weapon types or just ones that do rolls on the cluster table

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -568,22 +568,23 @@ public class SpecialAbility implements MekHqXmlSerializable {
         return implants.get(name);
     }
 
-    public static String chooseWeaponSpecialization(int type, boolean isClan, int techLvl, int year, boolean clusterOnly) {
-        ArrayList<String> candidates = new ArrayList<>();
+    public static String chooseWeaponSpecialization(final Person person, final int techLvl,
+                                                    final int year, final boolean clusterOnly) {
+        final List<String> candidates = new ArrayList<>();
         for (Enumeration<EquipmentType> e = EquipmentType.getAllTypes(); e.hasMoreElements();) {
-            EquipmentType et = e.nextElement();
+            final EquipmentType et = e.nextElement();
 
-            if (!isWeaponEligibleForSPA(et, type, clusterOnly)) {
+            if (!isWeaponEligibleForSPA(et, person.getPrimaryRole(), clusterOnly)) {
                 continue;
             }
 
-            WeaponType wt = (WeaponType) et;
+            final WeaponType wt = (WeaponType) et;
 
-            if (TechConstants.isClan(wt.getTechLevel(year)) != isClan) {
+            if (TechConstants.isClan(wt.getTechLevel(year)) != person.isClanner()) {
                 continue;
             }
 
-            int lvl = wt.getTechLevel(year);
+            final int lvl = wt.getTechLevel(year);
             if (lvl < 0) {
                 continue;
             }
@@ -606,10 +607,8 @@ public class SpecialAbility implements MekHqXmlSerializable {
                 ntimes--;
             }
         }
-        if (candidates.isEmpty()) {
-            return "??";
-        }
-        return Utilities.getRandomItem(candidates);
+
+        return candidates.isEmpty() ? "??" : Utilities.getRandomItem(candidates);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 MegaMek team
+ * Copyright (C) 2019-2021 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,11 +10,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.personnel.generator;
 
@@ -31,7 +31,6 @@ import mekhq.Utilities;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SpecialAbility;
-import mekhq.campaign.personnel.generator.AbstractSpecialAbilityGenerator;
 
 /**
  * Generates a single special ability for a {@link Person}.
@@ -56,68 +55,76 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
         List<SpecialAbility> weightedList = SpecialAbility.getWeightedSpecialAbilities(abilityList);
 
         String name = Utilities.getRandomItem(weightedList).getName();
-        if (name.equals(OptionsConstants.GUNNERY_SPECIALIST)) {
-            String special = Crew.SPECIAL_NONE;
-            switch (Compute.randomInt(2)) {
-                case 0:
-                    special = Crew.SPECIAL_ENERGY;
-                    break;
-                case 1:
-                    special = Crew.SPECIAL_BALLISTIC;
-                    break;
-                case 2:
-                    special = Crew.SPECIAL_MISSILE;
-                    break;
+        switch (name) {
+            case OptionsConstants.GUNNERY_SPECIALIST: {
+                final String special;
+                switch (Compute.randomInt(2)) {
+                    case 0:
+                        special = Crew.SPECIAL_ENERGY;
+                        break;
+                    case 1:
+                        special = Crew.SPECIAL_BALLISTIC;
+                        break;
+                    case 2:
+                    default:
+                        special = Crew.SPECIAL_MISSILE;
+                        break;
+                }
+                person.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, special);
+                break;
             }
-            person.getOptions()
-                .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, special);
-        } else if (name.equals(OptionsConstants.GUNNERY_RANGE_MASTER)) {
-            String special = Crew.RANGEMASTER_NONE;
-            switch (Compute.randomInt(2)) {
-                case 0:
-                    special = Crew.RANGEMASTER_MEDIUM;
-                    break;
-                case 1:
-                    special = Crew.RANGEMASTER_LONG;
-                    break;
-                case 2:
-                    special = Crew.RANGEMASTER_EXTREME;
-                    break;
+            case OptionsConstants.GUNNERY_RANGE_MASTER: {
+                final String special;
+                switch (Compute.randomInt(2)) {
+                    case 0:
+                        special = Crew.RANGEMASTER_MEDIUM;
+                        break;
+                    case 1:
+                        special = Crew.RANGEMASTER_LONG;
+                        break;
+                    case 2:
+                    default:
+                        special = Crew.RANGEMASTER_EXTREME;
+                        break;
+                }
+                person.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, special);
+                break;
             }
-            person.getOptions()
-                .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, special);
-        } else if (name.equals(OptionsConstants.MISC_HUMAN_TRO)) {
-            String special = Crew.HUMANTRO_NONE;
-            switch (Compute.randomInt(3)) {
-                case 0:
-                    special = Crew.HUMANTRO_MECH;
-                    break;
-                case 1:
-                    special = Crew.HUMANTRO_AERO;
-                    break;
-                case 2:
-                    special = Crew.HUMANTRO_VEE;
-                    break;
-                case 3:
-                    special = Crew.HUMANTRO_BA;
-                    break;
+            case OptionsConstants.MISC_HUMAN_TRO: {
+                final String special;
+                switch (Compute.randomInt(3)) {
+                    case 0:
+                        special = Crew.HUMANTRO_MECH;
+                        break;
+                    case 1:
+                        special = Crew.HUMANTRO_AERO;
+                        break;
+                    case 2:
+                        special = Crew.HUMANTRO_VEE;
+                        break;
+                    case 3:
+                    default:
+                        special = Crew.HUMANTRO_BA;
+                        break;
+                }
+                person.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, special);
+                break;
             }
-            person.getOptions()
-                .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, special);
-        } else if (name.equals(OptionsConstants.GUNNERY_WEAPON_SPECIALIST)) {
-            person.getOptions()
-                .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name,
-                    SpecialAbility.chooseWeaponSpecialization(person.getPrimaryRole(), person.getOriginFaction().isClan(),
-                            getCampaignOptions(person).getTechLevel(), person.getCampaign().getGameYear(), false));
-        } else if (name.equals(OptionsConstants.GUNNERY_SANDBLASTER)) {
-            person.getOptions()
-                .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name,
-                    SpecialAbility.chooseWeaponSpecialization(person.getPrimaryRole(), person.getOriginFaction().isClan(),
-                            getCampaignOptions(person).getTechLevel(), person.getCampaign().getGameYear(), true));
-        } else {
-            person.getOptions()
-                .acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, true);
+            case OptionsConstants.GUNNERY_WEAPON_SPECIALIST:
+                person.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES, name,
+                        SpecialAbility.chooseWeaponSpecialization(person,
+                                getCampaignOptions(person).getTechLevel(), person.getCampaign().getGameYear(), false));
+                break;
+            case OptionsConstants.GUNNERY_SANDBLASTER:
+                person.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES, name,
+                        SpecialAbility.chooseWeaponSpecialization(person,
+                                getCampaignOptions(person).getTechLevel(), person.getCampaign().getGameYear(), true));
+                break;
+            default:
+                person.getOptions().acquireAbility(PilotOptions.LVL3_ADVANTAGES, name, true);
+                break;
         }
+
         return name;
     }
 
@@ -127,14 +134,8 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
             IOption ability = i.nextElement();
             if (!ability.booleanValue()) {
                 SpecialAbility spa = SpecialAbility.getAbility(ability.getName());
-                if(null == spa) {
-                    continue;
-                }
-                if(!spa.isEligible(person.isClanner(), person.getSkills(),
-                        person.getOptions())) {
-                    continue;
-                }
-                if(spa.getWeight() <= 0) {
+                if ((spa == null) || (spa.getWeight() <= 0)
+                        || (!spa.isEligible(person.isClanner(), person.getSkills(), person.getOptions()))) {
                     continue;
                 }
                 eligible.add(spa);
@@ -143,6 +144,7 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
         return eligible;
     }
 
+    @Deprecated
     private CampaignOptions getCampaignOptions(Person person) {
         return person.getCampaign().getCampaignOptions();
     }


### PR DESCRIPTION
This fixes #2415, in addition to swapping the code over to a weighted map, fixing comparison by incorrectly compared tech level magic int sets (which... we have more than a few of), and actually having certain weapons be rarer than others, with it now being quite a find to get a test pilot or one who uses very rare weaponry.

To review: Whitespace differences off. The first commit is code rework, the second is the actual meat of the PR.