### PR TITLE
Issue #2418: Ensure context menu shortcut works on our tables

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -230,7 +230,7 @@ public final class BriefingTab extends CampaignGuiTab {
         scenarioSorter.setComparator(ScenarioTableModel.COL_DATE, new DateStringComparator());
         scenarioTable.setRowSorter(scenarioSorter);
         scenarioTable.setShowGrid(false);
-        scenarioTable.addMouseListener(new ScenarioTableMouseAdapter(getCampaignGui(), scenarioTable, scenarioModel));
+        ScenarioTableMouseAdapter.connect(getCampaignGui(), scenarioTable, scenarioModel);
         scenarioTable.setIntercellSpacing(new Dimension(0, 0));
         scenarioTable.getSelectionModel().addListSelectionListener(ev -> refreshScenarioView());
 

--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -351,7 +351,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
         }
         procurementTable.setIntercellSpacing(new Dimension(0, 0));
         procurementTable.setShowGrid(false);
-        procurementTable.addMouseListener(new ProcurementTableMouseAdapter(getCampaignGui()));
+        ProcurementTableMouseAdapter.connect(getCampaignGui(), procurementTable, procurementModel);
         procurementTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
         procurementTable.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0), "ADD");

--- a/MekHQ/src/mekhq/gui/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/FinancesTab.java
@@ -121,8 +121,7 @@ public final class FinancesTab extends CampaignGuiTab {
         financeModel = new FinanceTableModel();
         financeTable = new JTable(financeModel);
         financeTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        financeTable.addMouseListener(new FinanceTableMouseAdapter(getCampaignGui(),
-                financeTable, financeModel));
+        FinanceTableMouseAdapter.connect(getCampaignGui(), financeTable, financeModel);
         financeTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         TableColumn column;
         for (int i = 0; i < FinanceTableModel.N_COL; i++) {
@@ -136,8 +135,7 @@ public final class FinancesTab extends CampaignGuiTab {
         loanModel = new LoanTableModel();
         loanTable = new JTable(loanModel);
         loanTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        loanTable.addMouseListener(new LoanTableMouseAdapter(getCampaignGui(),
-                loanTable, loanModel));
+        LoanTableMouseAdapter.connect(getCampaignGui(), loanTable, loanModel);
         loanTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         for (int i = 0; i < LoanTableModel.N_COL; i++) {
             column = loanTable.getColumnModel().getColumn(i);

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -22,7 +22,6 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.event.MouseEvent;
 import java.util.*;
 
 import javax.swing.DefaultComboBoxModel;
@@ -186,22 +185,6 @@ public final class HangarTab extends CampaignGuiTab {
         sortKeys.add(new RowSorter.SortKey(UnitTableModel.COL_TYPE, SortOrder.DESCENDING));
         sortKeys.add(new RowSorter.SortKey(UnitTableModel.COL_WCLASS, SortOrder.DESCENDING));
         unitSorter.setSortKeys(sortKeys);
-        unitTable.addMouseListener(new UnitTableMouseAdapter(getCampaignGui(),
-                unitTable, unitModel) {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2) {
-                    if ((splitUnit.getSize().width - splitUnit.getDividerLocation() + splitUnit
-                            .getDividerSize()) < HangarTab.UNIT_VIEW_WIDTH) {
-                        // expand
-                        splitUnit.resetToPreferredSizes();
-                    } else {
-                        // collapse
-                        splitUnit.setDividerLocation(1.0);
-                    }
-                }
-            }
-        });
         unitTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         TableColumn column;
         for (int i = 0; i < UnitTableModel.N_COL; i++) {
@@ -234,6 +217,8 @@ public final class HangarTab extends CampaignGuiTab {
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
         add(splitUnit, gridBagConstraints);
+
+        UnitTableMouseAdapter.connect(getCampaignGui(), unitTable, unitModel, splitUnit);
     }
 
     private void setUserPreferences() {

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -19,7 +19,6 @@
 package mekhq.gui;
 
 import java.awt.*;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 import java.util.UUID;
@@ -193,22 +192,6 @@ public final class PersonnelTab extends CampaignGuiTab {
         sortKeys.add(new RowSorter.SortKey(PersonnelTableModel.COL_RANK, SortOrder.DESCENDING));
         sortKeys.add(new RowSorter.SortKey(PersonnelTableModel.COL_SKILL, SortOrder.DESCENDING));
         personnelSorter.setSortKeys(sortKeys);
-        personnelTable.addMouseListener(new PersonnelTableMouseAdapter(getCampaignGui(), personnelTable, personModel) {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                if ((e.getButton() == MouseEvent.BUTTON1) && (e.getClickCount() == 2)) {
-                    if ((splitPersonnel.getSize().width
-                            - splitPersonnel.getDividerLocation() + splitPersonnel
-                                .getDividerSize()) < PersonnelTab.PERSONNEL_VIEW_WIDTH) {
-                        // expand
-                        splitPersonnel.resetToPreferredSizes();
-                    } else {
-                        // collapse
-                        splitPersonnel.setDividerLocation(1.0);
-                    }
-                }
-            }
-        });
         TableColumn column;
         for (int i = 0; i < PersonnelTableModel.N_COL; i++) {
             column = personnelTable.getColumnModel().getColumn(i);
@@ -240,6 +223,8 @@ public final class PersonnelTab extends CampaignGuiTab {
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
         add(splitPersonnel, gridBagConstraints);
+
+        PersonnelTableMouseAdapter.connect(getCampaignGui(), personnelTable, personModel, splitPersonnel);
 
         filterPersonnel();
     }

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -238,8 +238,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         servicedUnitTable.setIntercellSpacing(new Dimension(0, 0));
         servicedUnitTable.setShowGrid(false);
         servicedUnitTable.getSelectionModel().addListSelectionListener(this::servicedUnitTableValueChanged);
-        servicedUnitTable.addMouseListener(new ServicedUnitsTableMouseAdapter(getCampaignGui(),
-                servicedUnitTable, servicedUnitModel));
+        ServicedUnitsTableMouseAdapter.connect(getCampaignGui(), servicedUnitTable, servicedUnitModel);
         JScrollPane scrollServicedUnitTable = new JScrollPane(servicedUnitTable);
         scrollServicedUnitTable.setMinimumSize(new java.awt.Dimension(350, 200));
         scrollServicedUnitTable.setPreferredSize(new java.awt.Dimension(350, 200));
@@ -393,7 +392,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         sortKeys = new ArrayList<>();
         sortKeys.add(new RowSorter.SortKey(0, SortOrder.ASCENDING));
         taskSorter.setSortKeys(sortKeys);
-        taskTable.addMouseListener(new TaskTableMouseAdapter(getCampaignGui(), taskTable, taskModel));
+        TaskTableMouseAdapter.connect(getCampaignGui(), taskTable, taskModel);
         JScrollPane scrollTaskTable = new JScrollPane(taskTable);
         scrollTaskTable.setMinimumSize(new java.awt.Dimension(200, 200));
         scrollTaskTable.setPreferredSize(new java.awt.Dimension(300, 300));

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -76,7 +76,7 @@ public final class TOETab extends CampaignGuiTab {
 
         orgModel = new OrgTreeModel(getCampaign());
         orgTree = new JTree(orgModel);
-        orgTree.addMouseListener(new TOEMouseAdapter(getCampaignGui()));
+        TOEMouseAdapter.connect(getCampaignGui(), orgTree);
         orgTree.setCellRenderer(new ForceRenderer());
         orgTree.setRowHeight(60);
         orgTree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -224,8 +224,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
             filterTechs();
             updateTechTarget();
         });
-        partsTable.addMouseListener(new PartsTableMouseAdapter(getCampaignGui(),
-                partsTable, partsModel));
+        PartsTableMouseAdapter.connect(getCampaignGui(), partsTable, partsModel);
 
         JScrollPane scrollPartsTable = new JScrollPane(partsTable);
         gridBagConstraints = new java.awt.GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/adapter/FinanceTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/FinanceTableMouseAdapter.java
@@ -19,13 +19,13 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
+import java.util.Optional;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
-import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.TransactionChangedEvent;
 import mekhq.campaign.event.TransactionVoidedEvent;
@@ -74,16 +74,10 @@ public class FinanceTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        return financeTable.getSelectedRowCount() > 0;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         int row = financeTable.getSelectedRow();
-        if (row < 0) {
-            return null;
+        if ((row < 0) || !gui.getCampaign().isGM()) {
+            return Optional.empty();
         }
 
         JPopupMenu popup = new JPopupMenu();
@@ -94,15 +88,13 @@ public class FinanceTableMouseAdapter extends JPopupMenuAdapter {
         JMenuItem deleteItem = new JMenuItem("Delete Transaction");
         deleteItem.setActionCommand("DELETE");
         deleteItem.addActionListener(this);
-        deleteItem.setEnabled(gui.getCampaign().isGM());
         menu.add(deleteItem);
 
         JMenuItem editItem = new JMenuItem("Edit Transaction");
         editItem.setActionCommand("EDIT");
         editItem.addActionListener(this);
-        editItem.setEnabled(gui.getCampaign().isGM());
         menu.add(editItem);
 
-        return popup;
+        return Optional.of(popup);
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/FinanceTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/FinanceTableMouseAdapter.java
@@ -19,15 +19,13 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
-import javax.swing.event.MouseInputAdapter;
 
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.TransactionChangedEvent;
 import mekhq.campaign.event.TransactionVoidedEvent;
@@ -36,16 +34,20 @@ import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.EditTransactionDialog;
 import mekhq.gui.model.FinanceTableModel;
 
-public class FinanceTableMouseAdapter extends MouseInputAdapter implements ActionListener {
+public class FinanceTableMouseAdapter extends JPopupMenuAdapter {
     private CampaignGUI gui;
     private JTable financeTable;
     private FinanceTableModel financeModel;
 
-    public FinanceTableMouseAdapter(CampaignGUI gui, JTable financeTable, FinanceTableModel financeModel) {
-        super();
+    protected FinanceTableMouseAdapter(CampaignGUI gui, JTable financeTable, FinanceTableModel financeModel) {
         this.gui = gui;
         this.financeTable = financeTable;
         this.financeModel = financeModel;
+    }
+
+    public static void connect(CampaignGUI gui, JTable financeTable, FinanceTableModel financeModel) {
+        new FinanceTableMouseAdapter(gui, financeTable, financeModel)
+                .connect(financeTable);
     }
 
     @Override
@@ -72,38 +74,35 @@ public class FinanceTableMouseAdapter extends MouseInputAdapter implements Actio
     }
 
     @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
+    protected boolean shouldShowPopup() {
+        return financeTable.getSelectedRowCount() > 0;
     }
 
     @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
-    }
-
-    private void maybeShowPopup(MouseEvent e) {
-        JPopupMenu popup = new JPopupMenu();
-        if (e.isPopupTrigger()) {
-            int row = financeTable.getSelectedRow();
-            if (row < 0) {
-                return;
-            }
-            JMenu menu = new JMenu("GM Mode");
-            popup.add(menu);
-
-            JMenuItem deleteItem = new JMenuItem("Delete Transaction");
-            deleteItem.setActionCommand("DELETE");
-            deleteItem.addActionListener(this);
-            deleteItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(deleteItem);
-
-            JMenuItem editItem = new JMenuItem("Edit Transaction");
-            editItem.setActionCommand("EDIT");
-            editItem.addActionListener(this);
-            editItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(editItem);
-
-            popup.show(e.getComponent(), e.getX(), e.getY());
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        int row = financeTable.getSelectedRow();
+        if (row < 0) {
+            return null;
         }
+
+        JPopupMenu popup = new JPopupMenu();
+
+        JMenu menu = new JMenu("GM Mode");
+        popup.add(menu);
+
+        JMenuItem deleteItem = new JMenuItem("Delete Transaction");
+        deleteItem.setActionCommand("DELETE");
+        deleteItem.addActionListener(this);
+        deleteItem.setEnabled(gui.getCampaign().isGM());
+        menu.add(deleteItem);
+
+        JMenuItem editItem = new JMenuItem("Edit Transaction");
+        editItem.setActionCommand("EDIT");
+        editItem.addActionListener(this);
+        editItem.setEnabled(gui.getCampaign().isGM());
+        menu.add(editItem);
+
+        return popup;
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/JPopupMenuAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/JPopupMenuAdapter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.adapter;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.JComponent;
+import javax.swing.JPopupMenu;
+import javax.swing.KeyStroke;
+import javax.swing.event.MouseInputAdapter;
+
+import megamek.common.annotations.Nullable;
+
+/**
+ * Provides a popup menu adapter for a component which also ensures that
+ * the accessibility chord SHIFT+F10 opens the popup as well.
+ */
+public abstract class JPopupMenuAdapter extends MouseInputAdapter implements ActionListener {
+    public static final String COMMAND_OPEN_POPUP = "SHIFT_F10";
+
+    /**
+     * Connect the popup menu adapter to the component. Implementations should call this
+     * to connect the popup menu to both right click and the SHIFT+F10 accessibility chord.
+     * @param component The component to trap context menu actions.
+     */
+    protected void connect(JComponent component) {
+        component.addMouseListener(this);
+
+        // Setup SHIFT+F10 for context menu support
+        KeyStroke keystroke = KeyStroke.getKeyStroke(KeyEvent.VK_F10, InputEvent.SHIFT_DOWN_MASK);
+        component.getInputMap(JComponent.WHEN_FOCUSED).put(keystroke, COMMAND_OPEN_POPUP);
+        component.getActionMap().put(COMMAND_OPEN_POPUP, new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                // Immediately return if there are no units selected
+                if (!shouldShowPopup()) {
+                    return;
+                }
+
+                JPopupMenu popup = createPopupMenu();
+                popup.show(component, component.getX(), component.getY());
+            }
+        });
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // Do nothing
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+        maybeShowPopup(e);
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        maybeShowPopup(e);
+    }
+
+    private void maybeShowPopup(MouseEvent e) {
+        if (e.isPopupTrigger()) {
+            // Immediately return if there are no units selected
+            if (!shouldShowPopup()) {
+                return;
+            }
+
+            JPopupMenu popup = createPopupMenu();
+            if (popup != null) {
+                popup.show(e.getComponent(), e.getX(), e.getY());
+            }
+        }
+    }
+
+    /**
+     * Gets a value indicating whether or not to show the popup.
+     */
+    protected abstract boolean shouldShowPopup();
+
+    /**
+     * Creates the popup menu, or returns {@code null} if the
+     * popup menu should not be shown.
+     * @return A {@link JPopupMenu} to show, or {@code null} if no
+     *         popup menu should be shown.
+     */
+    @Nullable
+    protected abstract JPopupMenu createPopupMenu();
+}

--- a/MekHQ/src/mekhq/gui/adapter/JPopupMenuAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/JPopupMenuAdapter.java
@@ -23,14 +23,13 @@ import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+import java.util.Optional;
 
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
 import javax.swing.event.MouseInputAdapter;
-
-import megamek.common.annotations.Nullable;
 
 /**
  * Provides a popup menu adapter for a component which also ensures that
@@ -55,13 +54,9 @@ public abstract class JPopupMenuAdapter extends MouseInputAdapter implements Act
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                // Immediately return if there are no units selected
-                if (!shouldShowPopup()) {
-                    return;
-                }
-
-                JPopupMenu popup = createPopupMenu();
-                popup.show(component, component.getX(), component.getY());
+                createPopupMenu().ifPresent(popup -> {
+                    popup.show(component, component.getX(), component.getY());
+                });
             }
         });
     }
@@ -83,29 +78,15 @@ public abstract class JPopupMenuAdapter extends MouseInputAdapter implements Act
 
     private void maybeShowPopup(MouseEvent e) {
         if (e.isPopupTrigger()) {
-            // Immediately return if there are no units selected
-            if (!shouldShowPopup()) {
-                return;
-            }
-
-            JPopupMenu popup = createPopupMenu();
-            if (popup != null) {
+            createPopupMenu().ifPresent(popup -> {
                 popup.show(e.getComponent(), e.getX(), e.getY());
-            }
+            });
         }
     }
 
     /**
-     * Gets a value indicating whether or not to show the popup.
+     * A {@link JPopupMenu} to show, if applicable.
+     * @return An optional {@link JPopupMenu} to show.
      */
-    protected abstract boolean shouldShowPopup();
-
-    /**
-     * Creates the popup menu, or returns {@code null} if the
-     * popup menu should not be shown.
-     * @return A {@link JPopupMenu} to show, or {@code null} if no
-     *         popup menu should be shown.
-     */
-    @Nullable
-    protected abstract JPopupMenu createPopupMenu();
+    protected abstract Optional<JPopupMenu> createPopupMenu();
 }

--- a/MekHQ/src/mekhq/gui/adapter/JPopupMenuAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/JPopupMenuAdapter.java
@@ -68,11 +68,15 @@ public abstract class JPopupMenuAdapter extends MouseInputAdapter implements Act
 
     @Override
     public void mousePressed(MouseEvent e) {
+        // Implement mousePressed per:
+        // https://docs.oracle.com/javase/tutorial/uiswing/components/menu.html#popup
         maybeShowPopup(e);
     }
 
     @Override
     public void mouseReleased(MouseEvent e) {
+        // Implement mouseReleased per:
+        // https://docs.oracle.com/javase/tutorial/uiswing/components/menu.html#popup
         maybeShowPopup(e);
     }
 

--- a/MekHQ/src/mekhq/gui/adapter/LoanTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/LoanTableMouseAdapter.java
@@ -1,6 +1,7 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.swing.JMenu;
@@ -9,7 +10,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
-import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.LoanRemovedEvent;
 import mekhq.campaign.event.PartRemovedEvent;
@@ -89,21 +89,14 @@ public class LoanTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        return loanTable.getSelectedRowCount() > 0;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         if (loanTable.getSelectedRowCount() == 0) {
-            return null;
+            return Optional.empty();
         }
 
         JPopupMenu popup = new JPopupMenu();
 
-        int row = loanTable.getSelectedRow();
-        Loan loan = loanModel.getLoan(loanTable.convertRowIndexToModel(row));
+        Loan loan = loanModel.getLoan(loanTable.convertRowIndexToModel(loanTable.getSelectedRow()));
         JMenuItem menuItem = null;
         JMenu menu = null;
         // **lets fill the pop up menu**//
@@ -117,18 +110,20 @@ public class LoanTableMouseAdapter extends JPopupMenuAdapter {
         menuItem.setActionCommand("DEFAULT");
         menuItem.addActionListener(this);
         popup.add(menuItem);
-        // GM mode
-        menu = new JMenu("GM Mode");
-        // remove part
-        menuItem = new JMenuItem("Remove Loan");
-        menuItem.setActionCommand("REMOVE");
-        menuItem.addActionListener(this);
-        menuItem.setEnabled(gui.getCampaign().isGM());
-        menu.add(menuItem);
-        // end
-        popup.addSeparator();
-        popup.add(menu);
 
-        return popup;
+        if (gui.getCampaign().isGM()) {
+            // GM mode
+            menu = new JMenu("GM Mode");
+            // remove part
+            menuItem = new JMenuItem("Remove Loan");
+            menuItem.setActionCommand("REMOVE");
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+            // end
+            popup.addSeparator();
+            popup.add(menu);
+        }
+
+        return Optional.of(popup);
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/LoanTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/LoanTableMouseAdapter.java
@@ -1,8 +1,6 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.util.UUID;
 
 import javax.swing.JMenu;
@@ -10,8 +8,8 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
-import javax.swing.event.MouseInputAdapter;
 
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.LoanRemovedEvent;
 import mekhq.campaign.event.PartRemovedEvent;
@@ -21,18 +19,20 @@ import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.PayCollateralDialog;
 import mekhq.gui.model.LoanTableModel;
 
-public class LoanTableMouseAdapter extends MouseInputAdapter implements
-        ActionListener {
+public class LoanTableMouseAdapter extends JPopupMenuAdapter {
     private CampaignGUI gui;
     private JTable loanTable;
     private LoanTableModel loanModel;
 
-    public LoanTableMouseAdapter(CampaignGUI gui, JTable loanTable,
-            LoanTableModel loanModel) {
-        super();
+    protected LoanTableMouseAdapter(CampaignGUI gui, JTable loanTable, LoanTableModel loanModel) {
         this.gui = gui;
         this.loanTable = loanTable;
         this.loanModel = loanModel;
+    }
+    
+    public static void connect(CampaignGUI gui, JTable loanTable, LoanTableModel loanModel) {
+        new LoanTableMouseAdapter(gui, loanTable, loanModel)
+                .connect(loanTable);
     }
 
     public void actionPerformed(ActionEvent action) {
@@ -89,49 +89,46 @@ public class LoanTableMouseAdapter extends MouseInputAdapter implements
     }
 
     @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
+    protected boolean shouldShowPopup() {
+        return loanTable.getSelectedRowCount() > 0;
     }
 
     @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
-    }
-
-    private void maybeShowPopup(MouseEvent e) {
-        JPopupMenu popup = new JPopupMenu();
-        if (e.isPopupTrigger()) {
-            if (loanTable.getSelectedRowCount() == 0) {
-                return;
-            }
-            int row = loanTable.getSelectedRow();
-            Loan loan = loanModel.getLoan(loanTable
-                    .convertRowIndexToModel(row));
-            JMenuItem menuItem = null;
-            JMenu menu = null;
-            // **lets fill the pop up menu**//
-            menuItem = new JMenuItem("Pay Off Full Balance ("
-                    + loan.getRemainingValue().toAmountAndSymbolString() + ")");
-            menuItem.setActionCommand("PAY_BALANCE");
-            menuItem.setEnabled(gui.getCampaign().getFunds().isGreaterOrEqualThan(loan.getRemainingValue()));
-            menuItem.addActionListener(this);
-            popup.add(menuItem);
-            menuItem = new JMenuItem("Default on This Loan");
-            menuItem.setActionCommand("DEFAULT");
-            menuItem.addActionListener(this);
-            popup.add(menuItem);
-            // GM mode
-            menu = new JMenu("GM Mode");
-            // remove part
-            menuItem = new JMenuItem("Remove Loan");
-            menuItem.setActionCommand("REMOVE");
-            menuItem.addActionListener(this);
-            menuItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(menuItem);
-            // end
-            popup.addSeparator();
-            popup.add(menu);
-            popup.show(e.getComponent(), e.getX(), e.getY());
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        if (loanTable.getSelectedRowCount() == 0) {
+            return null;
         }
+
+        JPopupMenu popup = new JPopupMenu();
+
+        int row = loanTable.getSelectedRow();
+        Loan loan = loanModel.getLoan(loanTable.convertRowIndexToModel(row));
+        JMenuItem menuItem = null;
+        JMenu menu = null;
+        // **lets fill the pop up menu**//
+        menuItem = new JMenuItem("Pay Off Full Balance ("
+                + loan.getRemainingValue().toAmountAndSymbolString() + ")");
+        menuItem.setActionCommand("PAY_BALANCE");
+        menuItem.setEnabled(gui.getCampaign().getFunds().isGreaterOrEqualThan(loan.getRemainingValue()));
+        menuItem.addActionListener(this);
+        popup.add(menuItem);
+        menuItem = new JMenuItem("Default on This Loan");
+        menuItem.setActionCommand("DEFAULT");
+        menuItem.addActionListener(this);
+        popup.add(menuItem);
+        // GM mode
+        menu = new JMenu("GM Mode");
+        // remove part
+        menuItem = new JMenuItem("Remove Loan");
+        menuItem.setActionCommand("REMOVE");
+        menuItem.addActionListener(this);
+        menuItem.setEnabled(gui.getCampaign().isGM());
+        menu.add(menuItem);
+        // end
+        popup.addSeparator();
+        popup.add(menu);
+
+        return popup;
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
@@ -1,8 +1,6 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
@@ -10,9 +8,9 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
-import javax.swing.event.MouseInputAdapter;
 
 import megamek.common.TargetRoll;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.PartChangedEvent;
 import mekhq.campaign.event.PartModeChangedEvent;
@@ -28,17 +26,21 @@ import mekhq.gui.dialog.PopupValueChoiceDialog;
 import mekhq.gui.model.PartsTableModel;
 import mekhq.service.MassRepairMassSalvageMode;
 
-public class PartsTableMouseAdapter extends MouseInputAdapter implements ActionListener {
+public class PartsTableMouseAdapter extends JPopupMenuAdapter {
 
     private CampaignGUI gui;
     private JTable partsTable;
     private PartsTableModel partsModel;
 
-    public PartsTableMouseAdapter(CampaignGUI gui, JTable partsTable, PartsTableModel partsModel) {
-        super();
+    protected PartsTableMouseAdapter(CampaignGUI gui, JTable partsTable, PartsTableModel partsModel) {
         this.gui = gui;
         this.partsTable = partsTable;
         this.partsModel = partsModel;
+    }
+        
+    public static void connect(CampaignGUI gui, JTable partsTable, PartsTableModel partsModel) {
+        new PartsTableMouseAdapter(gui, partsTable, partsModel)
+                .connect(partsTable);
     }
 
     public void actionPerformed(ActionEvent action) {
@@ -186,16 +188,6 @@ public class PartsTableMouseAdapter extends MouseInputAdapter implements ActionL
         }
     }
 
-    @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
-    }
-
-    @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
-    }
-
     public boolean areAllPartsArmor(Part[] parts) {
         for (Part p : parts) {
             if (!(p instanceof Armor)) {
@@ -250,170 +242,178 @@ public class PartsTableMouseAdapter extends MouseInputAdapter implements ActionL
         return true;
     }
 
-    private void maybeShowPopup(MouseEvent e) {
+    @Override
+    protected boolean shouldShowPopup() {
+        return partsTable.getSelectedRowCount() > 0;
+    }
+
+    @Override
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        if (partsTable.getSelectedRowCount() == 0) {
+            return null;
+        }
+
         JPopupMenu popup = new JPopupMenu();
-        if (e.isPopupTrigger()) {
-            if (partsTable.getSelectedRowCount() == 0) {
-                return;
-            }
-            int[] rows = partsTable.getSelectedRows();
-            JMenuItem menuItem = null;
-            JMenu menu = null;
-            JCheckBoxMenuItem cbMenuItem = null;
-            Part[] parts = new Part[rows.length];
-            boolean oneSelected = false;
-            for (int i = 0; i < rows.length; i++) {
-                parts[i] = partsModel.getPartAt(partsTable.convertRowIndexToModel(rows[i]));
-            }
-            Part part = null;
-            if (parts.length == 1) {
-                oneSelected = true;
-                part = parts[0];
-            }
-            // **lets fill the pop up menu**//
-            // sell part
-            if (gui.getCampaign().getCampaignOptions().canSellParts() && areAllPartsPresent(parts)) {
-                menu = new JMenu("Sell");
-                if (areAllPartsAmmo(parts)) {
-                    menuItem = new JMenuItem("Sell All Ammo of This Type");
-                    menuItem.setActionCommand("SELL_ALL");
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-                    if (oneSelected && ((AmmoStorage) part).getShots() > 1) {
-                        menuItem = new JMenuItem("Sell # Ammo of This Type...");
-                        menuItem.setActionCommand("SELL_N");
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-                } else if (areAllPartsArmor(parts)) {
-                    menuItem = new JMenuItem("Sell All Armor of This Type");
-                    menuItem.setActionCommand("SELL_ALL");
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-                    if (oneSelected && ((Armor) part).getAmount() > 1) {
-                        menuItem = new JMenuItem("Sell # Armor points of This Type...");
-                        menuItem.setActionCommand("SELL_N");
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-                } else if (areAllPartsNotAmmo(parts)) {
-                    menuItem = new JMenuItem("Sell Single Part of This Type");
-                    menuItem.setActionCommand("SELL");
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-                    menuItem = new JMenuItem("Sell All Parts of This Type");
-                    menuItem.setActionCommand("SELL_ALL");
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-                    if (oneSelected && part.getQuantity() > 2) {
-                        menuItem = new JMenuItem("Sell # Parts of This Type...");
-                        menuItem.setActionCommand("SELL_N");
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-                } else {
-                    // when armor, ammo, and non-ammo only allow sell all
-                    menuItem = new JMenuItem("Sell All Parts of This Type");
-                    menuItem.setActionCommand("SELL_ALL");
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-                }
-                popup.add(menu);
-            }
 
-            // also add the ability to order one or many parts, if we have at least one part selected
-            if(rows.length > 0) {
-                menu = new JMenu("Buy");
-                menuItem = new JMenuItem("Buy Single Part of This Type");
-                menuItem.setActionCommand("BUY");
+        int[] rows = partsTable.getSelectedRows();
+        JMenuItem menuItem = null;
+        JMenu menu = null;
+        JCheckBoxMenuItem cbMenuItem = null;
+        Part[] parts = new Part[rows.length];
+        boolean oneSelected = false;
+        for (int i = 0; i < rows.length; i++) {
+            parts[i] = partsModel.getPartAt(partsTable.convertRowIndexToModel(rows[i]));
+        }
+        Part part = null;
+        if (parts.length == 1) {
+            oneSelected = true;
+            part = parts[0];
+        }
+        // **lets fill the pop up menu**//
+        // sell part
+        if (gui.getCampaign().getCampaignOptions().canSellParts() && areAllPartsPresent(parts)) {
+            menu = new JMenu("Sell");
+            if (areAllPartsAmmo(parts)) {
+                menuItem = new JMenuItem("Sell All Ammo of This Type");
+                menuItem.setActionCommand("SELL_ALL");
                 menuItem.addActionListener(this);
                 menu.add(menuItem);
-
-                if(oneSelected) {
-                    menuItem = new JMenuItem ("Buy # Parts of This Type...");
-                    menuItem.setActionCommand("BUY_N");
+                if (oneSelected && ((AmmoStorage) part).getShots() > 1) {
+                    menuItem = new JMenuItem("Sell # Ammo of This Type...");
+                    menuItem.setActionCommand("SELL_N");
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
                 }
-
-                popup.add(menu);
-            }
-
-            if (oneSelected && part.needsFixing() && part.isPresent()) {
-                menu = new JMenu("Repair Mode");
-                for (WorkTime wt : WorkTime.DEFAULT_TIMES) {
-                    cbMenuItem = new JCheckBoxMenuItem(wt.name);
-                    if (part.getMode() == wt) {
-                        cbMenuItem.setSelected(true);
-                    } else {
-                        cbMenuItem.setActionCommand("CHANGE_MODE:" + wt.id);
-                        cbMenuItem.addActionListener(this);
-                    }
-                    cbMenuItem.setEnabled(!part.isBeingWorkedOn());
-                    menu.add(cbMenuItem);
-                }
-                popup.add(menu);
-
-                menuItem = new JMenuItem("Mass Repair");
-                menuItem.setActionCommand("MASS_REPAIR");
-                menuItem.addActionListener(this);
-                popup.add(menuItem);
-            }
-            if (areAllPartsInTransit(parts)) {
-                menuItem = new JMenuItem("Cancel This Delivery");
-                menuItem.setActionCommand("CANCEL_ORDER");
-                menuItem.addActionListener(this);
-                popup.add(menuItem);
-            }
-            menuItem = new JMenuItem("Export Parts");
-            menuItem.addActionListener(ev -> gui.miExportPartsActionPerformed(ev));
-            menuItem.setEnabled(true);
-            popup.add(menuItem);
-
-            // remove from omnipods
-            if (areAllPartsPodded(parts)) {
-                menu = new JMenu("Remove Pod");
-                menuItem = new JMenuItem("Remove Single Pod of This Type");
-                menuItem.setActionCommand("DEPOD");
+            } else if (areAllPartsArmor(parts)) {
+                menuItem = new JMenuItem("Sell All Armor of This Type");
+                menuItem.setActionCommand("SELL_ALL");
                 menuItem.addActionListener(this);
                 menu.add(menuItem);
-                menuItem = new JMenuItem("Remove All Pods of This Type");
-                menuItem.setActionCommand("DEPOD_ALL");
+                if (oneSelected && ((Armor) part).getAmount() > 1) {
+                    menuItem = new JMenuItem("Sell # Armor points of This Type...");
+                    menuItem.setActionCommand("SELL_N");
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+            } else if (areAllPartsNotAmmo(parts)) {
+                menuItem = new JMenuItem("Sell Single Part of This Type");
+                menuItem.setActionCommand("SELL");
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+                menuItem = new JMenuItem("Sell All Parts of This Type");
+                menuItem.setActionCommand("SELL_ALL");
                 menuItem.addActionListener(this);
                 menu.add(menuItem);
                 if (oneSelected && part.getQuantity() > 2) {
-                    menuItem = new JMenuItem("Remove # Pods of This Type...");
-                    menuItem.setActionCommand("DEPOD_N");
+                    menuItem = new JMenuItem("Sell # Parts of This Type...");
+                    menuItem.setActionCommand("SELL_N");
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
                 }
-                popup.add(menu);
-            }
-            // GM mode
-            menu = new JMenu("GM Mode");
-            if (areAllPartsInTransit(parts)) {
-                menuItem = new JMenuItem("Deliver Part Now");
-                menuItem.setActionCommand("ARRIVE");
+            } else {
+                // when armor, ammo, and non-ammo only allow sell all
+                menuItem = new JMenuItem("Sell All Parts of This Type");
+                menuItem.setActionCommand("SELL_ALL");
                 menuItem.addActionListener(this);
-                menuItem.setEnabled(gui.getCampaign().isGM());
                 menu.add(menuItem);
             }
-            // remove part
-            menuItem = new JMenuItem("Remove Part");
-            menuItem.setActionCommand("REMOVE");
-            menuItem.addActionListener(this);
-            menuItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(menuItem);
-            // set part quality
-            menuItem = new JMenuItem("Set Quality...");
-            menuItem.setActionCommand("SET_QUALITY");
-            menuItem.addActionListener(this);
-            menuItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(menuItem);
-            // end
-            popup.addSeparator();
             popup.add(menu);
-            popup.show(e.getComponent(), e.getX(), e.getY());
         }
+
+        // also add the ability to order one or many parts, if we have at least one part selected
+        if(rows.length > 0) {
+            menu = new JMenu("Buy");
+            menuItem = new JMenuItem("Buy Single Part of This Type");
+            menuItem.setActionCommand("BUY");
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+
+            if(oneSelected) {
+                menuItem = new JMenuItem ("Buy # Parts of This Type...");
+                menuItem.setActionCommand("BUY_N");
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+            }
+
+            popup.add(menu);
+        }
+
+        if (oneSelected && part.needsFixing() && part.isPresent()) {
+            menu = new JMenu("Repair Mode");
+            for (WorkTime wt : WorkTime.DEFAULT_TIMES) {
+                cbMenuItem = new JCheckBoxMenuItem(wt.name);
+                if (part.getMode() == wt) {
+                    cbMenuItem.setSelected(true);
+                } else {
+                    cbMenuItem.setActionCommand("CHANGE_MODE:" + wt.id);
+                    cbMenuItem.addActionListener(this);
+                }
+                cbMenuItem.setEnabled(!part.isBeingWorkedOn());
+                menu.add(cbMenuItem);
+            }
+            popup.add(menu);
+
+            menuItem = new JMenuItem("Mass Repair");
+            menuItem.setActionCommand("MASS_REPAIR");
+            menuItem.addActionListener(this);
+            popup.add(menuItem);
+        }
+        if (areAllPartsInTransit(parts)) {
+            menuItem = new JMenuItem("Cancel This Delivery");
+            menuItem.setActionCommand("CANCEL_ORDER");
+            menuItem.addActionListener(this);
+            popup.add(menuItem);
+        }
+        menuItem = new JMenuItem("Export Parts");
+        menuItem.addActionListener(ev -> gui.miExportPartsActionPerformed(ev));
+        menuItem.setEnabled(true);
+        popup.add(menuItem);
+
+        // remove from omnipods
+        if (areAllPartsPodded(parts)) {
+            menu = new JMenu("Remove Pod");
+            menuItem = new JMenuItem("Remove Single Pod of This Type");
+            menuItem.setActionCommand("DEPOD");
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+            menuItem = new JMenuItem("Remove All Pods of This Type");
+            menuItem.setActionCommand("DEPOD_ALL");
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+            if (oneSelected && part.getQuantity() > 2) {
+                menuItem = new JMenuItem("Remove # Pods of This Type...");
+                menuItem.setActionCommand("DEPOD_N");
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+            }
+            popup.add(menu);
+        }
+        // GM mode
+        menu = new JMenu("GM Mode");
+        if (areAllPartsInTransit(parts)) {
+            menuItem = new JMenuItem("Deliver Part Now");
+            menuItem.setActionCommand("ARRIVE");
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(gui.getCampaign().isGM());
+            menu.add(menuItem);
+        }
+        // remove part
+        menuItem = new JMenuItem("Remove Part");
+        menuItem.setActionCommand("REMOVE");
+        menuItem.addActionListener(this);
+        menuItem.setEnabled(gui.getCampaign().isGM());
+        menu.add(menuItem);
+        // set part quality
+        menuItem = new JMenuItem("Set Quality...");
+        menuItem.setActionCommand("SET_QUALITY");
+        menuItem.addActionListener(this);
+        menuItem.setEnabled(gui.getCampaign().isGM());
+        menu.add(menuItem);
+        // end
+        popup.addSeparator();
+        popup.add(menu);
+
+        return popup;
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
@@ -1,6 +1,7 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
+import java.util.Optional;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
@@ -10,7 +11,6 @@ import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
 import megamek.common.TargetRoll;
-import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.PartChangedEvent;
 import mekhq.campaign.event.PartModeChangedEvent;
@@ -243,15 +243,9 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        return partsTable.getSelectedRowCount() > 0;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         if (partsTable.getSelectedRowCount() == 0) {
-            return null;
+            return Optional.empty();
         }
 
         JPopupMenu popup = new JPopupMenu();
@@ -389,31 +383,31 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
             }
             popup.add(menu);
         }
-        // GM mode
-        menu = new JMenu("GM Mode");
-        if (areAllPartsInTransit(parts)) {
-            menuItem = new JMenuItem("Deliver Part Now");
-            menuItem.setActionCommand("ARRIVE");
-            menuItem.addActionListener(this);
-            menuItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(menuItem);
-        }
-        // remove part
-        menuItem = new JMenuItem("Remove Part");
-        menuItem.setActionCommand("REMOVE");
-        menuItem.addActionListener(this);
-        menuItem.setEnabled(gui.getCampaign().isGM());
-        menu.add(menuItem);
-        // set part quality
-        menuItem = new JMenuItem("Set Quality...");
-        menuItem.setActionCommand("SET_QUALITY");
-        menuItem.addActionListener(this);
-        menuItem.setEnabled(gui.getCampaign().isGM());
-        menu.add(menuItem);
-        // end
-        popup.addSeparator();
-        popup.add(menu);
 
-        return popup;
+        if (gui.getCampaign().isGM()) {
+            // GM mode
+            menu = new JMenu("GM Mode");
+            if (areAllPartsInTransit(parts)) {
+                menuItem = new JMenuItem("Deliver Part Now");
+                menuItem.setActionCommand("ARRIVE");
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+            }
+            // remove part
+            menuItem = new JMenuItem("Remove Part");
+            menuItem.setActionCommand("REMOVE");
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+            // set part quality
+            menuItem = new JMenuItem("Set Quality...");
+            menuItem.setActionCommand("SET_QUALITY");
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+            // end
+            popup.addSeparator();
+            popup.add(menu);
+        }
+
+        return Optional.of(popup);
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -20,7 +20,6 @@ package mekhq.gui.adapter;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.time.LocalDate;
 import java.util.*;
@@ -28,12 +27,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.swing.*;
-import javax.swing.event.MouseInputAdapter;
 
 import megamek.client.ui.swing.dialog.imageChooser.AbstractIconChooserDialog;
 import megamek.client.ui.swing.dialog.imageChooser.PortraitChooserDialog;
 import megamek.client.ui.swing.util.MenuScroller;
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
@@ -55,13 +54,14 @@ import mekhq.campaign.personnel.ranks.Ranks;
 import mekhq.campaign.unit.HangarSorter;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.CampaignGUI;
+import mekhq.gui.PersonnelTab;
 import mekhq.gui.dialog.*;
 import mekhq.gui.model.PersonnelTableModel;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.MultiLineTooltip;
 import mekhq.gui.utilities.StaticChecks;
 
-public class PersonnelTableMouseAdapter extends MouseInputAdapter implements ActionListener {
+public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private static final String CMD_RANKSYSTEM = "RANKSYSTEM";
     private static final String CMD_RANK = "RANK";
     private static final String CMD_MANEI_DOMINI_RANK = "MD_RANK";
@@ -137,18 +137,38 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
     private static final String TRUE = String.valueOf(true);
     private static final String FALSE = String.valueOf(false);
 
-    private CampaignGUI gui;
-    private JTable personnelTable;
-    private PersonnelTableModel personnelModel;
-    private ResourceBundle resourceMap;
+    private final CampaignGUI gui;
+    private final JTable personnelTable;
+    private final PersonnelTableModel personnelModel;
+    private final ResourceBundle resourceMap;
 
-    public PersonnelTableMouseAdapter(CampaignGUI gui, JTable personnelTable,
+    protected PersonnelTableMouseAdapter(CampaignGUI gui, JTable personnelTable,
                                       PersonnelTableModel personnelModel) {
-        super();
         this.gui = gui;
         this.personnelTable = personnelTable;
         this.personnelModel = personnelModel;
         resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonnelTableMouseAdapter", new EncodeControl()); //$NON-NLS-1$
+    }
+
+    public static void connect(CampaignGUI gui, JTable personnelTable,
+            PersonnelTableModel personnelModel, JSplitPane splitPersonnel) {
+        new PersonnelTableMouseAdapter(gui, personnelTable, personnelModel) {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if ((e.getButton() == MouseEvent.BUTTON1) && (e.getClickCount() == 2)) {
+                    int width = splitPersonnel.getSize().width;
+                    int location = splitPersonnel.getDividerLocation();
+                    int size = splitPersonnel.getDividerSize();
+                    if ((width - location + size) < PersonnelTab.PERSONNEL_VIEW_WIDTH) {
+                        // expand
+                        splitPersonnel.resetToPreferredSizes();
+                    } else {
+                        // collapse
+                        splitPersonnel.setDividerLocation(1.0);
+                    }
+                }
+            }
+        }.connect(personnelTable);
     }
 
     // MechWarrior Edge Options
@@ -1107,16 +1127,6 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
         gui.getCampaign().personUpdated(person);
     }
 
-    @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
-    }
-
-    @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
-    }
-
     private Person[] getSelectedPeople() {
         Person[] selected = new Person[personnelTable.getSelectedRowCount()];
         int[] rows = personnelTable.getSelectedRows();
@@ -1127,1570 +1137,1576 @@ public class PersonnelTableMouseAdapter extends MouseInputAdapter implements Act
         return selected;
     }
 
-    private void maybeShowPopup(MouseEvent e) {
+    @Override
+    protected boolean shouldShowPopup() {
+        return personnelTable.getSelectedRowCount() > 0;
+    }
+
+    @Override
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        if (personnelTable.getSelectedRowCount() == 0) {
+            return null;
+        }
+
         JPopupMenu popup = new JPopupMenu();
 
-        if (e.isPopupTrigger()) {
-            if (personnelTable.getSelectedRowCount() == 0) {
-                return;
-            }
-            int row = personnelTable.getSelectedRow();
-            boolean oneSelected = personnelTable.getSelectedRowCount() == 1;
-            Person person = personnelModel.getPerson(personnelTable.convertRowIndexToModel(row));
-            JMenuItem menuItem;
-            JMenu menu;
-            JMenu submenu;
-            JCheckBoxMenuItem cbMenuItem;
-            Person[] selected = getSelectedPeople();
-            // lets fill the pop up menu
-            if (StaticChecks.areAllEligible(selected, true)) {
-                menu = new JMenu(resourceMap.getString("changeRank.text"));
-                Ranks ranks = person.getRanks();
-                for (int rankOrder = 0; rankOrder < Ranks.RC_NUM; rankOrder++) {
-                    Rank rank = ranks.getAllRanks().get(rankOrder);
-                    int profession = person.getProfession();
+        int row = personnelTable.getSelectedRow();
+        boolean oneSelected = personnelTable.getSelectedRowCount() == 1;
+        Person person = personnelModel.getPerson(personnelTable.convertRowIndexToModel(row));
+        JMenuItem menuItem;
+        JMenu menu;
+        JMenu submenu;
+        JCheckBoxMenuItem cbMenuItem;
+        Person[] selected = getSelectedPeople();
+        // lets fill the pop up menu
+        if (StaticChecks.areAllEligible(selected, true)) {
+            menu = new JMenu(resourceMap.getString("changeRank.text"));
+            Ranks ranks = person.getRanks();
+            for (int rankOrder = 0; rankOrder < Ranks.RC_NUM; rankOrder++) {
+                Rank rank = ranks.getAllRanks().get(rankOrder);
+                int profession = person.getProfession();
 
-                    // Empty professions need swapped before the continuation
-                    while (ranks.isEmptyProfession(profession) && (profession != Ranks.RPROF_MW)) {
+                // Empty professions need swapped before the continuation
+                while (ranks.isEmptyProfession(profession) && (profession != Ranks.RPROF_MW)) {
+                    profession = ranks.getAlternateProfession(profession);
+                }
+
+                if (rank.getName(profession).equals(HYPHEN)) {
+                    continue;
+                }
+
+                // re-route through any profession redirections,
+                // starting with the empty profession check
+                while (rank.getName(profession).startsWith("--") && (profession != Ranks.RPROF_MW)) {
+                    if (rank.getName(profession).equals("--")) {
                         profession = ranks.getAlternateProfession(profession);
+                    } else if (rank.getName(profession).startsWith("--")) {
+                        profession = ranks.getAlternateProfession(rank.getName(profession));
                     }
+                }
 
-                    if (rank.getName(profession).equals(HYPHEN)) {
-                        continue;
-                    }
-
-                    // re-route through any profession redirections,
-                    // starting with the empty profession check
-                    while (rank.getName(profession).startsWith("--") && (profession != Ranks.RPROF_MW)) {
-                        if (rank.getName(profession).equals("--")) {
-                            profession = ranks.getAlternateProfession(profession);
-                        } else if (rank.getName(profession).startsWith("--")) {
-                            profession = ranks.getAlternateProfession(rank.getName(profession));
-                        }
-                    }
-
-                    if (rank.getRankLevels(profession) > 0) {
-                        submenu = new JMenu(rank.getName(profession));
-                        for (int level = 0; level <= rank.getRankLevels(profession); level++) {
-                            cbMenuItem = new JCheckBoxMenuItem(rank.getName(profession)
-                                    + Utilities.getRomanNumeralsFromArabicNumber(level, true));
-                            cbMenuItem.setActionCommand(makeCommand(CMD_RANK, String.valueOf(rankOrder), String.valueOf(level)));
-                            if ((person.getRankNumeric() == rankOrder) && (person.getRankLevel() == level)) {
-                                cbMenuItem.setSelected(true);
-                            }
-                            cbMenuItem.addActionListener(this);
-                            cbMenuItem.setEnabled(true);
-                            submenu.add(cbMenuItem);
-                        }
-                        JMenuHelpers.addMenuIfNonEmpty(menu, submenu, MAX_POPUP_ITEMS);
-                    } else {
-                        cbMenuItem = new JCheckBoxMenuItem(rank.getName(profession));
-                        cbMenuItem.setActionCommand(makeCommand(CMD_RANK, String.valueOf(rankOrder)));
-                        if (person.getRankNumeric() == rankOrder) {
+                if (rank.getRankLevels(profession) > 0) {
+                    submenu = new JMenu(rank.getName(profession));
+                    for (int level = 0; level <= rank.getRankLevels(profession); level++) {
+                        cbMenuItem = new JCheckBoxMenuItem(rank.getName(profession)
+                                + Utilities.getRomanNumeralsFromArabicNumber(level, true));
+                        cbMenuItem.setActionCommand(makeCommand(CMD_RANK, String.valueOf(rankOrder), String.valueOf(level)));
+                        if ((person.getRankNumeric() == rankOrder) && (person.getRankLevel() == level)) {
                             cbMenuItem.setSelected(true);
                         }
                         cbMenuItem.addActionListener(this);
                         cbMenuItem.setEnabled(true);
-                        menu.add(cbMenuItem);
+                        submenu.add(cbMenuItem);
                     }
+                    JMenuHelpers.addMenuIfNonEmpty(menu, submenu, MAX_POPUP_ITEMS);
+                } else {
+                    cbMenuItem = new JCheckBoxMenuItem(rank.getName(profession));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_RANK, String.valueOf(rankOrder)));
+                    if (person.getRankNumeric() == rankOrder) {
+                        cbMenuItem.setSelected(true);
+                    }
+                    cbMenuItem.addActionListener(this);
+                    cbMenuItem.setEnabled(true);
+                    menu.add(cbMenuItem);
                 }
-                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
             }
-            menu = new JMenu(resourceMap.getString("changeRankSystem.text"));
-            // First allow them to revert to the campaign system
-            cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("useCampaignRankSystem.text"));
-            cbMenuItem.setActionCommand(makeCommand(CMD_RANKSYSTEM, "-1"));
+            JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+        }
+        menu = new JMenu(resourceMap.getString("changeRankSystem.text"));
+        // First allow them to revert to the campaign system
+        cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("useCampaignRankSystem.text"));
+        cbMenuItem.setActionCommand(makeCommand(CMD_RANKSYSTEM, "-1"));
+        cbMenuItem.addActionListener(this);
+        cbMenuItem.setEnabled(true);
+        menu.add(cbMenuItem);
+        for (int system = 0; system < Ranks.RS_NUM; system++) {
+            if (system == Ranks.RS_CUSTOM) {
+                continue;
+            }
+            final Ranks ranks = Ranks.getRanksFromSystem(system);
+            if (ranks == null) {
+                continue;
+            }
+            cbMenuItem = new JCheckBoxMenuItem(ranks.getRankSystemName());
+            cbMenuItem.setActionCommand(makeCommand(CMD_RANKSYSTEM, String.valueOf(system)));
             cbMenuItem.addActionListener(this);
             cbMenuItem.setEnabled(true);
+            if (system == person.getRanks().getRankSystem()) {
+                cbMenuItem.setSelected(true);
+            }
             menu.add(cbMenuItem);
-            for (int system = 0; system < Ranks.RS_NUM; system++) {
-                if (system == Ranks.RS_CUSTOM) {
-                    continue;
-                }
-                final Ranks ranks = Ranks.getRanksFromSystem(system);
-                if (ranks == null) {
-                    continue;
-                }
-                cbMenuItem = new JCheckBoxMenuItem(ranks.getRankSystemName());
-                cbMenuItem.setActionCommand(makeCommand(CMD_RANKSYSTEM, String.valueOf(system)));
+        }
+        JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+
+        if (StaticChecks.areAllWoB(selected)) {
+            // MD Ranks
+            menu = new JMenu(resourceMap.getString("changeMDRank.text"));
+            for (ManeiDominiRank maneiDominiRank : ManeiDominiRank.values()) {
+                cbMenuItem = new JCheckBoxMenuItem(maneiDominiRank.toString());
+                cbMenuItem.setActionCommand(makeCommand(CMD_MANEI_DOMINI_RANK, maneiDominiRank.name()));
                 cbMenuItem.addActionListener(this);
-                cbMenuItem.setEnabled(true);
-                if (system == person.getRanks().getRankSystem()) {
+                if (person.getManeiDominiRank() == maneiDominiRank) {
                     cbMenuItem.setSelected(true);
                 }
                 menu.add(cbMenuItem);
             }
             JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
 
-            if (StaticChecks.areAllWoB(selected)) {
-                // MD Ranks
-                menu = new JMenu(resourceMap.getString("changeMDRank.text"));
-                for (ManeiDominiRank maneiDominiRank : ManeiDominiRank.values()) {
-                    cbMenuItem = new JCheckBoxMenuItem(maneiDominiRank.toString());
-                    cbMenuItem.setActionCommand(makeCommand(CMD_MANEI_DOMINI_RANK, maneiDominiRank.name()));
-                    cbMenuItem.addActionListener(this);
-                    if (person.getManeiDominiRank() == maneiDominiRank) {
-                        cbMenuItem.setSelected(true);
-                    }
-                    menu.add(cbMenuItem);
-                }
-                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
-
-                // MD Classes
-                menu = new JMenu(resourceMap.getString("changeMDClass.text"));
-                for (ManeiDominiClass maneiDominiClass : ManeiDominiClass.values()) {
-                    cbMenuItem = new JCheckBoxMenuItem(maneiDominiClass.toString());
-                    cbMenuItem.setActionCommand(makeCommand(CMD_MANEI_DOMINI_CLASS, maneiDominiClass.name()));
-                    cbMenuItem.addActionListener(this);
-                    if (maneiDominiClass == person.getManeiDominiClass()) {
-                        cbMenuItem.setSelected(true);
-                    }
-                    menu.add(cbMenuItem);
-                }
-                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
-            }
-
-            if (StaticChecks.areAllWoBOrComstar(selected)) {
-                menu = new JMenu(resourceMap.getString("changePrimaryDesignation.text"));
-                for (ROMDesignation romDesignation : ROMDesignation.values()) {
-                    cbMenuItem = new JCheckBoxMenuItem(romDesignation.toString());
-                    cbMenuItem.setActionCommand(makeCommand(CMD_PRIMARY_DESIGNATOR, romDesignation.name()));
-                    cbMenuItem.addActionListener(this);
-                    if (romDesignation == person.getPrimaryDesignator()) {
-                        cbMenuItem.setSelected(true);
-                    }
-                    menu.add(cbMenuItem);
-                }
-                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
-
-                menu = new JMenu(resourceMap.getString("changeSecondaryDesignation.text"));
-                for (ROMDesignation romDesignation : ROMDesignation.values()) {
-                    cbMenuItem = new JCheckBoxMenuItem(romDesignation.toString());
-                    cbMenuItem.setActionCommand(makeCommand(CMD_SECONDARY_DESIGNATOR, romDesignation.name()));
-                    cbMenuItem.addActionListener(this);
-                    if (romDesignation == person.getSecondaryDesignator()) {
-                        cbMenuItem.setSelected(true);
-                    }
-                    menu.add(cbMenuItem);
-                }
-                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
-            }
-            menu = new JMenu(resourceMap.getString("changeStatus.text"));
-            for (PersonnelStatus status : PersonnelStatus.values()) {
-                cbMenuItem = new JCheckBoxMenuItem(status.toString());
-                if (person.getStatus() == status) {
+            // MD Classes
+            menu = new JMenu(resourceMap.getString("changeMDClass.text"));
+            for (ManeiDominiClass maneiDominiClass : ManeiDominiClass.values()) {
+                cbMenuItem = new JCheckBoxMenuItem(maneiDominiClass.toString());
+                cbMenuItem.setActionCommand(makeCommand(CMD_MANEI_DOMINI_CLASS, maneiDominiClass.name()));
+                cbMenuItem.addActionListener(this);
+                if (maneiDominiClass == person.getManeiDominiClass()) {
                     cbMenuItem.setSelected(true);
                 }
-                cbMenuItem.setActionCommand(makeCommand(CMD_CHANGE_STATUS, status.name()));
-                cbMenuItem.addActionListener(this);
                 menu.add(cbMenuItem);
             }
-            popup.add(menu);
+            JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+        }
 
-            if (StaticChecks.areAnyFree(selected)) {
-                popup.add(newMenuItem(resourceMap.getString("imprison.text"), CMD_IMPRISON));
-            } else {
-                // If none are free, then we can put the Free option
-                popup.add(newMenuItem(resourceMap.getString("free.text"), CMD_FREE));
-            }
-
-            if (gui.getCampaign().getCampaignOptions().useAtBPrisonerRansom()
-                    && StaticChecks.areAllPrisoners(selected)) {
-                popup.add(newMenuItem(resourceMap.getString("ransom.text"), CMD_RANSOM));
-            }
-
-            if (StaticChecks.areAnyWillingToDefect(selected)) {
-                popup.add(newMenuItem(resourceMap.getString("recruit.text"), CMD_RECRUIT));
-            }
-
-            menu = new JMenu(resourceMap.getString("changePrimaryRole.text"));
-            for (int i = Person.T_MECHWARRIOR; i < Person.T_NUM; i++) {
-                if (person.canPerformRole(i) && (person.getSecondaryRole() != i)) {
-                    cbMenuItem = new JCheckBoxMenuItem(Person.getRoleDesc(
-                            i, gui.getCampaign().getFaction().isClan()));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_PRIMARY_ROLE, String.valueOf(i)));
-                    if (person.getPrimaryRole() == i) {
-                        cbMenuItem.setSelected(true);
-                    }
-                    cbMenuItem.addActionListener(this);
-                    cbMenuItem.setEnabled(true);
-                    menu.add(cbMenuItem);
+        if (StaticChecks.areAllWoBOrComstar(selected)) {
+            menu = new JMenu(resourceMap.getString("changePrimaryDesignation.text"));
+            for (ROMDesignation romDesignation : ROMDesignation.values()) {
+                cbMenuItem = new JCheckBoxMenuItem(romDesignation.toString());
+                cbMenuItem.setActionCommand(makeCommand(CMD_PRIMARY_DESIGNATOR, romDesignation.name()));
+                cbMenuItem.addActionListener(this);
+                if (romDesignation == person.getPrimaryDesignator()) {
+                    cbMenuItem.setSelected(true);
                 }
+                menu.add(cbMenuItem);
             }
-            if (menu.getItemCount() > MAX_POPUP_ITEMS) {
-                MenuScroller.setScrollerFor(menu, MAX_POPUP_ITEMS);
-            }
-            popup.add(menu);
-            menu = new JMenu(resourceMap.getString("changeSecondaryRole.text")); //$NON-NLS-1$
-            for (int i = 0; i < Person.T_NUM; i++) {
-                if ((i == Person.T_NONE) || (person.canPerformRole(i) && (person.getPrimaryRole() != i))) {
-                    // you cant be an astech if you are a tech, or a medic
-                    // if you are a doctor
-                    if (person.isTechPrimary() && (i == Person.T_ASTECH)) {
-                        continue;
-                    }
-                    if ((person.getPrimaryRole() == Person.T_DOCTOR) && (i == Person.T_MEDIC)) {
-                        continue;
-                    }
-                    cbMenuItem = new JCheckBoxMenuItem(Person.getRoleDesc(
-                            i, gui.getCampaign().getFaction().isClan()));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_SECONDARY_ROLE, String.valueOf(i)));
-                    if (person.getSecondaryRole() == i) {
-                        cbMenuItem.setSelected(true);
-                    }
-                    cbMenuItem.addActionListener(this);
-                    cbMenuItem.setEnabled(true);
-                    menu.add(cbMenuItem);
+            JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+
+            menu = new JMenu(resourceMap.getString("changeSecondaryDesignation.text"));
+            for (ROMDesignation romDesignation : ROMDesignation.values()) {
+                cbMenuItem = new JCheckBoxMenuItem(romDesignation.toString());
+                cbMenuItem.setActionCommand(makeCommand(CMD_SECONDARY_DESIGNATOR, romDesignation.name()));
+                cbMenuItem.addActionListener(this);
+                if (romDesignation == person.getSecondaryDesignator()) {
+                    cbMenuItem.setSelected(true);
                 }
+                menu.add(cbMenuItem);
             }
-            if (menu.getItemCount() > MAX_POPUP_ITEMS) {
-                MenuScroller.setScrollerFor(menu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+        }
+        menu = new JMenu(resourceMap.getString("changeStatus.text"));
+        for (PersonnelStatus status : PersonnelStatus.values()) {
+            cbMenuItem = new JCheckBoxMenuItem(status.toString());
+            if (person.getStatus() == status) {
+                cbMenuItem.setSelected(true);
             }
-            popup.add(menu);
-            // Bloodnames
-            if (StaticChecks.areAllClanEligible(selected)) {
-                menuItem = new JMenuItem(resourceMap.getString("giveRandomBloodname.text"));
-                menuItem.setActionCommand(CMD_BLOODNAME);
-                menuItem.addActionListener(this);
-                menuItem.setEnabled(StaticChecks.areAllActive(selected));
-                popup.add(menuItem);
+            cbMenuItem.setActionCommand(makeCommand(CMD_CHANGE_STATUS, status.name()));
+            cbMenuItem.addActionListener(this);
+            menu.add(cbMenuItem);
+        }
+        popup.add(menu);
+
+        if (StaticChecks.areAnyFree(selected)) {
+            popup.add(newMenuItem(resourceMap.getString("imprison.text"), CMD_IMPRISON));
+        } else {
+            // If none are free, then we can put the Free option
+            popup.add(newMenuItem(resourceMap.getString("free.text"), CMD_FREE));
+        }
+
+        if (gui.getCampaign().getCampaignOptions().useAtBPrisonerRansom()
+                && StaticChecks.areAllPrisoners(selected)) {
+            popup.add(newMenuItem(resourceMap.getString("ransom.text"), CMD_RANSOM));
+        }
+
+        if (StaticChecks.areAnyWillingToDefect(selected)) {
+            popup.add(newMenuItem(resourceMap.getString("recruit.text"), CMD_RECRUIT));
+        }
+
+        menu = new JMenu(resourceMap.getString("changePrimaryRole.text"));
+        for (int i = Person.T_MECHWARRIOR; i < Person.T_NUM; i++) {
+            if (person.canPerformRole(i) && (person.getSecondaryRole() != i)) {
+                cbMenuItem = new JCheckBoxMenuItem(Person.getRoleDesc(
+                        i, gui.getCampaign().getFaction().isClan()));
+                cbMenuItem.setActionCommand(makeCommand(CMD_PRIMARY_ROLE, String.valueOf(i)));
+                if (person.getPrimaryRole() == i) {
+                    cbMenuItem.setSelected(true);
+                }
+                cbMenuItem.addActionListener(this);
+                cbMenuItem.setEnabled(true);
+                menu.add(cbMenuItem);
             }
-
-            // change salary
-            if (gui.getCampaign().getCampaignOptions().payForSalaries()) {
-                menuItem = new JMenuItem(resourceMap.getString("setSalary.text")); //$NON-NLS-1$
-                menuItem.setActionCommand(CMD_EDIT_SALARY);
-                menuItem.addActionListener(this);
-                menuItem.setEnabled(StaticChecks.areAllActive(selected));
-                popup.add(menuItem);
+        }
+        if (menu.getItemCount() > MAX_POPUP_ITEMS) {
+            MenuScroller.setScrollerFor(menu, MAX_POPUP_ITEMS);
+        }
+        popup.add(menu);
+        menu = new JMenu(resourceMap.getString("changeSecondaryRole.text")); //$NON-NLS-1$
+        for (int i = 0; i < Person.T_NUM; i++) {
+            if ((i == Person.T_NONE) || (person.canPerformRole(i) && (person.getPrimaryRole() != i))) {
+                // you cant be an astech if you are a tech, or a medic
+                // if you are a doctor
+                if (person.isTechPrimary() && (i == Person.T_ASTECH)) {
+                    continue;
+                }
+                if ((person.getPrimaryRole() == Person.T_DOCTOR) && (i == Person.T_MEDIC)) {
+                    continue;
+                }
+                cbMenuItem = new JCheckBoxMenuItem(Person.getRoleDesc(
+                        i, gui.getCampaign().getFaction().isClan()));
+                cbMenuItem.setActionCommand(makeCommand(CMD_SECONDARY_ROLE, String.valueOf(i)));
+                if (person.getSecondaryRole() == i) {
+                    cbMenuItem.setSelected(true);
+                }
+                cbMenuItem.addActionListener(this);
+                cbMenuItem.setEnabled(true);
+                menu.add(cbMenuItem);
             }
+        }
+        if (menu.getItemCount() > MAX_POPUP_ITEMS) {
+            MenuScroller.setScrollerFor(menu, MAX_POPUP_ITEMS);
+        }
+        popup.add(menu);
+        // Bloodnames
+        if (StaticChecks.areAllClanEligible(selected)) {
+            menuItem = new JMenuItem(resourceMap.getString("giveRandomBloodname.text"));
+            menuItem.setActionCommand(CMD_BLOODNAME);
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(StaticChecks.areAllActive(selected));
+            popup.add(menuItem);
+        }
 
-            if (!person.isDeployed()) {
-                // Assign pilot to unit/none
-                menu = new JMenu(resourceMap.getString("assignToUnit.text")); //$NON-NLS-1$
-                JMenu pilotMenu = new JMenu(resourceMap.getString("assignAsPilot.text")); //$NON-NLS-1$
-                JMenu pilotUnitTypeMenu = new JMenu();
-                JMenu pilotEntityWeightMenu = new JMenu();
-                JMenu driverMenu = new JMenu(resourceMap.getString("assignAsDriver.text")); //$NON-NLS-1$
-                JMenu driverUnitTypeMenu = new JMenu();
-                JMenu driverEntityWeightMenu = new JMenu();
-                JMenu crewMenu = new JMenu(resourceMap.getString("assignAsCrewmember.text")); //$NON-NLS-1$
-                JMenu crewUnitTypeMenu = new JMenu();
-                JMenu crewEntityWeightMenu = new JMenu();
-                JMenu gunnerMenu = new JMenu(resourceMap.getString("assignAsGunner.text")); //$NON-NLS-1$
-                JMenu gunnerUnitTypeMenu = new JMenu();
-                JMenu gunnerEntityWeightMenu = new JMenu();
-                JMenu navMenu = new JMenu(resourceMap.getString("assignAsNavigator.text")); //$NON-NLS-1$
-                JMenu navUnitTypeMenu = new JMenu();
-                JMenu navEntityWeightMenu = new JMenu();
-                JMenu soldierMenu = new JMenu(resourceMap.getString("assignAsSoldier.text")); //$NON-NLS-1$
-                JMenu soldierUnitTypeMenu = new JMenu();
-                JMenu soldierEntityWeightMenu = new JMenu();
-                JMenu techOfficerMenu = new JMenu(resourceMap.getString("assignAsTechOfficer.text")); //$NON-NLS-1$
-                JMenu techOfficerUnitTypeMenu = new JMenu();
-                JMenu techOfficerEntityWeightMenu = new JMenu();
-                JMenu consoleCmdrMenu = new JMenu(resourceMap.getString("assignAsConsoleCmdr.text")); //$NON-NLS-1$
-                JMenu consoleCmdrUnitTypeMenu = new JMenu();
-                JMenu consoleCmdrEntityWeightMenu = new JMenu();
-                JMenu techMenu = new JMenu(resourceMap.getString("assignAsTech.text")); //$NON-NLS-1$
-                JMenu techUnitTypeMenu = new JMenu();
-                JMenu techEntityWeightMenu = new JMenu();
+        // change salary
+        if (gui.getCampaign().getCampaignOptions().payForSalaries()) {
+            menuItem = new JMenuItem(resourceMap.getString("setSalary.text")); //$NON-NLS-1$
+            menuItem.setActionCommand(CMD_EDIT_SALARY);
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(StaticChecks.areAllActive(selected));
+            popup.add(menuItem);
+        }
 
-                int unitType = -1;
-                int weightClass = -1;
+        if (!person.isDeployed()) {
+            // Assign pilot to unit/none
+            menu = new JMenu(resourceMap.getString("assignToUnit.text")); //$NON-NLS-1$
+            JMenu pilotMenu = new JMenu(resourceMap.getString("assignAsPilot.text")); //$NON-NLS-1$
+            JMenu pilotUnitTypeMenu = new JMenu();
+            JMenu pilotEntityWeightMenu = new JMenu();
+            JMenu driverMenu = new JMenu(resourceMap.getString("assignAsDriver.text")); //$NON-NLS-1$
+            JMenu driverUnitTypeMenu = new JMenu();
+            JMenu driverEntityWeightMenu = new JMenu();
+            JMenu crewMenu = new JMenu(resourceMap.getString("assignAsCrewmember.text")); //$NON-NLS-1$
+            JMenu crewUnitTypeMenu = new JMenu();
+            JMenu crewEntityWeightMenu = new JMenu();
+            JMenu gunnerMenu = new JMenu(resourceMap.getString("assignAsGunner.text")); //$NON-NLS-1$
+            JMenu gunnerUnitTypeMenu = new JMenu();
+            JMenu gunnerEntityWeightMenu = new JMenu();
+            JMenu navMenu = new JMenu(resourceMap.getString("assignAsNavigator.text")); //$NON-NLS-1$
+            JMenu navUnitTypeMenu = new JMenu();
+            JMenu navEntityWeightMenu = new JMenu();
+            JMenu soldierMenu = new JMenu(resourceMap.getString("assignAsSoldier.text")); //$NON-NLS-1$
+            JMenu soldierUnitTypeMenu = new JMenu();
+            JMenu soldierEntityWeightMenu = new JMenu();
+            JMenu techOfficerMenu = new JMenu(resourceMap.getString("assignAsTechOfficer.text")); //$NON-NLS-1$
+            JMenu techOfficerUnitTypeMenu = new JMenu();
+            JMenu techOfficerEntityWeightMenu = new JMenu();
+            JMenu consoleCmdrMenu = new JMenu(resourceMap.getString("assignAsConsoleCmdr.text")); //$NON-NLS-1$
+            JMenu consoleCmdrUnitTypeMenu = new JMenu();
+            JMenu consoleCmdrEntityWeightMenu = new JMenu();
+            JMenu techMenu = new JMenu(resourceMap.getString("assignAsTech.text")); //$NON-NLS-1$
+            JMenu techUnitTypeMenu = new JMenu();
+            JMenu techEntityWeightMenu = new JMenu();
 
-                if (oneSelected && person.getStatus().isActive() && person.getPrisonerStatus().isFree()) {
-                    for (Unit unit : HangarSorter.defaultSorting().getUnits(gui.getCampaign().getHangar())) {
-                        if (!unit.isAvailable()) {
-                            continue;
-                        } else if (unit.getEntity().getUnitType() != unitType) {
-                            unitType = unit.getEntity().getUnitType();
-                            String unitTypeName = UnitType.getTypeName(unitType);
-                            weightClass = unit.getEntity().getWeightClass();
-                            String weightClassName = unit.getEntity().getWeightClassName();
+            int unitType = -1;
+            int weightClass = -1;
 
-                            // Add Weight Menus to Unit Type Menus
-                            JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(techOfficerUnitTypeMenu, techOfficerEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(consoleCmdrUnitTypeMenu, consoleCmdrEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(techUnitTypeMenu, techEntityWeightMenu, MAX_POPUP_ITEMS);
+            if (oneSelected && person.getStatus().isActive() && person.getPrisonerStatus().isFree()) {
+                for (Unit unit : HangarSorter.defaultSorting().getUnits(gui.getCampaign().getHangar())) {
+                    if (!unit.isAvailable()) {
+                        continue;
+                    } else if (unit.getEntity().getUnitType() != unitType) {
+                        unitType = unit.getEntity().getUnitType();
+                        String unitTypeName = UnitType.getTypeName(unitType);
+                        weightClass = unit.getEntity().getWeightClass();
+                        String weightClassName = unit.getEntity().getWeightClassName();
 
-                            // Then add the Unit Type Menus to the Role Menus
-                            JMenuHelpers.addMenuIfNonEmpty(pilotMenu, pilotUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(driverMenu, driverUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(crewMenu, crewUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(gunnerMenu, gunnerUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(navMenu, navUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(soldierMenu, soldierUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(techOfficerMenu, techOfficerUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(consoleCmdrMenu, consoleCmdrUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(techMenu, techUnitTypeMenu, MAX_POPUP_ITEMS);
+                        // Add Weight Menus to Unit Type Menus
+                        JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(techOfficerUnitTypeMenu, techOfficerEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(consoleCmdrUnitTypeMenu, consoleCmdrEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(techUnitTypeMenu, techEntityWeightMenu, MAX_POPUP_ITEMS);
 
-                            // Create new UnitType and EntityWeight Menus
-                            pilotUnitTypeMenu = new JMenu(unitTypeName);
-                            pilotEntityWeightMenu = new JMenu(weightClassName);
-                            driverUnitTypeMenu = new JMenu(unitTypeName);
-                            driverEntityWeightMenu = new JMenu(weightClassName);
-                            crewUnitTypeMenu = new JMenu(unitTypeName);
-                            crewEntityWeightMenu = new JMenu(weightClassName);
-                            gunnerUnitTypeMenu = new JMenu(unitTypeName);
-                            gunnerEntityWeightMenu = new JMenu(weightClassName);
-                            navUnitTypeMenu = new JMenu(unitTypeName);
-                            navEntityWeightMenu = new JMenu(weightClassName);
-                            soldierUnitTypeMenu = new JMenu(unitTypeName);
-                            soldierEntityWeightMenu = new JMenu(weightClassName);
-                            techOfficerUnitTypeMenu = new JMenu(unitTypeName);
-                            techOfficerEntityWeightMenu = new JMenu(weightClassName);
-                            consoleCmdrUnitTypeMenu = new JMenu(unitTypeName);
-                            consoleCmdrEntityWeightMenu = new JMenu(weightClassName);
-                            techUnitTypeMenu = new JMenu(unitTypeName);
-                            techEntityWeightMenu = new JMenu(weightClassName);
-                        } else if (unit.getEntity().getWeightClass() != weightClass) {
-                            weightClass = unit.getEntity().getWeightClass();
-                            String weightClassName = unit.getEntity().getWeightClassName();
+                        // Then add the Unit Type Menus to the Role Menus
+                        JMenuHelpers.addMenuIfNonEmpty(pilotMenu, pilotUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(driverMenu, driverUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(crewMenu, crewUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(gunnerMenu, gunnerUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(navMenu, navUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(soldierMenu, soldierUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(techOfficerMenu, techOfficerUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(consoleCmdrMenu, consoleCmdrUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(techMenu, techUnitTypeMenu, MAX_POPUP_ITEMS);
 
-                            JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(techOfficerUnitTypeMenu, techOfficerEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(consoleCmdrUnitTypeMenu, consoleCmdrEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(techUnitTypeMenu, techEntityWeightMenu, MAX_POPUP_ITEMS);
+                        // Create new UnitType and EntityWeight Menus
+                        pilotUnitTypeMenu = new JMenu(unitTypeName);
+                        pilotEntityWeightMenu = new JMenu(weightClassName);
+                        driverUnitTypeMenu = new JMenu(unitTypeName);
+                        driverEntityWeightMenu = new JMenu(weightClassName);
+                        crewUnitTypeMenu = new JMenu(unitTypeName);
+                        crewEntityWeightMenu = new JMenu(weightClassName);
+                        gunnerUnitTypeMenu = new JMenu(unitTypeName);
+                        gunnerEntityWeightMenu = new JMenu(weightClassName);
+                        navUnitTypeMenu = new JMenu(unitTypeName);
+                        navEntityWeightMenu = new JMenu(weightClassName);
+                        soldierUnitTypeMenu = new JMenu(unitTypeName);
+                        soldierEntityWeightMenu = new JMenu(weightClassName);
+                        techOfficerUnitTypeMenu = new JMenu(unitTypeName);
+                        techOfficerEntityWeightMenu = new JMenu(weightClassName);
+                        consoleCmdrUnitTypeMenu = new JMenu(unitTypeName);
+                        consoleCmdrEntityWeightMenu = new JMenu(weightClassName);
+                        techUnitTypeMenu = new JMenu(unitTypeName);
+                        techEntityWeightMenu = new JMenu(weightClassName);
+                    } else if (unit.getEntity().getWeightClass() != weightClass) {
+                        weightClass = unit.getEntity().getWeightClass();
+                        String weightClassName = unit.getEntity().getWeightClassName();
 
-                            pilotEntityWeightMenu = new JMenu(weightClassName);
-                            driverEntityWeightMenu = new JMenu(weightClassName);
-                            crewEntityWeightMenu = new JMenu(weightClassName);
-                            gunnerEntityWeightMenu = new JMenu(weightClassName);
-                            navEntityWeightMenu = new JMenu(weightClassName);
-                            soldierEntityWeightMenu = new JMenu(weightClassName);
-                            techOfficerEntityWeightMenu = new JMenu(weightClassName);
-                            consoleCmdrEntityWeightMenu = new JMenu(weightClassName);
-                            techEntityWeightMenu = new JMenu(weightClassName);
+                        JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(techOfficerUnitTypeMenu, techOfficerEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(consoleCmdrUnitTypeMenu, consoleCmdrEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(techUnitTypeMenu, techEntityWeightMenu, MAX_POPUP_ITEMS);
+
+                        pilotEntityWeightMenu = new JMenu(weightClassName);
+                        driverEntityWeightMenu = new JMenu(weightClassName);
+                        crewEntityWeightMenu = new JMenu(weightClassName);
+                        gunnerEntityWeightMenu = new JMenu(weightClassName);
+                        navEntityWeightMenu = new JMenu(weightClassName);
+                        soldierEntityWeightMenu = new JMenu(weightClassName);
+                        techOfficerEntityWeightMenu = new JMenu(weightClassName);
+                        consoleCmdrEntityWeightMenu = new JMenu(weightClassName);
+                        techEntityWeightMenu = new JMenu(weightClassName);
+                    }
+
+                    if (unit.usesSoloPilot()) {
+                        if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())
+                                && person.canGun(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_PILOT, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            pilotEntityWeightMenu.add(cbMenuItem);
                         }
-
-                        if (unit.usesSoloPilot()) {
-                            if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())
-                                    && person.canGun(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_PILOT, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
+                    } else if (unit.usesSoldiers()) {
+                        if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            soldierEntityWeightMenu.add(cbMenuItem);
+                        }
+                    } else {
+                        if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_DRIVER, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            if (unit.getEntity() instanceof Aero || unit.getEntity() instanceof Mech) {
                                 pilotEntityWeightMenu.add(cbMenuItem);
+                            } else {
+                                driverEntityWeightMenu.add(cbMenuItem);
                             }
-                        } else if (unit.usesSoldiers()) {
-                            if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                soldierEntityWeightMenu.add(cbMenuItem);
-                            }
-                        } else {
-                            if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_DRIVER, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                if (unit.getEntity() instanceof Aero || unit.getEntity() instanceof Mech) {
-                                    pilotEntityWeightMenu.add(cbMenuItem);
-                                } else {
-                                    driverEntityWeightMenu.add(cbMenuItem);
-                                }
-                            }
-                            if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                gunnerEntityWeightMenu.add(cbMenuItem);
-                            }
-                            if (unit.canTakeMoreVesselCrew()
-                                    && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
-                                    || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_CREW, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                crewEntityWeightMenu.add(cbMenuItem);
-                            }
-                            if (unit.canTakeNavigator() && person.hasSkill(SkillType.S_NAV)) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_NAVIGATOR, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                navEntityWeightMenu.add(cbMenuItem);
-                            }
-                            if (unit.canTakeTechOfficer()) {
-                                //For a vehicle command console we will require the commander to be a driver or a gunner, but not necessarily both
-                                if (unit.getEntity() instanceof Tank) {
-                                    if (person.canDrive(unit.getEntity()) || person.canGun(unit.getEntity())) {
-                                        cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                        cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                        cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH_OFFICER, unit.getId().toString()));
-                                        cbMenuItem.addActionListener(this);
-                                        consoleCmdrEntityWeightMenu.add(cbMenuItem);
-                                    }
-                                } else if (person.canDrive(unit.getEntity()) && person.canGun(unit.getEntity())) {
+                        }
+                        if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            gunnerEntityWeightMenu.add(cbMenuItem);
+                        }
+                        if (unit.canTakeMoreVesselCrew()
+                                && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
+                                || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_CREW, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            crewEntityWeightMenu.add(cbMenuItem);
+                        }
+                        if (unit.canTakeNavigator() && person.hasSkill(SkillType.S_NAV)) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_NAVIGATOR, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            navEntityWeightMenu.add(cbMenuItem);
+                        }
+                        if (unit.canTakeTechOfficer()) {
+                            //For a vehicle command console we will require the commander to be a driver or a gunner, but not necessarily both
+                            if (unit.getEntity() instanceof Tank) {
+                                if (person.canDrive(unit.getEntity()) || person.canGun(unit.getEntity())) {
                                     cbMenuItem = new JCheckBoxMenuItem(unit.getName());
                                     cbMenuItem.setSelected(unit.equals(person.getUnit()));
                                     cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH_OFFICER, unit.getId().toString()));
                                     cbMenuItem.addActionListener(this);
-                                    techOfficerEntityWeightMenu.add(cbMenuItem);
+                                    consoleCmdrEntityWeightMenu.add(cbMenuItem);
                                 }
+                            } else if (person.canDrive(unit.getEntity()) && person.canGun(unit.getEntity())) {
+                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH_OFFICER, unit.getId().toString()));
+                                cbMenuItem.addActionListener(this);
+                                techOfficerEntityWeightMenu.add(cbMenuItem);
                             }
-                        }
-                        if (unit.canTakeTech() && person.canTech(unit.getEntity())
-                                && (person.getMaintenanceTimeUsing() + unit.getMaintenanceTime() <= 480)) {
-                            cbMenuItem = new JCheckBoxMenuItem(String.format(resourceMap.getString("maintenanceTimeDesc.format"), //$NON-NLS-1$
-                                    unit.getName(), unit.getMaintenanceTime()));
-                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH, unit.getId().toString()));
-                            cbMenuItem.addActionListener(this);
-                            techEntityWeightMenu.add(cbMenuItem);
                         }
                     }
-                } else if (StaticChecks.areAllActive(selected) && StaticChecks.areAllEligible(selected)) {
-                    for (Unit unit : HangarSorter.defaultSorting().getUnits(gui.getCampaign().getHangar())) {
-                        if (!unit.isAvailable()) {
+                    if (unit.canTakeTech() && person.canTech(unit.getEntity())
+                            && (person.getMaintenanceTimeUsing() + unit.getMaintenanceTime() <= 480)) {
+                        cbMenuItem = new JCheckBoxMenuItem(String.format(resourceMap.getString("maintenanceTimeDesc.format"), //$NON-NLS-1$
+                                unit.getName(), unit.getMaintenanceTime()));
+                        cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                        cbMenuItem.setActionCommand(makeCommand(CMD_ADD_TECH, unit.getId().toString()));
+                        cbMenuItem.addActionListener(this);
+                        techEntityWeightMenu.add(cbMenuItem);
+                    }
+                }
+            } else if (StaticChecks.areAllActive(selected) && StaticChecks.areAllEligible(selected)) {
+                for (Unit unit : HangarSorter.defaultSorting().getUnits(gui.getCampaign().getHangar())) {
+                    if (!unit.isAvailable()) {
+                        continue;
+                    } else if (unit.getEntity().getUnitType() != unitType) {
+                        unitType = unit.getEntity().getUnitType();
+                        String unitTypeName = UnitType.getTypeName(unitType);
+                        weightClass = unit.getEntity().getWeightClass();
+                        String weightClassName = unit.getEntity().getWeightClassName();
+
+                        // Add Weight Menus to Unit Type Menus
+                        JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
+
+                        // Then add the Unit Type Menus to the Role Menus
+                        JMenuHelpers.addMenuIfNonEmpty(pilotMenu, pilotUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(driverMenu, driverUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(crewMenu, crewUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(gunnerMenu, gunnerUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(navMenu, navUnitTypeMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(soldierMenu, soldierUnitTypeMenu, MAX_POPUP_ITEMS);
+
+                        // Create new UnitType and EntityWeight Menus
+                        pilotUnitTypeMenu = new JMenu(unitTypeName);
+                        pilotEntityWeightMenu = new JMenu(weightClassName);
+                        driverUnitTypeMenu = new JMenu(unitTypeName);
+                        driverEntityWeightMenu = new JMenu(weightClassName);
+                        crewUnitTypeMenu = new JMenu(unitTypeName);
+                        crewEntityWeightMenu = new JMenu(weightClassName);
+                        gunnerUnitTypeMenu = new JMenu(unitTypeName);
+                        gunnerEntityWeightMenu = new JMenu(weightClassName);
+                        navUnitTypeMenu = new JMenu(unitTypeName);
+                        navEntityWeightMenu = new JMenu(weightClassName);
+                        soldierUnitTypeMenu = new JMenu(unitTypeName);
+                        soldierEntityWeightMenu = new JMenu(weightClassName);
+                    } else if (unit.getEntity().getWeightClass() != weightClass) {
+                        weightClass = unit.getEntity().getWeightClass();
+                        String weightClassName = unit.getEntity().getWeightClassName();
+
+                        JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
+                        JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
+
+                        pilotEntityWeightMenu = new JMenu(weightClassName);
+                        driverEntityWeightMenu = new JMenu(weightClassName);
+                        crewEntityWeightMenu = new JMenu(weightClassName);
+                        gunnerEntityWeightMenu = new JMenu(weightClassName);
+                        navEntityWeightMenu = new JMenu(weightClassName);
+                        soldierEntityWeightMenu = new JMenu(weightClassName);
+                    }
+
+                    if (StaticChecks.areAllInfantry(selected)) {
+                        if (!(unit.getEntity() instanceof Infantry) || unit.getEntity() instanceof BattleArmor) {
                             continue;
-                        } else if (unit.getEntity().getUnitType() != unitType) {
-                            unitType = unit.getEntity().getUnitType();
-                            String unitTypeName = UnitType.getTypeName(unitType);
-                            weightClass = unit.getEntity().getWeightClass();
-                            String weightClassName = unit.getEntity().getWeightClassName();
+                        }
+                        if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            soldierEntityWeightMenu.add(cbMenuItem);
+                        }
+                    } else if (StaticChecks.areAllBattleArmor(selected)) {
+                        if (!(unit.getEntity() instanceof BattleArmor)) {
+                            continue;
+                        }
+                        if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            soldierEntityWeightMenu.add(cbMenuItem);
+                        }
+                    } else if (StaticChecks.areAllVeeGunners(selected)) {
+                        if (!(unit.getEntity() instanceof Tank)) {
+                            continue;
+                        }
+                        if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            gunnerEntityWeightMenu.add(cbMenuItem);
+                        }
+                    } else if (StaticChecks.areAllVesselGunners(selected)) {
+                        if (!(unit.getEntity() instanceof Aero)) {
+                            continue;
+                        }
+                        if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            gunnerEntityWeightMenu.add(cbMenuItem);
+                        }
+                    } else if (StaticChecks.areAllVesselCrew(selected)) {
+                        if (!(unit.getEntity() instanceof Aero)) {
+                            continue;
+                        }
+                        if (unit.canTakeMoreVesselCrew()
+                                && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
+                                || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_CREW, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            crewEntityWeightMenu.add(cbMenuItem);
+                        }
+                    } else if (StaticChecks.areAllVesselPilots(selected)) {
+                        if (!(unit.getEntity() instanceof Aero)) {
+                            continue;
+                        }
+                        if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_VESSEL_PILOT, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            pilotEntityWeightMenu.add(cbMenuItem);
+                        }
+                    } else if (StaticChecks.areAllVesselNavigators(selected)) {
+                        if (!(unit.getEntity() instanceof Aero)) {
+                            continue;
+                        }
+                        if (unit.canTakeNavigator() && person.hasSkill(SkillType.S_NAV)) {
+                            cbMenuItem = new JCheckBoxMenuItem(unit.getName());
+                            cbMenuItem.setSelected(unit.equals(person.getUnit()));
+                            cbMenuItem.setActionCommand(makeCommand(CMD_ADD_NAVIGATOR, unit.getId().toString()));
+                            cbMenuItem.addActionListener(this);
+                            navEntityWeightMenu.add(cbMenuItem);
+                        }
+                    }
+                }
+            }
 
-                            // Add Weight Menus to Unit Type Menus
-                            JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
+            // Add the last grouping of entity weight menus to the last grouping of entity menus
+            JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(techOfficerUnitTypeMenu, techOfficerEntityWeightMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(consoleCmdrUnitTypeMenu, consoleCmdrEntityWeightMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(techUnitTypeMenu, techEntityWeightMenu, MAX_POPUP_ITEMS);
 
-                            // Then add the Unit Type Menus to the Role Menus
-                            JMenuHelpers.addMenuIfNonEmpty(pilotMenu, pilotUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(driverMenu, driverUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(crewMenu, crewUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(gunnerMenu, gunnerUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(navMenu, navUnitTypeMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(soldierMenu, soldierUnitTypeMenu, MAX_POPUP_ITEMS);
+            // then add the last grouping of entity menus to the primary menus
+            JMenuHelpers.addMenuIfNonEmpty(pilotMenu, pilotUnitTypeMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(driverMenu, driverUnitTypeMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(crewMenu, crewUnitTypeMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(gunnerMenu, gunnerUnitTypeMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(navMenu, navUnitTypeMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(soldierMenu, soldierUnitTypeMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(techOfficerMenu, techOfficerUnitTypeMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(consoleCmdrMenu, consoleCmdrUnitTypeMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(techMenu, techUnitTypeMenu, MAX_POPUP_ITEMS);
 
-                            // Create new UnitType and EntityWeight Menus
-                            pilotUnitTypeMenu = new JMenu(unitTypeName);
-                            pilotEntityWeightMenu = new JMenu(weightClassName);
-                            driverUnitTypeMenu = new JMenu(unitTypeName);
-                            driverEntityWeightMenu = new JMenu(weightClassName);
-                            crewUnitTypeMenu = new JMenu(unitTypeName);
-                            crewEntityWeightMenu = new JMenu(weightClassName);
-                            gunnerUnitTypeMenu = new JMenu(unitTypeName);
-                            gunnerEntityWeightMenu = new JMenu(weightClassName);
-                            navUnitTypeMenu = new JMenu(unitTypeName);
-                            navEntityWeightMenu = new JMenu(weightClassName);
-                            soldierUnitTypeMenu = new JMenu(unitTypeName);
-                            soldierEntityWeightMenu = new JMenu(weightClassName);
-                        } else if (unit.getEntity().getWeightClass() != weightClass) {
-                            weightClass = unit.getEntity().getWeightClass();
-                            String weightClassName = unit.getEntity().getWeightClassName();
+            // and finally add any non-empty menus to the primary menu
+            JMenuHelpers.addMenuIfNonEmpty(menu, pilotMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(menu, driverMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(menu, crewMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(menu, gunnerMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(menu, navMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(menu, soldierMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(menu, techOfficerMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(menu, consoleCmdrMenu, MAX_POPUP_ITEMS);
+            JMenuHelpers.addMenuIfNonEmpty(menu, techMenu, MAX_POPUP_ITEMS);
 
-                            JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
-                            JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
+            // and we always include the None checkbox
+            cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("none.text"));
+            cbMenuItem.setActionCommand(makeCommand(CMD_REMOVE_UNIT, "-1"));
+            cbMenuItem.addActionListener(this);
+            menu.add(cbMenuItem);
 
-                            pilotEntityWeightMenu = new JMenu(weightClassName);
-                            driverEntityWeightMenu = new JMenu(weightClassName);
-                            crewEntityWeightMenu = new JMenu(weightClassName);
-                            gunnerEntityWeightMenu = new JMenu(weightClassName);
-                            navEntityWeightMenu = new JMenu(weightClassName);
-                            soldierEntityWeightMenu = new JMenu(weightClassName);
+            if ((menu.getItemCount() > 1) || (person.getUnit() != null)
+                    || !person.getTechUnits().isEmpty()) {
+                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+            }
+        }
+
+        if (oneSelected && person.getStatus().isActive()) {
+            if (gui.getCampaign().getCampaignOptions().useManualMarriages()
+                    && person.oldEnoughToMarry(gui.getCampaign()) && !person.getGenealogy().hasSpouse()) {
+                menu = new JMenu(resourceMap.getString("chooseSpouse.text"));
+                JMenu maleMenu = new JMenu(resourceMap.getString("spouseMenuMale.text"));
+                JMenu femaleMenu = new JMenu(resourceMap.getString("spouseMenuFemale.text"));
+                JMenu spouseMenu;
+
+                LocalDate today = gui.getCampaign().getLocalDate();
+
+                List<Person> personnel = new ArrayList<>(gui.getCampaign().getPersonnel());
+                personnel.sort(Comparator.comparing((Person p) -> p.getAge(today)).thenComparing(Person::getSurname));
+
+                for (Person ps : personnel) {
+                    if (person.safeSpouse(ps, gui.getCampaign())) {
+                        String pStatus;
+
+                        if (ps.getPrisonerStatus().isBondsman()) {
+                            pStatus = String.format(resourceMap.getString("marriageBondsmanDesc.format"),
+                                    ps.getFullName(), ps.getAge(today), ps.getRoleDesc());
+                        } else if (ps.getPrisonerStatus().isPrisoner()) {
+                            pStatus = String.format(resourceMap.getString("marriagePrisonerDesc.format"),
+                                    ps.getFullName(), ps.getAge(today), ps.getRoleDesc());
+                        } else {
+                            pStatus = String.format(resourceMap.getString("marriagePartnerDesc.format"),
+                                    ps.getFullName(), ps.getAge(today), ps.getRoleDesc());
                         }
 
-                        if (StaticChecks.areAllInfantry(selected)) {
-                            if (!(unit.getEntity() instanceof Infantry) || unit.getEntity() instanceof BattleArmor) {
-                                continue;
-                            }
-                            if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                soldierEntityWeightMenu.add(cbMenuItem);
-                            }
-                        } else if (StaticChecks.areAllBattleArmor(selected)) {
-                            if (!(unit.getEntity() instanceof BattleArmor)) {
-                                continue;
-                            }
-                            if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_SOLDIER, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                soldierEntityWeightMenu.add(cbMenuItem);
-                            }
-                        } else if (StaticChecks.areAllVeeGunners(selected)) {
-                            if (!(unit.getEntity() instanceof Tank)) {
-                                continue;
-                            }
-                            if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                gunnerEntityWeightMenu.add(cbMenuItem);
-                            }
-                        } else if (StaticChecks.areAllVesselGunners(selected)) {
-                            if (!(unit.getEntity() instanceof Aero)) {
-                                continue;
-                            }
-                            if (unit.canTakeMoreGunners() && person.canGun(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_GUNNER, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                gunnerEntityWeightMenu.add(cbMenuItem);
-                            }
-                        } else if (StaticChecks.areAllVesselCrew(selected)) {
-                            if (!(unit.getEntity() instanceof Aero)) {
-                                continue;
-                            }
-                            if (unit.canTakeMoreVesselCrew()
-                                    && ((unit.getEntity().isAero() && person.hasSkill(SkillType.S_TECH_VESSEL))
-                                    || ((unit.getEntity().isSupportVehicle() && person.hasSkill(SkillType.S_TECH_MECHANIC))))) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_CREW, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                crewEntityWeightMenu.add(cbMenuItem);
-                            }
-                        } else if (StaticChecks.areAllVesselPilots(selected)) {
-                            if (!(unit.getEntity() instanceof Aero)) {
-                                continue;
-                            }
-                            if (unit.canTakeMoreDrivers() && person.canDrive(unit.getEntity())) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_VESSEL_PILOT, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                pilotEntityWeightMenu.add(cbMenuItem);
-                            }
-                        } else if (StaticChecks.areAllVesselNavigators(selected)) {
-                            if (!(unit.getEntity() instanceof Aero)) {
-                                continue;
-                            }
-                            if (unit.canTakeNavigator() && person.hasSkill(SkillType.S_NAV)) {
-                                cbMenuItem = new JCheckBoxMenuItem(unit.getName());
-                                cbMenuItem.setSelected(unit.equals(person.getUnit()));
-                                cbMenuItem.setActionCommand(makeCommand(CMD_ADD_NAVIGATOR, unit.getId().toString()));
-                                cbMenuItem.addActionListener(this);
-                                navEntityWeightMenu.add(cbMenuItem);
-                            }
+                        spouseMenu = new JMenu(pStatus);
+
+                        for (Marriage style : Marriage.values()) {
+                            spouseMenu.add(newMenuItem(style.getDropDownText(),
+                                    makeCommand(CMD_ADD_SPOUSE, ps.getId().toString(), style.name())));
+                        }
+
+                        if (ps.getGender().isMale()) {
+                            maleMenu.add(spouseMenu);
+                        } else {
+                            femaleMenu.add(spouseMenu);
                         }
                     }
                 }
 
-                // Add the last grouping of entity weight menus to the last grouping of entity menus
-                JMenuHelpers.addMenuIfNonEmpty(pilotUnitTypeMenu, pilotEntityWeightMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(driverUnitTypeMenu, driverEntityWeightMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(crewUnitTypeMenu, crewEntityWeightMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(gunnerUnitTypeMenu, gunnerEntityWeightMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(navUnitTypeMenu, navEntityWeightMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(soldierUnitTypeMenu, soldierEntityWeightMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(techOfficerUnitTypeMenu, techOfficerEntityWeightMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(consoleCmdrUnitTypeMenu, consoleCmdrEntityWeightMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(techUnitTypeMenu, techEntityWeightMenu, MAX_POPUP_ITEMS);
+                if (person.getGender().isMale()) {
+                    JMenuHelpers.addMenuIfNonEmpty(menu, femaleMenu, MAX_POPUP_ITEMS);
+                    JMenuHelpers.addMenuIfNonEmpty(menu, maleMenu, MAX_POPUP_ITEMS);
+                } else {
+                    JMenuHelpers.addMenuIfNonEmpty(menu, maleMenu, MAX_POPUP_ITEMS);
+                    JMenuHelpers.addMenuIfNonEmpty(menu, femaleMenu, MAX_POPUP_ITEMS);
+                }
 
-                // then add the last grouping of entity menus to the primary menus
-                JMenuHelpers.addMenuIfNonEmpty(pilotMenu, pilotUnitTypeMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(driverMenu, driverUnitTypeMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(crewMenu, crewUnitTypeMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(gunnerMenu, gunnerUnitTypeMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(navMenu, navUnitTypeMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(soldierMenu, soldierUnitTypeMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(techOfficerMenu, techOfficerUnitTypeMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(consoleCmdrMenu, consoleCmdrUnitTypeMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(techMenu, techUnitTypeMenu, MAX_POPUP_ITEMS);
+                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+            }
 
-                // and finally add any non-empty menus to the primary menu
-                JMenuHelpers.addMenuIfNonEmpty(menu, pilotMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(menu, driverMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(menu, crewMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(menu, gunnerMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(menu, navMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(menu, soldierMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(menu, techOfficerMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(menu, consoleCmdrMenu, MAX_POPUP_ITEMS);
-                JMenuHelpers.addMenuIfNonEmpty(menu, techMenu, MAX_POPUP_ITEMS);
+            if (person.getGenealogy().hasSpouse()) {
+                menu = new JMenu(resourceMap.getString("removeSpouse.text"));
 
-                // and we always include the None checkbox
-                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("none.text"));
-                cbMenuItem.setActionCommand(makeCommand(CMD_REMOVE_UNIT, "-1"));
+                for (Divorce divorceType : Divorce.values()) {
+                    JMenuItem divorceMenu = new JMenuItem(divorceType.toString());
+                    divorceMenu.setActionCommand(makeCommand(CMD_REMOVE_SPOUSE, divorceType.name()));
+                    divorceMenu.addActionListener(this);
+                    menu.add(divorceMenu);
+                }
+
+                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+            }
+        }
+
+        //region Awards Menu
+        JMenu awardMenu = new JMenu(resourceMap.getString("award.text"));
+        List<String> setNames = AwardsFactory.getInstance().getAllSetNames();
+        Collections.sort(setNames);
+        for (String setName : setNames) {
+            JMenu setAwardMenu = new JMenu(setName);
+
+            List<Award> awardsOfSet = AwardsFactory.getInstance().getAllAwardsForSet(setName);
+            Collections.sort(awardsOfSet);
+
+            for (Award award : awardsOfSet) {
+                if (!award.canBeAwarded(selected)) {
+                    continue;
+                }
+
+                StringBuilder awardMenuItem = new StringBuilder();
+                awardMenuItem.append(String.format("%s", award.getName()));
+
+                if ((award.getXPReward() != 0) || (award.getEdgeReward() != 0)) {
+                    awardMenuItem.append(" (");
+
+                    if (award.getXPReward() != 0) {
+                        awardMenuItem.append(award.getXPReward()).append(" XP");
+                        if (award.getEdgeReward() != 0) {
+                            awardMenuItem.append(" & ");
+                        }
+                    }
+
+                    if (award.getEdgeReward() != 0) {
+                        awardMenuItem.append(award.getEdgeReward()).append(" Edge");
+                    }
+
+                    awardMenuItem.append(")");
+                }
+
+                menuItem = new JMenuItem(awardMenuItem.toString());
+                menuItem.setToolTipText(MultiLineTooltip.splitToolTip(award.getDescription()));
+                menuItem.setActionCommand(makeCommand(CMD_ADD_AWARD, award.getSet(), award.getName()));
+                menuItem.addActionListener(this);
+                setAwardMenu.add(menuItem);
+            }
+
+            JMenuHelpers.addMenuIfNonEmpty(awardMenu, setAwardMenu, MAX_POPUP_ITEMS);
+        }
+
+        if (StaticChecks.doAnyHaveAnAward(selected)) {
+            if (awardMenu.getItemCount() > 0) {
+                awardMenu.addSeparator();
+            }
+
+            JMenu removeAwardMenu = new JMenu(resourceMap.getString("removeAward.text"));
+
+            if (oneSelected) {
+                for (Award award : person.getAwardController().getAwards()) {
+                    JMenu singleAwardMenu = new JMenu(award.getName());
+                    for (String date : award.getFormattedDates()) {
+                        JMenuItem specificAwardMenu = new JMenuItem(date);
+                        specificAwardMenu.setActionCommand(makeCommand(CMD_RMV_AWARD, award.getSet(), award.getName(), date));
+                        specificAwardMenu.addActionListener(this);
+                        singleAwardMenu.add(specificAwardMenu);
+                    }
+                    JMenuHelpers.addMenuIfNonEmpty(removeAwardMenu, singleAwardMenu, MAX_POPUP_ITEMS);
+                }
+            } else {
+                Set<Award> awards = new TreeSet<>((a1, a2) -> {
+                    if (a1.getSet().equalsIgnoreCase(a2.getSet())) {
+                        return a1.getName().compareToIgnoreCase(a2.getName());
+                    } else {
+                        return a1.getSet().compareToIgnoreCase(a2.getSet());
+                    }
+                });
+                for (Person p : selected) {
+                    awards.addAll(p.getAwardController().getAwards());
+                }
+
+                for (Award award : awards) {
+                    JMenuItem singleAwardMenu = new JMenuItem(award.getName());
+                    singleAwardMenu.setActionCommand(makeCommand(CMD_RMV_AWARD, award.getSet(), award.getName()));
+                    singleAwardMenu.addActionListener(this);
+                    removeAwardMenu.add(singleAwardMenu);
+                }
+            }
+            JMenuHelpers.addMenuIfNonEmpty(awardMenu, removeAwardMenu, MAX_POPUP_ITEMS);
+        }
+        popup.add(awardMenu);
+        //endregion Awards Menu
+
+        //region Spend XP Menu
+        if (oneSelected && person.getStatus().isActive()) {
+            menu = new JMenu(resourceMap.getString("spendXP.text"));
+            if (gui.getCampaign().getCampaignOptions().useAbilities()) {
+                JMenu abMenu = new JMenu(resourceMap.getString("spendOnSpecialAbilities.text"));
+                int cost;
+
+                List<SpecialAbility> specialAbilities = new ArrayList<>(SpecialAbility.getAllSpecialAbilities().values());
+                specialAbilities.sort(Comparator.comparing(SpecialAbility::getName));
+
+                for (SpecialAbility spa : specialAbilities) {
+                    if (null == spa) {
+                        continue;
+                    }
+                    if (!spa.isEligible(person)) {
+                        continue;
+                    }
+                    cost = spa.getCost();
+                    String costDesc;
+                    if (cost < 0) {
+                        costDesc = resourceMap.getString("costNotPossible.text");
+                    } else {
+                        costDesc = String.format(resourceMap.getString("costValue.format"), cost);
+                    }
+                    boolean available = (cost >= 0) && (person.getXP() >= cost);
+                    if (spa.getName().equals(OptionsConstants.GUNNERY_WEAPON_SPECIALIST)) {
+                        Unit u = person.getUnit();
+                        if (null != u) {
+                            JMenu specialistMenu = new JMenu(resourceMap.getString("weaponSpecialist.text"));
+                            TreeSet<String> uniqueWeapons = new TreeSet<>();
+                            for (int j = 0; j < u.getEntity().getWeaponList().size(); j++) {
+                                Mounted m = u.getEntity().getWeaponList().get(j);
+                                uniqueWeapons.add(m.getName());
+                            }
+                            boolean isSpecialist = person.getOptions().booleanOption(spa.getName());
+                            for (String name : uniqueWeapons) {
+                                if (!(isSpecialist
+                                        && person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
+                                    menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), name, costDesc));
+                                    menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_WEAPON_SPECIALIST, name, String.valueOf(cost)));
+                                    menuItem.addActionListener(this);
+                                    menuItem.setEnabled(available);
+                                    specialistMenu.add(menuItem);
+                                }
+                            }
+                            if (specialistMenu.getMenuComponentCount() > 0) {
+                                abMenu.add(specialistMenu);
+                            }
+                        }
+                    } else if (spa.getName().equals(OptionsConstants.MISC_HUMAN_TRO)) {
+                        JMenu specialistMenu = new JMenu(resourceMap.getString("humantro.text"));
+                        List<Object> tros = new ArrayList<>();
+                        if (person.getOptions().getOption(OptionsConstants.MISC_HUMAN_TRO).booleanValue()) {
+                            Object val = person.getOptions().getOption(OptionsConstants.MISC_HUMAN_TRO).getValue();
+                            if (val instanceof Collection<?>) {
+                                tros.addAll((Collection<?>) val);
+                            } else {
+                                tros.add(val);
+                            }
+                        }
+                        menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("humantro_mek.text"), costDesc));
+                        if (!tros.contains(Crew.HUMANTRO_MECH)) {
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_MECH, String.valueOf(cost)));
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(available);
+                            specialistMenu.add(menuItem);
+                        }
+                        if (!tros.contains(Crew.HUMANTRO_AERO)) {
+                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("humantro_aero.text"), costDesc));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_AERO, String.valueOf(cost)));
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(available);
+                            specialistMenu.add(menuItem);
+                        }
+                        if (!tros.contains(Crew.HUMANTRO_VEE)) {
+                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("humantro_vee.text"), costDesc));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_VEE, String.valueOf(cost)));
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(available);
+                            specialistMenu.add(menuItem);
+                        }
+                        if (!tros.contains(Crew.HUMANTRO_BA)) {
+                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("humantro_ba.text"), costDesc));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_BA, String.valueOf(cost)));
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(available);
+                            specialistMenu.add(menuItem);
+                        }
+                        if (specialistMenu.getMenuComponentCount() > 0) {
+                            abMenu.add(specialistMenu);
+                        }
+                    } else if (spa.getName().equals(OptionsConstants.GUNNERY_SPECIALIST)
+                            && !person.getOptions().booleanOption(OptionsConstants.GUNNERY_SPECIALIST)) {
+                        JMenu specialistMenu = new JMenu(resourceMap.getString("specialist.text"));
+                        menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("laserSpecialist.text"), costDesc));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_ENERGY, String.valueOf(cost)));
+                        menuItem.addActionListener(this);
+                        menuItem.setEnabled(available);
+                        specialistMenu.add(menuItem);
+                        menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("missileSpecialist.text"), costDesc));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_MISSILE, String.valueOf(cost)));
+                        menuItem.addActionListener(this);
+                        menuItem.setEnabled(available);
+                        specialistMenu.add(menuItem);
+                        menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("ballisticSpecialist.text"), costDesc));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_BALLISTIC, String.valueOf(cost)));
+                        menuItem.addActionListener(this);
+                        menuItem.setEnabled(available);
+                        specialistMenu.add(menuItem);
+                        abMenu.add(specialistMenu);
+                    } else if (spa.getName().equals(OptionsConstants.GUNNERY_RANGE_MASTER)) {
+                        JMenu specialistMenu = new JMenu(resourceMap.getString("rangemaster.text"));
+                        List<Object> ranges = new ArrayList<>();
+                        if (person.getOptions().getOption(OptionsConstants.GUNNERY_RANGE_MASTER).booleanValue()) {
+                            Object val = person.getOptions().getOption(OptionsConstants.GUNNERY_RANGE_MASTER).getValue();
+                            if (val instanceof Collection<?>) {
+                                ranges.addAll((Collection<?>) val);
+                            } else {
+                                ranges.add(val);
+                            }
+                        }
+                        if (!ranges.contains(Crew.RANGEMASTER_MEDIUM)) {
+                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("rangemaster_med.text"), costDesc));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_MEDIUM, String.valueOf(cost)));
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(available);
+                            specialistMenu.add(menuItem);
+                        }
+                        if (!ranges.contains(Crew.RANGEMASTER_LONG)) {
+                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("rangemaster_lng.text"), costDesc));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_LONG, String.valueOf(cost)));
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(available);
+                            specialistMenu.add(menuItem);
+                        }
+                        if (!ranges.contains(Crew.RANGEMASTER_EXTREME)) {
+                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("rangemaster_xtm.text"), costDesc));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_EXTREME, String.valueOf(cost)));
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(available);
+                            specialistMenu.add(menuItem);
+                        }
+                        if (specialistMenu.getMenuComponentCount() > 0) {
+                            abMenu.add(specialistMenu);
+                        }
+                    } else if ((person.getOptions().getOption(spa.getName()).getType() == IOption.CHOICE)
+                            && !(person.getOptions().getOption(spa.getName()).booleanValue())) {
+                        JMenu specialistMenu = new JMenu(spa.getDisplayName());
+                        List<String> choices = spa.getChoiceValues();
+                        for (String s : choices) {
+                            if (s.equalsIgnoreCase("none")) {
+                                continue;
+                            }
+                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"),
+                                    s, costDesc));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_CUSTOM_CHOICE,
+                                    s, String.valueOf(cost), spa.getName()));
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(available);
+                            specialistMenu.add(menuItem);
+                        }
+                        if (specialistMenu.getMenuComponentCount() > 0) {
+                            abMenu.add(specialistMenu);
+                        }
+                    } else if (!person.getOptions().booleanOption(spa.getName())) {
+                        menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), spa.getDisplayName(), costDesc));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ABILITY, spa.getName(), String.valueOf(cost)));
+                        menuItem.addActionListener(this);
+                        menuItem.setEnabled(available);
+                        abMenu.add(menuItem);
+                    }
+                }
+                JMenuHelpers.addMenuIfNonEmpty(menu, abMenu);
+            }
+
+            JMenu currentMenu = new JMenu(resourceMap.getString("spendOnCurrentSkills.text"));
+            JMenu newMenu = new JMenu(resourceMap.getString("spendOnNewSkills.text"));
+            for (int i = 0; i < SkillType.getSkillList().length; i++) {
+                String type = SkillType.getSkillList()[i];
+                int cost = person.hasSkill(type) ? person.getSkill(type).getCostToImprove() : SkillType.getType(type).getCost(0);
+                if (cost >= 0) {
+                    String desc = String.format(resourceMap.getString("skillDesc.format"), type, cost);
+                    menuItem = new JMenuItem(desc);
+                    menuItem.setActionCommand(makeCommand(CMD_IMPROVE, type, String.valueOf(cost)));
+                    menuItem.addActionListener(this);
+                    menuItem.setEnabled(person.getXP() >= cost);
+                    if (person.hasSkill(type)) {
+                        currentMenu.add(menuItem);
+                    } else {
+                        newMenu.add(menuItem);
+                    }
+                }
+            }
+            JMenuHelpers.addMenuIfNonEmpty(menu, currentMenu);
+            JMenuHelpers.addMenuIfNonEmpty(menu, newMenu);
+
+            // Edge Purchasing
+            if (gui.getCampaign().getCampaignOptions().useEdge()) {
+                JMenu edgeMenu = new JMenu(resourceMap.getString("edge.text"));
+                int cost = gui.getCampaign().getCampaignOptions().getEdgeCost();
+
+                if ((cost >= 0) && (person.getXP() >= cost)) {
+                    menuItem = new JMenuItem(String.format(resourceMap.getString("spendOnEdge.text"), cost));
+                    menuItem.setActionCommand(makeCommand(CMD_BUY_EDGE, String.valueOf(cost)));
+                    menuItem.addActionListener(this);
+                    edgeMenu.add(menuItem);
+                }
+                JMenuHelpers.addMenuIfNonEmpty(menu, edgeMenu);
+            }
+            JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+            //endregion Spend XP Menu
+
+            //region Edge Triggers
+            if (gui.getCampaign().getCampaignOptions().useEdge()) {
+                menu = new JMenu(resourceMap.getString("setEdgeTriggers.text"));
+
+                //Start of Edge reroll options
+                //MechWarriors
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerHeadHits.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_HEADHIT));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_HEADHIT));
+                if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
+                }
                 cbMenuItem.addActionListener(this);
                 menu.add(cbMenuItem);
 
-                if ((menu.getItemCount() > 1) || (person.getUnit() != null)
-                        || !person.getTechUnits().isEmpty()) {
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerTAC.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_TAC));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_TAC));
+                if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
                 }
-            }
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-            if (oneSelected && person.getStatus().isActive()) {
-                if (gui.getCampaign().getCampaignOptions().useManualMarriages()
-                        && person.oldEnoughToMarry(gui.getCampaign()) && !person.getGenealogy().hasSpouse()) {
-                    menu = new JMenu(resourceMap.getString("chooseSpouse.text"));
-                    JMenu maleMenu = new JMenu(resourceMap.getString("spouseMenuMale.text"));
-                    JMenu femaleMenu = new JMenu(resourceMap.getString("spouseMenuFemale.text"));
-                    JMenu spouseMenu;
-
-                    LocalDate today = gui.getCampaign().getLocalDate();
-
-                    List<Person> personnel = new ArrayList<>(gui.getCampaign().getPersonnel());
-                    personnel.sort(Comparator.comparing((Person p) -> p.getAge(today)).thenComparing(Person::getSurname));
-
-                    for (Person ps : personnel) {
-                        if (person.safeSpouse(ps, gui.getCampaign())) {
-                            String pStatus;
-
-                            if (ps.getPrisonerStatus().isBondsman()) {
-                                pStatus = String.format(resourceMap.getString("marriageBondsmanDesc.format"),
-                                        ps.getFullName(), ps.getAge(today), ps.getRoleDesc());
-                            } else if (ps.getPrisonerStatus().isPrisoner()) {
-                                pStatus = String.format(resourceMap.getString("marriagePrisonerDesc.format"),
-                                        ps.getFullName(), ps.getAge(today), ps.getRoleDesc());
-                            } else {
-                                pStatus = String.format(resourceMap.getString("marriagePartnerDesc.format"),
-                                        ps.getFullName(), ps.getAge(today), ps.getRoleDesc());
-                            }
-
-                            spouseMenu = new JMenu(pStatus);
-
-                            for (Marriage style : Marriage.values()) {
-                                spouseMenu.add(newMenuItem(style.getDropDownText(),
-                                        makeCommand(CMD_ADD_SPOUSE, ps.getId().toString(), style.name())));
-                            }
-
-                            if (ps.getGender().isMale()) {
-                                maleMenu.add(spouseMenu);
-                            } else {
-                                femaleMenu.add(spouseMenu);
-                            }
-                        }
-                    }
-
-                    if (person.getGender().isMale()) {
-                        JMenuHelpers.addMenuIfNonEmpty(menu, femaleMenu, MAX_POPUP_ITEMS);
-                        JMenuHelpers.addMenuIfNonEmpty(menu, maleMenu, MAX_POPUP_ITEMS);
-                    } else {
-                        JMenuHelpers.addMenuIfNonEmpty(menu, maleMenu, MAX_POPUP_ITEMS);
-                        JMenuHelpers.addMenuIfNonEmpty(menu, femaleMenu, MAX_POPUP_ITEMS);
-                    }
-
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerKO.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_KO));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_KO));
+                if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
                 }
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-                if (person.getGenealogy().hasSpouse()) {
-                    menu = new JMenu(resourceMap.getString("removeSpouse.text"));
-
-                    for (Divorce divorceType : Divorce.values()) {
-                        JMenuItem divorceMenu = new JMenuItem(divorceType.toString());
-                        divorceMenu.setActionCommand(makeCommand(CMD_REMOVE_SPOUSE, divorceType.name()));
-                        divorceMenu.addActionListener(this);
-                        menu.add(divorceMenu);
-                    }
-
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerExplosion.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_EXPLOSION));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_EXPLOSION));
+                if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
                 }
-            }
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-            //region Awards Menu
-            JMenu awardMenu = new JMenu(resourceMap.getString("award.text"));
-            List<String> setNames = AwardsFactory.getInstance().getAllSetNames();
-            Collections.sort(setNames);
-            for (String setName : setNames) {
-                JMenu setAwardMenu = new JMenu(setName);
-
-                List<Award> awardsOfSet = AwardsFactory.getInstance().getAllAwardsForSet(setName);
-                Collections.sort(awardsOfSet);
-
-                for (Award award : awardsOfSet) {
-                    if (!award.canBeAwarded(selected)) {
-                        continue;
-                    }
-
-                    StringBuilder awardMenuItem = new StringBuilder();
-                    awardMenuItem.append(String.format("%s", award.getName()));
-
-                    if ((award.getXPReward() != 0) || (award.getEdgeReward() != 0)) {
-                        awardMenuItem.append(" (");
-
-                        if (award.getXPReward() != 0) {
-                            awardMenuItem.append(award.getXPReward()).append(" XP");
-                            if (award.getEdgeReward() != 0) {
-                                awardMenuItem.append(" & ");
-                            }
-                        }
-
-                        if (award.getEdgeReward() != 0) {
-                            awardMenuItem.append(award.getEdgeReward()).append(" Edge");
-                        }
-
-                        awardMenuItem.append(")");
-                    }
-
-                    menuItem = new JMenuItem(awardMenuItem.toString());
-                    menuItem.setToolTipText(MultiLineTooltip.splitToolTip(award.getDescription()));
-                    menuItem.setActionCommand(makeCommand(CMD_ADD_AWARD, award.getSet(), award.getName()));
-                    menuItem.addActionListener(this);
-                    setAwardMenu.add(menuItem);
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerMASCFailure.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_MASC_FAILURE));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_MASC_FAILURE));
+                if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
                 }
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-                JMenuHelpers.addMenuIfNonEmpty(awardMenu, setAwardMenu, MAX_POPUP_ITEMS);
-            }
-
-            if (StaticChecks.doAnyHaveAnAward(selected)) {
-                if (awardMenu.getItemCount() > 0) {
-                    awardMenu.addSeparator();
+                //Aero pilots and gunners
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroAltLoss.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_ALT_LOSS));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_ALT_LOSS));
+                if (person.getPrimaryRole() != Person.T_SPACE_PILOT
+                        && person.getPrimaryRole() != Person.T_SPACE_GUNNER
+                        && person.getPrimaryRole() != Person.T_AERO_PILOT) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
                 }
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-                JMenu removeAwardMenu = new JMenu(resourceMap.getString("removeAward.text"));
-
-                if (oneSelected) {
-                    for (Award award : person.getAwardController().getAwards()) {
-                        JMenu singleAwardMenu = new JMenu(award.getName());
-                        for (String date : award.getFormattedDates()) {
-                            JMenuItem specificAwardMenu = new JMenuItem(date);
-                            specificAwardMenu.setActionCommand(makeCommand(CMD_RMV_AWARD, award.getSet(), award.getName(), date));
-                            specificAwardMenu.addActionListener(this);
-                            singleAwardMenu.add(specificAwardMenu);
-                        }
-                        JMenuHelpers.addMenuIfNonEmpty(removeAwardMenu, singleAwardMenu, MAX_POPUP_ITEMS);
-                    }
-                } else {
-                    Set<Award> awards = new TreeSet<>((a1, a2) -> {
-                        if (a1.getSet().equalsIgnoreCase(a2.getSet())) {
-                            return a1.getName().compareToIgnoreCase(a2.getName());
-                        } else {
-                            return a1.getSet().compareToIgnoreCase(a2.getSet());
-                        }
-                    });
-                    for (Person p : selected) {
-                        awards.addAll(p.getAwardController().getAwards());
-                    }
-
-                    for (Award award : awards) {
-                        JMenuItem singleAwardMenu = new JMenuItem(award.getName());
-                        singleAwardMenu.setActionCommand(makeCommand(CMD_RMV_AWARD, award.getSet(), award.getName()));
-                        singleAwardMenu.addActionListener(this);
-                        removeAwardMenu.add(singleAwardMenu);
-                    }
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroExplosion.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_EXPLOSION));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_EXPLOSION));
+                if ((person.getPrimaryRole() != Person.T_SPACE_PILOT)
+                        && (person.getPrimaryRole() != Person.T_SPACE_GUNNER)
+                        && (person.getPrimaryRole() != Person.T_AERO_PILOT)) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
                 }
-                JMenuHelpers.addMenuIfNonEmpty(awardMenu, removeAwardMenu, MAX_POPUP_ITEMS);
-            }
-            popup.add(awardMenu);
-            //endregion Awards Menu
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-            //region Spend XP Menu
-            if (oneSelected && person.getStatus().isActive()) {
-                menu = new JMenu(resourceMap.getString("spendXP.text"));
-                if (gui.getCampaign().getCampaignOptions().useAbilities()) {
-                    JMenu abMenu = new JMenu(resourceMap.getString("spendOnSpecialAbilities.text"));
-                    int cost;
-
-                    List<SpecialAbility> specialAbilities = new ArrayList<>(SpecialAbility.getAllSpecialAbilities().values());
-                    specialAbilities.sort(Comparator.comparing(SpecialAbility::getName));
-
-                    for (SpecialAbility spa : specialAbilities) {
-                        if (null == spa) {
-                            continue;
-                        }
-                        if (!spa.isEligible(person)) {
-                            continue;
-                        }
-                        cost = spa.getCost();
-                        String costDesc;
-                        if (cost < 0) {
-                            costDesc = resourceMap.getString("costNotPossible.text");
-                        } else {
-                            costDesc = String.format(resourceMap.getString("costValue.format"), cost);
-                        }
-                        boolean available = (cost >= 0) && (person.getXP() >= cost);
-                        if (spa.getName().equals(OptionsConstants.GUNNERY_WEAPON_SPECIALIST)) {
-                            Unit u = person.getUnit();
-                            if (null != u) {
-                                JMenu specialistMenu = new JMenu(resourceMap.getString("weaponSpecialist.text"));
-                                TreeSet<String> uniqueWeapons = new TreeSet<>();
-                                for (int j = 0; j < u.getEntity().getWeaponList().size(); j++) {
-                                    Mounted m = u.getEntity().getWeaponList().get(j);
-                                    uniqueWeapons.add(m.getName());
-                                }
-                                boolean isSpecialist = person.getOptions().booleanOption(spa.getName());
-                                for (String name : uniqueWeapons) {
-                                    if (!(isSpecialist
-                                            && person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
-                                        menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), name, costDesc));
-                                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_WEAPON_SPECIALIST, name, String.valueOf(cost)));
-                                        menuItem.addActionListener(this);
-                                        menuItem.setEnabled(available);
-                                        specialistMenu.add(menuItem);
-                                    }
-                                }
-                                if (specialistMenu.getMenuComponentCount() > 0) {
-                                    abMenu.add(specialistMenu);
-                                }
-                            }
-                        } else if (spa.getName().equals(OptionsConstants.MISC_HUMAN_TRO)) {
-                            JMenu specialistMenu = new JMenu(resourceMap.getString("humantro.text"));
-                            List<Object> tros = new ArrayList<>();
-                            if (person.getOptions().getOption(OptionsConstants.MISC_HUMAN_TRO).booleanValue()) {
-                                Object val = person.getOptions().getOption(OptionsConstants.MISC_HUMAN_TRO).getValue();
-                                if (val instanceof Collection<?>) {
-                                    tros.addAll((Collection<?>) val);
-                                } else {
-                                    tros.add(val);
-                                }
-                            }
-                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("humantro_mek.text"), costDesc));
-                            if (!tros.contains(Crew.HUMANTRO_MECH)) {
-                                menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_MECH, String.valueOf(cost)));
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(available);
-                                specialistMenu.add(menuItem);
-                            }
-                            if (!tros.contains(Crew.HUMANTRO_AERO)) {
-                                menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("humantro_aero.text"), costDesc));
-                                menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_AERO, String.valueOf(cost)));
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(available);
-                                specialistMenu.add(menuItem);
-                            }
-                            if (!tros.contains(Crew.HUMANTRO_VEE)) {
-                                menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("humantro_vee.text"), costDesc));
-                                menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_VEE, String.valueOf(cost)));
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(available);
-                                specialistMenu.add(menuItem);
-                            }
-                            if (!tros.contains(Crew.HUMANTRO_BA)) {
-                                menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("humantro_ba.text"), costDesc));
-                                menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_BA, String.valueOf(cost)));
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(available);
-                                specialistMenu.add(menuItem);
-                            }
-                            if (specialistMenu.getMenuComponentCount() > 0) {
-                                abMenu.add(specialistMenu);
-                            }
-                        } else if (spa.getName().equals(OptionsConstants.GUNNERY_SPECIALIST)
-                                && !person.getOptions().booleanOption(OptionsConstants.GUNNERY_SPECIALIST)) {
-                            JMenu specialistMenu = new JMenu(resourceMap.getString("specialist.text"));
-                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("laserSpecialist.text"), costDesc));
-                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_ENERGY, String.valueOf(cost)));
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(available);
-                            specialistMenu.add(menuItem);
-                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("missileSpecialist.text"), costDesc));
-                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_MISSILE, String.valueOf(cost)));
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(available);
-                            specialistMenu.add(menuItem);
-                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("ballisticSpecialist.text"), costDesc));
-                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_BALLISTIC, String.valueOf(cost)));
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(available);
-                            specialistMenu.add(menuItem);
-                            abMenu.add(specialistMenu);
-                        } else if (spa.getName().equals(OptionsConstants.GUNNERY_RANGE_MASTER)) {
-                            JMenu specialistMenu = new JMenu(resourceMap.getString("rangemaster.text"));
-                            List<Object> ranges = new ArrayList<>();
-                            if (person.getOptions().getOption(OptionsConstants.GUNNERY_RANGE_MASTER).booleanValue()) {
-                                Object val = person.getOptions().getOption(OptionsConstants.GUNNERY_RANGE_MASTER).getValue();
-                                if (val instanceof Collection<?>) {
-                                    ranges.addAll((Collection<?>) val);
-                                } else {
-                                    ranges.add(val);
-                                }
-                            }
-                            if (!ranges.contains(Crew.RANGEMASTER_MEDIUM)) {
-                                menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("rangemaster_med.text"), costDesc));
-                                menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_MEDIUM, String.valueOf(cost)));
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(available);
-                                specialistMenu.add(menuItem);
-                            }
-                            if (!ranges.contains(Crew.RANGEMASTER_LONG)) {
-                                menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("rangemaster_lng.text"), costDesc));
-                                menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_LONG, String.valueOf(cost)));
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(available);
-                                specialistMenu.add(menuItem);
-                            }
-                            if (!ranges.contains(Crew.RANGEMASTER_EXTREME)) {
-                                menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), resourceMap.getString("rangemaster_xtm.text"), costDesc));
-                                menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_EXTREME, String.valueOf(cost)));
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(available);
-                                specialistMenu.add(menuItem);
-                            }
-                            if (specialistMenu.getMenuComponentCount() > 0) {
-                                abMenu.add(specialistMenu);
-                            }
-                        } else if ((person.getOptions().getOption(spa.getName()).getType() == IOption.CHOICE)
-                                && !(person.getOptions().getOption(spa.getName()).booleanValue())) {
-                            JMenu specialistMenu = new JMenu(spa.getDisplayName());
-                            List<String> choices = spa.getChoiceValues();
-                            for (String s : choices) {
-                                if (s.equalsIgnoreCase("none")) {
-                                    continue;
-                                }
-                                menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"),
-                                        s, costDesc));
-                                menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_CUSTOM_CHOICE,
-                                        s, String.valueOf(cost), spa.getName()));
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(available);
-                                specialistMenu.add(menuItem);
-                            }
-                            if (specialistMenu.getMenuComponentCount() > 0) {
-                                abMenu.add(specialistMenu);
-                            }
-                        } else if (!person.getOptions().booleanOption(spa.getName())) {
-                            menuItem = new JMenuItem(String.format(resourceMap.getString("abilityDesc.format"), spa.getDisplayName(), costDesc));
-                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ABILITY, spa.getName(), String.valueOf(cost)));
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(available);
-                            abMenu.add(menuItem);
-                        }
-                    }
-                    JMenuHelpers.addMenuIfNonEmpty(menu, abMenu);
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroKO.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_KO));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_KO));
+                if (person.getPrimaryRole() != Person.T_AERO_PILOT) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
                 }
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-                JMenu currentMenu = new JMenu(resourceMap.getString("spendOnCurrentSkills.text"));
-                JMenu newMenu = new JMenu(resourceMap.getString("spendOnNewSkills.text"));
-                for (int i = 0; i < SkillType.getSkillList().length; i++) {
-                    String type = SkillType.getSkillList()[i];
-                    int cost = person.hasSkill(type) ? person.getSkill(type).getCostToImprove() : SkillType.getType(type).getCost(0);
-                    if (cost >= 0) {
-                        String desc = String.format(resourceMap.getString("skillDesc.format"), type, cost);
-                        menuItem = new JMenuItem(desc);
-                        menuItem.setActionCommand(makeCommand(CMD_IMPROVE, type, String.valueOf(cost)));
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(person.getXP() >= cost);
-                        if (person.hasSkill(type)) {
-                            currentMenu.add(menuItem);
-                        } else {
-                            newMenu.add(menuItem);
-                        }
-                    }
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroLuckyCrit.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_LUCKY_CRIT));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_LUCKY_CRIT));
+                if ((person.getPrimaryRole() != Person.T_SPACE_PILOT)
+                        && (person.getPrimaryRole() != Person.T_SPACE_GUNNER)
+                        && (person.getPrimaryRole() != Person.T_AERO_PILOT)) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
                 }
-                JMenuHelpers.addMenuIfNonEmpty(menu, currentMenu);
-                JMenuHelpers.addMenuIfNonEmpty(menu, newMenu);
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-                // Edge Purchasing
-                if (gui.getCampaign().getCampaignOptions().useEdge()) {
-                    JMenu edgeMenu = new JMenu(resourceMap.getString("edge.text"));
-                    int cost = gui.getCampaign().getCampaignOptions().getEdgeCost();
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroNukeCrit.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_NUKE_CRIT));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_NUKE_CRIT));
+                if ((person.getPrimaryRole() != Person.T_SPACE_PILOT)
+                        && (person.getPrimaryRole() != Person.T_SPACE_GUNNER)) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
+                }
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
 
-                    if ((cost >= 0) && (person.getXP() >= cost)) {
-                        menuItem = new JMenuItem(String.format(resourceMap.getString("spendOnEdge.text"), cost));
-                        menuItem.setActionCommand(makeCommand(CMD_BUY_EDGE, String.valueOf(cost)));
-                        menuItem.addActionListener(this);
-                        edgeMenu.add(menuItem);
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroTrnBayCrit.text"));
+                cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_UNIT_CARGO_LOST));
+                cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_UNIT_CARGO_LOST));
+                if ((person.getPrimaryRole() != Person.T_SPACE_PILOT)
+                        && (person.getPrimaryRole() != Person.T_SPACE_GUNNER)) {
+                    cbMenuItem.setForeground(new Color(150, 150, 150));
+                }
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
+
+                // Support Edge
+                if (gui.getCampaign().getCampaignOptions().useSupportEdge()) {
+                    //Doctors
+                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerHealCheck.text"));
+                    cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_MEDICAL));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_MEDICAL));
+                    if (person.getPrimaryRole() != Person.T_DOCTOR) {
+                        cbMenuItem.setForeground(new Color(150, 150, 150));
                     }
-                    JMenuHelpers.addMenuIfNonEmpty(menu, edgeMenu);
+                    cbMenuItem.addActionListener(this);
+                    menu.add(cbMenuItem);
+
+                    //Techs
+                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerBreakPart.text"));
+                    cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_BREAK_PART));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART));
+                    if (!person.isTechPrimary()) {
+                        cbMenuItem.setForeground(new Color(150, 150, 150));
+                    }
+                    cbMenuItem.addActionListener(this);
+                    menu.add(cbMenuItem);
+
+                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerFailedRefit.text"));
+                    cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
+                    if (!person.isTechPrimary()) {
+                        cbMenuItem.setForeground(new Color(150, 150, 150));
+                    }
+                    cbMenuItem.addActionListener(this);
+                    menu.add(cbMenuItem);
+
+                    //Admins
+                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAcquireCheck.text"));
+                    cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
+                    if (!person.isAdminPrimary()) {
+                        cbMenuItem.setForeground(new Color(150, 150, 150));
+                    }
+                    cbMenuItem.addActionListener(this);
+                    menu.add(cbMenuItem);
                 }
                 JMenuHelpers.addMenuIfNonEmpty(popup, menu);
-                //endregion Spend XP Menu
+            }
+            //endregion Edge Triggers
 
-                //region Edge Triggers
-                if (gui.getCampaign().getCampaignOptions().useEdge()) {
-                    menu = new JMenu(resourceMap.getString("setEdgeTriggers.text"));
+            menu = new JMenu(resourceMap.getString("specialFlags.text"));
+            cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("dependent.text"));
+            cbMenuItem.setSelected(person.isDependent());
+            cbMenuItem.setActionCommand(CMD_DEPENDENT);
+            cbMenuItem.addActionListener(this);
+            menu.add(cbMenuItem);
 
-                    //Start of Edge reroll options
-                    //MechWarriors
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerHeadHits.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_HEADHIT));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_HEADHIT));
-                    if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+            cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("commander.text"));
+            cbMenuItem.setSelected(person.isCommander());
+            cbMenuItem.setActionCommand(CMD_COMMANDER);
+            cbMenuItem.addActionListener(this);
+            menu.add(cbMenuItem);
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerTAC.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_TAC));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_TAC));
-                    if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+            cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("tryingToMarry.text"));
+            cbMenuItem.setToolTipText(resourceMap.getString("tryingToMarry.toolTipText"));
+            cbMenuItem.setSelected(person.isTryingToMarry());
+            cbMenuItem.setActionCommand(CMD_TRYING_TO_MARRY);
+            cbMenuItem.addActionListener(this);
+            menu.add(cbMenuItem);
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerKO.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_KO));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_KO));
-                    if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+            if (gui.getCampaign().getCampaignOptions().useUnofficialProcreation()
+                    && person.getGender().isFemale()) {
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("tryingToConceive.text"));
+                cbMenuItem.setToolTipText(resourceMap.getString("tryingToConceive.toolTipText"));
+                cbMenuItem.setSelected(person.isTryingToConceive());
+                cbMenuItem.setActionCommand(CMD_TRYING_TO_CONCEIVE);
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
+            }
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerExplosion.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_EXPLOSION));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_EXPLOSION));
-                    if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+            cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("founder.text"));
+            cbMenuItem.setSelected(person.isFounder());
+            cbMenuItem.setActionCommand(CMD_FOUNDER);
+            cbMenuItem.addActionListener(this);
+            menu.add(cbMenuItem);
+            popup.add(menu);
+        } else if (StaticChecks.areAllActive(selected)) {
+            if (gui.getCampaign().getCampaignOptions().useEdge()) {
+                menu = new JMenu(resourceMap.getString("setEdgeTriggers.text"));
+                submenu = new JMenu(resourceMap.getString("on.text"));
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerMASCFailure.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_MASC_FAILURE));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_MASC_FAILURE));
-                    if (person.getPrimaryRole() != Person.T_MECHWARRIOR) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerHeadHits.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_HEADHIT, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                    //Aero pilots and gunners
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroAltLoss.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_ALT_LOSS));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_ALT_LOSS));
-                    if (person.getPrimaryRole() != Person.T_SPACE_PILOT
-                            && person.getPrimaryRole() != Person.T_SPACE_GUNNER
-                            && person.getPrimaryRole() != Person.T_AERO_PILOT) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerTAC.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_TAC, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroExplosion.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_EXPLOSION));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_EXPLOSION));
-                    if ((person.getPrimaryRole() != Person.T_SPACE_PILOT)
-                            && (person.getPrimaryRole() != Person.T_SPACE_GUNNER)
-                            && (person.getPrimaryRole() != Person.T_AERO_PILOT)) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerKO.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_KO, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroKO.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_KO));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_KO));
-                    if (person.getPrimaryRole() != Person.T_AERO_PILOT) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerExplosion.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_EXPLOSION, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroLuckyCrit.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_LUCKY_CRIT));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_LUCKY_CRIT));
-                    if ((person.getPrimaryRole() != Person.T_SPACE_PILOT)
-                            && (person.getPrimaryRole() != Person.T_SPACE_GUNNER)
-                            && (person.getPrimaryRole() != Person.T_AERO_PILOT)) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerMASCFailure.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_MASC_FAILURE, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroNukeCrit.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_NUKE_CRIT));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_NUKE_CRIT));
-                    if ((person.getPrimaryRole() != Person.T_SPACE_PILOT)
-                            && (person.getPrimaryRole() != Person.T_SPACE_GUNNER)) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroAltLoss.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_ALT_LOSS, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAeroTrnBayCrit.text"));
-                    cbMenuItem.setSelected(person.getOptions().booleanOption(OPT_EDGE_WHEN_AERO_UNIT_CARGO_LOST));
-                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_UNIT_CARGO_LOST));
-                    if ((person.getPrimaryRole() != Person.T_SPACE_PILOT)
-                            && (person.getPrimaryRole() != Person.T_SPACE_GUNNER)) {
-                        cbMenuItem.setForeground(new Color(150, 150, 150));
-                    }
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroExplosion.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_EXPLOSION, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                    // Support Edge
-                    if (gui.getCampaign().getCampaignOptions().useSupportEdge()) {
-                        //Doctors
-                        cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerHealCheck.text"));
-                        cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_MEDICAL));
-                        cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_MEDICAL));
-                        if (person.getPrimaryRole() != Person.T_DOCTOR) {
-                            cbMenuItem.setForeground(new Color(150, 150, 150));
-                        }
-                        cbMenuItem.addActionListener(this);
-                        menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroKO.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_KO, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                        //Techs
-                        cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerBreakPart.text"));
-                        cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_BREAK_PART));
-                        cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART));
-                        if (!person.isTechPrimary()) {
-                            cbMenuItem.setForeground(new Color(150, 150, 150));
-                        }
-                        cbMenuItem.addActionListener(this);
-                        menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroLuckyCrit.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_LUCKY_CRIT, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                        cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerFailedRefit.text"));
-                        cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
-                        cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
-                        if (!person.isTechPrimary()) {
-                            cbMenuItem.setForeground(new Color(150, 150, 150));
-                        }
-                        cbMenuItem.addActionListener(this);
-                        menu.add(cbMenuItem);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroNukeCrit.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_NUKE_CRIT, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
 
-                        //Admins
-                        cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("edgeTriggerAcquireCheck.text"));
-                        cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
-                        cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
-                        if (!person.isAdminPrimary()) {
-                            cbMenuItem.setForeground(new Color(150, 150, 150));
-                        }
-                        cbMenuItem.addActionListener(this);
-                        menu.add(cbMenuItem);
-                    }
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroTrnBayCrit.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_UNIT_CARGO_LOST, TRUE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                if (gui.getCampaign().getCampaignOptions().useSupportEdge()) {
+                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerHealCheck.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_MEDICAL, TRUE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+
+                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerBreakPart.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART, TRUE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+
+                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerFailedRefit.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT, TRUE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+
+                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAcquireCheck.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL, TRUE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
                 }
-                //endregion Edge Triggers
+                JMenuHelpers.addMenuIfNonEmpty(menu, submenu);
 
-                menu = new JMenu(resourceMap.getString("specialFlags.text"));
+                submenu = new JMenu(resourceMap.getString("off.text"));
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerHeadHits.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_HEADHIT, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerTAC.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_TAC, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerKO.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_KO, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerExplosion.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_EXPLOSION, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerMASCFailure.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_MASC_FAILURE, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroAltLoss.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_ALT_LOSS, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroExplosion.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_EXPLOSION, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroKO.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_KO, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroLuckyCrit.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_LUCKY_CRIT, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroNukeCrit.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_NUKE_CRIT, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroTrnBayCrit.text"));
+                menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_UNIT_CARGO_LOST, FALSE));
+                menuItem.addActionListener(this);
+                submenu.add(menuItem);
+
+                if (gui.getCampaign().getCampaignOptions().useSupportEdge()) {
+                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerHealCheck.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_MEDICAL, FALSE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+
+                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerBreakPart.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART, FALSE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+
+                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerFailedRefit.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT, FALSE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+
+                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAcquireCheck.text"));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL, FALSE));
+                    menuItem.addActionListener(this);
+                    submenu.add(menuItem);
+                }
+                JMenuHelpers.addMenuIfNonEmpty(menu, submenu);
+                JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+            }
+
+            menu = new JMenu(resourceMap.getString("specialFlags.text"));
+            if (StaticChecks.areEitherAllDependentsOrNot(selected)) {
                 cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("dependent.text"));
-                cbMenuItem.setSelected(person.isDependent());
+                cbMenuItem.setSelected(selected[0].isDependent());
                 cbMenuItem.setActionCommand(CMD_DEPENDENT);
                 cbMenuItem.addActionListener(this);
                 menu.add(cbMenuItem);
+            }
 
-                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("commander.text"));
-                cbMenuItem.setSelected(person.isCommander());
-                cbMenuItem.setActionCommand(CMD_COMMANDER);
-                cbMenuItem.addActionListener(this);
-                menu.add(cbMenuItem);
-
+            if (StaticChecks.areEitherAllTryingToMarryOrNot(selected)) {
                 cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("tryingToMarry.text"));
                 cbMenuItem.setToolTipText(resourceMap.getString("tryingToMarry.toolTipText"));
-                cbMenuItem.setSelected(person.isTryingToMarry());
+                cbMenuItem.setSelected(selected[0].isTryingToMarry());
                 cbMenuItem.setActionCommand(CMD_TRYING_TO_MARRY);
                 cbMenuItem.addActionListener(this);
                 menu.add(cbMenuItem);
+            }
 
-                if (gui.getCampaign().getCampaignOptions().useUnofficialProcreation()
-                        && person.getGender().isFemale()) {
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("tryingToConceive.text"));
-                    cbMenuItem.setToolTipText(resourceMap.getString("tryingToConceive.toolTipText"));
-                    cbMenuItem.setSelected(person.isTryingToConceive());
-                    cbMenuItem.setActionCommand(CMD_TRYING_TO_CONCEIVE);
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
-                }
+            if (gui.getCampaign().getCampaignOptions().useUnofficialProcreation()
+                    && StaticChecks.areAllFemale(selected)
+                    && StaticChecks.areEitherAllTryingToConceiveOrNot(selected)) {
+                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("tryingToConceive.text"));
+                cbMenuItem.setToolTipText(resourceMap.getString("tryingToConceive.toolTipText"));
+                cbMenuItem.setSelected(selected[0].isTryingToConceive());
+                cbMenuItem.setActionCommand(CMD_TRYING_TO_CONCEIVE);
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
+            }
 
+            if (StaticChecks.areEitherAllFoundersOrNot(selected)) {
                 cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("founder.text"));
                 cbMenuItem.setSelected(person.isFounder());
                 cbMenuItem.setActionCommand(CMD_FOUNDER);
                 cbMenuItem.addActionListener(this);
                 menu.add(cbMenuItem);
-                popup.add(menu);
-            } else if (StaticChecks.areAllActive(selected)) {
-                if (gui.getCampaign().getCampaignOptions().useEdge()) {
-                    menu = new JMenu(resourceMap.getString("setEdgeTriggers.text"));
-                    submenu = new JMenu(resourceMap.getString("on.text"));
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerHeadHits.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_HEADHIT, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerTAC.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_TAC, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerKO.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_KO, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerExplosion.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_EXPLOSION, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerMASCFailure.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_MASC_FAILURE, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroAltLoss.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_ALT_LOSS, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroExplosion.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_EXPLOSION, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroKO.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_KO, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroLuckyCrit.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_LUCKY_CRIT, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroNukeCrit.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_NUKE_CRIT, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroTrnBayCrit.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_UNIT_CARGO_LOST, TRUE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    if (gui.getCampaign().getCampaignOptions().useSupportEdge()) {
-                        menuItem = new JMenuItem(resourceMap.getString("edgeTriggerHealCheck.text"));
-                        menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_MEDICAL, TRUE));
-                        menuItem.addActionListener(this);
-                        submenu.add(menuItem);
-
-                        menuItem = new JMenuItem(resourceMap.getString("edgeTriggerBreakPart.text"));
-                        menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART, TRUE));
-                        menuItem.addActionListener(this);
-                        submenu.add(menuItem);
-
-                        menuItem = new JMenuItem(resourceMap.getString("edgeTriggerFailedRefit.text"));
-                        menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT, TRUE));
-                        menuItem.addActionListener(this);
-                        submenu.add(menuItem);
-
-                        menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAcquireCheck.text"));
-                        menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL, TRUE));
-                        menuItem.addActionListener(this);
-                        submenu.add(menuItem);
-                    }
-                    JMenuHelpers.addMenuIfNonEmpty(menu, submenu);
-
-                    submenu = new JMenu(resourceMap.getString("off.text"));
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerHeadHits.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_HEADHIT, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerTAC.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_TAC, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerKO.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_KO, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerExplosion.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_EXPLOSION, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerMASCFailure.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_MASC_FAILURE, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroAltLoss.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_ALT_LOSS, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroExplosion.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_EXPLOSION, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroKO.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_KO, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroLuckyCrit.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_LUCKY_CRIT, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroNukeCrit.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_NUKE_CRIT, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAeroTrnBayCrit.text"));
-                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, OPT_EDGE_WHEN_AERO_UNIT_CARGO_LOST, FALSE));
-                    menuItem.addActionListener(this);
-                    submenu.add(menuItem);
-
-                    if (gui.getCampaign().getCampaignOptions().useSupportEdge()) {
-                        menuItem = new JMenuItem(resourceMap.getString("edgeTriggerHealCheck.text"));
-                        menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_MEDICAL, FALSE));
-                        menuItem.addActionListener(this);
-                        submenu.add(menuItem);
-
-                        menuItem = new JMenuItem(resourceMap.getString("edgeTriggerBreakPart.text"));
-                        menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART, FALSE));
-                        menuItem.addActionListener(this);
-                        submenu.add(menuItem);
-
-                        menuItem = new JMenuItem(resourceMap.getString("edgeTriggerFailedRefit.text"));
-                        menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT, FALSE));
-                        menuItem.addActionListener(this);
-                        submenu.add(menuItem);
-
-                        menuItem = new JMenuItem(resourceMap.getString("edgeTriggerAcquireCheck.text"));
-                        menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL, FALSE));
-                        menuItem.addActionListener(this);
-                        submenu.add(menuItem);
-                    }
-                    JMenuHelpers.addMenuIfNonEmpty(menu, submenu);
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu);
-                }
-
-                menu = new JMenu(resourceMap.getString("specialFlags.text"));
-                if (StaticChecks.areEitherAllDependentsOrNot(selected)) {
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("dependent.text"));
-                    cbMenuItem.setSelected(selected[0].isDependent());
-                    cbMenuItem.setActionCommand(CMD_DEPENDENT);
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
-                }
-
-                if (StaticChecks.areEitherAllTryingToMarryOrNot(selected)) {
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("tryingToMarry.text"));
-                    cbMenuItem.setToolTipText(resourceMap.getString("tryingToMarry.toolTipText"));
-                    cbMenuItem.setSelected(selected[0].isTryingToMarry());
-                    cbMenuItem.setActionCommand(CMD_TRYING_TO_MARRY);
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
-                }
-
-                if (gui.getCampaign().getCampaignOptions().useUnofficialProcreation()
-                        && StaticChecks.areAllFemale(selected)
-                        && StaticChecks.areEitherAllTryingToConceiveOrNot(selected)) {
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("tryingToConceive.text"));
-                    cbMenuItem.setToolTipText(resourceMap.getString("tryingToConceive.toolTipText"));
-                    cbMenuItem.setSelected(selected[0].isTryingToConceive());
-                    cbMenuItem.setActionCommand(CMD_TRYING_TO_CONCEIVE);
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
-                }
-
-                if (StaticChecks.areEitherAllFoundersOrNot(selected)) {
-                    cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("founder.text"));
-                    cbMenuItem.setSelected(person.isFounder());
-                    cbMenuItem.setActionCommand(CMD_FOUNDER);
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
-                }
-                JMenuHelpers.addMenuIfNonEmpty(popup, menu);
             }
+            JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+        }
 
-            // generate new appropriate random portrait
-            menuItem = new JMenuItem(resourceMap.getString("randomizePortrait.text"));
-            menuItem.setActionCommand(CMD_RANDOM_PORTRAIT);
+        // generate new appropriate random portrait
+        menuItem = new JMenuItem(resourceMap.getString("randomizePortrait.text"));
+        menuItem.setActionCommand(CMD_RANDOM_PORTRAIT);
+        menuItem.addActionListener(this);
+        popup.add(menuItem);
+
+        // change portrait
+        menuItem = new JMenuItem(resourceMap.getString(oneSelected ? "changePortrait.text" : "bulkAssignSinglePortrait.text"));
+        menuItem.setActionCommand(CMD_EDIT_PORTRAIT);
+        menuItem.addActionListener(this);
+        popup.add(menuItem);
+
+        if (oneSelected) {
+            // change Biography
+            menuItem = new JMenuItem(resourceMap.getString("changeBiography.text")); //$NON-NLS-1$
+            menuItem.setActionCommand(CMD_EDIT_BIOGRAPHY);
             menuItem.addActionListener(this);
             popup.add(menuItem);
 
-            // change portrait
-            menuItem = new JMenuItem(resourceMap.getString(oneSelected ? "changePortrait.text" : "bulkAssignSinglePortrait.text"));
-            menuItem.setActionCommand(CMD_EDIT_PORTRAIT);
+            menuItem = new JMenuItem(resourceMap.getString("changeCallsign.text")); //$NON-NLS-1$
+            menuItem.setActionCommand(CMD_CALLSIGN);
             menuItem.addActionListener(this);
             popup.add(menuItem);
 
-            if (oneSelected) {
-                // change Biography
-                menuItem = new JMenuItem(resourceMap.getString("changeBiography.text")); //$NON-NLS-1$
-                menuItem.setActionCommand(CMD_EDIT_BIOGRAPHY);
-                menuItem.addActionListener(this);
-                popup.add(menuItem);
-
-                menuItem = new JMenuItem(resourceMap.getString("changeCallsign.text")); //$NON-NLS-1$
-                menuItem.setActionCommand(CMD_CALLSIGN);
-                menuItem.addActionListener(this);
-                popup.add(menuItem);
-
-                menuItem = new JMenuItem(resourceMap.getString("editPersonnelLog.text")); //$NON-NLS-1$
-                menuItem.setActionCommand(CMD_EDIT_PERSONNEL_LOG);
-                menuItem.addActionListener(this);
-                popup.add(menuItem);
-            }
-
-            menuItem = new JMenuItem(resourceMap.getString("addSingleLogEntry.text")); //$NON-NLS-1$
-            menuItem.setActionCommand(CMD_ADD_LOG_ENTRY);
+            menuItem = new JMenuItem(resourceMap.getString("editPersonnelLog.text")); //$NON-NLS-1$
+            menuItem.setActionCommand(CMD_EDIT_PERSONNEL_LOG);
             menuItem.addActionListener(this);
             popup.add(menuItem);
+        }
 
-            if (oneSelected) {
-                // Edit mission log
-                menuItem = new JMenuItem(resourceMap.getString("editMissionLog.text")); //$NON-NLS-1$
-                menuItem.setActionCommand(CMD_EDIT_MISSIONS_LOG);
-                menuItem.addActionListener(this);
-                popup.add(menuItem);
-            }
+        menuItem = new JMenuItem(resourceMap.getString("addSingleLogEntry.text")); //$NON-NLS-1$
+        menuItem.setActionCommand(CMD_ADD_LOG_ENTRY);
+        menuItem.addActionListener(this);
+        popup.add(menuItem);
 
-            // Add one item to all personnel mission logs
-            menuItem = new JMenuItem(resourceMap.getString("addMissionEntry.text")); //$NON-NLS-1$
-            menuItem.setActionCommand(CMD_ADD_MISSION_ENTRY);
+        if (oneSelected) {
+            // Edit mission log
+            menuItem = new JMenuItem(resourceMap.getString("editMissionLog.text")); //$NON-NLS-1$
+            menuItem.setActionCommand(CMD_EDIT_MISSIONS_LOG);
             menuItem.addActionListener(this);
             popup.add(menuItem);
+        }
 
-            if (oneSelected) {
-                menuItem = new JMenuItem(resourceMap.getString("editKillLog.text")); //$NON-NLS-1$
-                menuItem.setActionCommand(CMD_EDIT_KILL_LOG);
-                menuItem.addActionListener(this);
-                menuItem.setEnabled(true);
-                popup.add(menuItem);
-            }
-            if (oneSelected || StaticChecks.allHaveSameUnit(selected)) {
-                menuItem = new JMenuItem(resourceMap.getString("assignKill.text")); //$NON-NLS-1$
-                menuItem.setActionCommand(CMD_ADD_KILL);
-                menuItem.addActionListener(this);
-                menuItem.setEnabled(true);
-                popup.add(menuItem);
-            }
-            menuItem = new JMenuItem(resourceMap.getString("exportPersonnel.text"));
-            menuItem.addActionListener(ev -> gui.miExportPersonActionPerformed(ev));
+        // Add one item to all personnel mission logs
+        menuItem = new JMenuItem(resourceMap.getString("addMissionEntry.text")); //$NON-NLS-1$
+        menuItem.setActionCommand(CMD_ADD_MISSION_ENTRY);
+        menuItem.addActionListener(this);
+        popup.add(menuItem);
+
+        if (oneSelected) {
+            menuItem = new JMenuItem(resourceMap.getString("editKillLog.text")); //$NON-NLS-1$
+            menuItem.setActionCommand(CMD_EDIT_KILL_LOG);
+            menuItem.addActionListener(this);
             menuItem.setEnabled(true);
             popup.add(menuItem);
-
-            if (gui.getCampaign().getCampaignOptions().getUseAtB() && StaticChecks.areAllActive(selected)) {
-                menuItem = new JMenuItem(resourceMap.getString("sack.text"));
-                menuItem.setActionCommand(CMD_SACK);
-                menuItem.addActionListener(this);
-                popup.add(menuItem);
-            }
-
-            //region GM Menu
-            if (gui.getCampaign().isGM()) {
-                popup.addSeparator();
-
-                menu = new JMenu(resourceMap.getString("gmMode.text"));
-
-                menuItem = new JMenu(resourceMap.getString("changePrisonerStatus.text"));
-                menuItem.add(newCheckboxMenu(
-                        PrisonerStatus.FREE.toString(),
-                        makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.FREE.name()),
-                        (person.getPrisonerStatus() == PrisonerStatus.FREE)));
-                menuItem.add(newCheckboxMenu(
-                        PrisonerStatus.PRISONER.toString(),
-                        makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER.name()),
-                        (person.getPrisonerStatus() == PrisonerStatus.PRISONER)));
-                menuItem.add(newCheckboxMenu(
-                        PrisonerStatus.PRISONER_DEFECTOR.toString(),
-                        makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER_DEFECTOR.name()),
-                        (person.getPrisonerStatus() == PrisonerStatus.PRISONER_DEFECTOR)));
-                menuItem.add(newCheckboxMenu(
-                        PrisonerStatus.BONDSMAN.toString(),
-                        makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.BONDSMAN.name()),
-                        (person.getPrisonerStatus() == PrisonerStatus.BONDSMAN)));
-                menu.add(menuItem);
-
-                menuItem = new JMenuItem(resourceMap.getString("removePerson.text"));
-                menuItem.setActionCommand(CMD_REMOVE);
-                menuItem.addActionListener(this);
-                menu.add(menuItem);
-
-                if (!gui.getCampaign().getCampaignOptions().useAdvancedMedical()) {
-                    menuItem = new JMenuItem(resourceMap.getString("editHits.text"));
-                    menuItem.setActionCommand(CMD_EDIT_HITS);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-                }
-
-                menuItem = new JMenuItem(resourceMap.getString("add1XP.text"));
-                menuItem.setActionCommand(CMD_ADD_1_XP);
-                menuItem.addActionListener(this);
-                menu.add(menuItem);
-
-                menuItem = new JMenuItem(resourceMap.getString("addXP.text"));
-                menuItem.setActionCommand(CMD_ADD_XP);
-                menuItem.addActionListener(this);
-                menu.add(menuItem);
-
-                menuItem = new JMenuItem(resourceMap.getString("setXP.text"));
-                menuItem.setActionCommand(CMD_SET_XP);
-                menuItem.addActionListener(this);
-                menu.add(menuItem);
-
-                if (gui.getCampaign().getCampaignOptions().useEdge()) {
-                    menuItem = new JMenuItem(resourceMap.getString("setEdge.text"));
-                    menuItem.setActionCommand(CMD_SET_EDGE);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-                }
-
-                if (oneSelected) {
-                    menuItem = new JMenuItem(resourceMap.getString("edit.text"));
-                    menuItem.setActionCommand(CMD_EDIT);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-
-                    menuItem = new JMenuItem(resourceMap.getString("loadGMTools.text"));
-                    menuItem.addActionListener(evt -> loadGMToolsForPerson(person));
-                    menu.add(menuItem);
-                }
-                if (gui.getCampaign().getCampaignOptions().useAdvancedMedical()) {
-                    menuItem = new JMenuItem(resourceMap.getString("removeAllInjuries.text"));
-                    menuItem.setActionCommand(CMD_CLEAR_INJURIES);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-
-                    if (oneSelected) {
-                        for (Injury i : person.getInjuries()) {
-                            menuItem = new JMenuItem(String.format(resourceMap.getString("removeInjury.format"), i.getName()));
-                            menuItem.setActionCommand(makeCommand(CMD_REMOVE_INJURY, i.getUUID().toString()));
-                            menuItem.addActionListener(this);
-                            menu.add(menuItem);
-                        }
-
-                        menuItem = new JMenuItem(resourceMap.getString("editInjuries.text"));
-                        menuItem.setActionCommand(CMD_EDIT_INJURIES);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-                }
-
-                if (oneSelected) {
-                    if (person.canProcreate(gui.getCampaign())) {
-                        menuItem = new JMenuItem(resourceMap.getString("addPregnancy.text"));
-                        menuItem.setActionCommand(CMD_ADD_PREGNANCY);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    } else if (person.isPregnant()) {
-                        menuItem = new JMenuItem(resourceMap.getString("removePregnancy.text"));
-                        menuItem.setActionCommand(CMD_REMOVE_PREGNANCY);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-                }
-                popup.add(menu);
-            }
-            //endregion GM Menu
-
-            popup.show(e.getComponent(), e.getX(), e.getY());
         }
+        if (oneSelected || StaticChecks.allHaveSameUnit(selected)) {
+            menuItem = new JMenuItem(resourceMap.getString("assignKill.text")); //$NON-NLS-1$
+            menuItem.setActionCommand(CMD_ADD_KILL);
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(true);
+            popup.add(menuItem);
+        }
+        menuItem = new JMenuItem(resourceMap.getString("exportPersonnel.text"));
+        menuItem.addActionListener(ev -> gui.miExportPersonActionPerformed(ev));
+        menuItem.setEnabled(true);
+        popup.add(menuItem);
+
+        if (gui.getCampaign().getCampaignOptions().getUseAtB() && StaticChecks.areAllActive(selected)) {
+            menuItem = new JMenuItem(resourceMap.getString("sack.text"));
+            menuItem.setActionCommand(CMD_SACK);
+            menuItem.addActionListener(this);
+            popup.add(menuItem);
+        }
+
+        //region GM Menu
+        if (gui.getCampaign().isGM()) {
+            popup.addSeparator();
+
+            menu = new JMenu(resourceMap.getString("gmMode.text"));
+
+            menuItem = new JMenu(resourceMap.getString("changePrisonerStatus.text"));
+            menuItem.add(newCheckboxMenu(
+                    PrisonerStatus.FREE.toString(),
+                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.FREE.name()),
+                    (person.getPrisonerStatus() == PrisonerStatus.FREE)));
+            menuItem.add(newCheckboxMenu(
+                    PrisonerStatus.PRISONER.toString(),
+                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER.name()),
+                    (person.getPrisonerStatus() == PrisonerStatus.PRISONER)));
+            menuItem.add(newCheckboxMenu(
+                    PrisonerStatus.PRISONER_DEFECTOR.toString(),
+                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER_DEFECTOR.name()),
+                    (person.getPrisonerStatus() == PrisonerStatus.PRISONER_DEFECTOR)));
+            menuItem.add(newCheckboxMenu(
+                    PrisonerStatus.BONDSMAN.toString(),
+                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.BONDSMAN.name()),
+                    (person.getPrisonerStatus() == PrisonerStatus.BONDSMAN)));
+            menu.add(menuItem);
+
+            menuItem = new JMenuItem(resourceMap.getString("removePerson.text"));
+            menuItem.setActionCommand(CMD_REMOVE);
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+
+            if (!gui.getCampaign().getCampaignOptions().useAdvancedMedical()) {
+                menuItem = new JMenuItem(resourceMap.getString("editHits.text"));
+                menuItem.setActionCommand(CMD_EDIT_HITS);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+            }
+
+            menuItem = new JMenuItem(resourceMap.getString("add1XP.text"));
+            menuItem.setActionCommand(CMD_ADD_1_XP);
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+
+            menuItem = new JMenuItem(resourceMap.getString("addXP.text"));
+            menuItem.setActionCommand(CMD_ADD_XP);
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+
+            menuItem = new JMenuItem(resourceMap.getString("setXP.text"));
+            menuItem.setActionCommand(CMD_SET_XP);
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+
+            if (gui.getCampaign().getCampaignOptions().useEdge()) {
+                menuItem = new JMenuItem(resourceMap.getString("setEdge.text"));
+                menuItem.setActionCommand(CMD_SET_EDGE);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+            }
+
+            if (oneSelected) {
+                menuItem = new JMenuItem(resourceMap.getString("edit.text"));
+                menuItem.setActionCommand(CMD_EDIT);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+
+                menuItem = new JMenuItem(resourceMap.getString("loadGMTools.text"));
+                menuItem.addActionListener(evt -> loadGMToolsForPerson(person));
+                menu.add(menuItem);
+            }
+            if (gui.getCampaign().getCampaignOptions().useAdvancedMedical()) {
+                menuItem = new JMenuItem(resourceMap.getString("removeAllInjuries.text"));
+                menuItem.setActionCommand(CMD_CLEAR_INJURIES);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+
+                if (oneSelected) {
+                    for (Injury i : person.getInjuries()) {
+                        menuItem = new JMenuItem(String.format(resourceMap.getString("removeInjury.format"), i.getName()));
+                        menuItem.setActionCommand(makeCommand(CMD_REMOVE_INJURY, i.getUUID().toString()));
+                        menuItem.addActionListener(this);
+                        menu.add(menuItem);
+                    }
+
+                    menuItem = new JMenuItem(resourceMap.getString("editInjuries.text"));
+                    menuItem.setActionCommand(CMD_EDIT_INJURIES);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+            }
+
+            if (oneSelected) {
+                if (person.canProcreate(gui.getCampaign())) {
+                    menuItem = new JMenuItem(resourceMap.getString("addPregnancy.text"));
+                    menuItem.setActionCommand(CMD_ADD_PREGNANCY);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                } else if (person.isPregnant()) {
+                    menuItem = new JMenuItem(resourceMap.getString("removePregnancy.text"));
+                    menuItem.setActionCommand(CMD_REMOVE_PREGNANCY);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+            }
+            popup.add(menu);
+        }
+        //endregion GM Menu
+
+        return popup;
     }
 
     private JMenuItem newMenuItem(String text, String command) {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -32,7 +32,6 @@ import megamek.client.ui.swing.dialog.imageChooser.AbstractIconChooserDialog;
 import megamek.client.ui.swing.dialog.imageChooser.PortraitChooserDialog;
 import megamek.client.ui.swing.util.MenuScroller;
 import megamek.common.*;
-import megamek.common.annotations.Nullable;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
@@ -1138,15 +1137,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        return personnelTable.getSelectedRowCount() > 0;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         if (personnelTable.getSelectedRowCount() == 0) {
-            return null;
+            return Optional.empty();
         }
 
         JPopupMenu popup = new JPopupMenu();
@@ -2706,7 +2699,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         }
         //endregion GM Menu
 
-        return popup;
+        return Optional.of(popup);
     }
 
     private JMenuItem newMenuItem(String text, String command) {

--- a/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
@@ -1,16 +1,12 @@
 package mekhq.gui.adapter;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
-
-import javax.swing.AbstractAction;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
-import javax.swing.event.MouseInputAdapter;
 
 import megamek.common.Entity;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.ProcurementEvent;
 import mekhq.campaign.parts.Part;
@@ -18,128 +14,118 @@ import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.model.ProcurementTableModel;
 
-public class ProcurementTableMouseAdapter extends MouseInputAdapter {
-    private CampaignGUI gui;
+public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
+    private final CampaignGUI gui;
+    private final JTable table;
+    private final ProcurementTableModel model;
 
-    public ProcurementTableMouseAdapter(CampaignGUI gui) {
-        super();
+    protected ProcurementTableMouseAdapter(CampaignGUI gui, JTable table, ProcurementTableModel model) {
         this.gui = gui;
+        this.table = table;
+        this.model = model;
+    }
+
+    public static void connect(CampaignGUI gui, JTable table, ProcurementTableModel model) {
+        new ProcurementTableMouseAdapter(gui, table, model)
+                .connect(table);
     }
 
     @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
+    protected boolean shouldShowPopup() {
+        // GM Only (for now)
+        return (table.getSelectedRowCount() > 0)
+                && gui.getCampaign().isGM();
     }
 
     @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
-    }
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        // GM Only (for now)
+        if ((table.getSelectedRowCount() == 0) || !gui.getCampaign().isGM()) {
+            return null;
+        }
 
-    @SuppressWarnings("serial")
-    private void maybeShowPopup(MouseEvent e) {
         JPopupMenu popup = new JPopupMenu();
         JMenuItem menuItem;
         JMenu menu;
-        final JTable table = (JTable) e.getSource();
-        final ProcurementTableModel model = (ProcurementTableModel) table
-                .getModel();
-        if (table.getSelectedRow() < 0) {
-            return;
-        }
-        if (table.getSelectedRowCount() == 0) {
-            return;
-        }
-        final int row = table
-                .convertRowIndexToModel(table.getSelectedRow());
+        final int row = table.convertRowIndexToModel(table.getSelectedRow());
         final int[] rows = table.getSelectedRows();
         final boolean oneSelected = table.getSelectedRowCount() == 1;
         
-        // GM Only (for now)
-        if (e.isPopupTrigger() && gui.getCampaign().isGM()) {
-            // **lets fill the pop up menu**//
-            // GM mode
-            menu = new JMenu("GM Mode");
+        // **lets fill the pop up menu**//
+        // GM mode
+        menu = new JMenu("GM Mode");
 
-            menuItem = new JMenuItem("Procure single item now");
-            menuItem.addActionListener(new AbstractAction() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    if (row < 0) {
-                        return;
+        menuItem = new JMenuItem("Procure single item now");
+        menuItem.addActionListener(evt -> {
+            if (row < 0) {
+                return;
+            }
+            if (oneSelected) {
+                model.getAcquisition(row)
+                        .ifPresent(ProcurementTableMouseAdapter.this::tryProcureOneItem);
+            } else {
+                for (int curRow : rows) {
+                    if (curRow < 0) {
+                        continue;
                     }
-                    if (oneSelected) {
-                        model.getAcquisition(row)
-                                .ifPresent(ProcurementTableMouseAdapter.this::tryProcureOneItem);
-                    } else {
-                        for (int curRow : rows) {
-                            if (curRow < 0) {
-                                continue;
-                            }
-                            model.getAcquisition(table.convertRowIndexToModel(curRow))
-                                    .ifPresent(ProcurementTableMouseAdapter.this::tryProcureOneItem);
-                        }
-                    }
+                    model.getAcquisition(table.convertRowIndexToModel(curRow))
+                            .ifPresent(ProcurementTableMouseAdapter.this::tryProcureOneItem);
                 }
-            });
-            menuItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(menuItem);
-            menuItem = new JMenuItem("Procure all items now");
-            menuItem.addActionListener(new AbstractAction() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    if (row < 0) {
-                        return;
+            }
+        });
+        menuItem.setEnabled(gui.getCampaign().isGM());
+        menu.add(menuItem);
+        menuItem = new JMenuItem("Procure all items now");
+        menuItem.addActionListener(evt -> {
+            if (row < 0) {
+                return;
+            }
+            if (oneSelected) {
+                model.getAcquisition(row)
+                        .ifPresent(ProcurementTableMouseAdapter.this::procureAllItems);
+            } else {
+                for (int curRow : rows) {
+                    if (curRow < 0) {
+                        continue;
                     }
-                    if (oneSelected) {
-                        model.getAcquisition(row)
-                                .ifPresent(ProcurementTableMouseAdapter.this::procureAllItems);
-                    } else {
-                        for (int curRow : rows) {
-                            if (curRow < 0) {
-                                continue;
-                            }
-                            model.getAcquisition(table.convertRowIndexToModel(curRow))
-                                    .ifPresent(ProcurementTableMouseAdapter.this::procureAllItems);
-                        }
-                    }
+                    model.getAcquisition(table.convertRowIndexToModel(curRow))
+                            .ifPresent(ProcurementTableMouseAdapter.this::procureAllItems);
                 }
-            });
-            menuItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(menuItem);
-            menuItem = new JMenuItem("Clear From the List");
-            menuItem.addActionListener(new AbstractAction() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    if (row < 0) {
-                        return;
+            }
+        });
+        menuItem.setEnabled(gui.getCampaign().isGM());
+        menu.add(menuItem);
+        menuItem = new JMenuItem("Clear From the List");
+        menuItem.addActionListener(evt -> {
+            if (row < 0) {
+                return;
+            }
+            if (oneSelected) {
+                model.getAcquisition(row).ifPresent(a -> {
+                    model.removeRow(row);
+                    MekHQ.triggerEvent(new ProcurementEvent(a));
+                });
+            } else {
+                for (int curRow : rows) {
+                    if (curRow < 0) {
+                        continue;
                     }
-                    if (oneSelected) {
-                        model.getAcquisition(row).ifPresent(a -> {
-                            model.removeRow(row);
-                            MekHQ.triggerEvent(new ProcurementEvent(a));
-                        });
-                    } else {
-                        for (int curRow : rows) {
-                            if (curRow < 0) {
-                                continue;
-                            }
-                            model.getAcquisition(table.convertRowIndexToModel(curRow))
-                                    .ifPresent(a -> {
-                                        model.removeRow(row);
-                                        MekHQ.triggerEvent(new ProcurementEvent(a));
-                                    });
-                        }
-                    }
+                    model.getAcquisition(table.convertRowIndexToModel(curRow))
+                            .ifPresent(a -> {
+                                model.removeRow(row);
+                                MekHQ.triggerEvent(new ProcurementEvent(a));
+                            });
                 }
-            });
-            menuItem.setEnabled(gui.getCampaign().isGM());
-            menu.add(menuItem);
-            // end
-            popup.addSeparator();
-            popup.add(menu);
-            popup.show(e.getComponent(), e.getX(), e.getY());
-        }
+            }
+        });
+        menuItem.setEnabled(gui.getCampaign().isGM());
+        menu.add(menuItem);
+        // end
+        popup.addSeparator();
+        popup.add(menu);
+
+        return popup;
     }
 
     private void procureAllItems(IAcquisitionWork acquisition) {

--- a/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
@@ -1,12 +1,13 @@
 package mekhq.gui.adapter;
 
+import java.util.Optional;
+
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
 import megamek.common.Entity;
-import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.ProcurementEvent;
 import mekhq.campaign.parts.Part;
@@ -31,18 +32,10 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        // GM Only (for now)
-        return (table.getSelectedRowCount() > 0)
-                && gui.getCampaign().isGM();
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         // GM Only (for now)
         if ((table.getSelectedRowCount() == 0) || !gui.getCampaign().isGM()) {
-            return null;
+            return Optional.empty();
         }
 
         JPopupMenu popup = new JPopupMenu();
@@ -74,7 +67,6 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
                 }
             }
         });
-        menuItem.setEnabled(gui.getCampaign().isGM());
         menu.add(menuItem);
         menuItem = new JMenuItem("Procure all items now");
         menuItem.addActionListener(evt -> {
@@ -94,7 +86,6 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
                 }
             }
         });
-        menuItem.setEnabled(gui.getCampaign().isGM());
         menu.add(menuItem);
         menuItem = new JMenuItem("Clear From the List");
         menuItem.addActionListener(evt -> {
@@ -119,13 +110,11 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
                 }
             }
         });
-        menuItem.setEnabled(gui.getCampaign().isGM());
         menu.add(menuItem);
         // end
-        popup.addSeparator();
         popup.add(menu);
 
-        return popup;
+        return Optional.of(popup);
     }
 
     private void procureAllItems(IAcquisitionWork acquisition) {

--- a/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
@@ -18,15 +18,13 @@
  */
 package mekhq.gui.adapter;
 
-import java.awt.event.MouseEvent;
-
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
-import javax.swing.event.MouseInputAdapter;
 
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.ScenarioChangedEvent;
 import mekhq.campaign.mission.Mission;
@@ -35,61 +33,62 @@ import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.CustomizeScenarioDialog;
 import mekhq.gui.model.ScenarioTableModel;
 
-public class ScenarioTableMouseAdapter extends MouseInputAdapter {
+public class ScenarioTableMouseAdapter extends JPopupMenuAdapter {
     //region Variable Declarations
     private CampaignGUI gui;
     private JTable scenarioTable;
     private ScenarioTableModel scenarioModel;
     //endregion Variable Declarations
 
-    public ScenarioTableMouseAdapter(CampaignGUI gui, JTable scenarioTable, ScenarioTableModel scenarioModel) {
-        super();
+    protected ScenarioTableMouseAdapter(CampaignGUI gui, JTable scenarioTable, ScenarioTableModel scenarioModel) {
         this.gui = gui;
         this.scenarioTable = scenarioTable;
         this.scenarioModel = scenarioModel;
     }
 
-    @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
+    public static void connect(CampaignGUI gui, JTable scenarioTable, ScenarioTableModel scenarioModel) {
+        new ScenarioTableMouseAdapter(gui, scenarioTable, scenarioModel)
+                .connect(scenarioTable);
     }
 
     @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
+    protected boolean shouldShowPopup() {
+        return scenarioTable.getSelectedRowCount() > 0;
     }
 
-    private void maybeShowPopup(MouseEvent e) {
-        JPopupMenu popup = new JPopupMenu();
-        if (e.isPopupTrigger() && (scenarioTable.getSelectedRowCount() > 0)) {
-            int row = scenarioTable.getSelectedRow();
-            if (row < 0) {
-                return;
-            }
-            Scenario scenario = scenarioModel.getScenario(scenarioTable.convertRowIndexToModel(row));
-            JMenuItem menuItem;
-            JMenu menu;
-
-            // lets fill the pop up menu
-            menuItem = new JMenuItem("Edit...");
-            menuItem.addActionListener(evt -> editScenario(scenario));
-            popup.add(menuItem);
-
-            //region GM mode
-            if (gui.getCampaign().isGM()) {
-                popup.addSeparator();
-
-                menu = new JMenu("GM Mode");
-                // remove scenario
-                menuItem = new JMenuItem("Remove Scenario");
-                menuItem.addActionListener(evt -> removeScenario(scenario));
-                menu.add(menuItem);
-
-                popup.add(menu);
-            }
-
-            popup.show(e.getComponent(), e.getX(), e.getY());
+    @Override
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        int row = scenarioTable.getSelectedRow();
+        if (row < 0) {
+            return null;
         }
+        
+        JPopupMenu popup = new JPopupMenu();
+
+        Scenario scenario = scenarioModel.getScenario(scenarioTable.convertRowIndexToModel(row));
+        JMenuItem menuItem;
+        JMenu menu;
+
+        // lets fill the pop up menu
+        menuItem = new JMenuItem("Edit...");
+        menuItem.addActionListener(evt -> editScenario(scenario));
+        popup.add(menuItem);
+
+        //region GM mode
+        if (gui.getCampaign().isGM()) {
+            popup.addSeparator();
+
+            menu = new JMenu("GM Mode");
+            // remove scenario
+            menuItem = new JMenuItem("Remove Scenario");
+            menuItem.addActionListener(evt -> removeScenario(scenario));
+            menu.add(menuItem);
+
+            popup.add(menu);
+        }
+
+        return popup;
     }
 
     private void editScenario(Scenario scenario) {

--- a/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
@@ -18,13 +18,14 @@
  */
 package mekhq.gui.adapter;
 
+import java.util.Optional;
+
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
-import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.ScenarioChangedEvent;
 import mekhq.campaign.mission.Mission;
@@ -52,16 +53,10 @@ public class ScenarioTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        return scenarioTable.getSelectedRowCount() > 0;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         int row = scenarioTable.getSelectedRow();
         if (row < 0) {
-            return null;
+            return Optional.empty();
         }
         
         JPopupMenu popup = new JPopupMenu();
@@ -88,7 +83,7 @@ public class ScenarioTableMouseAdapter extends JPopupMenuAdapter {
             popup.add(menu);
         }
 
-        return popup;
+        return Optional.of(popup);
     }
 
     private void editScenario(Scenario scenario) {

--- a/MekHQ/src/mekhq/gui/adapter/ServicedUnitsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ServicedUnitsTableMouseAdapter.java
@@ -19,8 +19,6 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
@@ -28,10 +26,9 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
-import javax.swing.event.MouseInputAdapter;
 
-import megamek.client.ui.swing.util.MenuScroller;
 import megamek.common.AmmoType;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.event.RepairStatusChangedEvent;
@@ -47,21 +44,25 @@ import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.StaticChecks;
 import mekhq.service.MassRepairService;
 
-public class ServicedUnitsTableMouseAdapter extends MouseInputAdapter
-        implements ActionListener {
+public class ServicedUnitsTableMouseAdapter extends JPopupMenuAdapter {
 
     private CampaignGUI gui;
     private JTable servicedUnitTable;
     private UnitTableModel servicedUnitModel;
 
-    public ServicedUnitsTableMouseAdapter(CampaignGUI gui, JTable servicedUnitTable,
+    protected ServicedUnitsTableMouseAdapter(CampaignGUI gui, JTable servicedUnitTable,
             UnitTableModel servicedUnitModel) {
-        super();
         this.gui = gui;
         this.servicedUnitTable = servicedUnitTable;
         this.servicedUnitModel = servicedUnitModel;
     }
 
+    public static void connect(CampaignGUI gui, JTable servicedUnitTable, UnitTableModel servicedUnitModel) {
+        new ServicedUnitsTableMouseAdapter(gui, servicedUnitTable, servicedUnitModel)
+                .connect(servicedUnitTable);
+    }
+
+    @Override
     public void actionPerformed(ActionEvent action) {
         String command = action.getActionCommand();
         @SuppressWarnings("unused")
@@ -139,125 +140,121 @@ public class ServicedUnitsTableMouseAdapter extends MouseInputAdapter
     }
 
     @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
+    protected boolean shouldShowPopup() {
+        return servicedUnitTable.getSelectedRowCount() > 0;
     }
 
     @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
-    }
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        if (servicedUnitTable.getSelectedRowCount() == 0) {
+            return null;
+        }
 
-    private void maybeShowPopup(MouseEvent e) {
         JPopupMenu popup = new JPopupMenu();
-        if (e.isPopupTrigger()) {
-            if (servicedUnitTable.getSelectedRowCount() == 0) {
-                return;
+
+        int[] rows = servicedUnitTable.getSelectedRows();
+        int row = servicedUnitTable.getSelectedRow();
+        boolean oneSelected = servicedUnitTable.getSelectedRowCount() == 1;
+        Unit unit = servicedUnitModel.getUnit(servicedUnitTable
+                .convertRowIndexToModel(row));
+        Unit[] units = new Unit[rows.length];
+        for (int i = 0; i < rows.length; i++) {
+            units[i] = servicedUnitModel.getUnit(servicedUnitTable
+                    .convertRowIndexToModel(rows[i]));
+        }
+        JMenuItem menuItem;
+        JMenu menu;
+        JCheckBoxMenuItem cbMenuItem;
+        // **lets fill the pop up menu**//
+        // change the location
+        menu = new JMenu("Change site");
+        int i;
+        for (i = 0; i < Unit.SITE_N; i++) {
+            cbMenuItem = new JCheckBoxMenuItem(Unit.getSiteName(i));
+            if (StaticChecks.areAllSameSite(units) && unit.getSite() == i) {
+                cbMenuItem.setSelected(true);
+            } else {
+                cbMenuItem.setActionCommand("CHANGE_SITE:" + i);
+                cbMenuItem.addActionListener(this);
             }
-            int[] rows = servicedUnitTable.getSelectedRows();
-            int row = servicedUnitTable.getSelectedRow();
-            boolean oneSelected = servicedUnitTable.getSelectedRowCount() == 1;
-            Unit unit = servicedUnitModel.getUnit(servicedUnitTable
-                    .convertRowIndexToModel(row));
-            Unit[] units = new Unit[rows.length];
-            for (int i = 0; i < rows.length; i++) {
-                units[i] = servicedUnitModel.getUnit(servicedUnitTable
-                        .convertRowIndexToModel(rows[i]));
-            }
-            JMenuItem menuItem;
-            JMenu menu;
-            JCheckBoxMenuItem cbMenuItem;
-            // **lets fill the pop up menu**//
-            // change the location
-            menu = new JMenu("Change site");
-            int i;
-            for (i = 0; i < Unit.SITE_N; i++) {
-                cbMenuItem = new JCheckBoxMenuItem(Unit.getSiteName(i));
-                if (StaticChecks.areAllSameSite(units) && unit.getSite() == i) {
-                    cbMenuItem.setSelected(true);
-                } else {
-                    cbMenuItem.setActionCommand("CHANGE_SITE:" + i);
-                    cbMenuItem.addActionListener(this);
+            menu.add(cbMenuItem);
+        }
+        menu.setEnabled(unit.isAvailable());
+        popup.add(menu);
+        // assign all tasks to a certain tech
+        /*
+            * menu = new JMenu("Assign all tasks"); i = 0; for (Person tech
+            * : gui.getCampaign().getTechs()) { menuItem = new
+            * JMenuItem(tech.getFullName());
+            * menuItem.setActionCommand("ASSIGN_TECH:" + i);
+            * menuItem.addActionListener(this);
+            * menuItem.setEnabled(tech.getMinutesLeft() > 0);
+            * menu.add(menuItem); i++; }
+            * menu.setEnabled(unit.isAvailable()); if (menu.getItemCount()
+            * > 20) { MenuScroller.setScrollerFor(menu, 20); }
+            * popup.add(menu);
+            */
+        // swap ammo
+        if (oneSelected) {
+            if (unit.getEntity().usesWeaponBays()) {
+                menuItem = new JMenuItem("Swap ammo...");
+                menuItem.setActionCommand("LC_SWAP_AMMO");
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            } else {
+                menu = new JMenu("Swap ammo");
+                JMenu ammoMenu;
+                for (AmmoBin ammo : unit.getWorkingAmmoBins()) {
+                    ammoMenu = new JMenu(ammo.getType().getDesc());
+                    AmmoType curType = ammo.getType();
+                    for (AmmoType atype : Utilities.getMunitionsFor(unit
+                            .getEntity(), curType, gui.getCampaign()
+                            .getCampaignOptions().getTechLevel())) {
+                        cbMenuItem = new JCheckBoxMenuItem(atype.getDesc());
+                        if (atype.equals(curType)) {
+                            cbMenuItem.setSelected(true);
+                        } else {
+                            cbMenuItem.addActionListener(evt -> {
+                                IUnitAction swapAmmoTypeAction = new SwapAmmoTypeAction(ammo, atype);
+                                swapAmmoTypeAction.execute(gui.getCampaign(), unit);
+                            });
+                        }
+                        ammoMenu.add(cbMenuItem);
+                        i++;
+                    }
+                    JMenuHelpers.addMenuIfNonEmpty(menu, ammoMenu);
                 }
-                menu.add(cbMenuItem);
             }
             menu.setEnabled(unit.isAvailable());
-            popup.add(menu);
-            // assign all tasks to a certain tech
-            /*
-             * menu = new JMenu("Assign all tasks"); i = 0; for (Person tech
-             * : gui.getCampaign().getTechs()) { menuItem = new
-             * JMenuItem(tech.getFullName());
-             * menuItem.setActionCommand("ASSIGN_TECH:" + i);
-             * menuItem.addActionListener(this);
-             * menuItem.setEnabled(tech.getMinutesLeft() > 0);
-             * menu.add(menuItem); i++; }
-             * menu.setEnabled(unit.isAvailable()); if (menu.getItemCount()
-             * > 20) { MenuScroller.setScrollerFor(menu, 20); }
-             * popup.add(menu);
-             */
-            // swap ammo
-            if (oneSelected) {
-                if (unit.getEntity().usesWeaponBays()) {
-                    menuItem = new JMenuItem("Swap ammo...");
-                    menuItem.setActionCommand("LC_SWAP_AMMO");
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                } else {
-                    menu = new JMenu("Swap ammo");
-                    JMenu ammoMenu;
-                    for (AmmoBin ammo : unit.getWorkingAmmoBins()) {
-                        ammoMenu = new JMenu(ammo.getType().getDesc());
-                        AmmoType curType = ammo.getType();
-                        for (AmmoType atype : Utilities.getMunitionsFor(unit
-                                .getEntity(), curType, gui.getCampaign()
-                                .getCampaignOptions().getTechLevel())) {
-                            cbMenuItem = new JCheckBoxMenuItem(atype.getDesc());
-                            if (atype.equals(curType)) {
-                                cbMenuItem.setSelected(true);
-                            } else {
-                                cbMenuItem.addActionListener(evt -> {
-                                    IUnitAction swapAmmoTypeAction = new SwapAmmoTypeAction(ammo, atype);
-                                    swapAmmoTypeAction.execute(gui.getCampaign(), unit);
-                                });
-                            }
-                            ammoMenu.add(cbMenuItem);
-                            i++;
-                        }
-                        JMenuHelpers.addMenuIfNonEmpty(menu, ammoMenu);
-                    }
-                }
-                menu.setEnabled(unit.isAvailable());
-                JMenuHelpers.addMenuIfNonEmpty(popup, menu);
-                // Salvage / Repair
-                if (unit.isSalvage()) {
-                    menuItem = new JMenuItem("Repair");
-                    menuItem.setActionCommand("REPAIR");
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(unit.isAvailable()
-                            && unit.isRepairable());
-                    popup.add(menuItem);
-                } else {
-                    menuItem = new JMenuItem("Salvage");
-                    menuItem.setActionCommand("SALVAGE");
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(unit.isAvailable());
-                    popup.add(menuItem);
-                }
+            JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+            // Salvage / Repair
+            if (unit.isSalvage()) {
+                menuItem = new JMenuItem("Repair");
+                menuItem.setActionCommand("REPAIR");
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(unit.isAvailable()
+                        && unit.isRepairable());
+                popup.add(menuItem);
+            } else {
+                menuItem = new JMenuItem("Salvage");
+                menuItem.setActionCommand("SALVAGE");
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(unit.isAvailable());
+                popup.add(menuItem);
+            }
 
-                if (!unit.isSelfCrewed() && unit.isAvailable() && !unit.isDeployed()) {
-                	String title = String.format("Mass %s", unit.isSalvage() ? "Salvage" : "Repair");
+            if (!unit.isSelfCrewed() && unit.isAvailable() && !unit.isDeployed()) {
+                String title = String.format("Mass %s", unit.isSalvage() ? "Salvage" : "Repair");
 
-                    menuItem = new JMenuItem(title);
-                    menuItem.setActionCommand("MASS_REPAIR_SALVAGE");
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(unit.isAvailable());
-                    popup.add(menuItem);
-                }
-
-                popup.show(e.getComponent(), e.getX(), e.getY());
+                menuItem = new JMenuItem(title);
+                menuItem.setActionCommand("MASS_REPAIR_SALVAGE");
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(unit.isAvailable());
+                popup.add(menuItem);
             }
         }
-    }
 
+        return popup;
+    }
 }

--- a/MekHQ/src/mekhq/gui/adapter/ServicedUnitsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ServicedUnitsTableMouseAdapter.java
@@ -19,6 +19,7 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
+import java.util.Optional;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
@@ -28,7 +29,6 @@ import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
 import megamek.common.AmmoType;
-import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.event.RepairStatusChangedEvent;
@@ -140,15 +140,9 @@ public class ServicedUnitsTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        return servicedUnitTable.getSelectedRowCount() > 0;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         if (servicedUnitTable.getSelectedRowCount() == 0) {
-            return null;
+            return Optional.empty();
         }
 
         JPopupMenu popup = new JPopupMenu();
@@ -255,6 +249,6 @@ public class ServicedUnitsTableMouseAdapter extends JPopupMenuAdapter {
             }
         }
 
-        return popup;
+        return Optional.of(popup);
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -593,15 +593,9 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        return tree.getSelectionPaths() != null;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         if (tree.getSelectionPaths() == null) {
-            return null;
+            return Optional.empty();
         }
 
         JPopupMenu popup = new JPopupMenu();
@@ -1485,7 +1479,8 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 popup.add(menuItem);
             }
         }
-        return popup;
+        
+        return Optional.of(popup);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -19,8 +19,6 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -29,7 +27,6 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
-import javax.swing.event.MouseInputAdapter;
 import javax.swing.tree.TreePath;
 
 import megamek.client.ui.swing.dialog.imageChooser.CamoChooserDialog;
@@ -65,12 +62,18 @@ import mekhq.gui.dialog.ImageChoiceDialog;
 import mekhq.gui.dialog.MarkdownEditorDialog;
 import mekhq.gui.utilities.StaticChecks;
 
-public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener {
-    private CampaignGUI gui;
+public class TOEMouseAdapter extends JPopupMenuAdapter {
+    private final CampaignGUI gui;
+    private final JTree tree;
 
-    public TOEMouseAdapter(CampaignGUI gui) {
-        super();
+    protected TOEMouseAdapter(CampaignGUI gui, JTree tree) {
         this.gui = gui;
+        this.tree = tree;
+    }
+
+    public static void connect(CampaignGUI gui, JTree tree) {
+        new TOEMouseAdapter(gui, tree)
+                .connect(tree);
     }
 
     //Named Constants for various commands
@@ -590,205 +593,277 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
     }
 
     @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
+    protected boolean shouldShowPopup() {
+        return tree.getSelectionPaths() != null;
     }
 
     @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
-    }
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        if (tree.getSelectionPaths() == null) {
+            return null;
+        }
 
-    private void maybeShowPopup(MouseEvent e) {
-        if (e.isPopupTrigger()) {
-            JPopupMenu popup = new JPopupMenu();
-            JMenuItem menuItem;
-            JMenu menu;
-            JTree tree = (JTree) e.getSource();
-            if ((tree == null) || (tree.getSelectionPaths() == null)) {
-                return;
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem menuItem;
+        JMenu menu;
+
+        // this is a little tricky because we want to
+        // distinguish forces and units, but the user can
+        // select multiple items of both types
+        // we will allow multiple selection of either units or forces
+        // but not both - if both are selected then default to
+        // unit and deselect all forces
+        Vector<Force> forces = new Vector<>();
+        Vector<Unit> unitsInForces = new Vector<>();
+        Vector<Unit> units = new Vector<>();
+        Vector<TreePath> uPath = new Vector<>();
+        for (TreePath path : tree.getSelectionPaths()) {
+            Object node = path.getLastPathComponent();
+            if (node instanceof Force) {
+                forces.add((Force) node);
             }
-            // this is a little tricky because we want to
-            // distinguish forces and units, but the user can
-            // select multiple items of both types
-            // we will allow multiple selection of either units or forces
-            // but not both - if both are selected then default to
-            // unit and deselect all forces
-            Vector<Force> forces = new Vector<>();
-            Vector<Unit> unitsInForces = new Vector<>();
-            Vector<Unit> units = new Vector<>();
-            Vector<TreePath> uPath = new Vector<>();
-            for (TreePath path : tree.getSelectionPaths()) {
-                Object node = path.getLastPathComponent();
-                if (node instanceof Force) {
-                    forces.add((Force) node);
-                }
-                if (node instanceof Unit) {
-                    units.add((Unit) node);
-                    uPath.add(path);
-                }
+            if (node instanceof Unit) {
+                units.add((Unit) node);
+                uPath.add(path);
             }
-            for (Force force: forces) {
-                for (UUID id : force.getAllUnits(false)) {
-                    Unit u = gui.getCampaign().getUnit(id);
-                    if (null != u) {
-                        unitsInForces.add(u);
-                    }
+        }
+        for (Force force: forces) {
+            for (UUID id : force.getAllUnits(false)) {
+                Unit u = gui.getCampaign().getUnit(id);
+                if (null != u) {
+                    unitsInForces.add(u);
                 }
             }
-            boolean forcesSelected = !forces.isEmpty();
-            boolean unitsSelected = !units.isEmpty();
-            // if both are selected then we prefer units
-            // and will deselect forces
-            if (forcesSelected & unitsSelected) {
-                forcesSelected = false;
-                TreePath[] paths = new TreePath[uPath.size()];
-                int i = 0;
-                for (TreePath p : uPath) {
-                    paths[i] = p;
-                    i++;
-                }
-                tree.setSelectionPaths(paths);
+        }
+        boolean forcesSelected = !forces.isEmpty();
+        boolean unitsSelected = !units.isEmpty();
+        // if both are selected then we prefer units
+        // and will deselect forces
+        if (forcesSelected & unitsSelected) {
+            forcesSelected = false;
+            TreePath[] paths = new TreePath[uPath.size()];
+            int i = 0;
+            for (TreePath p : uPath) {
+                paths[i] = p;
+                i++;
             }
-            boolean multipleSelection = (forcesSelected && forces.size() > 1) || (unitsSelected && units.size() > 1);
-            if (forcesSelected) {
-                Force force = forces.get(0);
-                StringBuilder forceIds = new StringBuilder("" + force.getId());
-                for (int i = 1; i < forces.size(); i++) {
-                    forceIds.append("|").append(forces.get(i).getId());
-                }
-                if (!multipleSelection) {
-                    menuItem = new JMenuItem("Change Name...");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_FORCE_NAME + forceIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    popup.add(menuItem);
-                    menuItem = new JMenuItem("Change Description...");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_FORCE_DESC + forceIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    popup.add(menuItem);
-                    menuItem = new JMenuItem("Add New Force...");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_FORCE + forceIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    popup.add(menuItem);
+            tree.setSelectionPaths(paths);
+        }
+        boolean multipleSelection = (forcesSelected && forces.size() > 1) || (unitsSelected && units.size() > 1);
+        if (forcesSelected) {
+            Force force = forces.get(0);
+            StringBuilder forceIds = new StringBuilder("" + force.getId());
+            for (int i = 1; i < forces.size(); i++) {
+                forceIds.append("|").append(forces.get(i).getId());
+            }
+            if (!multipleSelection) {
+                menuItem = new JMenuItem("Change Name...");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_FORCE_NAME + forceIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                popup.add(menuItem);
+                menuItem = new JMenuItem("Change Description...");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_FORCE_DESC + forceIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                popup.add(menuItem);
+                menuItem = new JMenuItem("Add New Force...");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_FORCE + forceIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                popup.add(menuItem);
 
-                    if (force.getTechID() == null) {
-                        menu = new JMenu("Add Tech to Force");
+                if (force.getTechID() == null) {
+                    menu = new JMenu("Add Tech to Force");
 
-                        JMenu mechTechs = new JMenu("Mech Techs");
-                        JMenu aeroTechs = new JMenu("Aero Techs");
-                        JMenu mechanics = new JMenu("Mechanics");
-                        JMenu baTechs = new JMenu("BA Techs");
+                    JMenu mechTechs = new JMenu("Mech Techs");
+                    JMenu aeroTechs = new JMenu("Aero Techs");
+                    JMenu mechanics = new JMenu("Mechanics");
+                    JMenu baTechs = new JMenu("BA Techs");
 
-                        int role;
-                        int previousRole = Person.T_MECH_TECH;
+                    int role;
+                    int previousRole = Person.T_MECH_TECH;
 
-                        JMenu eliteMenu = new JMenu(SkillType.ELITE_NM);
-                        JMenu veteranMenu = new JMenu(SkillType.VETERAN_NM);
-                        JMenu regularMenu = new JMenu(SkillType.REGULAR_NM);
-                        JMenu greenMenu = new JMenu(SkillType.GREEN_NM);
-                        JMenu ultraGreenMenu = new JMenu(SkillType.ULTRA_GREEN_NM);
-                        JMenu currentMenu = mechTechs;
+                    JMenu eliteMenu = new JMenu(SkillType.ELITE_NM);
+                    JMenu veteranMenu = new JMenu(SkillType.VETERAN_NM);
+                    JMenu regularMenu = new JMenu(SkillType.REGULAR_NM);
+                    JMenu greenMenu = new JMenu(SkillType.GREEN_NM);
+                    JMenu ultraGreenMenu = new JMenu(SkillType.ULTRA_GREEN_NM);
+                    JMenu currentMenu = mechTechs;
 
-                        // Get the list of techs, then sort them based on their tech role
-                        List<Person> techList = gui.getCampaign().getTechs();
-                        techList.sort((o1, o2) -> {
-                            int r1 = o1.isTechPrimary() ? o1.getPrimaryRole() : o1.getSecondaryRole();
-                            int r2 = o2.isTechPrimary() ? o2.getPrimaryRole() : o2.getSecondaryRole();
-                            return r1 - r2;
-                        });
-                        for (Person tech : techList) {
-                            if ((tech.getMaintenanceTimeUsing() == 0) && !tech.isEngineer()) {
-                                role = tech.isTechPrimary() ? tech.getPrimaryRole() : tech.getSecondaryRole();
-                                String skillLvl = SkillType.getExperienceLevelName(tech.getExperienceLevel(!tech.isTechPrimary()));
+                    // Get the list of techs, then sort them based on their tech role
+                    List<Person> techList = gui.getCampaign().getTechs();
+                    techList.sort((o1, o2) -> {
+                        int r1 = o1.isTechPrimary() ? o1.getPrimaryRole() : o1.getSecondaryRole();
+                        int r2 = o2.isTechPrimary() ? o2.getPrimaryRole() : o2.getSecondaryRole();
+                        return r1 - r2;
+                    });
+                    for (Person tech : techList) {
+                        if ((tech.getMaintenanceTimeUsing() == 0) && !tech.isEngineer()) {
+                            role = tech.isTechPrimary() ? tech.getPrimaryRole() : tech.getSecondaryRole();
+                            String skillLvl = SkillType.getExperienceLevelName(tech.getExperienceLevel(!tech.isTechPrimary()));
 
-                                // We need to add all the non-empty menus to the current menu, then
-                                // the current menu must be added to the main menu if the role changes
-                                // This enables us to use significantly less code to do the same thing
-                                if (role > previousRole) {
-                                    previousRole = role;
+                            // We need to add all the non-empty menus to the current menu, then
+                            // the current menu must be added to the main menu if the role changes
+                            // This enables us to use significantly less code to do the same thing
+                            if (role > previousRole) {
+                                previousRole = role;
 
-                                    // Adding menus if they aren't empty and adding scrollbars if they
-                                    // contain more than MAX_POPUP_ITEMS items
-                                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, eliteMenu, MAX_POPUP_ITEMS);
-                                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, veteranMenu, MAX_POPUP_ITEMS);
-                                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, regularMenu, MAX_POPUP_ITEMS);
-                                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, greenMenu, MAX_POPUP_ITEMS);
-                                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, ultraGreenMenu, MAX_POPUP_ITEMS);
-                                    JMenuHelpers.addMenuIfNonEmpty(menu, currentMenu, MAX_POPUP_ITEMS);
+                                // Adding menus if they aren't empty and adding scrollbars if they
+                                // contain more than MAX_POPUP_ITEMS items
+                                JMenuHelpers.addMenuIfNonEmpty(currentMenu, eliteMenu, MAX_POPUP_ITEMS);
+                                JMenuHelpers.addMenuIfNonEmpty(currentMenu, veteranMenu, MAX_POPUP_ITEMS);
+                                JMenuHelpers.addMenuIfNonEmpty(currentMenu, regularMenu, MAX_POPUP_ITEMS);
+                                JMenuHelpers.addMenuIfNonEmpty(currentMenu, greenMenu, MAX_POPUP_ITEMS);
+                                JMenuHelpers.addMenuIfNonEmpty(currentMenu, ultraGreenMenu, MAX_POPUP_ITEMS);
+                                JMenuHelpers.addMenuIfNonEmpty(menu, currentMenu, MAX_POPUP_ITEMS);
 
-                                    eliteMenu = new JMenu(SkillType.ELITE_NM);
-                                    veteranMenu = new JMenu(SkillType.VETERAN_NM);
-                                    regularMenu = new JMenu(SkillType.REGULAR_NM);
-                                    greenMenu = new JMenu(SkillType.GREEN_NM);
-                                    ultraGreenMenu = new JMenu(SkillType.ULTRA_GREEN_NM);
-                                    switch (role) {
-                                        case Person.T_MECHANIC:
-                                            currentMenu = mechanics;
-                                            break;
-                                        case Person.T_AERO_TECH:
-                                            currentMenu = aeroTechs;
-                                            break;
-                                        case Person.T_BA_TECH:
-                                            currentMenu = baTechs;
-                                            break;
-                                    }
-                                }
-
-                                menuItem = new JMenuItem(tech.getFullTitle() + " (" + tech.getRoleDesc() + ")");
-                                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_LANCE_TECH + tech.getId() + "|" + forceIds);
-                                menuItem.addActionListener(this);
-                                switch (skillLvl) {
-                                    case SkillType.ELITE_NM:
-                                        eliteMenu.add(menuItem);
+                                eliteMenu = new JMenu(SkillType.ELITE_NM);
+                                veteranMenu = new JMenu(SkillType.VETERAN_NM);
+                                regularMenu = new JMenu(SkillType.REGULAR_NM);
+                                greenMenu = new JMenu(SkillType.GREEN_NM);
+                                ultraGreenMenu = new JMenu(SkillType.ULTRA_GREEN_NM);
+                                switch (role) {
+                                    case Person.T_MECHANIC:
+                                        currentMenu = mechanics;
                                         break;
-                                    case SkillType.VETERAN_NM:
-                                        veteranMenu.add(menuItem);
+                                    case Person.T_AERO_TECH:
+                                        currentMenu = aeroTechs;
                                         break;
-                                    case SkillType.REGULAR_NM:
-                                        regularMenu.add(menuItem);
-                                        break;
-                                    case SkillType.GREEN_NM:
-                                        greenMenu.add(menuItem);
-                                        break;
-                                    case SkillType.ULTRA_GREEN_NM:
-                                        ultraGreenMenu.add(menuItem);
+                                    case Person.T_BA_TECH:
+                                        currentMenu = baTechs;
                                         break;
                                 }
                             }
-                        }
 
-                        // We need to add the last role to the menu after we assign the last tech
-                        JMenuHelpers.addMenuIfNonEmpty(currentMenu, eliteMenu, MAX_POPUP_ITEMS);
-                        JMenuHelpers.addMenuIfNonEmpty(currentMenu, veteranMenu, MAX_POPUP_ITEMS);
-                        JMenuHelpers.addMenuIfNonEmpty(currentMenu, regularMenu, MAX_POPUP_ITEMS);
-                        JMenuHelpers.addMenuIfNonEmpty(currentMenu, greenMenu, MAX_POPUP_ITEMS);
-                        JMenuHelpers.addMenuIfNonEmpty(currentMenu, ultraGreenMenu, MAX_POPUP_ITEMS);
-                        JMenuHelpers.addMenuIfNonEmpty(menu, currentMenu, MAX_POPUP_ITEMS);
-                        JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
-                    } else {
-                        menuItem = new JMenuItem("Remove Tech from Force");
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_LANCE_TECH + force.getTechID() + "|" + forceIds);
-                        menuItem.addActionListener(this);
-                        popup.add(menuItem);
+                            menuItem = new JMenuItem(tech.getFullTitle() + " (" + tech.getRoleDesc() + ")");
+                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_LANCE_TECH + tech.getId() + "|" + forceIds);
+                            menuItem.addActionListener(this);
+                            switch (skillLvl) {
+                                case SkillType.ELITE_NM:
+                                    eliteMenu.add(menuItem);
+                                    break;
+                                case SkillType.VETERAN_NM:
+                                    veteranMenu.add(menuItem);
+                                    break;
+                                case SkillType.REGULAR_NM:
+                                    regularMenu.add(menuItem);
+                                    break;
+                                case SkillType.GREEN_NM:
+                                    greenMenu.add(menuItem);
+                                    break;
+                                case SkillType.ULTRA_GREEN_NM:
+                                    ultraGreenMenu.add(menuItem);
+                                    break;
+                            }
+                        }
                     }
 
-                    menu = new JMenu("Add Unit");
-                    menu.setEnabled(false);
-                    HashMap<String, JMenu> unitTypeMenus = new HashMap<>();
-                    HashMap<String, JMenu> weightClassForUnitType = new HashMap<>();
-                    final List<Integer> svTypes = Arrays.asList(UnitType.TANK,
-                            UnitType.VTOL, UnitType.NAVAL, UnitType.CONV_FIGHTER);
+                    // We need to add the last role to the menu after we assign the last tech
+                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, eliteMenu, MAX_POPUP_ITEMS);
+                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, veteranMenu, MAX_POPUP_ITEMS);
+                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, regularMenu, MAX_POPUP_ITEMS);
+                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, greenMenu, MAX_POPUP_ITEMS);
+                    JMenuHelpers.addMenuIfNonEmpty(currentMenu, ultraGreenMenu, MAX_POPUP_ITEMS);
+                    JMenuHelpers.addMenuIfNonEmpty(menu, currentMenu, MAX_POPUP_ITEMS);
+                    JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+                } else {
+                    menuItem = new JMenuItem("Remove Tech from Force");
+                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_LANCE_TECH + force.getTechID() + "|" + forceIds);
+                    menuItem.addActionListener(this);
+                    popup.add(menuItem);
+                }
 
-                    for (int i = 0; i < UnitType.SIZE; i++)
-                    {
-                        String unittype = UnitType.getTypeName(i);
-                        String displayname = UnitType.getTypeDisplayableName(i);
-                        unitTypeMenus.put(unittype, new JMenu(displayname));
-                        unitTypeMenus.get(unittype).setName(unittype);
-                        unitTypeMenus.get(unittype).setEnabled(false);
+                menu = new JMenu("Add Unit");
+                menu.setEnabled(false);
+                HashMap<String, JMenu> unitTypeMenus = new HashMap<>();
+                HashMap<String, JMenu> weightClassForUnitType = new HashMap<>();
+                final List<Integer> svTypes = Arrays.asList(UnitType.TANK,
+                        UnitType.VTOL, UnitType.NAVAL, UnitType.CONV_FIGHTER);
+
+                for (int i = 0; i < UnitType.SIZE; i++)
+                {
+                    String unittype = UnitType.getTypeName(i);
+                    String displayname = UnitType.getTypeDisplayableName(i);
+                    unitTypeMenus.put(unittype, new JMenu(displayname));
+                    unitTypeMenus.get(unittype).setName(unittype);
+                    unitTypeMenus.get(unittype).setEnabled(false);
+                    for (int j = 0; j < EntityWeightClass.getWeightLimitByType(unittype).length; j++) {
+                        double tonnage = EntityWeightClass.getWeightLimitByType(unittype)[j];
+                        // Skip over the padding 0s
+                        if (tonnage == 0) {
+                            continue;
+                        }
+
+                        int weightClass = EntityWeightClass.getWeightClass(tonnage, unittype);
+                        String displayname2 = EntityWeightClass.getClassName(weightClass, unittype, false);
+                        String weightClassMenuName = unittype + "_"
+                                + EntityWeightClass.getClassName(weightClass, unittype, false);
+                        weightClassForUnitType.put(weightClassMenuName, new JMenu(displayname2));
+                        weightClassForUnitType.get(weightClassMenuName).setName(weightClassMenuName);
+                        weightClassForUnitType.get(weightClassMenuName).setEnabled(false);
+                    }
+                }
+
+                for (int wc = EntityWeightClass.WEIGHT_SMALL_SUPPORT; wc <= EntityWeightClass.WEIGHT_LARGE_SUPPORT; wc++) {
+                    for (int ut : svTypes) {
+                        String typeName = UnitType.getTypeName(ut);
+                        String wcName = EntityWeightClass.getClassName(wc, typeName, true);
+                        String menuName = typeName + "_" + wcName;
+                        JMenu m = new JMenu(wcName);
+                        m.setName(menuName);
+                        m.setEnabled(false);
+                        weightClassForUnitType.put(menuName, m);
+                    }
+                }
+
+                // Only add units that have commanders
+                // Or Gun Emplacements!
+                // TODO: Or Robotic Systems!
+                JMenu unsorted = new JMenu("Unsorted");
+
+                HangarSorter.weightSorted().forEachUnit(gui.getCampaign().getHangar(), u -> {
+                    String type = UnitType.getTypeName(u.getEntity().getUnitType());
+                    String className = u.getEntity().getWeightClassName();
+                    if (null != u.getCommander()) {
+                        Person p = u.getCommander();
+                        if (p.getStatus().isActive() && (u.getForceId() < 1) && u.isPresent()) {
+                            JMenuItem menuItem0 = new JMenuItem(p.getFullTitle() + ", " + u.getName());
+                            menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
+                            menuItem0.addActionListener(this);
+                            menuItem0.setEnabled(u.isAvailable());
+                            if (null != weightClassForUnitType.get(type + "_" + className)) {
+                                weightClassForUnitType.get(type + "_" + className).add(menuItem0);
+                                weightClassForUnitType.get(type + "_" + className).setEnabled(true);
+                            } else {
+                                unsorted.add(menuItem0);
+                            }
+                            unitTypeMenus.get(type).setEnabled(true);
+                        }
+                    }
+                    if (u.getEntity() instanceof GunEmplacement) {
+                        if (u.getForceId() < 1 && u.isPresent()) {
+                            JMenuItem menuItem0 = new JMenuItem("AutoTurret, " + u.getName());
+                            menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
+                            menuItem0.addActionListener(this);
+                            menuItem0.setEnabled(u.isAvailable());
+                            if (null != weightClassForUnitType.get(type + "_" + className)) {
+                                weightClassForUnitType.get(type + "_" + className).add(menuItem0);
+                                weightClassForUnitType.get(type + "_" + className).setEnabled(true);
+                            } else {
+                                unsorted.add(menuItem0);
+                            }
+                            unitTypeMenus.get(type).setEnabled(true);
+                        }
+                    }
+                });
+
+                for (int i = 0; i < UnitType.SIZE; i++)
+                {
+                    String unittype = UnitType.getTypeName(i);
+                    JMenu tmp = unitTypeMenus.get(UnitType.getTypeName(i));
+                    if (tmp.isEnabled()) {
                         for (int j = 0; j < EntityWeightClass.getWeightLimitByType(unittype).length; j++) {
                             double tonnage = EntityWeightClass.getWeightLimitByType(unittype)[j];
                             // Skip over the padding 0s
@@ -797,174 +872,459 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                             }
 
                             int weightClass = EntityWeightClass.getWeightClass(tonnage, unittype);
-                            String displayname2 = EntityWeightClass.getClassName(weightClass, unittype, false);
-                            String weightClassMenuName = unittype + "_"
-                                    + EntityWeightClass.getClassName(weightClass, unittype, false);
-                            weightClassForUnitType.put(weightClassMenuName, new JMenu(displayname2));
-                            weightClassForUnitType.get(weightClassMenuName).setName(weightClassMenuName);
-                            weightClassForUnitType.get(weightClassMenuName).setEnabled(false);
-                        }
-                    }
-
-                    for (int wc = EntityWeightClass.WEIGHT_SMALL_SUPPORT; wc <= EntityWeightClass.WEIGHT_LARGE_SUPPORT; wc++) {
-                        for (int ut : svTypes) {
-                            String typeName = UnitType.getTypeName(ut);
-                            String wcName = EntityWeightClass.getClassName(wc, typeName, true);
-                            String menuName = typeName + "_" + wcName;
-                            JMenu m = new JMenu(wcName);
-                            m.setName(menuName);
-                            m.setEnabled(false);
-                            weightClassForUnitType.put(menuName, m);
-                        }
-                    }
-
-                    // Only add units that have commanders
-                    // Or Gun Emplacements!
-                    // TODO: Or Robotic Systems!
-                    JMenu unsorted = new JMenu("Unsorted");
-
-                    HangarSorter.weightSorted().forEachUnit(gui.getCampaign().getHangar(), u -> {
-                        String type = UnitType.getTypeName(u.getEntity().getUnitType());
-                        String className = u.getEntity().getWeightClassName();
-                        if (null != u.getCommander()) {
-                            Person p = u.getCommander();
-                            if (p.getStatus().isActive() && (u.getForceId() < 1) && u.isPresent()) {
-                                JMenuItem menuItem0 = new JMenuItem(p.getFullTitle() + ", " + u.getName());
-                                menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
-                                menuItem0.addActionListener(this);
-                                menuItem0.setEnabled(u.isAvailable());
-                                if (null != weightClassForUnitType.get(type + "_" + className)) {
-                                    weightClassForUnitType.get(type + "_" + className).add(menuItem0);
-                                    weightClassForUnitType.get(type + "_" + className).setEnabled(true);
-                                } else {
-                                    unsorted.add(menuItem0);
-                                }
-                                unitTypeMenus.get(type).setEnabled(true);
+                            JMenu tmp2 = weightClassForUnitType.get(unittype + "_" + EntityWeightClass.getClassName(weightClass, unittype, false));
+                            if (tmp2.isEnabled()) {
+                                tmp.add(tmp2);
                             }
                         }
-                        if (u.getEntity() instanceof GunEmplacement) {
-                            if (u.getForceId() < 1 && u.isPresent()) {
-                                JMenuItem menuItem0 = new JMenuItem("AutoTurret, " + u.getName());
-                                menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
-                                menuItem0.addActionListener(this);
-                                menuItem0.setEnabled(u.isAvailable());
-                                if (null != weightClassForUnitType.get(type + "_" + className)) {
-                                    weightClassForUnitType.get(type + "_" + className).add(menuItem0);
-                                    weightClassForUnitType.get(type + "_" + className).setEnabled(true);
-                                } else {
-                                    unsorted.add(menuItem0);
-                                }
-                                unitTypeMenus.get(type).setEnabled(true);
-                            }
-                        }
-                    });
+                        menu.add(tmp);
+                        menu.setEnabled(true);
+                    }
+                }
 
-                    for (int i = 0; i < UnitType.SIZE; i++)
-                    {
-                        String unittype = UnitType.getTypeName(i);
-                        JMenu tmp = unitTypeMenus.get(UnitType.getTypeName(i));
-                        if (tmp.isEnabled()) {
-                            for (int j = 0; j < EntityWeightClass.getWeightLimitByType(unittype).length; j++) {
-                                double tonnage = EntityWeightClass.getWeightLimitByType(unittype)[j];
-                                // Skip over the padding 0s
-                                if (tonnage == 0) {
-                                    continue;
-                                }
-
-                                int weightClass = EntityWeightClass.getWeightClass(tonnage, unittype);
-                                JMenu tmp2 = weightClassForUnitType.get(unittype + "_" + EntityWeightClass.getClassName(weightClass, unittype, false));
-                                if (tmp2.isEnabled()) {
-                                    tmp.add(tmp2);
-                                }
+                for (int ut : svTypes) {
+                    String unittype = UnitType.getTypeName(ut);
+                    JMenu tmp = unitTypeMenus.get(UnitType.getTypeName(ut));
+                    if (tmp.isEnabled()) {
+                        for (int wc = EntityWeightClass.WEIGHT_SMALL_SUPPORT; wc <= EntityWeightClass.WEIGHT_LARGE_SUPPORT; wc++) {
+                            JMenu tmp2 = weightClassForUnitType.get(unittype + "_" + EntityWeightClass.getClassName(wc, unittype, true));
+                            if (tmp2.isEnabled()) {
+                                tmp.add(tmp2);
                             }
                             menu.add(tmp);
                             menu.setEnabled(true);
                         }
                     }
+                }
+                if (unsorted.getComponentCount() > 0 || unsorted.getItemCount() > 0) {
+                    menu.add(unsorted);
+                    menu.setEnabled(true);
+                }
+                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
 
-                    for (int ut : svTypes) {
-                        String unittype = UnitType.getTypeName(ut);
-                        JMenu tmp = unitTypeMenus.get(UnitType.getTypeName(ut));
-                        if (tmp.isEnabled()) {
-                            for (int wc = EntityWeightClass.WEIGHT_SMALL_SUPPORT; wc <= EntityWeightClass.WEIGHT_LARGE_SUPPORT; wc++) {
-                                JMenu tmp2 = weightClassForUnitType.get(unittype + "_" + EntityWeightClass.getClassName(wc, unittype, true));
-                                if (tmp2.isEnabled()) {
-                                    tmp.add(tmp2);
-                                }
-                                menu.add(tmp);
-                                menu.setEnabled(true);
+                menuItem = new JMenuItem("Change Force Icon...");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_FORCE_ICON + forceIds);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+
+                menuItem = new JMenuItem("Change Force Camo...");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_FORCE_CAMO + forceIds);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            menuItem = new JMenuItem(force.isCombatForce() ? "Make Non-Combat Force" : "Make Combat Force");
+            menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUS + forceIds);
+            menuItem.addActionListener(this);
+            popup.add(menuItem);
+
+            menuItem = new JMenuItem(force.isCombatForce() ? "Make Force and Subforces Non-Combat Forces" : "Make Force and Subforces Combat Forces");
+            menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUSES + forceIds);
+            menuItem.addActionListener(this);
+            popup.add(menuItem);
+
+            if (StaticChecks.areAllForcesUndeployed(forces) && StaticChecks.areAllCombatForces(forces)) {
+                menu = new JMenu("Deploy Force");
+                menu.setEnabled(false);
+                JMenu missionMenu;
+                for (Mission m : gui.getCampaign().getMissions()) {
+                    if (!m.isActive()) {
+                        continue;
+                    }
+                    missionMenu = new JMenu(m.getName());
+                    for (Scenario s : m.getScenarios()) {
+                        if (s.isCurrent()) {
+                            if (gui.getCampaign().getCampaignOptions().getUseAtB()
+                                    && (s instanceof AtBScenario)
+                                    && !((AtBScenario) s).canDeployForces(forces, gui.getCampaign())) {
+                                continue;
                             }
+                            menuItem = new JMenuItem(s.getName());
+                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_FORCE + s.getId() + "|" + forceIds);
+                            menuItem.addActionListener(this);
+                            missionMenu.add(menuItem);
+                            menu.setEnabled(true);
                         }
                     }
-                    if (unsorted.getComponentCount() > 0 || unsorted.getItemCount() > 0) {
-                        menu.add(unsorted);
-                        menu.setEnabled(true);
-                    }
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
-
-                    menuItem = new JMenuItem("Change Force Icon...");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_FORCE_ICON + forceIds);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-
-                    menuItem = new JMenuItem("Change Force Camo...");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_FORCE_CAMO + forceIds);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
+                    JMenuHelpers.addMenuIfNonEmpty(menu, missionMenu, MAX_POPUP_ITEMS);
                 }
-
-                menuItem = new JMenuItem(force.isCombatForce() ? "Make Non-Combat Force" : "Make Combat Force");
-                menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUS + forceIds);
+                JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
+            }
+            if (StaticChecks.areAllForcesDeployed(forces)) {
+                menuItem = new JMenuItem("Undeploy Force");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_FORCE + forceIds);
                 menuItem.addActionListener(this);
                 popup.add(menuItem);
+            }
+            menuItem = new JMenuItem("Remove Force");
+            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_FORCE + forceIds);
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(!StaticChecks.areAnyForcesDeployed(forces) && !StaticChecks.areAnyUnitsDeployed(unitsInForces));
+            popup.add(menuItem);
+            //Attempt to Assign all units in the selected force(s) to a transport ship.
+            //This checks to see if the ship is in a basic state that can accept units.
+            //Capacity gets checked once the action is submitted.
+            menu = new JMenu(TOEMouseAdapter.ASSIGN_FORCE_TRN_TITLE);
+            // Add submenus for different types of transports
+            JMenu m_trn = new JMenu(TOEMouseAdapter.MECH_CARRIERS);
+            JMenu pm_trn = new JMenu(TOEMouseAdapter.PROTOMECH_CARRIERS);
+            JMenu lv_trn = new JMenu(TOEMouseAdapter.LVEE_CARRIERS);
+            JMenu hv_trn = new JMenu(TOEMouseAdapter.HVEE_CARRIERS);
+            JMenu shv_trn = new JMenu(TOEMouseAdapter.SHVEE_CARRIERS);
+            JMenu ba_trn = new JMenu(TOEMouseAdapter.BA_CARRIERS);
+            JMenu i_trn = new JMenu(TOEMouseAdapter.INFANTRY_CARRIERS);
+            JMenu a_trn = new JMenu(TOEMouseAdapter.ASF_CARRIERS);
+            JMenu sc_trn = new JMenu(TOEMouseAdapter.SC_CARRIERS);
+            JMenu singleUnitMenu = new JMenu();
 
-                menuItem = new JMenuItem(force.isCombatForce() ? "Make Force and Subforces Non-Combat Forces" : "Make Force and Subforces Combat Forces");
-                menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUSES + forceIds);
-                menuItem.addActionListener(this);
-                popup.add(menuItem);
-
-                if (StaticChecks.areAllForcesUndeployed(forces) && StaticChecks.areAllCombatForces(forces)) {
-                    menu = new JMenu("Deploy Force");
-                    menu.setEnabled(false);
-                    JMenu missionMenu;
-                    for (Mission m : gui.getCampaign().getMissions()) {
-                        if (!m.isActive()) {
+            if (unitsInForces.size() > 0) {
+                Unit unit = unitsInForces.get(0);
+                String unitIds = "" + unit.getId().toString();
+                boolean shipInSelection = false;
+                boolean allUnitsSameType = false;
+                double unitWeight = 0;
+                int singleUnitType = -1;
+                for (int i = 1; i < unitsInForces.size(); i++) {
+                    unitIds += "|" + unitsInForces.get(i).getId().toString();
+                    unit = unitsInForces.get(i);
+                    if (unit != null && (unit.getEntity() != null && unit.getEntity().isLargeCraft())) {
+                        shipInSelection = true;
+                        break;
+                    }
+                }
+                //Check to see if all selected units are of the same type
+                for (int i = 0; i < UnitType.SIZE; i++) {
+                    if (StaticChecks.areAllUnitsSameType(unitsInForces, i)) {
+                        singleUnitType = i;
+                        allUnitsSameType = true;
+                        singleUnitMenu.setText(String.format(TOEMouseAdapter.VARIABLE_TRANSPORT,UnitType.getTypeName(singleUnitType)));
+                        break;
+                    }
+                }
+                //Only display the Assign to Ship command if your command has at least 1 valid transport
+                //and if your selection does not include a transport
+                if (!shipInSelection && !gui.getCampaign().getTransportShips().isEmpty()) {
+                    for (Unit ship : gui.getCampaign().getTransportShips()) {
+                        if (ship.isSalvage() || (ship.getCommander() == null)) {
                             continue;
                         }
-                        missionMenu = new JMenu(m.getName());
-                        for (Scenario s : m.getScenarios()) {
-                            if (s.isCurrent()) {
-                                if (gui.getCampaign().getCampaignOptions().getUseAtB()
-                                        && (s instanceof AtBScenario)
-                                        && !((AtBScenario) s).canDeployForces(forces, gui.getCampaign())) {
-                                    continue;
-                                }
-                                menuItem = new JMenuItem(s.getName());
-                                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_FORCE + s.getId() + "|" + forceIds);
-                                menuItem.addActionListener(this);
-                                missionMenu.add(menuItem);
-                                menu.setEnabled(true);
+
+                        UUID id = ship.getId();
+                        if (allUnitsSameType) {
+                            double capacity = ship.getCorrectBayCapacity(singleUnitType, unitWeight);
+                            if (capacity > 0) {
+                                JMenuItem shipMenuItem = new JMenuItem(ship.getName() + " , Space available: " + capacity);
+                                shipMenuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
+                                shipMenuItem.addActionListener(this);
+                                shipMenuItem.setEnabled(true);
+                                singleUnitMenu.add(shipMenuItem);
+                                singleUnitMenu.setEnabled(true);
+                            }
+                        } else {
+                            //Add this ship to the appropriate submenu(s). Most transports will fit into multiple
+                            //categories
+                            if (ship.getASFCapacity() > 0) {
+                                a_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentASFCapacity()));
+                                a_trn.setEnabled(true);
+                            }
+                            if (ship.getBattleArmorCapacity() > 0) {
+                                ba_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentBattleArmorCapacity()));
+                                ba_trn.setEnabled(true);
+                            }
+                            if (ship.getInfantryCapacity() > 0) {
+                                i_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentInfantryCapacity()));
+                                i_trn.setEnabled(true);
+                            }
+                            if (ship.getMechCapacity() > 0) {
+                                m_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentMechCapacity()));
+                                m_trn.setEnabled(true);
+                            }
+                            if (ship.getProtomechCapacity() > 0) {
+                                pm_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentProtomechCapacity()));
+                                pm_trn.setEnabled(true);
+                            }
+                            if (ship.getSmallCraftCapacity() > 0) {
+                                sc_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentSmallCraftCapacity()));
+                                sc_trn.setEnabled(true);
+                            }
+                            if (ship.getLightVehicleCapacity() > 0) {
+                                lv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentLightVehicleCapacity()));
+                                lv_trn.setEnabled(true);
+                            }
+                            if (ship.getHeavyVehicleCapacity() > 0) {
+                                hv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentHeavyVehicleCapacity()));
+                                hv_trn.setEnabled(true);
+                            }
+                            if (ship.getSuperHeavyVehicleCapacity() > 0) {
+                                shv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentSuperHeavyVehicleCapacity()));
+                                shv_trn.setEnabled(true);
                             }
                         }
-                        JMenuHelpers.addMenuIfNonEmpty(menu, missionMenu, MAX_POPUP_ITEMS);
                     }
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu, MAX_POPUP_ITEMS);
                 }
-                if (StaticChecks.areAllForcesDeployed(forces)) {
-                    menuItem = new JMenuItem("Undeploy Force");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_FORCE + forceIds);
+                if (a_trn.getMenuComponentCount() > 0 || a_trn.getItemCount() > 0) {
+                    menu.add(a_trn);
+                }
+                if (ba_trn.getMenuComponentCount() > 0 || ba_trn.getItemCount() > 0) {
+                    menu.add(ba_trn);
+                }
+                if (i_trn.getMenuComponentCount() > 0 || i_trn.getItemCount() > 0) {
+                    menu.add(i_trn);
+                }
+                if (m_trn.getMenuComponentCount() > 0 || m_trn.getItemCount() > 0) {
+                    menu.add(m_trn);
+                }
+                if (pm_trn.getMenuComponentCount() > 0 || pm_trn.getItemCount() > 0) {
+                    menu.add(pm_trn);
+                }
+                if (sc_trn.getMenuComponentCount() > 0 || sc_trn.getItemCount() > 0) {
+                    menu.add(sc_trn);
+                }
+                if (lv_trn.getMenuComponentCount() > 0 || lv_trn.getItemCount() > 0) {
+                    menu.add(lv_trn);
+                }
+                if (hv_trn.getMenuComponentCount() > 0 || hv_trn.getItemCount() > 0) {
+                    menu.add(hv_trn);
+                }
+                if (shv_trn.getMenuComponentCount() > 0 || shv_trn.getItemCount() > 0) {
+                    menu.add(shv_trn);
+                }
+                if (singleUnitMenu.getMenuComponentCount() > 0 || singleUnitMenu.getItemCount() > 0) {
+                    menu.add(singleUnitMenu);
+                }
+                if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
+                    popup.add(menu);
+                }
+                if (menu.getMenuComponentCount() > 30) {
+                    MenuScroller.setScrollerFor(menu, 30);
+                }
+                if (StaticChecks.areAllUnitsTransported(unitsInForces)) {
+                    menuItem = new JMenuItem(TOEMouseAdapter.UNASSIGN_FORCE_TRN_TITLE);
+                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNASSIGN_FROM_SHIP + unitIds);
                     menuItem.addActionListener(this);
+                    menuItem.setEnabled(true);
                     popup.add(menuItem);
                 }
-                menuItem = new JMenuItem("Remove Force");
-                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_FORCE + forceIds);
+            }
+        } else if (unitsSelected) {
+            Unit unit = units.get(0);
+            String unitIds = "" + unit.getId().toString();
+            for (int i = 1; i < units.size(); i++) {
+                unitIds += "|" + units.get(i).getId().toString();
+            }
+            JMenu networkMenu = new JMenu("Network");
+            JMenu availMenu;
+            if (StaticChecks.areAllUnitsC3Slaves(units)) {
+                availMenu = new JMenu("Slave to");
+                for (String[] network : gui.getCampaign()
+                        .getAvailableC3MastersForSlaves()) {
+                    int nodesFree = Integer.parseInt(network[1]);
+                    if (nodesFree >= units.size()) {
+                        menuItem = new JMenuItem(network[2] + ": "
+                                + network[1] + " nodes free");
+                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_SLAVE
+                                + network[0] + "|" + unitIds);
+                        menuItem.addActionListener(this);
+                        menuItem.setEnabled(true);
+                        availMenu.add(menuItem);
+                    }
+                }
+                if (availMenu.getMenuComponentCount() > 0 || availMenu.getItemCount() > 0) {
+                    networkMenu.add(availMenu);
+                }
+            }
+            if (StaticChecks.areAllUnitsIndependentC3Masters(units)) {
+                menuItem = new JMenuItem("Set as Company Level Master");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_SET_CO_MASTER
+                        + unitIds);
                 menuItem.addActionListener(this);
-                menuItem.setEnabled(!StaticChecks.areAnyForcesDeployed(forces) && !StaticChecks.areAnyUnitsDeployed(unitsInForces));
-                popup.add(menuItem);
-                //Attempt to Assign all units in the selected force(s) to a transport ship.
-                //This checks to see if the ship is in a basic state that can accept units.
-                //Capacity gets checked once the action is submitted.
-                menu = new JMenu(TOEMouseAdapter.ASSIGN_FORCE_TRN_TITLE);
+                menuItem.setEnabled(true);
+                networkMenu.add(menuItem);
+                availMenu = new JMenu("Slave to");
+                for (String[] network : gui.getCampaign()
+                        .getAvailableC3MastersForMasters()) {
+                    int nodesFree = Integer.parseInt(network[1]);
+                    if (nodesFree >= units.size()) {
+                        menuItem = new JMenuItem(network[2] + ": "
+                                + network[1] + " nodes free");
+                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_SLAVE
+                                + network[0] + "|" + unitIds);
+                        menuItem.addActionListener(this);
+                        menuItem.setEnabled(true);
+                        availMenu.add(menuItem);
+                    }
+                }
+                if (availMenu.getMenuComponentCount() > 0 || availMenu.getItemCount() > 0) {
+                    networkMenu.add(availMenu);
+                }
+            }
+            if (StaticChecks.areAllUnitsCompanyLevelMasters(units)) {
+                menuItem = new JMenuItem("Set as Independent Master");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_SET_IND_MASTER
+                        + unitIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                networkMenu.add(menuItem);
+            }
+            if (StaticChecks.doAllUnitsHaveC3Master(units)) {
+                menuItem = new JMenuItem("Remove from network");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_C3
+                        + unitIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                networkMenu.add(menuItem);
+            }
+            //Naval C3 checks
+            if (StaticChecks.doAllUnitsHaveNC3(units)) {
+                if (multipleSelection
+                        && StaticChecks.areAllUnitsNotNC3Networked(units)
+                        && units.size() < 7) {
+                    menuItem = new JMenuItem("Create new NC3 network");
+                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CREATE_NC3
+                            + unitIds);
+                    menuItem.addActionListener(this);
+                    menuItem.setEnabled(true);
+                    networkMenu.add(menuItem);
+                }
+                if (StaticChecks.areAllUnitsNotNC3Networked(units)) {
+                    availMenu = new JMenu("Add to network");
+                    for (String[] network : gui.getCampaign()
+                            .getAvailableNC3Networks()) {
+                        int nodesFree = Integer.parseInt(network[1]);
+                        if (nodesFree >= units.size()) {
+                            menuItem = new JMenuItem(network[0] + ": "
+                                    + network[1] + " nodes free");
+                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_TO_NETWORK
+                                    + network[0] + "|" + unitIds);
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(true);
+                            availMenu.add(menuItem);
+                        }
+                    }
+                    if (availMenu.getMenuComponentCount() > 0 || availMenu.getItemCount() > 0) {
+                        networkMenu.add(availMenu);
+                    }
+                }
+                if (StaticChecks.areAllUnitsNC3Networked(units)) {
+                    menuItem = new JMenuItem("Remove from network");
+                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_FROM_NETWORK
+                            + unitIds);
+                    menuItem.addActionListener(this);
+                    menuItem.setEnabled(true);
+                    networkMenu.add(menuItem);
+                    if (StaticChecks.areAllUnitsOnSameNC3Network(units)) {
+                        menuItem = new JMenuItem("Disband this network");
+                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DISBAND_NETWORK
+                                + unitIds);
+                        menuItem.addActionListener(this);
+                        menuItem.setEnabled(true);
+                        networkMenu.add(menuItem);
+                    }
+                }
+            }
+            if (StaticChecks.doAllUnitsHaveC3i(units)) {
+                if (multipleSelection
+                        && StaticChecks.areAllUnitsNotC3iNetworked(units)
+                        && units.size() < 7) {
+                    menuItem = new JMenuItem("Create new C3i network");
+                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CREATE_C3I
+                            + unitIds);
+                    menuItem.addActionListener(this);
+                    menuItem.setEnabled(true);
+                    networkMenu.add(menuItem);
+                }
+                if (StaticChecks.areAllUnitsNotC3iNetworked(units)) {
+                    availMenu = new JMenu("Add to network");
+                    for (String[] network : gui.getCampaign()
+                            .getAvailableC3iNetworks()) {
+                        int nodesFree = Integer.parseInt(network[1]);
+                        if (nodesFree >= units.size()) {
+                            menuItem = new JMenuItem(network[0] + ": "
+                                    + network[1] + " nodes free");
+                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_TO_NETWORK
+                                    + network[0] + "|" + unitIds);
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(true);
+                            availMenu.add(menuItem);
+                        }
+                    }
+                    if (availMenu.getMenuComponentCount() > 0 || availMenu.getItemCount() > 0) {
+                        networkMenu.add(availMenu);
+                    }
+                }
+                if (StaticChecks.areAllUnitsC3iNetworked(units)) {
+                    menuItem = new JMenuItem("Remove from network");
+                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_FROM_NETWORK
+                            + unitIds);
+                    menuItem.addActionListener(this);
+                    menuItem.setEnabled(true);
+                    networkMenu.add(menuItem);
+                    if (StaticChecks.areAllUnitsOnSameC3iNetwork(units)) {
+                        menuItem = new JMenuItem("Disband this network");
+                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DISBAND_NETWORK
+                                + unitIds);
+                        menuItem.addActionListener(this);
+                        menuItem.setEnabled(true);
+                        networkMenu.add(menuItem);
+                    }
+                }
+            }
+            if (networkMenu.getMenuComponentCount() > 0 || networkMenu.getItemCount() > 0) {
+                MenuScroller.createScrollBarsOnMenus(networkMenu);
+                popup.add(networkMenu);
+            }
+            menuItem = new JMenuItem("Remove Unit from TO&E");
+            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_UNIT
+                    + unitIds);
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(!StaticChecks.areAnyUnitsDeployed(units));
+            popup.add(menuItem);
+            if (StaticChecks.areAllUnitsAvailable(units)) {
+                //Deploy unit to a scenario - includes submenus for scenario selection
+                menu = new JMenu("Deploy Unit");
+                JMenu missionMenu;
+                for (Mission m : gui.getCampaign().getMissions()) {
+                    if (!m.isActive()) {
+                        continue;
+                    }
+                    missionMenu = new JMenu(m.getName());
+                    for (Scenario s : m.getScenarios()) {
+                        if (s.isCurrent()) {
+                            if (gui.getCampaign().getCampaignOptions()
+                                    .getUseAtB()
+                                    && s instanceof AtBScenario
+                                    && !((AtBScenario) s)
+                                    .canDeployUnits(units,
+                                            gui.getCampaign())) {
+                                continue;
+                            }
+                            menuItem = new JMenuItem(s.getName());
+                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_UNIT
+                                    + s.getId() + "|" + unitIds);
+                            menuItem.addActionListener(this);
+                            menuItem.setEnabled(true);
+                            missionMenu.add(menuItem);
+                        }
+                    }
+                    if (missionMenu.getMenuComponentCount() > 30) {
+                        MenuScroller.setScrollerFor(missionMenu, 30);
+                    }
+                    menu.add(missionMenu);
+                }
+                // Scroll bar in case the list is too long for one screen
+                if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
+                    MenuScroller.createScrollBarsOnMenus(menu);
+                    popup.add(menu);
+                }
+
+
+                //First, only display the Assign to Ship command if your command has at least 1 valid transport
+                //and if your selection does not include a transport
+                boolean shipInSelection = false;
+                boolean allUnitsSameType = false;
+                double unitWeight = 0;
+                int singleUnitType = -1;
+
                 // Add submenus for different types of transports
                 JMenu m_trn = new JMenu(TOEMouseAdapter.MECH_CARRIERS);
                 JMenu pm_trn = new JMenu(TOEMouseAdapter.PROTOMECH_CARRIERS);
@@ -977,516 +1337,155 @@ public class TOEMouseAdapter extends MouseInputAdapter implements ActionListener
                 JMenu sc_trn = new JMenu(TOEMouseAdapter.SC_CARRIERS);
                 JMenu singleUnitMenu = new JMenu();
 
-                if (unitsInForces.size() > 0) {
-                    Unit unit = unitsInForces.get(0);
-                    String unitIds = "" + unit.getId().toString();
-                    boolean shipInSelection = false;
-                    boolean allUnitsSameType = false;
-                    double unitWeight = 0;
-                    int singleUnitType = -1;
-                    for (int i = 1; i < unitsInForces.size(); i++) {
-                        unitIds += "|" + unitsInForces.get(i).getId().toString();
-                        unit = unitsInForces.get(i);
-                        if (unit != null && (unit.getEntity() != null && unit.getEntity().isLargeCraft())) {
-                            shipInSelection = true;
-                            break;
-                        }
+                for (Unit u : units) {
+                    if (u.getEntity() != null && u.getEntity().isLargeCraft()) {
+                        shipInSelection = true;
+                        break;
                     }
-                    //Check to see if all selected units are of the same type
-                    for (int i = 0; i < UnitType.SIZE; i++) {
-                        if (StaticChecks.areAllUnitsSameType(unitsInForces, i)) {
-                            singleUnitType = i;
-                            allUnitsSameType = true;
-                            singleUnitMenu.setText(String.format(TOEMouseAdapter.VARIABLE_TRANSPORT,UnitType.getTypeName(singleUnitType)));
-                            break;
-                        }
-                    }
-                    //Only display the Assign to Ship command if your command has at least 1 valid transport
-                    //and if your selection does not include a transport
-                    if (!shipInSelection && !gui.getCampaign().getTransportShips().isEmpty()) {
-                        for (Unit ship : gui.getCampaign().getTransportShips()) {
-                            if (ship.isSalvage() || (ship.getCommander() == null)) {
-                                continue;
-                            }
+                }
 
-                            UUID id = ship.getId();
-                            if (allUnitsSameType) {
-                                double capacity = ship.getCorrectBayCapacity(singleUnitType, unitWeight);
-                                if (capacity > 0) {
-                                    JMenuItem shipMenuItem = new JMenuItem(ship.getName() + " , Space available: " + capacity);
-                                    shipMenuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
-                                    shipMenuItem.addActionListener(this);
-                                    shipMenuItem.setEnabled(true);
-                                    singleUnitMenu.add(shipMenuItem);
-                                    singleUnitMenu.setEnabled(true);
-                                }
-                            } else {
-                                //Add this ship to the appropriate submenu(s). Most transports will fit into multiple
-                                //categories
-                                if (ship.getASFCapacity() > 0) {
-                                    a_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentASFCapacity()));
-                                    a_trn.setEnabled(true);
-                                }
-                                if (ship.getBattleArmorCapacity() > 0) {
-                                    ba_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentBattleArmorCapacity()));
-                                    ba_trn.setEnabled(true);
-                                }
-                                if (ship.getInfantryCapacity() > 0) {
-                                    i_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentInfantryCapacity()));
-                                    i_trn.setEnabled(true);
-                                }
-                                if (ship.getMechCapacity() > 0) {
-                                    m_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentMechCapacity()));
-                                    m_trn.setEnabled(true);
-                                }
-                                if (ship.getProtomechCapacity() > 0) {
-                                    pm_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentProtomechCapacity()));
-                                    pm_trn.setEnabled(true);
-                                }
-                                if (ship.getSmallCraftCapacity() > 0) {
-                                    sc_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentSmallCraftCapacity()));
-                                    sc_trn.setEnabled(true);
-                                }
-                                if (ship.getLightVehicleCapacity() > 0) {
-                                    lv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentLightVehicleCapacity()));
-                                    lv_trn.setEnabled(true);
-                                }
-                                if (ship.getHeavyVehicleCapacity() > 0) {
-                                    hv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentHeavyVehicleCapacity()));
-                                    hv_trn.setEnabled(true);
-                                }
-                                if (ship.getSuperHeavyVehicleCapacity() > 0) {
-                                    shv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentSuperHeavyVehicleCapacity()));
-                                    shv_trn.setEnabled(true);
-                                }
-                            }
-                        }
-                    }
-                    if (a_trn.getMenuComponentCount() > 0 || a_trn.getItemCount() > 0) {
-                        menu.add(a_trn);
-                    }
-                    if (ba_trn.getMenuComponentCount() > 0 || ba_trn.getItemCount() > 0) {
-                        menu.add(ba_trn);
-                    }
-                    if (i_trn.getMenuComponentCount() > 0 || i_trn.getItemCount() > 0) {
-                        menu.add(i_trn);
-                    }
-                    if (m_trn.getMenuComponentCount() > 0 || m_trn.getItemCount() > 0) {
-                        menu.add(m_trn);
-                    }
-                    if (pm_trn.getMenuComponentCount() > 0 || pm_trn.getItemCount() > 0) {
-                        menu.add(pm_trn);
-                    }
-                    if (sc_trn.getMenuComponentCount() > 0 || sc_trn.getItemCount() > 0) {
-                        menu.add(sc_trn);
-                    }
-                    if (lv_trn.getMenuComponentCount() > 0 || lv_trn.getItemCount() > 0) {
-                        menu.add(lv_trn);
-                    }
-                    if (hv_trn.getMenuComponentCount() > 0 || hv_trn.getItemCount() > 0) {
-                        menu.add(hv_trn);
-                    }
-                    if (shv_trn.getMenuComponentCount() > 0 || shv_trn.getItemCount() > 0) {
-                        menu.add(shv_trn);
-                    }
-                    if (singleUnitMenu.getMenuComponentCount() > 0 || singleUnitMenu.getItemCount() > 0) {
-                        menu.add(singleUnitMenu);
-                    }
-                    if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
-                        popup.add(menu);
-                    }
-                    if (menu.getMenuComponentCount() > 30) {
-                        MenuScroller.setScrollerFor(menu, 30);
-                    }
-                    if (StaticChecks.areAllUnitsTransported(unitsInForces)) {
-                        menuItem = new JMenuItem(TOEMouseAdapter.UNASSIGN_FORCE_TRN_TITLE);
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNASSIGN_FROM_SHIP + unitIds);
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(true);
-                        popup.add(menuItem);
+                //Check to see if all selected units are of the same type
+                for (int i = 0; i < UnitType.SIZE; i++) {
+                    if (StaticChecks.areAllUnitsSameType(units, i)) {
+                        singleUnitType = i;
+                        allUnitsSameType = true;
+                        singleUnitMenu.setText(String.format(TOEMouseAdapter.VARIABLE_TRANSPORT,UnitType.getTypeName(singleUnitType)));
+                        break;
                     }
                 }
-            } else if (unitsSelected) {
-                Unit unit = units.get(0);
-                String unitIds = "" + unit.getId().toString();
-                for (int i = 1; i < units.size(); i++) {
-                    unitIds += "|" + units.get(i).getId().toString();
-                }
-                JMenu networkMenu = new JMenu("Network");
-                JMenu availMenu;
-                if (StaticChecks.areAllUnitsC3Slaves(units)) {
-                    availMenu = new JMenu("Slave to");
-                    for (String[] network : gui.getCampaign()
-                            .getAvailableC3MastersForSlaves()) {
-                        int nodesFree = Integer.parseInt(network[1]);
-                        if (nodesFree >= units.size()) {
-                            menuItem = new JMenuItem(network[2] + ": "
-                                    + network[1] + " nodes free");
-                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_SLAVE
-                                    + network[0] + "|" + unitIds);
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(true);
-                            availMenu.add(menuItem);
-                        }
-                    }
-                    if (availMenu.getMenuComponentCount() > 0 || availMenu.getItemCount() > 0) {
-                        networkMenu.add(availMenu);
-                    }
-                }
-                if (StaticChecks.areAllUnitsIndependentC3Masters(units)) {
-                    menuItem = new JMenuItem("Set as Company Level Master");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_SET_CO_MASTER
-                            + unitIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    networkMenu.add(menuItem);
-                    availMenu = new JMenu("Slave to");
-                    for (String[] network : gui.getCampaign()
-                            .getAvailableC3MastersForMasters()) {
-                        int nodesFree = Integer.parseInt(network[1]);
-                        if (nodesFree >= units.size()) {
-                            menuItem = new JMenuItem(network[2] + ": "
-                                    + network[1] + " nodes free");
-                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_SLAVE
-                                    + network[0] + "|" + unitIds);
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(true);
-                            availMenu.add(menuItem);
-                        }
-                    }
-                    if (availMenu.getMenuComponentCount() > 0 || availMenu.getItemCount() > 0) {
-                        networkMenu.add(availMenu);
-                    }
-                }
-                if (StaticChecks.areAllUnitsCompanyLevelMasters(units)) {
-                    menuItem = new JMenuItem("Set as Independent Master");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_SET_IND_MASTER
-                            + unitIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    networkMenu.add(menuItem);
-                }
-                if (StaticChecks.doAllUnitsHaveC3Master(units)) {
-                    menuItem = new JMenuItem("Remove from network");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_C3
-                            + unitIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    networkMenu.add(menuItem);
-                }
-                //Naval C3 checks
-                if (StaticChecks.doAllUnitsHaveNC3(units)) {
-                    if (multipleSelection
-                            && StaticChecks.areAllUnitsNotNC3Networked(units)
-                            && units.size() < 7) {
-                        menuItem = new JMenuItem("Create new NC3 network");
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CREATE_NC3
-                                + unitIds);
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(true);
-                        networkMenu.add(menuItem);
-                    }
-                    if (StaticChecks.areAllUnitsNotNC3Networked(units)) {
-                        availMenu = new JMenu("Add to network");
-                        for (String[] network : gui.getCampaign()
-                                .getAvailableNC3Networks()) {
-                            int nodesFree = Integer.parseInt(network[1]);
-                            if (nodesFree >= units.size()) {
-                                menuItem = new JMenuItem(network[0] + ": "
-                                        + network[1] + " nodes free");
-                                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_TO_NETWORK
-                                        + network[0] + "|" + unitIds);
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(true);
-                                availMenu.add(menuItem);
-                            }
-                        }
-                        if (availMenu.getMenuComponentCount() > 0 || availMenu.getItemCount() > 0) {
-                            networkMenu.add(availMenu);
-                        }
-                    }
-                    if (StaticChecks.areAllUnitsNC3Networked(units)) {
-                        menuItem = new JMenuItem("Remove from network");
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_FROM_NETWORK
-                                + unitIds);
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(true);
-                        networkMenu.add(menuItem);
-                        if (StaticChecks.areAllUnitsOnSameNC3Network(units)) {
-                            menuItem = new JMenuItem("Disband this network");
-                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DISBAND_NETWORK
-                                    + unitIds);
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(true);
-                            networkMenu.add(menuItem);
-                        }
-                    }
-                }
-                if (StaticChecks.doAllUnitsHaveC3i(units)) {
-                    if (multipleSelection
-                            && StaticChecks.areAllUnitsNotC3iNetworked(units)
-                            && units.size() < 7) {
-                        menuItem = new JMenuItem("Create new C3i network");
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CREATE_C3I
-                                + unitIds);
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(true);
-                        networkMenu.add(menuItem);
-                    }
-                    if (StaticChecks.areAllUnitsNotC3iNetworked(units)) {
-                        availMenu = new JMenu("Add to network");
-                        for (String[] network : gui.getCampaign()
-                                .getAvailableC3iNetworks()) {
-                            int nodesFree = Integer.parseInt(network[1]);
-                            if (nodesFree >= units.size()) {
-                                menuItem = new JMenuItem(network[0] + ": "
-                                        + network[1] + " nodes free");
-                                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_TO_NETWORK
-                                        + network[0] + "|" + unitIds);
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(true);
-                                availMenu.add(menuItem);
-                            }
-                        }
-                        if (availMenu.getMenuComponentCount() > 0 || availMenu.getItemCount() > 0) {
-                            networkMenu.add(availMenu);
-                        }
-                    }
-                    if (StaticChecks.areAllUnitsC3iNetworked(units)) {
-                        menuItem = new JMenuItem("Remove from network");
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_FROM_NETWORK
-                                + unitIds);
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(true);
-                        networkMenu.add(menuItem);
-                        if (StaticChecks.areAllUnitsOnSameC3iNetwork(units)) {
-                            menuItem = new JMenuItem("Disband this network");
-                            menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DISBAND_NETWORK
-                                    + unitIds);
-                            menuItem.addActionListener(this);
-                            menuItem.setEnabled(true);
-                            networkMenu.add(menuItem);
-                        }
-                    }
-                }
-                if (networkMenu.getMenuComponentCount() > 0 || networkMenu.getItemCount() > 0) {
-                    MenuScroller.createScrollBarsOnMenus(networkMenu);
-                    popup.add(networkMenu);
-                }
-                menuItem = new JMenuItem("Remove Unit from TO&E");
-                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_UNIT
-                        + unitIds);
-                menuItem.addActionListener(this);
-                menuItem.setEnabled(!StaticChecks.areAnyUnitsDeployed(units));
-                popup.add(menuItem);
-                if (StaticChecks.areAllUnitsAvailable(units)) {
-                    //Deploy unit to a scenario - includes submenus for scenario selection
-                    menu = new JMenu("Deploy Unit");
-                    JMenu missionMenu;
-                    for (Mission m : gui.getCampaign().getMissions()) {
-                        if (!m.isActive()) {
+                if (!shipInSelection && !gui.getCampaign().getTransportShips().isEmpty()) {
+                    //Attempt to Assign unit to a transport ship. This checks to see if the ship
+                    //is in a basic state that can accept units. Capacity gets checked once the action
+                    //is submitted.
+                    menu = new JMenu("Assign Unit to Transport Ship");
+                    for (Unit ship : gui.getCampaign().getTransportShips()) {
+                        if (ship.isSalvage() || (ship.getCommander() == null)) {
                             continue;
                         }
-                        missionMenu = new JMenu(m.getName());
-                        for (Scenario s : m.getScenarios()) {
-                            if (s.isCurrent()) {
-                                if (gui.getCampaign().getCampaignOptions()
-                                        .getUseAtB()
-                                        && s instanceof AtBScenario
-                                        && !((AtBScenario) s)
-                                        .canDeployUnits(units,
-                                                gui.getCampaign())) {
-                                    continue;
-                                }
-                                menuItem = new JMenuItem(s.getName());
-                                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_UNIT
-                                        + s.getId() + "|" + unitIds);
-                                menuItem.addActionListener(this);
-                                menuItem.setEnabled(true);
-                                missionMenu.add(menuItem);
+
+                        UUID id = ship.getId();
+                        if (allUnitsSameType) {
+                            double capacity = ship.getCorrectBayCapacity(singleUnitType, unitWeight);
+                            if (capacity > 0) {
+                                JMenuItem shipMenuItem = new JMenuItem(ship.getName() + " , Space available: " + capacity);
+                                shipMenuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
+                                shipMenuItem.addActionListener(this);
+                                shipMenuItem.setEnabled(true);
+                                singleUnitMenu.add(shipMenuItem);
+                                singleUnitMenu.setEnabled(true);
                             }
-                        }
-                        if (missionMenu.getMenuComponentCount() > 30) {
-                            MenuScroller.setScrollerFor(missionMenu, 30);
-                        }
-                        menu.add(missionMenu);
-                    }
-                    // Scroll bar in case the list is too long for one screen
-                    if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
-                        MenuScroller.createScrollBarsOnMenus(menu);
-                        popup.add(menu);
-                    }
-
-
-                    //First, only display the Assign to Ship command if your command has at least 1 valid transport
-                    //and if your selection does not include a transport
-                    boolean shipInSelection = false;
-                    boolean allUnitsSameType = false;
-                    double unitWeight = 0;
-                    int singleUnitType = -1;
-
-                    // Add submenus for different types of transports
-                    JMenu m_trn = new JMenu(TOEMouseAdapter.MECH_CARRIERS);
-                    JMenu pm_trn = new JMenu(TOEMouseAdapter.PROTOMECH_CARRIERS);
-                    JMenu lv_trn = new JMenu(TOEMouseAdapter.LVEE_CARRIERS);
-                    JMenu hv_trn = new JMenu(TOEMouseAdapter.HVEE_CARRIERS);
-                    JMenu shv_trn = new JMenu(TOEMouseAdapter.SHVEE_CARRIERS);
-                    JMenu ba_trn = new JMenu(TOEMouseAdapter.BA_CARRIERS);
-                    JMenu i_trn = new JMenu(TOEMouseAdapter.INFANTRY_CARRIERS);
-                    JMenu a_trn = new JMenu(TOEMouseAdapter.ASF_CARRIERS);
-                    JMenu sc_trn = new JMenu(TOEMouseAdapter.SC_CARRIERS);
-                    JMenu singleUnitMenu = new JMenu();
-
-                    for (Unit u : units) {
-                        if (u.getEntity() != null && u.getEntity().isLargeCraft()) {
-                            shipInSelection = true;
-                            break;
-                        }
-                    }
-
-                    //Check to see if all selected units are of the same type
-                    for (int i = 0; i < UnitType.SIZE; i++) {
-                        if (StaticChecks.areAllUnitsSameType(units, i)) {
-                            singleUnitType = i;
-                            allUnitsSameType = true;
-                            singleUnitMenu.setText(String.format(TOEMouseAdapter.VARIABLE_TRANSPORT,UnitType.getTypeName(singleUnitType)));
-                            break;
-                        }
-                    }
-                    if (!shipInSelection && !gui.getCampaign().getTransportShips().isEmpty()) {
-                        //Attempt to Assign unit to a transport ship. This checks to see if the ship
-                        //is in a basic state that can accept units. Capacity gets checked once the action
-                        //is submitted.
-                        menu = new JMenu("Assign Unit to Transport Ship");
-                        for (Unit ship : gui.getCampaign().getTransportShips()) {
-                            if (ship.isSalvage() || (ship.getCommander() == null)) {
-                                continue;
+                        } else {
+                            //Add this ship to the appropriate submenu(s). Most transports will fit into multiple
+                            //categories
+                            if (ship.getASFCapacity() > 0) {
+                                a_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentASFCapacity()));
+                                a_trn.setEnabled(true);
                             }
-
-                            UUID id = ship.getId();
-                            if (allUnitsSameType) {
-                                double capacity = ship.getCorrectBayCapacity(singleUnitType, unitWeight);
-                                if (capacity > 0) {
-                                    JMenuItem shipMenuItem = new JMenuItem(ship.getName() + " , Space available: " + capacity);
-                                    shipMenuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
-                                    shipMenuItem.addActionListener(this);
-                                    shipMenuItem.setEnabled(true);
-                                    singleUnitMenu.add(shipMenuItem);
-                                    singleUnitMenu.setEnabled(true);
-                                }
-                            } else {
-                                //Add this ship to the appropriate submenu(s). Most transports will fit into multiple
-                                //categories
-                                if (ship.getASFCapacity() > 0) {
-                                    a_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentASFCapacity()));
-                                    a_trn.setEnabled(true);
-                                }
-                                if (ship.getBattleArmorCapacity() > 0) {
-                                    ba_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentBattleArmorCapacity()));
-                                    ba_trn.setEnabled(true);
-                                }
-                                if (ship.getInfantryCapacity() > 0) {
-                                    i_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentInfantryCapacity()));
-                                    i_trn.setEnabled(true);
-                                }
-                                if (ship.getMechCapacity() > 0) {
-                                    m_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentMechCapacity()));
-                                    m_trn.setEnabled(true);
-                                }
-                                if (ship.getProtomechCapacity() > 0) {
-                                    pm_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentProtomechCapacity()));
-                                    pm_trn.setEnabled(true);
-                                }
-                                if (ship.getSmallCraftCapacity() > 0) {
-                                    sc_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentSmallCraftCapacity()));
-                                    sc_trn.setEnabled(true);
-                                }
-                                if (ship.getLightVehicleCapacity() > 0) {
-                                    lv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentLightVehicleCapacity()));
-                                    lv_trn.setEnabled(true);
-                                }
-                                if (ship.getHeavyVehicleCapacity() > 0) {
-                                    hv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentHeavyVehicleCapacity()));
-                                    hv_trn.setEnabled(true);
-                                }
-                                if (ship.getSuperHeavyVehicleCapacity() > 0) {
-                                    shv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentSuperHeavyVehicleCapacity()));
-                                    shv_trn.setEnabled(true);
-                                }
+                            if (ship.getBattleArmorCapacity() > 0) {
+                                ba_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentBattleArmorCapacity()));
+                                ba_trn.setEnabled(true);
+                            }
+                            if (ship.getInfantryCapacity() > 0) {
+                                i_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentInfantryCapacity()));
+                                i_trn.setEnabled(true);
+                            }
+                            if (ship.getMechCapacity() > 0) {
+                                m_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentMechCapacity()));
+                                m_trn.setEnabled(true);
+                            }
+                            if (ship.getProtomechCapacity() > 0) {
+                                pm_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentProtomechCapacity()));
+                                pm_trn.setEnabled(true);
+                            }
+                            if (ship.getSmallCraftCapacity() > 0) {
+                                sc_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentSmallCraftCapacity()));
+                                sc_trn.setEnabled(true);
+                            }
+                            if (ship.getLightVehicleCapacity() > 0) {
+                                lv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentLightVehicleCapacity()));
+                                lv_trn.setEnabled(true);
+                            }
+                            if (ship.getHeavyVehicleCapacity() > 0) {
+                                hv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentHeavyVehicleCapacity()));
+                                hv_trn.setEnabled(true);
+                            }
+                            if (ship.getSuperHeavyVehicleCapacity() > 0) {
+                                shv_trn.add(transportMenuItem(ship.getName(),id,unitIds,ship.getCurrentSuperHeavyVehicleCapacity()));
+                                shv_trn.setEnabled(true);
                             }
                         }
                     }
-                    if (a_trn.getMenuComponentCount() > 0 || a_trn.getItemCount() > 0) {
-                        menu.add(a_trn);
-                    }
-                    if (ba_trn.getMenuComponentCount() > 0 || ba_trn.getItemCount() > 0) {
-                        menu.add(ba_trn);
-                    }
-                    if (i_trn.getMenuComponentCount() > 0 || i_trn.getItemCount() > 0) {
-                        menu.add(i_trn);
-                    }
-                    if (m_trn.getMenuComponentCount() > 0 || m_trn.getItemCount() > 0) {
-                        menu.add(m_trn);
-                    }
-                    if (pm_trn.getMenuComponentCount() > 0 || pm_trn.getItemCount() > 0) {
-                        menu.add(pm_trn);
-                    }
-                    if (sc_trn.getMenuComponentCount() > 0 || sc_trn.getItemCount() > 0) {
-                        menu.add(sc_trn);
-                    }
-                    if (lv_trn.getMenuComponentCount() > 0 || lv_trn.getItemCount() > 0) {
-                        menu.add(lv_trn);
-                    }
-                    if (hv_trn.getMenuComponentCount() > 0 || hv_trn.getItemCount() > 0) {
-                        menu.add(hv_trn);
-                    }
-                    if (shv_trn.getMenuComponentCount() > 0 || shv_trn.getItemCount() > 0) {
-                        menu.add(shv_trn);
-                    }
-                    if (singleUnitMenu.getMenuComponentCount() > 0 || singleUnitMenu.getItemCount() > 0) {
-                        menu.add(singleUnitMenu);
-                    }
-                    if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
-                        popup.add(menu);
-                    }
-                    if (menu.getMenuComponentCount() > 30) {
-                        MenuScroller.setScrollerFor(menu, 30);
-                    }
                 }
-                if (StaticChecks.areAllUnitsDeployed(units)) {
-                    menuItem = new JMenuItem("Undeploy Unit");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_UNIT
-                            + unitIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    popup.add(menuItem);
+                if (a_trn.getMenuComponentCount() > 0 || a_trn.getItemCount() > 0) {
+                    menu.add(a_trn);
                 }
-                if (StaticChecks.areAllUnitsTransported(units)) {
-                    menuItem = new JMenuItem("Unassign Unit from Transport Ship");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNASSIGN_FROM_SHIP
-                            + unitIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    popup.add(menuItem);
+                if (ba_trn.getMenuComponentCount() > 0 || ba_trn.getItemCount() > 0) {
+                    menu.add(ba_trn);
                 }
-                if (!multipleSelection) {
-                    menuItem = new JMenuItem("Go to Unit in Hangar");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_GOTO_UNIT
-                            + unitIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    popup.add(menuItem);
-                    menuItem = new JMenuItem(
-                            "Go to Pilot/Commander in Personnel");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_GOTO_PILOT
-                            + unitIds);
-                    menuItem.addActionListener(this);
-                    menuItem.setEnabled(true);
-                    popup.add(menuItem);
+                if (i_trn.getMenuComponentCount() > 0 || i_trn.getItemCount() > 0) {
+                    menu.add(i_trn);
+                }
+                if (m_trn.getMenuComponentCount() > 0 || m_trn.getItemCount() > 0) {
+                    menu.add(m_trn);
+                }
+                if (pm_trn.getMenuComponentCount() > 0 || pm_trn.getItemCount() > 0) {
+                    menu.add(pm_trn);
+                }
+                if (sc_trn.getMenuComponentCount() > 0 || sc_trn.getItemCount() > 0) {
+                    menu.add(sc_trn);
+                }
+                if (lv_trn.getMenuComponentCount() > 0 || lv_trn.getItemCount() > 0) {
+                    menu.add(lv_trn);
+                }
+                if (hv_trn.getMenuComponentCount() > 0 || hv_trn.getItemCount() > 0) {
+                    menu.add(hv_trn);
+                }
+                if (shv_trn.getMenuComponentCount() > 0 || shv_trn.getItemCount() > 0) {
+                    menu.add(shv_trn);
+                }
+                if (singleUnitMenu.getMenuComponentCount() > 0 || singleUnitMenu.getItemCount() > 0) {
+                    menu.add(singleUnitMenu);
+                }
+                if (menu.getMenuComponentCount() > 0 || menu.getItemCount() > 0) {
+                    popup.add(menu);
+                }
+                if (menu.getMenuComponentCount() > 30) {
+                    MenuScroller.setScrollerFor(menu, 30);
                 }
             }
-            popup.show(e.getComponent(), e.getX(), e.getY());
+            if (StaticChecks.areAllUnitsDeployed(units)) {
+                menuItem = new JMenuItem("Undeploy Unit");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_UNIT
+                        + unitIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                popup.add(menuItem);
+            }
+            if (StaticChecks.areAllUnitsTransported(units)) {
+                menuItem = new JMenuItem("Unassign Unit from Transport Ship");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNASSIGN_FROM_SHIP
+                        + unitIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                popup.add(menuItem);
+            }
+            if (!multipleSelection) {
+                menuItem = new JMenuItem("Go to Unit in Hangar");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_GOTO_UNIT
+                        + unitIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                popup.add(menuItem);
+                menuItem = new JMenuItem(
+                        "Go to Pilot/Commander in Personnel");
+                menuItem.setActionCommand(TOEMouseAdapter.COMMAND_GOTO_PILOT
+                        + unitIds);
+                menuItem.addActionListener(this);
+                menuItem.setEnabled(true);
+                popup.add(menuItem);
+            }
         }
+        return popup;
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TaskTableMouseAdapter.java
@@ -20,6 +20,7 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
+import java.util.Optional;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
@@ -29,7 +30,6 @@ import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
 import megamek.common.TargetRoll;
-import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.event.PartChangedEvent;
 import mekhq.campaign.event.PartModeChangedEvent;
@@ -148,28 +148,18 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
 
 
     @Override
-    protected boolean shouldShowPopup() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         int row = taskTable.getSelectedRow();
         if (row < 0) {
-            return false;
-        }
-        
-        return taskModel.getTaskAt(taskTable.convertRowIndexToModel(row)) != null;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
-        JPopupMenu popup = new JPopupMenu();
-        int row = taskTable.getSelectedRow();
-        if (row < 0) {
-            return null;
+            return Optional.empty();
         }
 
         IPartWork partWork = taskModel.getTaskAt(taskTable.convertRowIndexToModel(row));
         if (partWork == null) {
-            return null;
+            return Optional.empty();
         }
+
+        JPopupMenu popup = new JPopupMenu();
 
         int[] rows = taskTable.getSelectedRows();
         IPartWork[] parts = new IPartWork[rows.length];
@@ -218,16 +208,20 @@ public class TaskTableMouseAdapter extends JPopupMenuAdapter {
             popup.add(menuItem);
         }
 
-        menu = new JMenu("GM Mode");
-        popup.add(menu);
-        // Auto complete task
+        if (gui.getCampaign().isGM()) {
+            popup.addSeparator();
+            menu = new JMenu("GM Mode");
 
-        menuItem = new JMenuItem("Complete Task");
-        menuItem.setActionCommand("FIX");
-        menuItem.addActionListener(this);
-        menuItem.setEnabled(gui.getCampaign().isGM() && isFixable);
-        menu.add(menuItem);
+            // Auto complete task
+            menuItem = new JMenuItem("Complete Task");
+            menuItem.setActionCommand("FIX");
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(isFixable);
+            menu.add(menuItem);
 
-        return popup;
+            popup.add(menu);
+        }
+
+        return Optional.of(popup);
     }
 }

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.UUID;
 import java.util.Vector;
@@ -543,15 +544,9 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     @Override
-    protected boolean shouldShowPopup() {
-        return unitTable.getSelectedRowCount() > 0;
-    }
-
-    @Override
-    @Nullable
-    protected JPopupMenu createPopupMenu() {
+    protected Optional<JPopupMenu> createPopupMenu() {
         if (unitTable.getSelectedRowCount() == 0) {
-            return null;
+            return Optional.empty();
         }
 
         //region Variable Declarations and Instantiations
@@ -1101,7 +1096,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             //endregion GM Mode
         }
 
-        return popup;
+        return Optional.of(popup);
     }
 
     private void addCustomUnitTag(Unit... units) {

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -19,7 +19,6 @@
 package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -36,9 +35,9 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
+import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.UIManager;
-import javax.swing.event.MouseInputAdapter;
 
 import megamek.client.ui.swing.UnitEditorDialog;
 import megamek.client.ui.swing.dialog.imageChooser.CamoChooserDialog;
@@ -72,13 +71,14 @@ import mekhq.campaign.unit.actions.StripUnitAction;
 import mekhq.campaign.unit.actions.SwapAmmoTypeAction;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.GuiTabType;
+import mekhq.gui.HangarTab;
 import mekhq.gui.MekLabTab;
 import mekhq.gui.dialog.*;
 import mekhq.gui.model.UnitTableModel;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.StaticChecks;
 
-public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionListener {
+public class UnitTableMouseAdapter extends JPopupMenuAdapter {
     //region Variable Declarations
     private CampaignGUI gui;
     private JTable unitTable;
@@ -146,11 +146,30 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionLi
     //endregion Commands
     //endregion Variable Declarations
 
-    public UnitTableMouseAdapter(CampaignGUI gui, JTable unitTable, UnitTableModel unitModel) {
-        super();
+    protected UnitTableMouseAdapter(CampaignGUI gui, JTable unitTable, UnitTableModel unitModel) {
         this.gui = gui;
         this.unitTable = unitTable;
         this.unitModel = unitModel;
+    }
+
+    public static void connect(CampaignGUI gui, JTable unitTable, UnitTableModel unitModel, JSplitPane splitUnit) {
+        new UnitTableMouseAdapter(gui, unitTable, unitModel) {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2) {
+                    int width = splitUnit.getSize().width;
+                    int location = splitUnit.getDividerLocation();
+                    int size = splitUnit.getDividerSize();
+                    if ((width - location + size) < HangarTab.UNIT_VIEW_WIDTH) {
+                        // expand
+                        splitUnit.resetToPreferredSizes();
+                    } else {
+                        // collapse
+                        splitUnit.setDividerLocation(1.0);
+                    }
+                }
+            }
+        }.connect(unitTable);
     }
 
     @Override
@@ -524,570 +543,565 @@ public class UnitTableMouseAdapter extends MouseInputAdapter implements ActionLi
     }
 
     @Override
-    public void mousePressed(MouseEvent e) {
-        maybeShowPopup(e);
+    protected boolean shouldShowPopup() {
+        return unitTable.getSelectedRowCount() > 0;
     }
 
     @Override
-    public void mouseReleased(MouseEvent e) {
-        maybeShowPopup(e);
-    }
+    @Nullable
+    protected JPopupMenu createPopupMenu() {
+        if (unitTable.getSelectedRowCount() == 0) {
+            return null;
+        }
 
-    private void maybeShowPopup(MouseEvent e) {
-        if (e.isPopupTrigger()) {
-            // Immediately return if there are no units selected
-            if (unitTable.getSelectedRowCount() == 0) {
-                return;
+        //region Variable Declarations and Instantiations
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem menuItem;
+        JMenu menu;
+        JCheckBoxMenuItem cbMenuItem;
+
+        boolean isGM = gui.getCampaign().isGM();
+
+        int[] rows = unitTable.getSelectedRows();
+        boolean oneSelected = unitTable.getSelectedRowCount() == 1;
+        Unit[] units = new Unit[rows.length];
+        for (int i = 0; i < rows.length; i++) {
+            units[i] = unitModel.getUnit(unitTable.convertRowIndexToModel(rows[i]));
+        }
+        Unit unit = units[0];
+
+        boolean nonePresent = true; // different menu if there is at least one present unit
+        for (Unit u : units) {
+            if (u.isPresent()) {
+                nonePresent = false;
+                break;
             }
+        }
+        //endregion Variable Declarations and Instantiations
 
-            //region Variable Declarations and Instantiations
-            JPopupMenu popup = new JPopupMenu();
-            JMenuItem menuItem;
-            JMenu menu;
-            JCheckBoxMenuItem cbMenuItem;
-
-            boolean isGM = gui.getCampaign().isGM();
-
-            int[] rows = unitTable.getSelectedRows();
-            boolean oneSelected = unitTable.getSelectedRowCount() == 1;
-            Unit[] units = new Unit[rows.length];
-            for (int i = 0; i < rows.length; i++) {
-                units[i] = unitModel.getUnit(unitTable.convertRowIndexToModel(rows[i]));
+        if (nonePresent) {
+            menuItem = new JMenuItem("Cancel This Delivery");
+            menuItem.setActionCommand(COMMAND_CANCEL_ORDER);
+            menuItem.addActionListener(this);
+            popup.add(menuItem);
+            if (isGM) {
+                popup.addSeparator();
+                menu = new JMenu("GM Mode");
+                menuItem = new JMenuItem("Unit Arrives Immediately");
+                menuItem.setActionCommand(COMMAND_ARRIVE);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+                popup.add(menu);
             }
-            Unit unit = units[0];
+        } else {
+            //region Determine if to Display
+            // this is used to determine whether or not to show parts of the GUI, especially for
+            // bulk selections
+            boolean oneMothballed = false; // If at least one unit is mothballed, we want to show unit activation
+            boolean oneMothballing = false; // If at least one unit is mothballing, we want to be able to cancel it
+            boolean oneActive = false; // If at least one unit is active, we want to enable mothballing
+            boolean oneDeployed = false; // If at least one unit is deployed, we want to show the remove deployment to GMs
+            boolean allDeployed = true; // don't show sell dialog if all units are deployed
+            boolean oneAvailableUnitBelowMaxCrew = false; // If one unit isn't fully crewed, enable bulk hiring
+            boolean oneNotPresent = false; // If a unit isn't present, enable instant arrival for GMs
+            boolean oneHasIndividualCamo = false; // If a unit has a unique camo, allow it to be removed
+            boolean oneHasCrew = false; // If a unit has crew, enable removing it
+            boolean allUnitsAreRepairable = true;  // If all units can be repaired, allow the repair flag to be selected
+            boolean areAllConventionalInfantry = true; // Conventional infantry can be disbanded, but no others
+            boolean noConventionalInfantry = true; // Conventional infantry can't be repaired/salvaged
+            boolean areAllRepairFlagged = true; // If everyone has the repair flag, then we show the repair flag box as selected
+            boolean areAllSalvageFlagged = true;  // Same as above, but with the salvage flag
+            boolean allRequireSameTechType = true; // If everyone requires the same tech type, we can allow bulk tech assignment
+            boolean allSameModel = true; // If everyone is the exact same unit and model of that unit
+            boolean oneRefitting = false; // If any one selected unit is refitting
+            boolean allAvailable = true; // If everyone is available
+            boolean allAvailableIgnoreRefit = true; // If everyone is available
 
-            boolean nonePresent = true; // different menu if there is at least one present unit
+            final String model = unit.getEntity().getShortNameRaw();
+            String skill = unit.determineUnitTechSkillType();
+            int maintenanceTime = 0;
             for (Unit u : units) {
-                if (u.isPresent()) {
-                    nonePresent = false;
-                    break;
+                if (u.isMothballed()) {
+                    oneMothballed = true;
+                } else if (u.isMothballing()) {
+                    oneMothballing = true;
+                } else {
+                    oneActive = true;
+                }
+
+                if ((u.getCrew().size() < u.getFullCrewSize()) && u.isAvailable()) {
+                    oneAvailableUnitBelowMaxCrew = true;
+                }
+
+                if (u.isDeployed()) {
+                    oneDeployed = true;
+                } else {
+                    allDeployed = false;
+                }
+
+                if (!u.isPresent()) {
+                    oneNotPresent = true;
+                }
+
+                if (allAvailableIgnoreRefit && !u.isAvailable(true)) {
+                    allAvailableIgnoreRefit = false;
+                    allAvailable = false;
+                } else if (allAvailable && !u.isAvailable()) {
+                    allAvailable = false;
+                }
+
+                if (u.isEntityCamo()) {
+                    oneHasIndividualCamo = true;
+                }
+
+                if (u.getCrew().size() > 0) {
+                    oneHasCrew = true;
+                }
+
+                if (!u.isRepairable()) {
+                    allUnitsAreRepairable = false;
+                }
+
+                if (u.isSalvage()) {
+                    areAllRepairFlagged = false;
+                } else {
+                    areAllSalvageFlagged = false;
+                }
+
+                if (u.getEntity().isConventionalInfantry()) {
+                    noConventionalInfantry = false;
+                } else {
+                    areAllConventionalInfantry = false;
+                }
+
+                if (!StringUtil.isNullOrEmpty(skill)) {
+                    if (!skill.equals(u.determineUnitTechSkillType())) {
+                        allRequireSameTechType = false;
+                        skill = ""; //little performance saving hack
+                        continue;
+                    }
+                    maintenanceTime += u.getMaintenanceTime();
+                    if (maintenanceTime > Person.PRIMARY_ROLE_SUPPORT_TIME) {
+                        skill = ""; //little performance saving hack
+                    }
+                }
+
+                if (!model.equals(u.getEntity().getShortNameRaw())) {
+                    allSameModel = false;
+                }
+
+                if (u.isRefitting()) {
+                    oneRefitting = true;
                 }
             }
-            //endregion Variable Declarations and Instantiations
+            //endregion Determine if to Display
 
-            if (nonePresent) {
-                menuItem = new JMenuItem("Cancel This Delivery");
-                menuItem.setActionCommand(COMMAND_CANCEL_ORDER);
+            // change the location
+            menu = new JMenu("Change site");
+            boolean allSameSite = StaticChecks.areAllSameSite(units);
+            for (int i = 0; i < Unit.SITE_N; i++) {
+                cbMenuItem = new JCheckBoxMenuItem(Unit.getSiteName(i));
+                if (allSameSite && unit.getSite() == i) {
+                    cbMenuItem.setSelected(true);
+                } else {
+                    cbMenuItem.setActionCommand(COMMAND_CHANGE_SITE + ":" + i);
+                    cbMenuItem.addActionListener(this);
+                }
+                menu.add(cbMenuItem);
+            }
+            menu.setEnabled(allAvailable);
+            popup.add(menu);
+
+            // swap ammo
+            if (oneSelected) {
+                if (unit.getEntity().usesWeaponBays()) {
+                    menuItem = new JMenuItem("Swap ammo...");
+                    menuItem.setActionCommand(COMMAND_LC_SWAP_AMMO);
+                    menuItem.addActionListener(this);
+                    popup.add(menuItem);
+                } else if (unit.getEntity().isSupportVehicle()
+                            && (unit.getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT)) {
+                    // Small SVs can configure ammo only if they have weapons that have
+                    // inferno ammo available
+                    if (unit.getEntity().getWeaponList().stream()
+                            .anyMatch(m -> (m.getType() instanceof InfantryWeapon)
+                                    && ((InfantryWeapon) m.getType()).hasInfernoAmmo())) {
+                        menuItem = new JMenuItem("Swap ammo...");
+                        menuItem.setActionCommand(COMMAND_SMALL_SV_SWAP_AMMO);
+                        menuItem.addActionListener(this);
+                        popup.add(menuItem);
+                    }
+                } else {
+                    menu = new JMenu("Swap ammo");
+                    for (AmmoBin ammo : unit.getWorkingAmmoBins()) {
+                        JMenu ammoMenu = new JMenu(ammo.getType().getDesc());
+                        AmmoType curType = ammo.getType();
+                        for (AmmoType atype : Utilities.getMunitionsFor(unit.getEntity(), curType,
+                                gui.getCampaign().getCampaignOptions().getTechLevel())) {
+                            cbMenuItem = new JCheckBoxMenuItem(atype.getDesc());
+                            if (atype.equals(curType)) {
+                                cbMenuItem.setSelected(true);
+                            } else {
+                                cbMenuItem.addActionListener(evt -> {
+                                    IUnitAction swapAmmoTypeAction = new SwapAmmoTypeAction(ammo, atype);
+                                    swapAmmoTypeAction.execute(gui.getCampaign(), unit);
+                                });
+                            }
+                            ammoMenu.add(cbMenuItem);
+                        }
+                        JMenuHelpers.addMenuIfNonEmpty(menu, ammoMenu);
+                    }
+                    menu.setEnabled(allAvailable);
+                    JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+                }
+            }
+
+            // Select bombs
+            if (oneSelected && unit.getEntity().isBomber()) {
+                menuItem = new JMenuItem("Select Bombs");
+                menuItem.setActionCommand(COMMAND_BOMBS);
                 menuItem.addActionListener(this);
                 popup.add(menuItem);
-                if (isGM) {
-                    popup.addSeparator();
-                    menu = new JMenu("GM Mode");
+            }
+
+            // Salvage / Repair
+            if (noConventionalInfantry) {
+                menu = new JMenu("Repair Status");
+                cbMenuItem = new JCheckBoxMenuItem("Repair");
+                cbMenuItem.setSelected(areAllRepairFlagged);
+                cbMenuItem.setActionCommand(COMMAND_REPAIR);
+                cbMenuItem.addActionListener(this);
+                cbMenuItem.setEnabled(allUnitsAreRepairable);
+                menu.add(cbMenuItem);
+
+                cbMenuItem = new JCheckBoxMenuItem("Salvage");
+                cbMenuItem.setSelected(areAllSalvageFlagged);
+                cbMenuItem.setActionCommand(COMMAND_SALVAGE);
+                cbMenuItem.addActionListener(this);
+                menu.add(cbMenuItem);
+                popup.add(menu);
+            }
+
+            if (oneActive) {
+                menuItem = new JMenuItem(oneSelected ? "Mothball" : "Mass Mothball");
+                menuItem.setActionCommand(COMMAND_MOTHBALL);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (oneMothballed) {
+                menuItem = new JMenuItem(oneSelected ? "Activate" : "Mass Activate");
+                menuItem.setActionCommand(COMMAND_ACTIVATE);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (oneMothballing) {
+                menuItem = new JMenuItem("Cancel Mothballing/Activation");
+                menuItem.setActionCommand(COMMAND_CANCEL_MOTHBALL);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (allRequireSameTechType && !StringUtil.isNullOrEmpty(skill)) {
+                menu = new JMenu("Assign Tech");
+                JMenu menuElite = new JMenu(SkillType.ELITE_NM);
+                JMenu menuVeteran = new JMenu(SkillType.VETERAN_NM);
+                JMenu menuRegular = new JMenu(SkillType.REGULAR_NM);
+                JMenu menuGreen = new JMenu(SkillType.GREEN_NM);
+                JMenu menuUltraGreen = new JMenu(SkillType.ULTRA_GREEN_NM);
+
+                int techsFound = 0;
+                for (Person tech : gui.getCampaign().getTechs()) {
+                    if (tech.hasSkill(skill)
+                            && (tech.getMaintenanceTimeUsing() + maintenanceTime)
+                                    <= Person.PRIMARY_ROLE_SUPPORT_TIME) {
+
+                        String skillLvl = "Unknown";
+                        if (tech.getSkillForWorkingOn(unit) != null) {
+                            skillLvl = SkillType.getExperienceLevelName(
+                                    tech.getSkillForWorkingOn(unit).getExperienceLevel());
+                        }
+
+                        JMenu subMenu;
+                        switch (skillLvl) {
+                            case SkillType.ELITE_NM:
+                                subMenu = menuElite;
+                                break;
+                            case SkillType.VETERAN_NM:
+                                subMenu = menuVeteran;
+                                break;
+                            case SkillType.REGULAR_NM:
+                                subMenu = menuRegular;
+                                break;
+                            case SkillType.GREEN_NM:
+                                subMenu = menuGreen;
+                                break;
+                            case SkillType.ULTRA_GREEN_NM:
+                                subMenu = menuUltraGreen;
+                                break;
+                            default:
+                                subMenu = null;
+                                break;
+                        }
+
+                        if (subMenu != null) {
+                            cbMenuItem = new JCheckBoxMenuItem(tech.getFullTitle()
+                                    + " (" + tech.getMaintenanceTimeUsing() + "m)");
+                            cbMenuItem.setActionCommand(COMMAND_ASSIGN_TECH + ":" + tech.getId());
+
+                            if (tech.equals(unit.getTech())) {
+                                cbMenuItem.setSelected(true);
+                            } else {
+                                cbMenuItem.addActionListener(this);
+                            }
+
+                            subMenu.add(cbMenuItem);
+                            if (cbMenuItem.isSelected()) {
+                                subMenu.setIcon(UIManager.getIcon("CheckBoxMenuItem.checkIcon"));
+                            }
+                            techsFound++;
+                        }
+                    }
+                }
+
+                if (techsFound > 0) {
+                    JMenuHelpers.addMenuIfNonEmpty(menu, menuElite);
+                    JMenuHelpers.addMenuIfNonEmpty(menu, menuVeteran);
+                    JMenuHelpers.addMenuIfNonEmpty(menu, menuRegular);
+                    JMenuHelpers.addMenuIfNonEmpty(menu, menuGreen);
+                    JMenuHelpers.addMenuIfNonEmpty(menu, menuUltraGreen);
+                    JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+                }
+            }
+
+            if (oneSelected && unit.requiresMaintenance()) {
+                menuItem = new JMenuItem("Show Last Maintenance Report");
+                menuItem.setActionCommand(COMMAND_MAINTENANCE_REPORT);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (oneSelected && !unit.isMothballed()
+                    && gui.getCampaign().getCampaignOptions().usePeacetimeCost()) {
+                menuItem = new JMenuItem("Show Monthly Supply Cost Report");
+                menuItem.setActionCommand(COMMAND_SUPPLY_COST);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (areAllConventionalInfantry) {
+                menuItem = new JMenuItem("Disband");
+                menuItem.setActionCommand(COMMAND_DISBAND);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            // Customize unit menu
+            if (allUnitsAreRepairable && allAvailableIgnoreRefit) {
+                menu = new JMenu("Customize");
+
+                // TODO : Should I be able to refit BA?
+                if (allSameModel && allAvailable
+                        && ((unit.getEntity() instanceof Mech)
+                        || (unit.getEntity() instanceof Tank)
+                        || (unit.getEntity() instanceof Aero)
+                        || ((unit.getEntity() instanceof Infantry)))) {
+                    menuItem = new JMenuItem(unit.getEntity().isOmni() ? "Choose configuration..."
+                            : "Choose Refit Kit...");
+                    menuItem.setActionCommand(COMMAND_REFIT_KIT);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+
+                if (allSameModel && allAvailable
+                        && ((unit.getEntity() instanceof Mech)
+                        || (unit.getEntity() instanceof Tank)
+                        || (unit.getEntity() instanceof Aero)
+                        || ((unit.getEntity() instanceof Infantry)
+                        || (unit.getEntity() instanceof Protomech)))) {
+                    menuItem = new JMenuItem("Refurbish Unit");
+                    menuItem.setActionCommand(COMMAND_REFURBISH);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+
+                if (oneSelected && gui.hasTab(GuiTabType.MEKLAB)) {
+                    menuItem = new JMenuItem("Customize in Mek Lab...");
+                    menuItem.setActionCommand(COMMAND_CUSTOMIZE);
+                    menuItem.addActionListener(this);
+                    menuItem.setEnabled(allAvailable
+                            && !(unit.getEntity() instanceof GunEmplacement));
+                    menu.add(menuItem);
+                }
+
+                if (oneRefitting) {
+                    menuItem = new JMenuItem("Cancel Customization");
+                    menuItem.setActionCommand(COMMAND_CANCEL_CUSTOMIZE);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+
+                    if (isGM) {
+                        menuItem = new JMenuItem("Complete Refit (GM)");
+                        menuItem.setActionCommand(COMMAND_REFIT_GM_COMPLETE);
+                        menuItem.addActionListener(this);
+                        menu.add(menuItem);
+                    }
+                }
+                JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+            }
+
+            // fill with personnel
+            if (oneAvailableUnitBelowMaxCrew) {
+                menuItem = new JMenuItem(resourceMap.getString("hireMinimumComplement.text"));
+                menuItem.setActionCommand(COMMAND_HIRE_FULL);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            // Camo
+            if (oneSelected && !unit.isEntityCamo()) {
+                menuItem = new JMenuItem(gui.getResourceMap()
+                        .getString("customizeMenu.individualCamo.text"));
+                menuItem.setActionCommand(COMMAND_INDI_CAMO);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+            if (oneHasIndividualCamo) {
+                menuItem = new JMenuItem(gui.getResourceMap()
+                        .getString("customizeMenu.removeIndividualCamo.text"));
+                menuItem.setActionCommand(COMMAND_REMOVE_INDI_CAMO);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (oneSelected && !gui.getCampaign().isCustom(unit)) {
+                menuItem = new JMenuItem("Tag as a custom unit");
+                menuItem.setActionCommand(COMMAND_TAG_CUSTOM);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (oneSelected && gui.getCampaign().getCampaignOptions().useQuirks()) {
+                menuItem = new JMenuItem("Edit Quirks");
+                menuItem.setActionCommand(COMMAND_QUIRKS);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (oneSelected) {
+                menuItem = new JMenuItem("Edit Unit History...");
+                menuItem.setActionCommand(COMMAND_CHANGE_HISTORY);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            // remove all personnel
+            if (oneHasCrew) {
+                popup.addSeparator();
+                menuItem = new JMenuItem("Remove all personnel");
+                menuItem.setActionCommand(COMMAND_REMOVE_ALL_PERSONNEL);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (oneSelected) {
+                menuItem = new JMenuItem("Name Unit");
+                menuItem.setActionCommand(COMMAND_FLUFF_NAME);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            if (oneSelected) {
+                menuItem = new JMenuItem("Show BV Calculation");
+                menuItem.setActionCommand(COMMAND_SHOW_BV_CALC);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            // sell unit
+            if (!allDeployed && gui.getCampaign().getCampaignOptions().canSellUnits()) {
+                popup.addSeparator();
+                menuItem = new JMenuItem("Sell Unit");
+                menuItem.setActionCommand(COMMAND_SELL);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
+            }
+
+            //region GM Mode
+            // GM mode - only show to GMs
+            if (isGM) {
+                popup.addSeparator();
+                menu = new JMenu("GM Mode");
+
+                menuItem = new JMenuItem("Remove Unit");
+                menuItem.setActionCommand(COMMAND_REMOVE);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+
+                menuItem = new JMenuItem("Strip Unit");
+                menuItem.setActionCommand(COMMAND_STRIP_UNIT);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+
+                if (oneActive) {
+                    menuItem = new JMenuItem(oneSelected ? "Mothball Unit" : "Mass Mothball Units");
+                    menuItem.setActionCommand(COMMAND_GM_MOTHBALL);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+
+                if (oneMothballed) {
+                    menuItem = new JMenuItem(oneSelected ? "Activate Unit" : "Mass Activate Units");
+                    menuItem.setActionCommand(COMMAND_GM_ACTIVATE);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+
+                if (oneDeployed) {
+                    menuItem = new JMenuItem("Undeploy Unit");
+                    menuItem.setActionCommand(COMMAND_UNDEPLOY);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+
+                if (oneAvailableUnitBelowMaxCrew) {
+                    menuItem = new JMenuItem(resourceMap.getString("addMinimumComplement.text"));
+                    menuItem.setActionCommand(COMMAND_HIRE_FULL_GM);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+
+                if (oneSelected) {
+                    menuItem = new JMenuItem("Edit Damage...");
+                    menuItem.setActionCommand(COMMAND_EDIT_DAMAGE);
+                    menuItem.addActionListener(this);
+                    menu.add(menuItem);
+                }
+
+                menuItem = new JMenuItem("Restore Unit");
+                menuItem.setActionCommand(COMMAND_RESTORE_UNIT);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+
+                menuItem = new JMenuItem("Set Quality...");
+                menuItem.setActionCommand(COMMAND_SET_QUALITY);
+                menuItem.addActionListener(this);
+                menu.add(menuItem);
+
+                if (oneNotPresent) {
                     menuItem = new JMenuItem("Unit Arrives Immediately");
                     menuItem.setActionCommand(COMMAND_ARRIVE);
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
-                    popup.add(menu);
-                }
-            } else {
-                //region Determine if to Display
-                // this is used to determine whether or not to show parts of the GUI, especially for
-                // bulk selections
-                boolean oneMothballed = false; // If at least one unit is mothballed, we want to show unit activation
-                boolean oneMothballing = false; // If at least one unit is mothballing, we want to be able to cancel it
-                boolean oneActive = false; // If at least one unit is active, we want to enable mothballing
-                boolean oneDeployed = false; // If at least one unit is deployed, we want to show the remove deployment to GMs
-                boolean allDeployed = true; // don't show sell dialog if all units are deployed
-                boolean oneAvailableUnitBelowMaxCrew = false; // If one unit isn't fully crewed, enable bulk hiring
-                boolean oneNotPresent = false; // If a unit isn't present, enable instant arrival for GMs
-                boolean oneHasIndividualCamo = false; // If a unit has a unique camo, allow it to be removed
-                boolean oneHasCrew = false; // If a unit has crew, enable removing it
-                boolean allUnitsAreRepairable = true;  // If all units can be repaired, allow the repair flag to be selected
-                boolean areAllConventionalInfantry = true; // Conventional infantry can be disbanded, but no others
-                boolean noConventionalInfantry = true; // Conventional infantry can't be repaired/salvaged
-                boolean areAllRepairFlagged = true; // If everyone has the repair flag, then we show the repair flag box as selected
-                boolean areAllSalvageFlagged = true;  // Same as above, but with the salvage flag
-                boolean allRequireSameTechType = true; // If everyone requires the same tech type, we can allow bulk tech assignment
-                boolean allSameModel = true; // If everyone is the exact same unit and model of that unit
-                boolean oneRefitting = false; // If any one selected unit is refitting
-                boolean allAvailable = true; // If everyone is available
-                boolean allAvailableIgnoreRefit = true; // If everyone is available
-
-                final String model = unit.getEntity().getShortNameRaw();
-                String skill = unit.determineUnitTechSkillType();
-                int maintenanceTime = 0;
-                for (Unit u : units) {
-                    if (u.isMothballed()) {
-                        oneMothballed = true;
-                    } else if (u.isMothballing()) {
-                        oneMothballing = true;
-                    } else {
-                        oneActive = true;
-                    }
-
-                    if ((u.getCrew().size() < u.getFullCrewSize()) && u.isAvailable()) {
-                        oneAvailableUnitBelowMaxCrew = true;
-                    }
-
-                    if (u.isDeployed()) {
-                        oneDeployed = true;
-                    } else {
-                        allDeployed = false;
-                    }
-
-                    if (!u.isPresent()) {
-                        oneNotPresent = true;
-                    }
-
-                    if (allAvailableIgnoreRefit && !u.isAvailable(true)) {
-                        allAvailableIgnoreRefit = false;
-                        allAvailable = false;
-                    } else if (allAvailable && !u.isAvailable()) {
-                        allAvailable = false;
-                    }
-
-                    if (u.isEntityCamo()) {
-                        oneHasIndividualCamo = true;
-                    }
-
-                    if (u.getCrew().size() > 0) {
-                        oneHasCrew = true;
-                    }
-
-                    if (!u.isRepairable()) {
-                        allUnitsAreRepairable = false;
-                    }
-
-                    if (u.isSalvage()) {
-                        areAllRepairFlagged = false;
-                    } else {
-                        areAllSalvageFlagged = false;
-                    }
-
-                    if (u.getEntity().isConventionalInfantry()) {
-                        noConventionalInfantry = false;
-                    } else {
-                        areAllConventionalInfantry = false;
-                    }
-
-                    if (!StringUtil.isNullOrEmpty(skill)) {
-                        if (!skill.equals(u.determineUnitTechSkillType())) {
-                            allRequireSameTechType = false;
-                            skill = ""; //little performance saving hack
-                            continue;
-                        }
-                        maintenanceTime += u.getMaintenanceTime();
-                        if (maintenanceTime > Person.PRIMARY_ROLE_SUPPORT_TIME) {
-                            skill = ""; //little performance saving hack
-                        }
-                    }
-
-                    if (!model.equals(u.getEntity().getShortNameRaw())) {
-                        allSameModel = false;
-                    }
-
-                    if (u.isRefitting()) {
-                        oneRefitting = true;
-                    }
-                }
-                //endregion Determine if to Display
-
-                // change the location
-                menu = new JMenu("Change site");
-                boolean allSameSite = StaticChecks.areAllSameSite(units);
-                for (int i = 0; i < Unit.SITE_N; i++) {
-                    cbMenuItem = new JCheckBoxMenuItem(Unit.getSiteName(i));
-                    if (allSameSite && unit.getSite() == i) {
-                        cbMenuItem.setSelected(true);
-                    } else {
-                        cbMenuItem.setActionCommand(COMMAND_CHANGE_SITE + ":" + i);
-                        cbMenuItem.addActionListener(this);
-                    }
-                    menu.add(cbMenuItem);
-                }
-                menu.setEnabled(allAvailable);
-                popup.add(menu);
-
-                // swap ammo
-                if (oneSelected) {
-                    if (unit.getEntity().usesWeaponBays()) {
-                        menuItem = new JMenuItem("Swap ammo...");
-                        menuItem.setActionCommand(COMMAND_LC_SWAP_AMMO);
-                        menuItem.addActionListener(this);
-                        popup.add(menuItem);
-                    } else if (unit.getEntity().isSupportVehicle()
-                                && (unit.getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT)) {
-                        // Small SVs can configure ammo only if they have weapons that have
-                        // inferno ammo available
-                        if (unit.getEntity().getWeaponList().stream()
-                                .anyMatch(m -> (m.getType() instanceof InfantryWeapon)
-                                        && ((InfantryWeapon) m.getType()).hasInfernoAmmo())) {
-                            menuItem = new JMenuItem("Swap ammo...");
-                            menuItem.setActionCommand(COMMAND_SMALL_SV_SWAP_AMMO);
-                            menuItem.addActionListener(this);
-                            popup.add(menuItem);
-                        }
-                    } else {
-                        menu = new JMenu("Swap ammo");
-                        for (AmmoBin ammo : unit.getWorkingAmmoBins()) {
-                            JMenu ammoMenu = new JMenu(ammo.getType().getDesc());
-                            AmmoType curType = ammo.getType();
-                            for (AmmoType atype : Utilities.getMunitionsFor(unit.getEntity(), curType,
-                                    gui.getCampaign().getCampaignOptions().getTechLevel())) {
-                                cbMenuItem = new JCheckBoxMenuItem(atype.getDesc());
-                                if (atype.equals(curType)) {
-                                    cbMenuItem.setSelected(true);
-                                } else {
-                                    cbMenuItem.addActionListener(evt -> {
-                                        IUnitAction swapAmmoTypeAction = new SwapAmmoTypeAction(ammo, atype);
-                                        swapAmmoTypeAction.execute(gui.getCampaign(), unit);
-                                    });
-                                }
-                                ammoMenu.add(cbMenuItem);
-                            }
-                            JMenuHelpers.addMenuIfNonEmpty(menu, ammoMenu);
-                        }
-                        menu.setEnabled(allAvailable);
-                        JMenuHelpers.addMenuIfNonEmpty(popup, menu);
-                    }
                 }
 
-                // Select bombs
-                if (oneSelected && unit.getEntity().isBomber()) {
-                    menuItem = new JMenuItem("Select Bombs");
-                    menuItem.setActionCommand(COMMAND_BOMBS);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                // Salvage / Repair
-                if (noConventionalInfantry) {
-                    menu = new JMenu("Repair Status");
-                    cbMenuItem = new JCheckBoxMenuItem("Repair");
-                    cbMenuItem.setSelected(areAllRepairFlagged);
-                    cbMenuItem.setActionCommand(COMMAND_REPAIR);
-                    cbMenuItem.addActionListener(this);
-                    cbMenuItem.setEnabled(allUnitsAreRepairable);
-                    menu.add(cbMenuItem);
-
-                    cbMenuItem = new JCheckBoxMenuItem("Salvage");
-                    cbMenuItem.setSelected(areAllSalvageFlagged);
-                    cbMenuItem.setActionCommand(COMMAND_SALVAGE);
-                    cbMenuItem.addActionListener(this);
-                    menu.add(cbMenuItem);
-                    popup.add(menu);
-                }
-
-                if (oneActive) {
-                    menuItem = new JMenuItem(oneSelected ? "Mothball" : "Mass Mothball");
-                    menuItem.setActionCommand(COMMAND_MOTHBALL);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (oneMothballed) {
-                    menuItem = new JMenuItem(oneSelected ? "Activate" : "Mass Activate");
-                    menuItem.setActionCommand(COMMAND_ACTIVATE);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (oneMothballing) {
-                    menuItem = new JMenuItem("Cancel Mothballing/Activation");
-                    menuItem.setActionCommand(COMMAND_CANCEL_MOTHBALL);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (allRequireSameTechType && !StringUtil.isNullOrEmpty(skill)) {
-                    menu = new JMenu("Assign Tech");
-                    JMenu menuElite = new JMenu(SkillType.ELITE_NM);
-                    JMenu menuVeteran = new JMenu(SkillType.VETERAN_NM);
-                    JMenu menuRegular = new JMenu(SkillType.REGULAR_NM);
-                    JMenu menuGreen = new JMenu(SkillType.GREEN_NM);
-                    JMenu menuUltraGreen = new JMenu(SkillType.ULTRA_GREEN_NM);
-
-                    int techsFound = 0;
-                    for (Person tech : gui.getCampaign().getTechs()) {
-                        if (tech.hasSkill(skill)
-                                && (tech.getMaintenanceTimeUsing() + maintenanceTime)
-                                        <= Person.PRIMARY_ROLE_SUPPORT_TIME) {
-
-                            String skillLvl = "Unknown";
-                            if (tech.getSkillForWorkingOn(unit) != null) {
-                                skillLvl = SkillType.getExperienceLevelName(
-                                        tech.getSkillForWorkingOn(unit).getExperienceLevel());
-                            }
-
-                            JMenu subMenu;
-                            switch (skillLvl) {
-                                case SkillType.ELITE_NM:
-                                    subMenu = menuElite;
-                                    break;
-                                case SkillType.VETERAN_NM:
-                                    subMenu = menuVeteran;
-                                    break;
-                                case SkillType.REGULAR_NM:
-                                    subMenu = menuRegular;
-                                    break;
-                                case SkillType.GREEN_NM:
-                                    subMenu = menuGreen;
-                                    break;
-                                case SkillType.ULTRA_GREEN_NM:
-                                    subMenu = menuUltraGreen;
-                                    break;
-                                default:
-                                    subMenu = null;
-                                    break;
-                            }
-
-                            if (subMenu != null) {
-                                cbMenuItem = new JCheckBoxMenuItem(tech.getFullTitle()
-                                        + " (" + tech.getMaintenanceTimeUsing() + "m)");
-                                cbMenuItem.setActionCommand(COMMAND_ASSIGN_TECH + ":" + tech.getId());
-
-                                if (tech.equals(unit.getTech())) {
-                                    cbMenuItem.setSelected(true);
-                                } else {
-                                    cbMenuItem.addActionListener(this);
-                                }
-
-                                subMenu.add(cbMenuItem);
-                                if (cbMenuItem.isSelected()) {
-                                    subMenu.setIcon(UIManager.getIcon("CheckBoxMenuItem.checkIcon"));
-                                }
-                                techsFound++;
-                            }
-                        }
-                    }
-
-                    if (techsFound > 0) {
-                        JMenuHelpers.addMenuIfNonEmpty(menu, menuElite);
-                        JMenuHelpers.addMenuIfNonEmpty(menu, menuVeteran);
-                        JMenuHelpers.addMenuIfNonEmpty(menu, menuRegular);
-                        JMenuHelpers.addMenuIfNonEmpty(menu, menuGreen);
-                        JMenuHelpers.addMenuIfNonEmpty(menu, menuUltraGreen);
-                        JMenuHelpers.addMenuIfNonEmpty(popup, menu);
-                    }
-                }
-
-                if (oneSelected && unit.requiresMaintenance()) {
-                    menuItem = new JMenuItem("Show Last Maintenance Report");
-                    menuItem.setActionCommand(COMMAND_MAINTENANCE_REPORT);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (oneSelected && !unit.isMothballed()
-                        && gui.getCampaign().getCampaignOptions().usePeacetimeCost()) {
-                    menuItem = new JMenuItem("Show Monthly Supply Cost Report");
-                    menuItem.setActionCommand(COMMAND_SUPPLY_COST);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (areAllConventionalInfantry) {
-                    menuItem = new JMenuItem("Disband");
-                    menuItem.setActionCommand(COMMAND_DISBAND);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                // Customize unit menu
-                if (allUnitsAreRepairable && allAvailableIgnoreRefit) {
-                    menu = new JMenu("Customize");
-
-                    // TODO : Should I be able to refit BA?
-                    if (allSameModel && allAvailable
-                            && ((unit.getEntity() instanceof Mech)
-                            || (unit.getEntity() instanceof Tank)
-                            || (unit.getEntity() instanceof Aero)
-                            || ((unit.getEntity() instanceof Infantry)))) {
-                        menuItem = new JMenuItem(unit.getEntity().isOmni() ? "Choose configuration..."
-                                : "Choose Refit Kit...");
-                        menuItem.setActionCommand(COMMAND_REFIT_KIT);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-
-                    if (allSameModel && allAvailable
-                            && ((unit.getEntity() instanceof Mech)
-                            || (unit.getEntity() instanceof Tank)
-                            || (unit.getEntity() instanceof Aero)
-                            || ((unit.getEntity() instanceof Infantry)
-                            || (unit.getEntity() instanceof Protomech)))) {
-                        menuItem = new JMenuItem("Refurbish Unit");
-                        menuItem.setActionCommand(COMMAND_REFURBISH);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-
-                    if (oneSelected && gui.hasTab(GuiTabType.MEKLAB)) {
-                        menuItem = new JMenuItem("Customize in Mek Lab...");
-                        menuItem.setActionCommand(COMMAND_CUSTOMIZE);
-                        menuItem.addActionListener(this);
-                        menuItem.setEnabled(allAvailable
-                                && !(unit.getEntity() instanceof GunEmplacement));
-                        menu.add(menuItem);
-                    }
-
-                    if (oneRefitting) {
-                        menuItem = new JMenuItem("Cancel Customization");
-                        menuItem.setActionCommand(COMMAND_CANCEL_CUSTOMIZE);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-
-                        if (isGM) {
-                            menuItem = new JMenuItem("Complete Refit (GM)");
-                            menuItem.setActionCommand(COMMAND_REFIT_GM_COMPLETE);
-                            menuItem.addActionListener(this);
-                            menu.add(menuItem);
-                        }
-                    }
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu);
-                }
-
-                // fill with personnel
-                if (oneAvailableUnitBelowMaxCrew) {
-                    menuItem = new JMenuItem(resourceMap.getString("hireMinimumComplement.text"));
-                    menuItem.setActionCommand(COMMAND_HIRE_FULL);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                // Camo
-                if (oneSelected && !unit.isEntityCamo()) {
-                    menuItem = new JMenuItem(gui.getResourceMap()
-                            .getString("customizeMenu.individualCamo.text"));
-                    menuItem.setActionCommand(COMMAND_INDI_CAMO);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-                if (oneHasIndividualCamo) {
-                    menuItem = new JMenuItem(gui.getResourceMap()
-                            .getString("customizeMenu.removeIndividualCamo.text"));
-                    menuItem.setActionCommand(COMMAND_REMOVE_INDI_CAMO);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (oneSelected && !gui.getCampaign().isCustom(unit)) {
-                    menuItem = new JMenuItem("Tag as a custom unit");
-                    menuItem.setActionCommand(COMMAND_TAG_CUSTOM);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (oneSelected && gui.getCampaign().getCampaignOptions().useQuirks()) {
-                    menuItem = new JMenuItem("Edit Quirks");
-                    menuItem.setActionCommand(COMMAND_QUIRKS);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (oneSelected) {
-                    menuItem = new JMenuItem("Edit Unit History...");
-                    menuItem.setActionCommand(COMMAND_CHANGE_HISTORY);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                // remove all personnel
-                if (oneHasCrew) {
-                    popup.addSeparator();
-                    menuItem = new JMenuItem("Remove all personnel");
-                    menuItem.setActionCommand(COMMAND_REMOVE_ALL_PERSONNEL);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (oneSelected) {
-                    menuItem = new JMenuItem("Name Unit");
-                    menuItem.setActionCommand(COMMAND_FLUFF_NAME);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                if (oneSelected) {
-                    menuItem = new JMenuItem("Show BV Calculation");
-                    menuItem.setActionCommand(COMMAND_SHOW_BV_CALC);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                // sell unit
-                if (!allDeployed && gui.getCampaign().getCampaignOptions().canSellUnits()) {
-                    popup.addSeparator();
-                    menuItem = new JMenuItem("Sell Unit");
-                    menuItem.setActionCommand(COMMAND_SELL);
-                    menuItem.addActionListener(this);
-                    popup.add(menuItem);
-                }
-
-                //region GM Mode
-                // GM mode - only show to GMs
-                if (isGM) {
-                    popup.addSeparator();
-                    menu = new JMenu("GM Mode");
-
-                    menuItem = new JMenuItem("Remove Unit");
-                    menuItem.setActionCommand(COMMAND_REMOVE);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-
-                    menuItem = new JMenuItem("Strip Unit");
-                    menuItem.setActionCommand(COMMAND_STRIP_UNIT);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-
-                    if (oneActive) {
-                        menuItem = new JMenuItem(oneSelected ? "Mothball Unit" : "Mass Mothball Units");
-                        menuItem.setActionCommand(COMMAND_GM_MOTHBALL);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-
-                    if (oneMothballed) {
-                        menuItem = new JMenuItem(oneSelected ? "Activate Unit" : "Mass Activate Units");
-                        menuItem.setActionCommand(COMMAND_GM_ACTIVATE);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-
-                    if (oneDeployed) {
-                        menuItem = new JMenuItem("Undeploy Unit");
-                        menuItem.setActionCommand(COMMAND_UNDEPLOY);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-
-                    if (oneAvailableUnitBelowMaxCrew) {
-                        menuItem = new JMenuItem(resourceMap.getString("addMinimumComplement.text"));
-                        menuItem.setActionCommand(COMMAND_HIRE_FULL_GM);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-
-                    if (oneSelected) {
-                        menuItem = new JMenuItem("Edit Damage...");
-                        menuItem.setActionCommand(COMMAND_EDIT_DAMAGE);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-
-                    menuItem = new JMenuItem("Restore Unit");
-                    menuItem.setActionCommand(COMMAND_RESTORE_UNIT);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-
-                    menuItem = new JMenuItem("Set Quality...");
-                    menuItem.setActionCommand(COMMAND_SET_QUALITY);
-                    menuItem.addActionListener(this);
-                    menu.add(menuItem);
-
-                    if (oneNotPresent) {
-                        menuItem = new JMenuItem("Unit Arrives Immediately");
-                        menuItem.setActionCommand(COMMAND_ARRIVE);
-                        menuItem.addActionListener(this);
-                        menu.add(menuItem);
-                    }
-
-                    JMenuHelpers.addMenuIfNonEmpty(popup, menu);
-                }
-                //endregion GM Mode
+                JMenuHelpers.addMenuIfNonEmpty(popup, menu);
             }
-            popup.show(e.getComponent(), e.getX(), e.getY());
+            //endregion GM Mode
         }
+
+        return popup;
     }
 
     private void addCustomUnitTag(Unit... units) {


### PR DESCRIPTION
This adds a new abstract class `JPopupMenuAdapter` to help connect the keyboard chord SHIFT+F10 to all of our context menus on JTable's and JTree's. This fixes #2418.

Apparently SHIFT+F10 sometimes works, but not always. This removes all doubt.