### PR TITLE
Issue 338 sort technician

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1588,6 +1588,8 @@ public class CampaignGUI extends JPanel {
             int TimePerDay;
 
             List<Person> techs = getCampaign().getTechs();
+            int lastRightTech = 0;
+
             techs.sort(Comparator.comparingInt(Person::getPrimaryRole));
             for (Person tech : techs) {
                 if (getCampaign().isWorkingOnRefit(tech) || tech.isEngineer()) {
@@ -1611,7 +1613,11 @@ public class CampaignGUI extends JPanel {
                         + tech.getMinutesLeft() + "/" + TimePerDay
                         + " minutes";
                 techHash.put(name, tech);
-                techList.add(name);
+                if(tech.isRightTechTypeFor(r)) {
+                    techList.add(lastRightTech++, name);
+                } else {
+                    techList.add(name);
+                }
             }
 
             String s = (String) JOptionPane.showInputDialog(frame,

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1628,7 +1628,20 @@ public class CampaignGUI extends JPanel {
                 return;
             }
 
-            r.setTech(techHash.get(s));
+            Person selectedTech = techHash.get(s);
+
+            if(!selectedTech.isRightTechTypeFor(r)) {
+                if(JOptionPane.NO_OPTION == JOptionPane
+                    .showConfirmDialog(
+                    null,
+                    "This tech is not appropriate for this unit. Would you like to continue?",
+                    "pending battle",
+                    JOptionPane.YES_NO_OPTION)) {
+                        return;
+                    }
+            }
+
+            r.setTech(selectedTech);
         } else {
             JOptionPane.showMessageDialog(frame,
                     "You have no techs available to work on this refit.",

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1587,10 +1587,9 @@ public class CampaignGUI extends JPanel {
             String skillLvl;
             int TimePerDay;
 
-            List<Person> techs = getCampaign().getTechs();
+            List<Person> techs = getCampaign().getTechs(false, null, true, true);
             int lastRightTech = 0;
 
-            techs.sort(Comparator.comparingInt(Person::getPrimaryRole));
             for (Person tech : techs) {
                 if (getCampaign().isWorkingOnRefit(tech) || tech.isEngineer()) {
                     continue;

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1612,7 +1612,7 @@ public class CampaignGUI extends JPanel {
                         + tech.getMinutesLeft() + "/" + TimePerDay
                         + " minutes";
                 techHash.put(name, tech);
-                if(tech.isRightTechTypeFor(r)) {
+                if (tech.isRightTechTypeFor(r)) {
                     techList.add(lastRightTech++, name);
                 } else {
                     techList.add(name);
@@ -1629,10 +1629,8 @@ public class CampaignGUI extends JPanel {
 
             Person selectedTech = techHash.get(s);
 
-            if(!selectedTech.isRightTechTypeFor(r)) {
-                if(JOptionPane.NO_OPTION == JOptionPane
-                    .showConfirmDialog(
-                    null,
+            if (!selectedTech.isRightTechTypeFor(r)) {
+                if (JOptionPane.NO_OPTION == JOptionPane.showConfirmDialog(null,
                     "This tech is not appropriate for this unit. Would you like to continue?",
                     "pending battle",
                     JOptionPane.YES_NO_OPTION)) {


### PR DESCRIPTION
https://github.com/MegaMek/mekhq/issues/338

Resolution of above issue. Progress over perfection. This change will notify players if they are about to use a wrong tech, and it will put the right techs per the Tech class (is right (refit target)) at the top.

I think this is best because tbh, I don't assign techs based on their skills. Some repairs take more or less long and I will assign like that. But a new player will assign a tech and only at the end discover they made a mistake. This fixes that issue.