### PR TITLE
2442: Fixing Multiple Ranks Issues

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3326,7 +3326,7 @@ public class Campaign implements Serializable, ITechManager {
                         fixPart(part, tech);
                     } catch (Exception e) {
                         MekHQ.getLogger().error(String.format(
-                                "Could not perform overnight maintenance on %s (%d) due to an error", 
+                                "Could not perform overnight maintenance on %s (%d) due to an error",
                                 part.getName(), part.getId()), e);
                         addReport(String.format("ERROR: an error occurred performing overnight maintenance on %s, check the log",
                                 part.getName()));
@@ -4362,10 +4362,6 @@ public class Campaign implements Serializable, ITechManager {
 
     public Ranks getRanks() {
         return ranks;
-    }
-
-    public void setRankSystem(int system) {
-        getRanks().setRankSystem(system);
     }
 
     public List<String> getAllRankNamesFor(int p) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -707,12 +707,8 @@ public class CampaignXmlParser {
                     retVal.updateTechFactionCode();
                 } else if (xn.equalsIgnoreCase("retainerEmployerCode")) {
                     retVal.setRetainerEmployerCode(wn.getTextContent());
-                } else if (xn.equalsIgnoreCase("officerCut")) {
-                    officerCut = Integer.parseInt(wn.getTextContent().trim());
-                } else if (xn.equalsIgnoreCase("rankNames")) {
-                    rankNames = wn.getTextContent().trim();
                 } else if (xn.equalsIgnoreCase("ranks") || xn.equalsIgnoreCase("rankSystem")) {
-                    Ranks r = Ranks.generateInstanceFromXML(wn, version);
+                    Ranks r = Ranks.generateInstanceFromXML(wn, version, false);
                     if (r != null) {
                         retVal.setRanks(r);
                     }
@@ -731,8 +727,7 @@ public class CampaignXmlParser {
                 } else if (xn.equalsIgnoreCase("overtime")) {
                     retVal.setOvertime(Boolean.parseBoolean(wn.getTextContent().trim()));
                 } else if (xn.equalsIgnoreCase("astechPool")) {
-                    retVal.setAstechPool(Integer.parseInt(wn.getTextContent()
-                            .trim()));
+                    retVal.setAstechPool(Integer.parseInt(wn.getTextContent().trim()));
                 } else if (xn.equalsIgnoreCase("astechPoolMinutes")) {
                     retVal.setAstechPoolMinutes(Integer.parseInt(wn.getTextContent().trim()));
                 } else if (xn.equalsIgnoreCase("astechPoolOvertime")) {
@@ -745,10 +740,6 @@ public class CampaignXmlParser {
                     retVal.setId(UUID.fromString(wn.getTextContent().trim()));
                 }
             }
-        }
-        if (null != rankNames) {
-            //backwards compatibility
-            retVal.getRanks().setRanksFromList(rankNames, officerCut);
         }
 
         // TODO: this could probably be better


### PR DESCRIPTION
This:
1) Overwrites the Campaign Ranks object instead of making some internal changes to the Ranks object in Campaign (which... I'm surprised wasn't causing more issues) (fixes #2442)
2) Prevents rank system data overwrite when loading a non-custom rank system from Campaign XML.
3) Tears out a bunch of old (7+ years) migration code, some of which was causing naming issues.
4) Sets rank system name migration to happen for any campaign before stable, to fix the previous name issues.
5) Swaps the Campaign Options Dialog rank system spinner to instead track based on the Ranks, which... was just a quick flip (I also tore out some old graphical code there, because it will need to be completely rewritten)