### PR TITLE
Use MM's new UnitNameTracker for name collisions

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -181,7 +181,7 @@ public class Campaign implements Serializable, ITechManager {
     private TreeMap<Integer, Scenario> scenarios = new TreeMap<>();
     private Map<UUID, List<Kill>> kills = new HashMap<>();
 
-    private Map<String, Integer> duplicateNameHash = new HashMap<>();
+    private final UnitNameTracker unitNameTracker = new UnitNameTracker();
 
     private int astechPool;
     private int astechPoolMinutes;
@@ -5528,42 +5528,21 @@ public class Campaign implements Serializable, ITechManager {
     /**
      * borrowed from megamek.client
      */
-    private void checkDuplicateNamesDuringAdd(Entity entity) {
-        if (duplicateNameHash.get(entity.getShortName()) == null) {
-            duplicateNameHash.put(entity.getShortName(), 1);
-        } else {
-            int count = duplicateNameHash.get(entity.getShortName());
-            count++;
-            duplicateNameHash.put(entity.getShortName(), count);
-            entity.duplicateMarker = count;
-            entity.generateShortName();
-            entity.generateDisplayName();
-        }
+    private synchronized void checkDuplicateNamesDuringAdd(Entity entity) {
+        unitNameTracker.add(entity);
     }
 
     /**
-     * If we remove a unit, we may need to update the duplicate identifier. TODO: This function is super slow :(
+     * If we remove a unit, we may need to update the duplicate identifier.
      *
      * @param entity This is the entity whose name is checked for any duplicates
      */
-    private void checkDuplicateNamesDuringDelete(Entity entity) {
-        Integer o = duplicateNameHash.get(entity.getShortNameRaw());
-        if (o != null) {
-            int count = o;
-            if (count > 1) {
-                for (Unit u : getUnits()) {
-                    Entity e = u.getEntity();
-                    if (e.getShortNameRaw().equals(entity.getShortNameRaw()) && (e.duplicateMarker > entity.duplicateMarker)) {
-                        e.duplicateMarker--;
-                        e.generateShortName();
-                        e.generateDisplayName();
-                    }
-                }
-                duplicateNameHash.put(entity.getShortNameRaw(), count - 1);
-            } else {
-                duplicateNameHash.remove(entity.getShortNameRaw());
-            }
-        }
+    private synchronized void checkDuplicateNamesDuringDelete(Entity entity) {
+        unitNameTracker.remove(entity, e -> {
+            // Regenerate entity names after a deletion
+            e.generateShortName();
+            e.generateDisplayName();
+        });
     }
 
     public String getUnitRatingText() {

--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -80,7 +80,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
         this.team = team;
         this.start = start;
         // Filter all nulls out of the parameter entityList
-        this.entityList = entityList.stream().filter(Objects::nonNull).collect(Collectors.toCollection(ArrayList::new));
+        setEntityList(entityList);
         this.camoCategory = camoCategory;
         this.camoFileName = camoFileName;
         this.colour = colour;

--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -21,6 +21,7 @@ package mekhq.campaign.mission;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -38,6 +39,7 @@ import megamek.client.bot.princess.PrincessException;
 import megamek.common.Board;
 import megamek.common.Compute;
 import megamek.common.Entity;
+import megamek.common.UnitNameTracker;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
@@ -45,6 +47,7 @@ import mekhq.MekHqXmlUtil;
 public class BotForce implements Serializable, MekHqXmlSerializable {
     private static final long serialVersionUID = 8259058549964342518L;
 
+    private final UnitNameTracker nameTracker = new UnitNameTracker();
     private String name;
     private List<Entity> entityList;
     private int team;
@@ -125,12 +128,34 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
     }
 
     public List<Entity> getEntityList() {
-        return entityList;
+        return Collections.unmodifiableList(entityList);
+    }
+
+    public boolean removeEntity(int index) {
+        Entity e = null;
+        if ((index >= 0) && (index < entityList.size())) {
+            e = entityList.remove(index);
+            nameTracker.remove(e, updated -> {
+                updated.generateShortName();
+                updated.generateDisplayName();
+            });
+        }
+
+        return e != null;
     }
 
     public void setEntityList(List<Entity> entityList) {
-        // Filter all nulls out of the parameter entityList
-        this.entityList = entityList.stream().filter(Objects::nonNull).collect(Collectors.toCollection(ArrayList::new));
+        nameTracker.clear();
+
+        List<Entity> entities = new ArrayList<>();
+        for (Entity e : entities) {
+            if (e != null) {
+                nameTracker.add(e);
+                entities.add(e);
+            }
+        }
+
+        this.entityList = entities;
     }
 
     public int getTeam() {

--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -148,7 +148,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
         nameTracker.clear();
 
         List<Entity> entities = new ArrayList<>();
-        for (Entity e : entities) {
+        for (Entity e : entityList) {
             if (e != null) {
                 nameTracker.add(e);
                 entities.add(e);

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -120,7 +120,7 @@ public class AtBScenarioModifierApplicator {
             BotForce bf = scenario.getBotForce(botForceIndex);
             if (bf.getTeam() == ScenarioForceTemplate.TEAM_IDS.get(eventRecipient.ordinal())) {
                 int unitIndexToRemove = Compute.randomInt(bf.getEntityList().size());
-                bf.getEntityList().remove(unitIndexToRemove);
+                bf.removeEntity(unitIndexToRemove);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -265,7 +265,9 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         //one gets some of the same things set
         if (null != this.entity) {
             en.setId(this.entity.getId());
-            en.duplicateMarker = this.entity.duplicateMarker;
+            en.setDuplicateMarker(this.entity.getDuplicateMarker());
+            en.generateShortName();
+            en.generateDisplayName();
         }
         this.entity = en;
     }


### PR DESCRIPTION
This switches to using MegaMek's new UnitNameTracker to avoid name collisions for a campaign.

Depends on https://github.com/MegaMek/megamek/pull/2632