### PR TITLE
Issue #2446: Calculate the scrollable block increment correctly

### DIFF
--- a/MekHQ/src/mekhq/gui/view/ScrollablePanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScrollablePanel.java
@@ -24,6 +24,7 @@ import java.awt.Rectangle;
 
 import javax.swing.JPanel;
 import javax.swing.Scrollable;
+import javax.swing.SwingConstants;
 
 /**
  * This is an extension of JPanel that implements scrollable so that all of our ViewPanel objects 
@@ -47,11 +48,15 @@ public class ScrollablePanel extends JPanel implements Scrollable{
     }
 
     public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
-        return 16;
+        if (SwingConstants.VERTICAL == orientation) {
+            return visibleRect.height;
+        } else {
+            return visibleRect.width;
+        }
     }
 
     public void setScrollableTracksViewportWidth(boolean value) {
-        trackViewportWidth = false;
+        trackViewportWidth = value;
     }
     
     public boolean getScrollableTracksViewportWidth() {

--- a/MekHQ/src/mekhq/gui/view/ScrollablePanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScrollablePanel.java
@@ -48,11 +48,9 @@ public class ScrollablePanel extends JPanel implements Scrollable{
     }
 
     public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
-        if (SwingConstants.VERTICAL == orientation) {
-            return visibleRect.height;
-        } else {
-            return visibleRect.width;
-        }
+        return (SwingConstants.VERTICAL == orientation)
+                ? visibleRect.height
+                : visibleRect.width;
     }
 
     public void setScrollableTracksViewportWidth(boolean value) {


### PR DESCRIPTION
MekHQ uses `ScrollablePanel` as a base class for panels that should be scrolled. Its implementation uses 16 pixels for both the unit and block scrolling increment, which breaks the basic UI assumption that block scrolling should be in "pages". This restores the intended behavior of block scrolling [by adopting what is effectively the JTable implementation](https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/javax/swing/JTable.html#getScrollableUnitIncrement(java.awt.Rectangle,int,int)):
> Returns visibleRect.height or visibleRect.width, depending on this table's orientation.

Fixes #2446