### PR TITLE
Issue #2452: Ensure a Lance's Force assignment is still valid

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1742,6 +1742,7 @@ public class Campaign implements Serializable, ITechManager {
         return parts.getPart(id);
     }
 
+    @Nullable
     public Force getForce(int id) {
         return forceIds.get(id);
     }

--- a/MekHQ/src/mekhq/campaign/force/Lance.java
+++ b/MekHQ/src/mekhq/campaign/force/Lance.java
@@ -227,7 +227,8 @@ public class Lance implements Serializable, MekHqXmlSerializable {
 
     public boolean isEligible(Campaign c) {
         // ensure the lance is marked as a combat force
-        if (!c.getForce(forceId).isCombatForce()) {
+        final Force force = c.getForce(forceId);
+        if ((force == null) || !force.isCombatForce()) {
             return false;
         }
 
@@ -247,7 +248,7 @@ public class Lance implements Serializable, MekHqXmlSerializable {
         }
 
         boolean hasGround = false;
-        for (UUID id : c.getForce(forceId).getUnits()) {
+        for (UUID id : force.getUnits()) {
             Unit unit = c.getUnit(id);
             if (null != unit) {
                 Entity entity = unit.getEntity();


### PR DESCRIPTION
If the force assignment for a lance becomes out-of-sync, when AtB generates scenarios for the lance an NPE may be raised. `Lance::isEligible` presumes `Campaign::getForce` will be non-null for the assigned force. This resolves the NPE by instead marking the lance as ineligible if its force is no longer valid.

Ultimately, the entirety of Lance/Force/Scenario/Mission need to be converted to using object references to avoid these problems in the future.

Fixes #2452