### PR TITLE
Issue #2459: Only calculate weight if EquipmertPart has a type

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -107,8 +107,8 @@ public class EquipmentPart extends Part {
     @Override
     public void setUnit(Unit u) {
         super.setUnit(u);
-        if (null != unit) {
-            equipTonnage = type.getTonnage(unit.getEntity(), size);
+        if ((u != null) && (type != null)) {
+            equipTonnage = type.getTonnage(u.getEntity(), size);
         }
     }
 


### PR DESCRIPTION
Fixes an NPE seen when assigning a unit to a bad equipment part by protecting against a null EquipmentType.

Fixes #2459.