### PR TITLE
2460: Improving Default AtBContract Name and Briefing Tab Sort

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -906,7 +906,8 @@ public class Campaign implements Serializable, ITechManager {
      */
     public List<Mission> getSortedMissions() {
         return getMissions().stream()
-                .sorted(Comparator.comparing(Mission::getStatus))
+                .sorted(Comparator.comparing(Mission::getStatus).thenComparing(m ->
+                        (m instanceof Contract) ? ((Contract) m).getStartDate() : LocalDate.now()))
                 .collect(Collectors.toList());
     }
 

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -22,6 +22,7 @@ package mekhq.campaign.market;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -327,11 +328,7 @@ public class ContractMarket implements Serializable {
             return null;
         }
 
-        AtBContract contract = new AtBContract(employer
-                + "-"
-                + Contract.generateRandomContractName()
-                + "-"
-                + MekHQ.getMekHQOptions().getDisplayFormattedDate(campaign.getLocalDate()));
+        AtBContract contract = new AtBContract("UnnamedContract");
         lastId++;
         contract.setId(lastId);
         contractIds.put(lastId, contract);
@@ -426,11 +423,10 @@ public class ContractMarket implements Serializable {
         contract.initContractDetails(campaign);
         contract.calculateContract(campaign);
 
-        //Ralgith had a version of this then the PR got added. Commenting this Out.
-/*        contract.setName(Factions.getInstance().getFaction(employer).getShortName() + "-" + String.format("%1$tY%1$tm", contract.getStartDate())
-                         + "-" + AtBContract.missionTypeNames[contract.getMissionType()]
-                         + "-" + Factions.getInstance().getFaction(contract.getEnemyCode()).getShortName()
-                         + "-" + contract.getLength());*/
+        contract.setName(String.format("%s - %s - %s %s",
+                campaign.getLocalDate().format(DateTimeFormatter.ofPattern("yyyy")), employer,
+                        contract.getSystem().getName(campaign.getLocalDate()),
+                        AtBContract.missionTypeNames[contract.getMissionType()]));
 
         return contract;
     }

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -28,8 +28,6 @@ import java.time.temporal.ChronoUnit;
 
 import mekhq.campaign.finances.Accountant;
 import mekhq.campaign.finances.Money;
-import org.apache.commons.text.CharacterPredicate;
-import org.apache.commons.text.RandomStringGenerator;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -453,21 +451,6 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
                 .minus(getTotalEstimatedOverheadExpenses(c))
                 .minus(getTotalEstimatedMaintenanceExpenses(c))
                 .minus(getTotalEstimatedPayrollExpenses(c));
-    }
-
-    public static String generateRandomContractName() {
-        RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('0', 'Z')
-                .filteredBy(UpperCaseAndDigits.UPPERANDDIGITS).build();
-        return generator.generate(15);
-    }
-
-    public enum UpperCaseAndDigits implements CharacterPredicate {
-        UPPERANDDIGITS {
-            @Override
-            public boolean test(int codePoint) {
-                return (Character.isDigit(codePoint) || Character.isUpperCase(codePoint));
-            }
-        }
     }
 
     private int getTravelDays(Campaign c) {


### PR DESCRIPTION
This swaps AtB Contract naming to use a nicer format than our current setup, and adds date sorting to missions.

These were raised in the chat for #2460, and I'd say this fixes #2460.