### PR TITLE
Better unit restore

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4921,8 +4921,24 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         return en.getDamageLevel(false);
     }
 
-    public void resetParts() {
-        parts = new ArrayList<>();
+    /**
+     * Removes all of the parts from a unit.
+     * 
+     * NOTE: this puts the unit in an inconsistent state, and
+     *       the unit should not be used until its parts have
+     *       been re-assigned.
+     * 
+     */
+    public void removeParts() {
+        for (Part part : parts) {
+            part.setUnit(null);
+
+            if (campaign != null) {
+                campaign.getWarehouse().removePart(part);
+            }
+        }
+
+        parts.clear();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -184,7 +184,7 @@ public class RestoreUnitAction implements IUnitAction {
     public interface IEntityCopyFactory {
         /**
          * Gets a copy of the entity.
-         * @param en The entity to copy.
+         * @param entity The entity to copy.
          * @return A copy of the entity, or {@code null} if a copy could not be made.
          */
         @Nullable
@@ -198,18 +198,18 @@ public class RestoreUnitAction implements IUnitAction {
     private static class FileSystemEntityCopyFactory implements IEntityCopyFactory {
         /**
          * Get a copy of the entity from the {@link MechSummaryCache}.
-         * @param en The entity to copy.
+         * @param entity The entity to copy.
          * @return A copy of the entity, or {@code null} if a copy could not be made.
          */
         @Nullable
-        public Entity copy(Entity en) {
-            final MechSummary ms = MechSummaryCache.getInstance().getMech(en.getShortNameRaw());
+        public Entity copy(Entity entity) {
+            final MechSummary ms = MechSummaryCache.getInstance().getMech(entity.getShortNameRaw());
             try {
                 if (ms != null) {
                     return new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
                 }
             } catch (EntityLoadingException e) {
-                MekHQ.getLogger().error("Cannot restore unit from entity, could not find: " + ms.getName(), e);
+                MekHQ.getLogger().error("Cannot restore unit from entity, could not find: " + entity.getShortNameRaw(), e);
             }
 
             return null;

--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -22,6 +22,8 @@ package mekhq.campaign.unit.actions;
 import java.util.*;
 
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megamek.common.loaders.EntityLoadingException;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.UnitChangedEvent;
@@ -34,8 +36,87 @@ import mekhq.campaign.unit.Unit;
  */
 public class RestoreUnitAction implements IUnitAction {
 
+    private final MechSummaryCache mechSummaryCache;
+
+    public RestoreUnitAction() {
+        this(MechSummaryCache.getInstance());
+    }
+
+    public RestoreUnitAction(MechSummaryCache mechSummaryCache) {
+        this.mechSummaryCache = Objects.requireNonNull(mechSummaryCache);
+    }
+
     @Override
     public void execute(Campaign campaign, Unit unit) {
+        Entity newEntity = getCopyOfEntity(unit.getEntity());
+        if (newEntity != null) {
+            restoreUnit(campaign, unit, newEntity);
+        } else {
+            // Fall back to the old way of restoring a unit if we could not
+            // create a copy of the entity from the summary cache
+            oldUnitRestoration(campaign, unit);
+        }
+
+        MekHQ.triggerEvent(new UnitChangedEvent(unit));
+    }
+
+    /**
+     * Restore a unit by swapping out its entity and replacing its parts.
+     * @param campaign The campaign which owns the unit.
+     * @param unit The unit to restore.
+     * @param newEntity The new entity to assign to the unit.
+     */
+    private void restoreUnit(Campaign campaign, Unit unit, Entity newEntity) {
+        // CAW: this logic is broadly similar to Campaign::addNewUnit
+        final Entity oldEntity = unit.getEntity();
+        newEntity.setId(oldEntity.getId());
+
+        campaign.getGame().removeEntity(oldEntity.getId(), 0);
+
+        newEntity.setOwner(campaign.getPlayer());
+        newEntity.setGame(campaign.getGame());
+        newEntity.setExternalIdAsString(unit.getId().toString());
+        campaign.getGame().addEntity(newEntity.getId(), newEntity);
+
+        unit.setEntity(newEntity);
+
+        unit.removeParts();
+
+        unit.initializeBaySpace();
+
+        unit.initializeParts(true);
+        unit.runDiagnostic(false);
+        unit.setSalvage(false);
+        unit.resetPilotAndEntity();
+    }
+
+    /**
+     * Get a copy of the entity from the {@link MechSummaryCache}.
+     * @param en The entity to copy.
+     * @return A copy of the entity, or {@code null} if a copy could not be made.
+     */
+    @Nullable
+    private Entity getCopyOfEntity(Entity en) {
+        final MechSummary ms = mechSummaryCache.getMech(en.getShortNameRaw());
+        try {
+            if (ms != null) {
+                return new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
+            }
+        } catch (EntityLoadingException e) {
+            MekHQ.getLogger().error("Cannot restore unit from entity, could not find: " + ms.getName(), e);
+        }
+
+        return null;
+    }
+
+    /**
+     * Restores a unit using the old per-part logic.
+     * @param campaign The campaign which owns the unit.
+     * @param unit The unit to restore.
+     */
+    private void oldUnitRestoration(Campaign campaign, Unit unit) {
+        MekHQ.getLogger().warning("Falling back to old unit restoration logic");
+
         unit.setSalvage(false);
 
         boolean needsCheck = true;
@@ -105,7 +186,5 @@ public class RestoreUnitAction implements IUnitAction {
                 }
             }
         }
-
-        MekHQ.triggerEvent(new UnitChangedEvent(unit));
     }
 }


### PR DESCRIPTION
This PR allows for better unit restore logic, fixing a number of issues we've seen in the past. The new strategy undertaken is to create a copy of the underlying entity then remove and replace all of the parts on the unit, as if we were adding a brand new unit.

If it cannot create a copy of the entity, it instead falls back to the old logic.

Fixes #2347.
Fixes #2299.
Fixes #2266.
Fixes #944.
Fixes #943.
Fixes #774.
Fixes #748.