### PR TITLE
Make sure we copy over the C3 master on restore

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -107,7 +107,14 @@ public class RestoreUnitAction implements IUnitAction {
      * @param target The target {@link Entity}.
      */
     private static void copyC3Networks(Entity source, Entity target) {
+        target.setC3UUIDAsString(source.getC3UUIDAsString());
         target.setC3Master(source.getC3Master(), false);
+        target.setC3MasterIsUUIDAsString(source.getC3MasterIsUUIDAsString());
+
+        for (int pos = 0; pos < Entity.MAX_C3i_NODES; ++pos) {
+            target.setC3iNextUUIDAsString(pos, source.getC3iNextUUIDAsString(pos));
+            target.setNC3NextUUIDAsString(pos, source.getNC3NextUUIDAsString(pos));
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -87,6 +87,8 @@ public class RestoreUnitAction implements IUnitAction {
         newEntity.setExternalIdAsString(unit.getId().toString());
         campaign.getGame().addEntity(newEntity.getId(), newEntity);
 
+        copyC3Networks(oldEntity, newEntity);
+
         unit.setEntity(newEntity);
 
         unit.removeParts();
@@ -97,6 +99,15 @@ public class RestoreUnitAction implements IUnitAction {
         unit.runDiagnostic(false);
         unit.setSalvage(false);
         unit.resetPilotAndEntity();
+    }
+
+    /**
+     * Copies the C3 network setup from the source to the target.
+     * @param source The source {@link Entity}.
+     * @param target The target {@link Entity}.
+     */
+    private static void copyC3Networks(Entity source, Entity target) {
+        target.setC3Master(source.getC3Master(), false);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -111,6 +111,22 @@ public class RestoreUnitAction implements IUnitAction {
         target.setC3Master(source.getC3Master(), false);
         target.setC3MasterIsUUIDAsString(source.getC3MasterIsUUIDAsString());
 
+        // Reassign the C3NetId
+        // TODO: Add Entity::setC3NetId(String)
+        String c3NetId = source.getC3NetId();
+        if (c3NetId != null) {
+            for (Entity entity : target.getGame().getEntitiesVector()) {
+                if (target.getId() == entity.getId()) {
+                    continue;
+                }
+
+                if (c3NetId.equals(entity.getC3NetId())) {
+                    target.setC3NetId(entity);
+                    break;
+                }
+            }
+        }
+
         for (int pos = 0; pos < Entity.MAX_C3i_NODES; ++pos) {
             target.setC3iNextUUIDAsString(pos, source.getC3iNextUUIDAsString(pos));
             target.setNC3NextUUIDAsString(pos, source.getNC3NextUUIDAsString(pos));


### PR DESCRIPTION
This PR builds on the new Unit Restore behavior and ensures the C3 network settings are copied as well.

TODO:
- [ ] Unit tests for C3 copy logic