### PR TITLE
338: Base Free Time Sort

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3176,6 +3176,15 @@ public class Person implements Serializable, MekHqXmlSerializable {
         return false;
     }
 
+    /**
+     * @return the person's current daily available tech time. This does NOT account for any expended
+     * time.
+     */
+    public int getDailyAvailableTechTime() {
+        return (isTechPrimary() ? PRIMARY_ROLE_SUPPORT_TIME : SECONDARY_ROLE_SUPPORT_TIME)
+                - getMaintenanceTimeUsing();
+    }
+
     public int getMaintenanceTimeUsing() {
         int time = 0;
         for (Unit u : getTechUnits()) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1552,12 +1552,11 @@ public class CampaignGUI extends JPanel {
                 return;
             }
             r.setTech(engineer);
-        } else if (getCampaign().getTechs().size() > 0) {
+        } else if (getCampaign().getActivePersonnel().stream().anyMatch(Person::isTech)) {
             String name;
             Map<String, Person> techHash = new HashMap<>();
             List<String> techList = new ArrayList<>();
             String skillLvl;
-            int TimePerDay;
 
             List<Person> techs = getCampaign().getTechs(false, null, true, true);
             int lastRightTech = 0;
@@ -1566,23 +1565,10 @@ public class CampaignGUI extends JPanel {
                 if (getCampaign().isWorkingOnRefit(tech) || tech.isEngineer()) {
                     continue;
                 }
-                if (tech.getSecondaryRole() == Person.T_MECH_TECH || tech.getSecondaryRole() == Person.T_MECHANIC || tech.getSecondaryRole() == Person.T_AERO_TECH) {
-                    TimePerDay = 240 - tech.getMaintenanceTimeUsing();
-                } else {
-                    TimePerDay = 480 - tech.getMaintenanceTimeUsing();
-                }
                 skillLvl = SkillType.getExperienceLevelName(tech.getExperienceLevel(false));
-                name = tech.getFullName()
-                        + ", "
-                        + skillLvl
-                        + " "
-                        + tech.getPrimaryRoleDesc()
-                        + " ("
-                        + getCampaign().getTargetFor(r, tech).getValueAsString()
-                        + "+)"
-                        + ", "
-                        + tech.getMinutesLeft() + "/" + TimePerDay
-                        + " minutes";
+                name = tech.getFullName() + ", " + skillLvl + " " + tech.getPrimaryRoleDesc()
+                        + " (" + getCampaign().getTargetFor(r, tech).getValueAsString() + "+), "
+                        + tech.getMinutesLeft() + "/" + tech.getDailyAvailableTechTime() + " minutes";
                 techHash.put(name, tech);
                 if (tech.isRightTechTypeFor(r)) {
                     techList.add(lastRightTech++, name);
@@ -1603,11 +1589,10 @@ public class CampaignGUI extends JPanel {
 
             if (!selectedTech.isRightTechTypeFor(r)) {
                 if (JOptionPane.NO_OPTION == JOptionPane.showConfirmDialog(null,
-                    "This tech is not appropriate for this unit. Would you like to continue?",
-                    "pending battle",
-                    JOptionPane.YES_NO_OPTION)) {
-                        return;
-                    }
+                        "This tech is not appropriate for this unit. Would you like to continue?",
+                        "Incorrect Tech Type", JOptionPane.YES_NO_OPTION)) {
+                    return;
+                }
             }
 
             r.setTech(selectedTech);

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -843,7 +843,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     public void refreshTechsList() {
         int selected = techTable.getSelectedRow();
         // The next gets all techs who have more than 0 minutes free, and sorted by skill descending (elites at bottom)
-        List<Person> techs = getCampaign().getTechs(true, null, true, false);
+        List<Person> techs = getCampaign().getTechs(true);
         techsModel.setData(techs);
         if ((selected > -1) && (selected < techs.size())) {
             techTable.setRowSelectionInterval(selected, selected);

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -564,7 +564,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
 
     public void refreshTechsList() {
         // The next gets all techs who have more than 0 minutes free, and sorted by skill descending (elites at bottom)
-        techsModel.setData(getCampaign().getTechs(true, null, true, false));
+        techsModel.setData(getCampaign().getTechs(true));
         String astechString = "<html><b>Astech Pool Minutes:</> " + getCampaign().getAstechPoolMinutes();
         if (getCampaign().isOvertimeAllowed()) {
             astechString += " [" + getCampaign().getAstechPoolOvertime() + " overtime]";

--- a/MekHQ/src/mekhq/gui/model/TaskTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TaskTableModel.java
@@ -153,7 +153,7 @@ public class TaskTableModel extends DataTableModel {
 
 	                if (null == tech) {
 	                	//Find a valid tech that we can copy their skill from
-	                	List<Person> techs = gui.getCampaign().getTechs(false);
+	                	List<Person> techs = gui.getCampaign().getTechs();
 
 	        			for (int i = techs.size() - 1; i >= 0; i--) {
 	        				Person techTemp = techs.get(i);

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -172,7 +172,7 @@ public class MassRepairService {
 
         campaign.addReport(msg);
 
-        List<Person> techs = campaign.getTechs(false);
+        List<Person> techs = campaign.getTechs();
 
         if (!techs.isEmpty()) {
             List<IPartWork> parts = unit.getPartsNeedingService(true);
@@ -302,7 +302,7 @@ public class MassRepairService {
                 "Units with unfixable limbs:", campaign);
 
         if (!unitActionsByStatus.isEmpty()) {
-            List<Person> techs = campaign.getTechs(false);
+            List<Person> techs = campaign.getTechs();
 
             if (!techs.isEmpty()) {
                 int count = 0;


### PR DESCRIPTION
This fixes #338 while simplifying any calls to the three overloaded methods.

Elite first is only done for refits, so using Person::getDailyAvailableTechTime as the sort is perfectly okay here.