### PR TITLE
Transfer Force info to MM, requires MM#2409 Lobby/GUI changes

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -281,6 +281,7 @@ public class AtBGameThread extends GameThread {
                     }
 
                     entity.setDeployRound(deploymentRound);
+                    entities.add(entity);
                 }
                 client.sendAddEntity(entities);
                 client.sendPlayerInfo();
@@ -403,7 +404,7 @@ public class AtBGameThread extends GameThread {
                 String forceName = botClient.getLocalPlayer().getName() + "|1";
                 var entities = new ArrayList<Entity>();
                 for (Entity entity : botForce.getEntityList()) {
-                    if (entity == null) {
+                    if (null == entity) {
                         continue;
                     }
                     entity.setOwner(botClient.getLocalPlayer());

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -43,6 +43,7 @@ import megamek.common.PlanetaryConditions;
 import megamek.common.UnitType;
 import megamek.common.logging.LogLevel;
 import mekhq.campaign.againstTheBot.enums.AtBLanceRole;
+import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.AtBScenario;
@@ -186,6 +187,7 @@ public class AtBGameThread extends GameThread {
                     }
                 }
 
+                var entities = new ArrayList<Entity>();
                 for (Unit unit : units) {
                     // Get the Entity
                     Entity entity = unit.getEntity();
@@ -225,11 +227,12 @@ public class AtBGameThread extends GameThread {
                         }
                     }
                     entity.setDeployRound(deploymentRound);
-                    // Add Mek to game
-                    client.sendAddEntity(entity);
-                    // Wait a few secs to not overuse bandwidth
-                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
+                    Force force = campaign.getForceFor(unit);
+                    entity.setForceString(force.getFullMMName());
+                    entities.add(entity);
                 }
+                client.sendAddEntity(entities);
+                
                 // Run through the units again. This time add transported units to the correct linkage,
                 // but only if the transport itself is in the game too.
                 for (Unit unit : units) {
@@ -252,6 +255,7 @@ public class AtBGameThread extends GameThread {
                 }
 
                 /* Add player-controlled ally units */
+                entities.clear();
                 for (Entity entity : scenario.getAlliesPlayer()) {
                     if (null == entity) {
                         continue;
@@ -277,10 +281,8 @@ public class AtBGameThread extends GameThread {
                     }
 
                     entity.setDeployRound(deploymentRound);
-                    client.sendAddEntity(entity);
-                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
                 }
-
+                client.sendAddEntity(entities);
                 client.sendPlayerInfo();
 
                 /* Add bots */
@@ -397,15 +399,18 @@ public class AtBGameThread extends GameThread {
                 botClient.getLocalPlayer().setColour(botForce.getColour());
 
                 botClient.sendPlayerInfo();
-
+                
+                String forceName = botClient.getLocalPlayer().getName() + "|1";
+                var entities = new ArrayList<Entity>();
                 for (Entity entity : botForce.getEntityList()) {
-                    if (null == entity) {
+                    if (entity == null) {
                         continue;
                     }
                     entity.setOwner(botClient.getLocalPlayer());
-                    botClient.sendAddEntity(entity);
-                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
+                    entity.setForceString(forceName);
+                    entities.add(entity);
                 }
+                botClient.sendAddEntity(entities);
             }
         } catch (Exception e) {
             MekHQ.getLogger().error(e);

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -119,7 +119,6 @@ class GameThread extends Thread implements CloseClientListener {
 
                 var entities = new ArrayList<Entity>();
                 for (Unit unit : units) {
-                    // Translate to MegaMek's Entity
                     Entity entity = unit.getEntity();
                     // Set the TempID for autoreporting
                     entity.setExternalIdAsString(unit.getId().toString());

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -13,10 +13,12 @@ package mekhq;
 
 import java.awt.KeyboardFocusManager;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import megamek.client.Client;
 import megamek.client.CloseClientListener;
+import megamek.client.ratgenerator.ForceDescriptor;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.util.MegaMekController;
 import megamek.common.Entity;
@@ -26,6 +28,7 @@ import megamek.common.QuirksHandler;
 import megamek.common.WeaponOrderHandler;
 import megamek.common.preference.PreferenceManager;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.force.Force;
 import mekhq.campaign.unit.Unit;
 
 class GameThread extends Thread implements CloseClientListener {
@@ -114,19 +117,18 @@ class GameThread extends Thread implements CloseClientListener {
                     Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
                 }
 
+                var entities = new ArrayList<Entity>();
                 for (Unit unit : units) {
-                    // Get the Entity
+                    // Translate to MegaMek's Entity
                     Entity entity = unit.getEntity();
                     // Set the TempID for autoreporting
                     entity.setExternalIdAsString(unit.getId().toString());
-                    // Set the owner
                     entity.setOwner(client.getLocalPlayer());
-                    // Add Mek to game
-                    client.sendAddEntity(entity);
-                    // Wait a few secs to not overuse bandwidth
-                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
+                    Force force = campaign.getForceFor(unit);
+                    entity.setForceString(force.getFullMMName());
+                    entities.add(entity);
                 }
-
+                client.sendAddEntity(entities);
                 client.sendPlayerInfo();
             }
 

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -189,6 +189,32 @@ public class Force implements Serializable {
         }
         return toReturn;
     }
+    
+    /**
+     * @return A String representation of the full hierarchical force including ID for MM export
+     */
+    public String getFullMMName() {
+        var ancestors = new ArrayList<Force>();
+        ancestors.add(this);
+        var p = parentForce;
+        while (p != null) {
+            ancestors.add(p);
+            p = p.parentForce;
+        }
+        
+        var result = "";
+        int id = 0;
+        for (int i = ancestors.size() - 1; i >= 0; i--) {
+            Force ancestor = ancestors.get(i);
+            id = 17 * id + ancestor.id + 1;
+            result += "\\" + ancestor.getName() + "|" + id;
+        }
+        // Remove the backslash at the start
+        if (result.length() > 0) {
+            result = result.substring(1);
+        }
+        return result;
+    }
 
     /**
      * Add a subforce to the subforce vector. In general, this


### PR DESCRIPTION
This requires the MegaMek lobby/force PR #2409!

Sends the force composition to MM when starting a scenario. Uses a String representation that is also used for loading/saving forces in MULs. Bot forces will receive a standard force based on the bot's name like "Rebels", see Screenshot (nvm the missing i18 entries, that's my Eclipse config).
Also replaces sending the entities individually with sending them as a block (which is required for the force setup to work in this way and, also, faster without the added thread sleep and if anything, safer, I guess).

![image](https://user-images.githubusercontent.com/17069663/112729725-ea2c3c80-8f2d-11eb-8f9b-2987412f34b0.png)

I imagine that when forces need to transport more to MM than structure and name we'd send the forces as a MegaMek.Force object, but for now, this works and is simple.