### PR TITLE
ProtoMech Bay Rating

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
@@ -462,10 +462,10 @@ public abstract class AbstractUnitRating implements IUnitRating {
         setFighterBayCount(0);
         setSmallCraftBayCount(0);
         setProtoBayCount(0);
-        setBaBayCount(0);
-        setLightVeeBayCount(0);
-        setHeavyVeeBayCount(0);
         setSuperHeavyVeeBayCount(0);
+        setHeavyVeeBayCount(0);
+        setLightVeeBayCount(0);
+        setBaBayCount(0);
         setInfantryBayCount(0);
         setDockingCollarCount(0);
 
@@ -493,22 +493,23 @@ public abstract class AbstractUnitRating implements IUnitRating {
             for (Bay bay : e.getTransportBays()) {
                 if (bay instanceof MechBay) {
                     setMechBayCount(getMechBayCount() + (int) bay.getCapacity());
-                } else if (bay instanceof ProtomechBay) {
-                    setProtoBayCount(getProtoBayCount() + (int) bay.getCapacity());
-                } else if (bay instanceof BattleArmorBay) {
-                    setBaBayCount(getBaBayCount() + (int) bay.getCapacity());
-                } else if (bay instanceof InfantryBay) {
-                    setInfantryBayCount(getInfantryBayCount() + (int) (bay.getCapacity() / ((InfantryBay) bay).getPlatoonType().getWeight()));
-                } else if (bay instanceof LightVehicleBay) {
-                    setLightVeeBayCount(getLightVeeBayCount() + (int) bay.getCapacity());
-                } else if (bay instanceof HeavyVehicleBay) {
-                    setHeavyVeeBayCount(getHeavyVeeBayCount() + (int) bay.getCapacity());
-                } else if (bay instanceof SuperHeavyVehicleBay) {
-                    setSuperHeavyVeeBayCount(getSuperHeavyVeeBayCount() + (int) bay.getCapacity());
                 } else if (bay instanceof ASFBay) {
                     setFighterBayCount(getFighterBayCount() + (int) bay.getCapacity());
                 } else if (bay instanceof SmallCraftBay) {
                     setSmallCraftBayCount(getSmallCraftBayCount() + (int) bay.getCapacity());
+                } else if (bay instanceof ProtomechBay) {
+                    setProtoBayCount(getProtoBayCount() + (int) bay.getCapacity());
+                } else if (bay instanceof SuperHeavyVehicleBay) {
+                    setSuperHeavyVeeBayCount(getSuperHeavyVeeBayCount() + (int) bay.getCapacity());
+                } else if (bay instanceof HeavyVehicleBay) {
+                    setHeavyVeeBayCount(getHeavyVeeBayCount() + (int) bay.getCapacity());
+                } else if (bay instanceof LightVehicleBay) {
+                    setLightVeeBayCount(getLightVeeBayCount() + (int) bay.getCapacity());
+                }  else if (bay instanceof BattleArmorBay) {
+                    setBaBayCount(getBaBayCount() + (int) bay.getCapacity());
+                } else if (bay instanceof InfantryBay) {
+                    setInfantryBayCount(getInfantryBayCount() + (int)
+                            Math.floor(bay.getCapacity() / ((InfantryBay) bay).getPlatoonType().getWeight()));
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
@@ -32,6 +32,7 @@ import megamek.common.BattleArmor;
 import megamek.common.BattleArmorBay;
 import megamek.common.Bay;
 import megamek.common.Dropship;
+import megamek.common.ProtomechBay;
 import megamek.common.SpaceStation;
 import megamek.common.Entity;
 import megamek.common.HeavyVehicleBay;
@@ -438,7 +439,6 @@ public abstract class AbstractUnitRating implements IUnitRating {
      * and this method will immediately exit.
      */
     protected void initValues() {
-        MekHQ.getLogger().methodBegin(getClass(), "initValues()");
         setCommanderList(new ArrayList<>());
         setNumberUnits(BigDecimal.ZERO);
         setTotalSkillLevels(BigDecimal.ZERO);
@@ -481,7 +481,6 @@ public abstract class AbstractUnitRating implements IUnitRating {
         setTransportPercent(BigDecimal.ZERO);
         setInitialized(true);
         clearSkillRatingCounts();
-        MekHQ.getLogger().methodEnd(getClass(), "initValues()");
     }
 
     /**
@@ -493,9 +492,11 @@ public abstract class AbstractUnitRating implements IUnitRating {
         if (((e instanceof Jumpship) || (e instanceof Dropship)) && !(e instanceof SpaceStation)) {
             for (Bay bay : e.getTransportBays()) {
                 if (bay instanceof MechBay) {
-                    setMechBayCount(getMechBayCount() + (int)bay.getCapacity());
+                    setMechBayCount(getMechBayCount() + (int) bay.getCapacity());
+                } else if (bay instanceof ProtomechBay) {
+                    setProtoBayCount(getProtoBayCount() + (int) bay.getCapacity());
                 } else if (bay instanceof BattleArmorBay) {
-                    setBaBayCount(getBaBayCount() + (int)bay.getCapacity());
+                    setBaBayCount(getBaBayCount() + (int) bay.getCapacity());
                 } else if (bay instanceof InfantryBay) {
                     setInfantryBayCount(getInfantryBayCount() + (int) (bay.getCapacity() / ((InfantryBay) bay).getPlatoonType().getWeight()));
                 } else if (bay instanceof LightVehicleBay) {


### PR DESCRIPTION
This fixes an issue raised on Discord where the bay rating for ProtoMechs is not taken into account. I also reorganized the checks so they are in the same order as they are in on the dialog in commit 2.