### PR TITLE
fix scenario date/force resets

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3028,12 +3028,15 @@ public class Campaign implements Serializable, ITechManager {
                 if ((s.getDate() != null) && s.getDate().isBefore(getLocalDate())) {
                     if (getCampaignOptions().getUseStratCon() &&
                             (s instanceof AtBDynamicScenario)) {
-                        StratconRulesManager.processIgnoredScenario(
+                        var stub = StratconRulesManager.processIgnoredScenario(
                                 (AtBDynamicScenario) s, contract.getStratconCampaignState());
-                        s.convertToStub(this, Scenario.S_DEFEAT);
-                                                
-                        addReport("Failure to deploy for " + s.getName() + " resulted in defeat.");
                         
+                        if (stub) {
+                            s.convertToStub(this, Scenario.S_DEFEAT);
+                            addReport("Failure to deploy for " + s.getName() + " resulted in defeat.");
+                        } else {
+                            s.clearAllForcesAndPersonnel(this);
+                        }
                     } else {
                         s.convertToStub(this, Scenario.S_DEFEAT);
                         contract.addPlayerMinorBreach();

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1344,7 +1344,7 @@ public class StratconRulesManager {
                                 .translate(scenario.getCoords().direction(closestAlliedFacilityCoords));
                         scenario.setCoords(newCoords);
 
-                        int daysForward = Math.min(1, track.getDeploymentTime());
+                        int daysForward = Math.max(1, track.getDeploymentTime());
 
                         scenario.setDeploymentDate(scenario.getDeploymentDate().plusDays(daysForward));
                         scenario.setActionDate(scenario.getActionDate().plusDays(daysForward));
@@ -1402,7 +1402,8 @@ public class StratconRulesManager {
                     // loop through scenarios - if we haven't deployed in time, 
                     // fail it and apply consequences
                     for (StratconScenario scenario : track.getScenarios().values()) {
-                        if (scenario.getDeploymentDate().isBefore(ev.getCampaign().getLocalDate())) {
+                        if (scenario.getDeploymentDate().isBefore(ev.getCampaign().getLocalDate()) &&
+                                scenario.getPrimaryForceIDs().isEmpty()) {
                             processIgnoredScenario(scenario, campaignState);
                         }
                     }


### PR DESCRIPTION
This fixes #2538 - basically, the scenario dates weren't resetting correctly and forces weren't undeploying properly for ignored scenarios.