### PR TITLE
randomly swap enemy when contract returns from rout state

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -47,6 +47,7 @@ import megamek.common.MechFileParser;
 import megamek.common.MechSummary;
 import megamek.common.UnitType;
 import megamek.common.loaders.EntityLoadingException;
+import megamek.common.util.WeightedMap;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
@@ -57,7 +58,6 @@ import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconContractDefinition;
 import mekhq.campaign.stratcon.StratconContractInitializer;
-import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
@@ -447,6 +447,7 @@ public class AtBContract extends Contract implements Serializable {
             if (today.isAfter(routEnd)) {
                 moraleLevel = MORALE_NORMAL;
                 routEnd = null;
+                updateEnemy(today); // mix it up a little
             } else {
                 moraleLevel = MORALE_ROUT;
             }
@@ -554,6 +555,19 @@ public class AtBContract extends Contract implements Serializable {
         moraleMod = 0;
     }
 
+    /**
+     * Changes the enemy to a randomly selected faction that's an enemy of 
+     * the current employer
+     */
+    private void updateEnemy(LocalDate today) {
+        String enemyCode = RandomFactionGenerator.getInstance().getEnemy(
+                Factions.getInstance().getFaction(employerCode), false, true);
+        setEnemyCode(enemyCode);
+        
+        Faction enemyFaction = Factions.getInstance().getFaction(enemyCode);
+        setEnemyBotName(enemyFaction.getFullName(today.getYear()));
+    }
+    
     public int getRepairLocation(int dragoonRating) {
         int retval = Unit.SITE_BAY;
         if ((missionType == MT_GUERRILLAWARFARE) ||
@@ -657,8 +671,6 @@ public class AtBContract extends Contract implements Serializable {
     }
 
     public void doBonusRoll(Campaign c) {
-        final String METHOD_NAME = "doBonusRoll(Campaign)"; //$NON-NLS-1$
-
         int number;
         String rat = null;
         int roll = Compute.d6();
@@ -702,7 +714,7 @@ public class AtBContract extends Contract implements Serializable {
                 try {
                     en = new MechFileParser(msl.get(0).getSourceFile(), msl.get(0).getEntryName()).getEntity();
                 } catch (EntityLoadingException ex) {
-                    MekHQ.getLogger().error(this, "Unable to load entity: " + msl.get(0).getSourceFile()
+                    MekHQ.getLogger().error("Unable to load entity: " + msl.get(0).getSourceFile()
                             + ": " + msl.get(0).getEntryName() + ": " + ex.getMessage(), ex);
                 }
             }

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -296,7 +296,7 @@ public class RandomFactionGenerator {
             mercWeight += key;
         }
         
-        enemyMap.add((int) (mercWeight / 10), Factions.getInstance().getFaction("MERC"));
+        enemyMap.add((int) Math.max(1, (mercWeight / 10)), Factions.getInstance().getFaction("MERC"));
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -237,6 +237,13 @@ public class RandomFactionGenerator {
     }
 
     /**
+     * Pick an enemy faction, possibly rebels, given an employer.
+     */
+    public String getEnemy(Faction employer, boolean useRebels) {
+        return getEnemy(employer, useRebels, false);
+    }
+    
+    /**
      * Selects an enemy faction for the given employer, weighted by length of shared border and
      * diplomatic relations. Factions at war or designated as rivals are twice as likely (cumulative)
      * to be chosen as opponents. Allied factions are ignored except for Clans, which halves
@@ -244,9 +251,11 @@ public class RandomFactionGenerator {
      *
      * @param employer  The faction offering the contract
      * @param useRebels Whether to include rebels as a possible opponent
+     * @param useMercs  Whether to include MERC as a possible opponent. Note, don't do this when
+     * first generating contract, as contract generation relies on the opfor having planets
      * @return          The faction to use as the opfor.
      */
-    public String getEnemy(Faction employer, boolean useRebels) {
+    public String getEnemy(Faction employer, boolean useRebels, boolean useMercs) {
         String employerName = employer != null ? employer.getShortName() : "no employer supplied or faction does not exist";
 
         /* Rebels occur on a 1-4 (d20) on nearly every enemy chart */
@@ -261,6 +270,11 @@ public class RandomFactionGenerator {
         if (null != employer) {
             employerName = employer.getShortName();
             WeightedMap<Faction> enemyMap = buildEnemyMap(employer);
+            
+            if (useMercs) {
+                appendMercsToEnemyMap(enemyMap);
+            }
+            
             enemy = enemyMap.randomItem();
         }
         if (null != enemy) {
@@ -273,6 +287,18 @@ public class RandomFactionGenerator {
         return "PIR";
     }
 
+    /**
+     * Appends MERC faction to the given enemy map, with approximately a 10% probability
+     */
+    protected void appendMercsToEnemyMap(WeightedMap<Faction> enemyMap) {
+        int mercWeight = 0;
+        for (int key : enemyMap.keySet()) {
+            mercWeight += key;
+        }
+        
+        enemyMap.add((int) (mercWeight / 10), Factions.getInstance().getFaction("MERC"));
+    }
+    
     /**
      * Builds a map of potential enemies keyed to cumulative weight
      *


### PR DESCRIPTION
Pretty simple: when a contract goes to rout morale then comes back, bring in a (probably) new opposing force. Now with potential for mercs!

Addresses #2487 