### PR TITLE
add damaged heat sinks as missing parts when loading unit

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3062,6 +3062,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     partsToAdd.add(gravDeckPart);
                 }
             }
+            
             //Only add heatsink parts to fighters. Larger craft get a cooling system instead.
             if (!(entity instanceof SmallCraft) && !(entity instanceof Jumpship)) {
                 int hsinks = ((Aero)entity).getOHeatSinks()
@@ -3073,14 +3074,25 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 if (sinkType == Aero.HEAT_DOUBLE && entity.isClan()) {
                     sinkType = AeroHeatSink.CLAN_HEAT_DOUBLE;
                 }
-                while (hsinks > 0) {
-                    AeroHeatSink aHeatSink = new AeroHeatSink((int)entity.getWeight(),
-                            sinkType, podhsinks > 0, getCampaign());
-                    addPart(aHeatSink);
-                    partsToAdd.add(aHeatSink);
-                    hsinks--;
-                    if (podhsinks > 0) {
-                        podhsinks--;
+                
+                // add busted heat sinks even if they're "engine free" so they can be repaired
+                if (hsinks == 0) {
+                    for (int x = 0; x < ((Aero) entity).getHeatSinkHits(); x++) {
+                        MissingAeroHeatSink aHeatSink = new MissingAeroHeatSink((int)entity.getWeight(),
+                                sinkType, false, getCampaign());
+                        addPart(aHeatSink);
+                        partsToAdd.add(aHeatSink);
+                    }
+                } else {
+                    while (hsinks > 0) {
+                        AeroHeatSink aHeatSink = new AeroHeatSink((int)entity.getWeight(),
+                                sinkType, podhsinks > 0, getCampaign());
+                        addPart(aHeatSink);
+                        partsToAdd.add(aHeatSink);
+                        hsinks--;
+                        if (podhsinks > 0) {
+                            podhsinks--;
+                        }
                     }
                 }
             }
@@ -5001,12 +5013,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 partsCost = partsCost.plus(6 * .002 * 10000);
             } else {
                 partsCost = partsCost.plus(entity.getWeight() * .002 * 10000);
-                MekHQ.getLogger().error(this, getName() + " is not a generic CI. Movement mode is " + entity.getMovementModeAsString());
+                MekHQ.getLogger().error(getName() + " is not a generic CI. Movement mode is " + entity.getMovementModeAsString());
             }
         } else {
             // Only ProtoMechs should fall here. Anything else needs to be logged
             if (!(entity instanceof Protomech)) {
-                MekHQ.getLogger().error(this, getName() + " has no Spare Parts value for unit type " + Entity.getEntityTypeName(entity.getEntityType()));
+                MekHQ.getLogger().error(getName() + " has no Spare Parts value for unit type " + Entity.getEntityTypeName(entity.getEntityType()));
             }
         }
 


### PR DESCRIPTION
This fixes an issue I noticed where, if an aerospace fighter with 10 heat sinks had taken heat sink hits, you couldn't ever fix it without restoring the unit. Adding the appropriate number of missing heat sink parts to the unit seems to solve the issue.