### PR TITLE
GM Tools Dialog: Removing Backported Method Use

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -149,27 +149,6 @@ public class Utilities {
     }
 
     /**
-     * @param num   the number of dice to roll
-     * @param faces the number of faces on those dice
-     * @return an Integer list of every dice roll, with index 0 containing the summed result
-     */
-    public static List<Integer> individualDice(int num, int faces) {
-        List<Integer> individualRolls = new ArrayList<>();
-        int result = 0, roll;
-        individualRolls.add(result);
-
-        for (int i = 0; i < num; i++) {
-            roll = Compute.randomInt(faces) + 1;
-            individualRolls.add(roll);
-            result += roll;
-        }
-
-        individualRolls.set(0, result);
-
-        return individualRolls;
-    }
-
-    /**
      * Get a random element out of a collection, with equal probability.
      * <p>
      * This is the same as calling the following code, only plays nicely with
@@ -181,7 +160,6 @@ public class Utilities {
      *
      * @return <i>null</i> if the collection itself is null or empty;
      * can return <i>null</i> if the collection contains <i>null</i> items.
-     *
      */
     public static @Nullable <T> T getRandomItem(final @Nullable Collection<? extends T> collection) {
         if ((collection == null) || collection.isEmpty()) {

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -33,6 +33,7 @@ import javax.swing.*;
 
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.generator.RandomCallsignGenerator;
+import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import megamek.common.MechFileParser;
@@ -44,7 +45,6 @@ import megamek.common.enums.Gender;
 import megamek.common.util.EncodeControl;
 import megamek.common.util.StringUtil;
 import mekhq.MekHQ;
-import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
@@ -825,7 +825,7 @@ public class GMToolsDialog extends JDialog {
 
     //region ActionEvent Handlers
     public void performDiceRoll() {
-        List<Integer> individualDice = Utilities.individualDice((Integer) numDice.getValue(),
+        List<Integer> individualDice = Compute.individualDice((Integer) numDice.getValue(),
                 (Integer) sizeDice.getValue());
         totalDiceResult.setText(String.format(resources.getString("totalDiceResult.text"),
                 individualDice.get(0)));


### PR DESCRIPTION
I've backported individual dice to Compute, so we no longer need the utilities method or use.