### PR TITLE
2553: Fixing preferences issue in the Personnel Market

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -119,6 +119,7 @@ public class PersonnelMarketDialog extends JDialog {
         lblUnitCost = new javax.swing.JLabel();
         panelOKBtns = new javax.swing.JPanel();
         lblPersonChoice = new javax.swing.JLabel();
+        comboRecruitRole = new JComboBox<>(PersonnelRole.values());
 
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setTitle("Personnel Market");
@@ -178,7 +179,6 @@ public class PersonnelMarketDialog extends JDialog {
             }
 
             final boolean isClan = campaign.getFaction().isClan();
-            comboRecruitRole = new JComboBox<>(PersonnelRole.values());
             comboRecruitRole.setRenderer(new DefaultListCellRenderer() {
                 @Override
                 public Component getListCellRendererComponent(JList<?> list, Object value, int index,


### PR DESCRIPTION
This fixes #2553 by moving where the combo box is initialized. This does take a bit more memory at all times, but ensures the preferences are kept between times this can be used..