### PR TITLE
Dependent Swapover: Removing Parental and Spousal Abandonment, Fixing None Primary Role

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonnelTableMouseAdapter.properties
+++ b/MekHQ/resources/mekhq/resources/PersonnelTableMouseAdapter.properties
@@ -45,7 +45,6 @@ confirmRetireQ.format=Do you really want to change the status of %s to a non-act
 costNotPossible.text=(Not Possible)
 costValue.format=(%dXP)
 crew.text=Crew
-dependent.text=Dependent
 tryingToMarry.text=Trying to Marry
 tryingToMarry.toolTipText=If this is selected then a person will be included as a potential spouse for marriages \n(standard checks still apply, so married personnel will not be included even if this flag is selected)
 tryingToConceive.text=Trying to Conceive

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1760,8 +1760,10 @@ public class Person implements Serializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("commander")) {
                     retVal.commander = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("dependent")) { // Legacy, 0.49.1 removal
-                    if (retVal.getPrimaryRole().isAstech() || retVal.getPrimaryRole().isNone()) {
-                        retVal.setPrimaryRole(PersonnelRole.DEPENDENT);
+                    // Legacy setup was as Astechs, but people (including me) often forgot to remove
+                    // the flag so... just ignoring if they aren't astechs
+                    if (retVal.getPrimaryRole().isAstech()) {
+                        retVal.setPrimaryRoleDirect(PersonnelRole.DEPENDENT);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("faction")) {
                     retVal.originFaction = Factions.getInstance().getFaction(wn2.getTextContent().trim());
@@ -1780,7 +1782,7 @@ public class Person implements Serializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("primaryRole")) {
                     final PersonnelRole primaryRole = PersonnelRole.parseFromString(wn2.getTextContent().trim());
                     if (version.isLowerThan("0.49.1") && primaryRole.isNone()) {
-                        retVal.setPrimaryRole(PersonnelRole.DEPENDENT);
+                        retVal.setPrimaryRoleDirect(PersonnelRole.DEPENDENT);
                     } else {
                         retVal.setPrimaryRoleDirect(primaryRole);
                     }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -37,6 +37,7 @@ import megamek.common.Protomech;
 import megamek.common.SmallCraft;
 import megamek.common.Tank;
 import megamek.common.TargetRoll;
+import megamek.common.TechConstants;
 import megamek.common.VTOL;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
@@ -718,6 +719,7 @@ public class Person implements Serializable {
             setSecondaryRoleDirect(PersonnelRole.NONE);
         }
 
+        // Now, we can perform the time in service and last rank change tracking change for dependents
         if (primaryRole.isDependent()) {
             setRecruitment(null);
             setLastRankChangeDate(null);
@@ -1776,7 +1778,12 @@ public class Person implements Serializable {
                 } else if (wn2.getNodeName().equalsIgnoreCase("biography")) {
                     retVal.biography = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("primaryRole")) {
-                    retVal.setPrimaryRoleDirect(PersonnelRole.parseFromString(wn2.getTextContent().trim()));
+                    final PersonnelRole primaryRole = PersonnelRole.parseFromString(wn2.getTextContent().trim());
+                    if (version.isLowerThan("0.49.1") && primaryRole.isNone()) {
+                        retVal.setPrimaryRole(PersonnelRole.DEPENDENT);
+                    } else {
+                        retVal.setPrimaryRoleDirect(primaryRole);
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("secondaryRole")) {
                     retVal.setSecondaryRoleDirect(PersonnelRole.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("acquisitions")) {
@@ -3384,7 +3391,7 @@ public class Person implements Serializable {
         originalUnitId = unit.getId();
         if (unit.getEntity().isClan()) {
             originalUnitTech = TECH_CLAN;
-        } else if (unit.getEntity().getTechLevel() > megamek.common.TechConstants.T_INTRO_BOXSET) {
+        } else if (unit.getEntity().getTechLevel() > TechConstants.T_INTRO_BOXSET) {
             originalUnitTech = TECH_IS2;
         } else {
             originalUnitTech = TECH_IS1;

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -208,7 +208,6 @@ public class Person implements Serializable {
     private int hits;
     private PrisonerStatus prisonerStatus;
 
-    private boolean dependent;
     private boolean commander;
 
     // Supports edge usage by a ship's engineer composite crewman
@@ -350,7 +349,6 @@ public class Person implements Serializable {
         primaryDesignator = ROMDesignation.NONE;
         secondaryDesignator = ROMDesignation.NONE;
         commander = false;
-        dependent = false;
         originFaction = Factions.getInstance().getFaction(factionCode);
         originPlanet = null;
         clan = originFaction.isClan();
@@ -459,22 +457,6 @@ public class Person implements Serializable {
         commander = tf;
     }
 
-    @Deprecated
-    public boolean isDependent() {
-        return dependent || getPrimaryRole().isDependent();
-    }
-
-    public void setDependent(boolean tf) {
-        dependent = tf;
-        if (dependent) {
-            setRecruitment(null);
-            setLastRankChangeDate(null);
-        } else {
-            setRecruitment(getCampaign().getLocalDate());
-            setLastRankChangeDate(getCampaign().getLocalDate());
-        }
-    }
-
     public PrisonerStatus getPrisonerStatus() {
         return prisonerStatus;
     }
@@ -515,7 +497,7 @@ public class Person implements Serializable {
                 }
                 break;
             case FREE:
-                if (!isDependent()) {
+                if (!getPrimaryRole().isDependent()) {
                     if (getCampaign().getCampaignOptions().getUseTimeInService()) {
                         setRecruitment(getCampaign().getLocalDate());
                     }
@@ -523,6 +505,7 @@ public class Person implements Serializable {
                         setLastRankChangeDate(getCampaign().getLocalDate());
                     }
                 }
+
                 if (log) {
                     if (freed) {
                         ServiceLogger.freed(this, getCampaign().getLocalDate(),
@@ -712,10 +695,13 @@ public class Person implements Serializable {
         return primaryRole;
     }
 
-    public void setPrimaryRole(PersonnelRole primaryRole) {
-        setPrimaryRoleDirect(primaryRole);
+    public void setPrimaryRole(final PersonnelRole primaryRole) {
+        // don't need to do any processing for no changes
+        if (primaryRole == getPrimaryRole()) {
+            return;
+        }
 
-        // Now, we need to make some secondary role assignments to None here for better UX in
+        // We need to make some secondary role assignments to None here for better UX in
         // assigning roles, following these rules:
         // 1) Cannot have the same primary and secondary roles
         // 2) Must have a None secondary role if you are a Dependent
@@ -731,6 +717,19 @@ public class Person implements Serializable {
                 || (primaryRole.isMedic() && getSecondaryRole().isMedicalStaff())) {
             setSecondaryRoleDirect(PersonnelRole.NONE);
         }
+
+        if (primaryRole.isDependent()) {
+            setRecruitment(null);
+            setLastRankChangeDate(null);
+        } else if (getPrimaryRole().isDependent()) {
+            setRecruitment(getCampaign().getLocalDate());
+            setLastRankChangeDate(getCampaign().getLocalDate());
+        }
+
+        // Finally, we can set the primary role
+        setPrimaryRoleDirect(primaryRole);
+
+        // and trigger the update event
         MekHQ.triggerEvent(new PersonChangedEvent(this));
     }
 
@@ -742,7 +741,11 @@ public class Person implements Serializable {
         return secondaryRole;
     }
 
-    public void setSecondaryRole(PersonnelRole secondaryRole) {
+    public void setSecondaryRole(final PersonnelRole secondaryRole) {
+        if (secondaryRole == getSecondaryRole()) {
+            return;
+        }
+
         setSecondaryRoleDirect(secondaryRole);
         MekHQ.triggerEvent(new PersonChangedEvent(this));
     }
@@ -1320,7 +1323,7 @@ public class Person implements Serializable {
             baby.setBirthday(campaign.getLocalDate());
 
             // Recruit the baby
-            campaign.recruitPerson(baby, prisonerStatus, baby.isDependent(), true, true);
+            campaign.recruitPerson(baby, prisonerStatus, true, true);
 
             // Create genealogy information
             baby.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, this);
@@ -1526,9 +1529,6 @@ public class Person implements Serializable {
             }
             if (commander) {
                 MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "commander", true);
-            }
-            if (dependent) {
-                MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "dependent", true);
             }
             // Always save the person's origin faction
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "faction", originFaction.getShortName());
@@ -1757,8 +1757,10 @@ public class Person implements Serializable {
                     retVal.callsign = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("commander")) {
                     retVal.commander = Boolean.parseBoolean(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("dependent")) {
-                    retVal.dependent = Boolean.parseBoolean(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("dependent")) { // Legacy, 0.49.1 removal
+                    if (retVal.getPrimaryRole().isAstech() || retVal.getPrimaryRole().isNone()) {
+                        retVal.setPrimaryRole(PersonnelRole.DEPENDENT);
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("faction")) {
                     retVal.originFaction = Factions.getInstance().getFaction(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("planetId")) {
@@ -2071,7 +2073,7 @@ public class Person implements Serializable {
     }
 
     public Money getSalary() {
-        if (!getPrisonerStatus().isFree() || isDependent()) {
+        if (!getPrisonerStatus().isFree()) {
             return Money.zero();
         }
 
@@ -2182,7 +2184,7 @@ public class Person implements Serializable {
         setRankLevel(rankLevel);
 
         if (campaign.getCampaignOptions().getUseTimeInRank()) {
-            if (getPrisonerStatus().isFree() && !isDependent()) {
+            if (getPrisonerStatus().isFree() && !getPrimaryRole().isDependent()) {
                 setLastRankChangeDate(campaign.getLocalDate());
             } else {
                 setLastRankChangeDate(null);

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -129,7 +129,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
             int proto = 0;
             int support = 0;
             for (Person p : campaign.getActivePersonnel()) {
-                if (p.getPrimaryRole().isNone() || p.isDependent() || !p.getPrisonerStatus().isFree()) {
+                if (p.getPrimaryRole().isDependentOrNone() || !p.getPrisonerStatus().isFree()) {
                     continue;
                 }
                 if (p.getPrimaryRole().isSupport()) {
@@ -168,7 +168,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
         }
 
         for (Person p : campaign.getActivePersonnel()) {
-            if (p.isDependent() || !p.getPrisonerStatus().isFree() || p.isDeployed()
+            if (p.getPrimaryRole().isDependent() || !p.getPrisonerStatus().isFree() || p.isDeployed()
                     || (p.isFounder() && campaign.getCampaignOptions().getFoundersNeverRetire())) {
                 continue;
             }

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -150,7 +150,7 @@ public class PersonnelReport extends Report {
 
         for (Person p : getCampaign().getPersonnel()) {
             // Add them to the total count
-            final boolean primarySupport = p.getPrimaryRole().isSupport();
+            final boolean primarySupport = p.getPrimaryRole().isSupport(true);
 
             if (primarySupport && p.getPrisonerStatus().isFree() && p.getStatus().isActive()) {
                 countPersonByType[p.getPrimaryRole().ordinal()]++;
@@ -190,7 +190,7 @@ public class PersonnelReport extends Report {
         sb.append(String.format("%-30s        %4s\n", "Total Support Personnel", countTotal));
 
         for (PersonnelRole role : personnelRoles) {
-            if (role.isSupport()) {
+            if (role.isSupport(true)) {
                 sb.append(String.format("    %-30s    %4s\n", role.getName(getCampaign().getFaction().isClan()),
                         countPersonByType[role.ordinal()]));
             }

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -180,7 +180,7 @@ public class PersonnelReport extends Report {
                 countDead++;
             }
 
-            if (p.isDependent() && p.getStatus().isActive() && p.getPrisonerStatus().isFree()) {
+            if (p.getPrimaryRole().isDependent() && p.getStatus().isActive() && p.getPrisonerStatus().isFree()) {
                 dependents++;
             }
         }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3063,7 +3063,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     partsToAdd.add(gravDeckPart);
                 }
             }
-            
+
             //Only add heatsink parts to fighters. Larger craft get a cooling system instead.
             if (!(entity instanceof SmallCraft) && !(entity instanceof Jumpship)) {
                 int hsinks = ((Aero)entity).getOHeatSinks()
@@ -3075,7 +3075,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 if (sinkType == Aero.HEAT_DOUBLE && entity.isClan()) {
                     sinkType = AeroHeatSink.CLAN_HEAT_DOUBLE;
                 }
-                
+
                 // add busted heat sinks even if they're "engine free" so they can be repaired
                 if (hsinks == 0) {
                     for (int x = 0; x < ((Aero) entity).getHeatSinkHits(); x++) {
@@ -4229,7 +4229,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     private void ensurePersonIsRegistered(Person p) {
         Objects.requireNonNull(p);
         if (null == getCampaign().getPerson(p.getId())) {
-            getCampaign().recruitPerson(p, p.getPrisonerStatus(), p.isDependent(), true,  false);
+            getCampaign().recruitPerson(p, p.getPrisonerStatus(), true,  false);
             MekHQ.getLogger().warning(String.format("The person %s added this unit %s, was not in the campaign.", p.getFullName(), getName()));
         }
     }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -90,7 +90,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private static final String CMD_REMOVE_INJURY = "REMOVE_INJURY"; //$NON-NLS-1$
     private static final String CMD_CLEAR_INJURIES = "CLEAR_INJURIES"; //$NON-NLS-1$
     private static final String CMD_CALLSIGN = "CALLSIGN"; //$NON-NLS-1$
-    private static final String CMD_DEPENDENT = "DEPENDENT"; //$NON-NLS-1$
     private static final String CMD_COMMANDER = "COMMANDER"; //$NON-NLS-1$
     private static final String CMD_TRYING_TO_CONCEIVE = "TRYING_TO_CONCEIVE";
     private static final String CMD_TRYING_TO_MARRY = "TRYING_TO_MARRY";
@@ -983,19 +982,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         }
                     }
                     gui.getCampaign().addReport(String.format(resourceMap.getString("setAsCommander.format"), selectedPerson.getHyperlinkedFullTitle())); //$NON-NLS-1$
-                    gui.getCampaign().personUpdated(selectedPerson);
-                }
-                break;
-            }
-            case CMD_DEPENDENT: {
-                if (people.length > 1) {
-                    boolean status = !people[0].isDependent();
-                    for (Person person : people) {
-                        person.setDependent(status);
-                        gui.getCampaign().personUpdated(person);
-                    }
-                } else {
-                    selectedPerson.setDependent(!selectedPerson.isDependent());
                     gui.getCampaign().personUpdated(selectedPerson);
                 }
                 break;
@@ -2234,12 +2220,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             //endregion Edge Triggers
 
             menu = new JMenu(resourceMap.getString("specialFlags.text"));
-            cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("dependent.text"));
-            cbMenuItem.setSelected(person.isDependent());
-            cbMenuItem.setActionCommand(CMD_DEPENDENT);
-            cbMenuItem.addActionListener(this);
-            menu.add(cbMenuItem);
-
             cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("commander.text"));
             cbMenuItem.setSelected(person.isCommander());
             cbMenuItem.setActionCommand(CMD_COMMANDER);
@@ -2435,14 +2415,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
 
             menu = new JMenu(resourceMap.getString("specialFlags.text"));
-            if (StaticChecks.areEitherAllDependentsOrNot(selected)) {
-                cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("dependent.text"));
-                cbMenuItem.setSelected(selected[0].isDependent());
-                cbMenuItem.setActionCommand(CMD_DEPENDENT);
-                cbMenuItem.addActionListener(this);
-                menu.add(cbMenuItem);
-            }
-
             if (StaticChecks.areEitherAllTryingToMarryOrNot(selected)) {
                 cbMenuItem = new JCheckBoxMenuItem(resourceMap.getString("tryingToMarry.text"));
                 cbMenuItem.setToolTipText(resourceMap.getString("tryingToMarry.toolTipText"));

--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -292,7 +292,7 @@ public enum PersonnelFilter {
                 return active && (MekHQ.getMekHQOptions().getPersonnelFilterOnPrimaryRole()
                         ? person.getPrimaryRole().isAdministratorHR() : person.hasRole(PersonnelRole.ADMINISTRATOR_HR));
             case DEPENDENT:
-                return active && person.isDependent();
+                return active && person.getPrimaryRole().isDependent();
             case FOUNDER:
                 return person.isFounder();
             case PRISONER:

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -604,22 +604,6 @@ public class StaticChecks {
 
     /**
      * @param people an array of people
-     * @return true if they are either all dependents or all not dependents, otherwise false
-     */
-    public static boolean areEitherAllDependentsOrNot(Person[] people) {
-        if (people.length > 0) {
-            boolean isDependent = people[0].isDependent();
-            for (Person person : people) {
-                if (isDependent != person.isDependent()) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @param people an array of people
      * @return true if all of the people are female, otherwise false
      */
     public static boolean areAllFemale(Person[] people) {

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -658,11 +658,10 @@ public class PersonViewPanel extends JScrollablePanel {
             firsty++;
         }
 
-        // We show the following if track total earnings is on for a free non-dependent, or if the
-        // person has tracked total earnings
+        // We show the following if track total earnings is on for a free person, or if the
+        // person has previously tracked total earnings
         if (campaign.getCampaignOptions().trackTotalEarnings()
-                && ((person.getPrisonerStatus().isFree() && !person.isDependent())
-                || person.getTotalEarnings().isGreaterThan(Money.zero()))) {
+                && (person.getPrisonerStatus().isFree() || person.getTotalEarnings().isGreaterThan(Money.zero()))) {
             JLabel lblTotalEarnings1 = new JLabel(resourceMap.getString("lblTotalEarnings1.text"));
             lblTotalEarnings1.setName("lblTotalEarnings1");
             gridBagConstraints = new GridBagConstraints();


### PR DESCRIPTION
This fixes a handful of bugs and finishes the dependent flag swapover. The bugs are:
1. Missing migration for legacy personnel with the None primary role
2. Removing children leaving the force while dependents, dependents leaving their spouse (by checking if their genealogy is empty during the automated removal).
3. Fixing Personnel Breakdown Report display for dependents