### PR TITLE
Stratcon - actually capture facilities

### DIFF
--- a/MekHQ/data/stratconfacilities/AlliedAirBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedAirBase.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileAirBase.xml</capturedDefinition>
 	<displayableName>Air Base</displayableName>
         <facilityType>AirBase</facilityType>
         <localModifiers>AlliedAirGarrison.xml</localModifiers>

--- a/MekHQ/data/stratconfacilities/AlliedArtilleryBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedArtilleryBase.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileArtilleryBase.xml</capturedDefinition>
 	<displayableName>Artillery Base</displayableName>
         <facilityType>ArtilleryBase</facilityType>
         <localModifiers>AlliedArtyGarrison.xml</localModifiers>

--- a/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
+++ b/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileBaseOfOperations.xml</capturedDefinition>
 	<displayableName>Base of Operations</displayableName>
         <facilityType>BaseOfOperations</facilityType>
         <owner>Allied</owner>

--- a/MekHQ/data/stratconfacilities/AlliedCommsCenter.xml
+++ b/MekHQ/data/stratconfacilities/AlliedCommsCenter.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileCommsCenter.xml</capturedDefinition>
 	<displayableName>Comms Center</displayableName>
         <facilityType>CommandCenter</facilityType>
         <owner>Allied</owner>

--- a/MekHQ/data/stratconfacilities/AlliedDataCenter.xml
+++ b/MekHQ/data/stratconfacilities/AlliedDataCenter.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileDataCenter.xml</capturedDefinition>
 	<displayableName>Data Center</displayableName>
         <facilityType>DataCenter</facilityType>
         <owner>Allied</owner>

--- a/MekHQ/data/stratconfacilities/AlliedEarlyWarningSystem.xml
+++ b/MekHQ/data/stratconfacilities/AlliedEarlyWarningSystem.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileEarlyWarningSystem.xml</capturedDefinition>
 	<displayableName>Early Warning Center</displayableName>
         <facilityType>EarlyWarningSystem</facilityType>
         <owner>Allied</owner>

--- a/MekHQ/data/stratconfacilities/AlliedIndustrialFacility.xml
+++ b/MekHQ/data/stratconfacilities/AlliedIndustrialFacility.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileIndustrialFacility.xml</capturedDefinition>
 	<displayableName>Industrial Center</displayableName>
         <facilityType>IndustrialFacility</facilityType>
         <owner>Allied</owner>

--- a/MekHQ/data/stratconfacilities/AlliedMekBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedMekBase.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileMekBase.xml</capturedDefinition>
 	<displayableName>Mech Base</displayableName>
         <facilityType>MekBase</facilityType>
         <localModifiers>AlliedMechGarrison.xml</localModifiers>

--- a/MekHQ/data/stratconfacilities/AlliedOrbitalDefense.xml
+++ b/MekHQ/data/stratconfacilities/AlliedOrbitalDefense.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileOrbitalDefense.xml</capturedDefinition>
 	<displayableName>Orbital Defense</displayableName>
         <facilityType>OrbitalDefense</facilityType>
         <owner>Allied</owner>

--- a/MekHQ/data/stratconfacilities/AlliedSupplyDepot.xml
+++ b/MekHQ/data/stratconfacilities/AlliedSupplyDepot.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileSupplyDepot.xml</capturedDefinition>
 	<displayableName>Supply Depot</displayableName>
         <facilityType>SupplyDepot</facilityType>
         <owner>Allied</owner>

--- a/MekHQ/data/stratconfacilities/AlliedTankBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedTankBase.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>HostileTankBase.xml</capturedDefinition>
 	<displayableName>Tank Base</displayableName>
         <facilityType>TankBase</facilityType>
         <localModifiers>AlliedTankGarrison.xml</localModifiers>

--- a/MekHQ/data/stratconfacilities/HostileAirBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileAirBase.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedAirBase.xml</capturedDefinition>
 	<displayableName>Air Base</displayableName>
         <facilityType>AirBase</facilityType>
         <localModifiers>EnemyAirGarrison.xml</localModifiers>

--- a/MekHQ/data/stratconfacilities/HostileArtilleryBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileArtilleryBase.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedArtilleryBase.xml</capturedDefinition>
 	<displayableName>Artillery Base</displayableName>
         <facilityType>ArtilleryBase</facilityType>
         <localModifiers>EnemyArtyGarrison.xml</localModifiers>

--- a/MekHQ/data/stratconfacilities/HostileBaseOfOperations.xml
+++ b/MekHQ/data/stratconfacilities/HostileBaseOfOperations.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedBaseOfOperations.xml</capturedDefinition>
 	<displayableName>Base of Operations</displayableName>
         <facilityType>BaseOfOperations</facilityType>
         <owner>Opposing</owner>

--- a/MekHQ/data/stratconfacilities/HostileCommsCenter.xml
+++ b/MekHQ/data/stratconfacilities/HostileCommsCenter.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedCommsCenter.xml</capturedDefinition>
 	<displayableName>Comms Center</displayableName>
         <facilityType>CommandCenter</facilityType>
         <owner>Opposing</owner>

--- a/MekHQ/data/stratconfacilities/HostileDataCenter.xml
+++ b/MekHQ/data/stratconfacilities/HostileDataCenter.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedDataCenter.xml</capturedDefinition>
 	<displayableName>Data Center</displayableName>
         <facilityType>DataCenter</facilityType>
         <owner>Opposing</owner>

--- a/MekHQ/data/stratconfacilities/HostileEarlyWarningSystem.xml
+++ b/MekHQ/data/stratconfacilities/HostileEarlyWarningSystem.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedEarlyWarningSystem.xml</capturedDefinition>
 	<displayableName>Early Warning Center</displayableName>
         <facilityType>EarlyWarningSystem</facilityType>
         <owner>Allied</owner>

--- a/MekHQ/data/stratconfacilities/HostileIndustrialFacility.xml
+++ b/MekHQ/data/stratconfacilities/HostileIndustrialFacility.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedIndustrialFacility.xml</capturedDefinition>
 	<displayableName>Industrial Center</displayableName>
         <facilityType>IndustrialFacility</facilityType>
         <owner>Opposing</owner>

--- a/MekHQ/data/stratconfacilities/HostileMekBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileMekBase.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedMekBase.xml</capturedDefinition>
 	<displayableName>Mech Base</displayableName>
         <facilityType>MekBase</facilityType>
         <localModifiers>EnemyMechGarrison.xml</localModifiers>

--- a/MekHQ/data/stratconfacilities/HostileOrbitalDefense.xml
+++ b/MekHQ/data/stratconfacilities/HostileOrbitalDefense.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedOrbitalDefense.xml</capturedDefinition>
 	<displayableName>Orbital Defense</displayableName>
         <facilityType>OrbitalDefense</facilityType>
         <owner>Opposing</owner>

--- a/MekHQ/data/stratconfacilities/HostileSupplyDepot.xml
+++ b/MekHQ/data/stratconfacilities/HostileSupplyDepot.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedSupplyDepot.xml</capturedDefinition>
 	<displayableName>Supply Depot</displayableName>
         <facilityType>SupplyDepot</facilityType>
         <owner>Opposing</owner>

--- a/MekHQ/data/stratconfacilities/HostileTankBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileTankBase.xml
@@ -1,4 +1,5 @@
 <StratconFacility>
+	<capturedDefinition>AlliedTankBase.xml</capturedDefinition>
 	<displayableName>Tank Base</displayableName>
         <facilityType>TankBase</facilityType>
         <localModifiers>EnemyTankGarrison.xml</localModifiers>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
@@ -17,9 +17,7 @@ package mekhq.campaign.stratcon;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -58,6 +56,7 @@ public class StratconFacility implements Cloneable {
     private int aggroRating;
     private List<String> sharedModifiers = new ArrayList<>();
     private List<String> localModifiers = new ArrayList<>();
+    private String capturedDefinition;
     //TODO: post-MVP
     //private Map<String, Integer> fixedGarrisonUnitStates = new HashMap<>();
     private boolean isStrategicObjective;
@@ -77,6 +76,7 @@ public class StratconFacility implements Cloneable {
         clone.visible = visible;
         clone.sharedModifiers = new ArrayList<>(sharedModifiers);
         clone.localModifiers = new ArrayList<>(localModifiers);
+        clone.setCapturedDefinition(capturedDefinition); 
         return clone;
     }
     
@@ -174,6 +174,18 @@ public class StratconFacility implements Cloneable {
         return ownershipChangeScore;
     }
     
+    /**
+     * If present, this is the name of the definition file to draw from
+     * when switching facility ownership.
+     */
+    public String getCapturedDefinition() {
+        return capturedDefinition;
+    }
+
+    public void setCapturedDefinition(String capturedDefinition) {
+        this.capturedDefinition = capturedDefinition;
+    }
+
     /**
      * Attempt to deserialize an instance of a StratconFacility from the passed-in file name
      * @return Possibly an instance of a StratconFacility

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconFacilityFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconFacilityFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import megamek.common.Compute;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.Utilities;
@@ -105,10 +106,19 @@ public class StratconFacilityFactory {
     }
     
     /**
-     * Gets a specific facility given an "ID" (the file name)
+     * Gets a specific facility given an "ID" (the file name).
+     * This method does not clone the facility and should not be used to put one on the board
      */
     public static StratconFacility getFacilityByName(String name) {
         return stratconFacilityMap.get(name);
+    }
+    
+    /**
+     * Gets a clone of a specific facility given the "ID" (file name), null if it doesn't exist.
+     */
+    @Nullable
+    public static StratconFacility getFacilityCloneByName(String name) {
+        return stratconFacilityMap.containsKey(name) ? stratconFacilityMap.get(name).clone() : null;
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1227,7 +1227,6 @@ public class StratconRulesManager {
      * modifier/type/alignment switches etc.
      */
     private static void switchFacilityOwner(StratconFacility facility) {
-        facility.setCapturedDefinition("AlliedArtilleryBase.xml");
         if (facility.getCapturedDefinition() != null && !facility.getCapturedDefinition().isBlank()) {
             StratconFacility newOwnerData = 
                     StratconFacilityFactory.getFacilityByName(facility.getCapturedDefinition());

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1210,11 +1210,7 @@ public class StratconRulesManager {
                     updateStrategicObjectiveCount(victory, scenario, facility, campaignState);
 
                     if ((facility != null) && (facility.getOwnershipChangeScore() > 0)) {
-                        if (facility.getOwner() == ForceAlignment.Allied) {
-                            facility.setOwner(ForceAlignment.Opposing);
-                        } else {
-                            facility.setOwner(ForceAlignment.Allied);
-                        }
+                        switchFacilityOwner(facility);
                     }
 
                     processTrackForceReturnDates(track, rst.getCampaign().getLocalDate());
@@ -1223,6 +1219,37 @@ public class StratconRulesManager {
                     break;
                 }
             }
+        }
+    }
+    
+    /**
+     * Contains logic for what should happen when a facility gets captured:
+     * modifier/type/alignment switches etc.
+     */
+    private static void switchFacilityOwner(StratconFacility facility) {
+        facility.setCapturedDefinition("AlliedArtilleryBase.xml");
+        if (facility.getCapturedDefinition() != null && !facility.getCapturedDefinition().isBlank()) {
+            StratconFacility newOwnerData = 
+                    StratconFacilityFactory.getFacilityByName(facility.getCapturedDefinition());
+            
+            if (newOwnerData != null) {
+                // for now, we only need to change a limited subset of the captured facility's data
+                // the rest can be retained; we may revisit this assumption later
+                facility.setCapturedDefinition(newOwnerData.getCapturedDefinition());
+                facility.setLocalModifiers(new ArrayList<>(newOwnerData.getLocalModifiers()));
+                facility.setSharedModifiers(new ArrayList<>(newOwnerData.getSharedModifiers()));
+                facility.setOwner(newOwnerData.getOwner());
+                
+                return;
+            }
+        }
+        
+        // if we the facility didn't have any data defined for what happens when it's captured
+        // fall back to the default of just switching the owner
+        if (facility.getOwner() == ForceAlignment.Allied) {
+            facility.setOwner(ForceAlignment.Opposing);
+        } else {
+            facility.setOwner(ForceAlignment.Allied);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1227,7 +1227,7 @@ public class StratconRulesManager {
      * modifier/type/alignment switches etc.
      */
     private static void switchFacilityOwner(StratconFacility facility) {
-        if (facility.getCapturedDefinition() != null && !facility.getCapturedDefinition().isBlank()) {
+        if ((facility.getCapturedDefinition() != null) && !facility.getCapturedDefinition().isBlank()) {
             StratconFacility newOwnerData = 
                     StratconFacilityFactory.getFacilityByName(facility.getCapturedDefinition());
             


### PR DESCRIPTION
This pull request fixes an issue I noticed where, when captured, facilities would pretend to be captured but still supply scenario modifiers associated with hostile versions of themselves.

We explicitly define what a facility becomes when captured to avoid messing around with trying to guess the "opposite" definition file or modifiers.