### PR TITLE
update reinforcement cost message for no SP/VP situation

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -1,5 +1,6 @@
 supportPoint.text=Support Point
 supportPointConvert.text=Will convert VP from SP
+reinforcementRoll.Text=<span color="red">Reinforement Roll</span>
 fromChainedScenario.text=Lance already deployed
 lanceInFightRole.text=Lance in Fight role
 

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -423,14 +423,11 @@ public class StratconScenarioWizard extends JDialog {
             costBuilder.append(resourceMap.getString("supportPoint.text"));
             if (currentCampaignState.getSupportPoints() <= 0) {
                 costBuilder.append(", ");
-                if (currentCampaignState.getVictoryPoints() <= 1) {
-                    costBuilder.append("<span color='red'>");
-                }
-                
-                costBuilder.append(resourceMap.getString("supportPointConvert.text"));
                 
                 if (currentCampaignState.getVictoryPoints() <= 1) {
-                    costBuilder.append("</span>");
+                    costBuilder.append(resourceMap.getString("reinforcementRoll.Text"));
+                } else {
+                    costBuilder.append(resourceMap.getString("supportPointConvert.text"));
                 }
             }
             break;


### PR DESCRIPTION
Make the message indicating reinforcement cost a little more clear when the player has no SP/VP.