### PR TITLE
fix multiple grounded dropship issues

### DIFF
--- a/MekHQ/data/scenariomodifiers/groundBattleModifiers.xml
+++ b/MekHQ/data/scenariomodifiers/groundBattleModifiers.xml
@@ -54,6 +54,9 @@
 			EnemyDropship.xml
 		</modifier>
 		<modifier>
+			GroundedEnemyDropship.xml
+		</modifier>
+		<modifier>
 			GoodIntel.xml
 		</modifier>
 		<modifier>

--- a/MekHQ/data/scenariomodifiers/modifiermanifest.xml
+++ b/MekHQ/data/scenariomodifiers/modifiermanifest.xml
@@ -60,6 +60,9 @@
 			EnemyDropship.xml
 		</modifier>
 		<modifier>
+			GroundedEnemyDropship.xml
+		</modifier>
+		<modifier>
 			GoodIntel.xml
 		</modifier>
 		<modifier>

--- a/MekHQ/data/scenariotemplates/Defend Grounded Dropship.xml
+++ b/MekHQ/data/scenariotemplates/Defend Grounded Dropship.xml
@@ -68,7 +68,15 @@
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>10</deploymentZone>
+                    <deploymentZone>1</deploymentZone>
+                    <deploymentZone>2</deploymentZone>
+                    <deploymentZone>3</deploymentZone>
+                    <deploymentZone>4</deploymentZone>
+                    <deploymentZone>5</deploymentZone>
+                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>7</deploymentZone>
+                    <deploymentZone>8</deploymentZone>
+                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>4</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -47,6 +47,7 @@ import megamek.common.Crew;
 import megamek.common.Entity;
 import megamek.common.EntityMovementMode;
 import megamek.common.EntityWeightClass;
+import megamek.common.IAero;
 import megamek.common.IBomber;
 import megamek.common.Infantry;
 import megamek.common.Mech;
@@ -2301,8 +2302,14 @@ public class AtBDynamicScenarioFactory {
      */
     private static void setStartingAltitude(List<Entity> entityList, int startingAltitude) {
         for (Entity entity : entityList) {
-            if (!entity.hasETypeFlag(Entity.ETYPE_VTOL)) {
+            if (entity instanceof IAero) {
                 entity.setAltitude(startingAltitude);
+                
+                // there's a lot of stuff that happens whan an aerospace unit
+                // "lands", so let's make sure it all happens
+                if (startingAltitude == 0) {
+                    ((IAero) entity).land();
+                }
             }
 
             entity.setElevation(startingAltitude);

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -318,7 +318,11 @@ public class CustomizeScenarioDialog extends JDialog {
             if (txtReport != null) {
                 scenario.setReport(txtReport.getText());
             }
-            scenario.setStatus((ScenarioStatus) choiceStatus.getSelectedItem());
+            
+            if (choiceStatus.getSelectedItem() != null) {
+                scenario.setStatus((ScenarioStatus) choiceStatus.getSelectedItem());
+            }
+            
             scenario.setDate(date);
         }
         scenario.resetLoot();


### PR DESCRIPTION
Four changes:
- grounded dropships were unavailable as potential scenario modifiers even though they should have been
- customize scenario dialog would reset status to null if editing a non-resolved scenario
- invoke full "land" code to set all appropriate values when initializing a grounded aerospace unit
- don't deploy opfor directly underneath allied dropship in 'Defend Dropship' scenario