### PR TITLE
2588: Fixing unmarketable check value for personnel table filter support check

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -187,7 +187,7 @@ public enum PersonnelFilter {
                         ? person.getPrimaryRole().isCombat() : person.hasCombatRole());
             case SUPPORT:
                 return active && (MekHQ.getMekHQOptions().getPersonnelFilterOnPrimaryRole()
-                        ? !person.getPrimaryRole().isCombat() : person.hasSupportRole(false));
+                        ? !person.getPrimaryRole().isCombat() : person.hasSupportRole(true));
             case MECHWARRIORS:
                 return active && (MekHQ.getMekHQOptions().getPersonnelFilterOnPrimaryRole()
                         ? person.getPrimaryRole().isMechWarriorGrouping()


### PR DESCRIPTION
This fixes #2588 