### PR TITLE
Scenario data fixes

### DIFF
--- a/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
@@ -53,9 +53,6 @@
                     <howMuch>-1</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails>
-		<additionalDetail>If the house unit is irrevocably destroyed, it will reduce contract score by 1.</additionalDetail>
-            </additionalDetails>
             <description>Preserve 100% of the following force(s) and unit(s):</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
@@ -27,4 +27,69 @@
 		<syncedForceName>Player</syncedForceName>
 		<useArtillery>false</useArtillery>
 	</forceDefinition>
+
+	<objectives>
+        <objective>
+            <associatedForceNames>
+                <associatedForceName>House Officer</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs/>
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+		<failureEffect>
+                    <effectType>ContractScoreUpdate</effectType>
+                    <effectScaling>Inverted</effectScaling>
+                    <howMuch>-1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <description>Preserve 100% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>100</percentage>
+            <timeLimit>0</timeLimit>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </objective>
+	<objective>
+            <associatedForceNames>
+                <associatedForceName>House Officer</associatedForceName>
+                <associatedForceName>Player</associatedForceName>
+                <associatedForceName>Allied Force</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs/>
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails/>
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimit>0</timeLimit>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </objective>
+        </objectives>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesAir.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesAir.xml
@@ -49,13 +49,10 @@
                 </failureEffect>
 		<failureEffect>
                     <effectType>ContractScoreUpdate</effectType>
-                    <effectScaling>Inverted</effectScaling>
+                    <effectScaling>Fixed</effectScaling>
                     <howMuch>-1</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails>
-		<additionalDetail>Each integrated force unit irrevocably destroyed will reduce contract score by 1.</additionalDetail>
-            </additionalDetails>
             <description>Preserve 100% of the following force(s) and unit(s):</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
@@ -3,28 +3,93 @@
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>
-<actualDeploymentZone>-1</actualDeploymentZone>
-<allowAeroBombs>false</allowAeroBombs>
-<allowedUnitType>0</allowedUnitType>
-<arrivalTurn>0</arrivalTurn>
-<canReinforceLinked>false</canReinforceLinked>
-<contributesToBV>false</contributesToBV>
-<contributesToMapSize>false</contributesToMapSize>
-<contributesToUnitCount>true</contributesToUnitCount>
-<deployOffboard>false</deployOffboard>
-<deploymentZones/>
-<destinationZone>4</destinationZone>
-<fixedUnitCount>2</fixedUnitCount>
-<forceAlignment>1</forceAlignment>
-<forceMultiplier>1.0</forceMultiplier>
-<forceName>Integrated Allies</forceName>
-<generationMethod>3</generationMethod>
-<generationOrder>1</generationOrder>
-<maxWeightClass>4</maxWeightClass>
-<retreatThreshold>0</retreatThreshold>
-<startingAltitude>0</startingAltitude>
-<syncDeploymentType>SameEdge</syncDeploymentType>
-<syncedForceName>Player</syncedForceName>
-<useArtillery>false</useArtillery>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>0</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>false</contributesToBV>
+		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToUnitCount>true</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+		<deploymentZones/>
+		<destinationZone>4</destinationZone>
+		<fixedUnitCount>2</fixedUnitCount>
+		<forceAlignment>1</forceAlignment>
+		<forceMultiplier>1.0</forceMultiplier>
+		<forceName>Integrated Allies</forceName>
+		<generationMethod>3</generationMethod>
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>
+		<retreatThreshold>0</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<syncDeploymentType>SameEdge</syncDeploymentType>
+		<syncedForceName>Player</syncedForceName>
+		<useArtillery>false</useArtillery>
 	</forceDefinition>
+
+	<objectives>
+        <objective>
+            <associatedForceNames>
+                <associatedForceName>Integrated Allies</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs/>
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+		<failureEffect>
+                    <effectType>ContractScoreUpdate</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>-1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <description>Preserve 100% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>100</percentage>
+            <timeLimit>0</timeLimit>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </objective>
+	<objective>
+            <associatedForceNames>
+                <associatedForceName>Integrated Allies</associatedForceName>
+                <associatedForceName>Player</associatedForceName>
+                <associatedForceName>Allied Force</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs/>
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails/>
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimit>0</timeLimit>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </objective>
+        </objectives>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/LiaisonAir.xml
+++ b/MekHQ/data/scenariomodifiers/LiaisonAir.xml
@@ -53,9 +53,6 @@
                     <howMuch>-1</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails>
-		<additionalDetail>If the liaison is irrevocably destroyed, it will reduce contract score by 1.</additionalDetail>
-            </additionalDetails>
             <description>Preserve 100% of the following force(s) and unit(s):</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>

--- a/MekHQ/data/scenariomodifiers/LiaisonGround.xml
+++ b/MekHQ/data/scenariomodifiers/LiaisonGround.xml
@@ -3,28 +3,93 @@
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>
-<actualDeploymentZone>-1</actualDeploymentZone>
-<allowAeroBombs>false</allowAeroBombs>
-<allowedUnitType>0</allowedUnitType>
-<arrivalTurn>0</arrivalTurn>
-<canReinforceLinked>false</canReinforceLinked>
-<contributesToBV>false</contributesToBV>
-<contributesToMapSize>false</contributesToMapSize>
-<contributesToUnitCount>true</contributesToUnitCount>
-<deployOffboard>false</deployOffboard>
-<deploymentZones/>
-<destinationZone>4</destinationZone>
-<fixedUnitCount>1</fixedUnitCount>
-<forceAlignment>0</forceAlignment>
-<forceMultiplier>1.0</forceMultiplier>
-<forceName>Attached Liaison</forceName>
-<generationMethod>3</generationMethod>
-<generationOrder>1</generationOrder>
-<maxWeightClass>4</maxWeightClass>
-<retreatThreshold>0</retreatThreshold>
-<startingAltitude>0</startingAltitude>
-<syncDeploymentType>SameEdge</syncDeploymentType>
-<syncedForceName>Player</syncedForceName>
-<useArtillery>false</useArtillery>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>0</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>false</contributesToBV>
+		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToUnitCount>true</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+		<deploymentZones/>
+		<destinationZone>4</destinationZone>
+		<fixedUnitCount>1</fixedUnitCount>
+		<forceAlignment>0</forceAlignment>
+		<forceMultiplier>1.0</forceMultiplier>
+		<forceName>Attached Liaison</forceName>
+		<generationMethod>3</generationMethod>
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>
+		<retreatThreshold>0</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<syncDeploymentType>SameEdge</syncDeploymentType>
+		<syncedForceName>Player</syncedForceName>
+		<useArtillery>false</useArtillery>
 	</forceDefinition>
+
+	<objectives>
+        <objective>
+            <associatedForceNames>
+                <associatedForceName>Attached Liaison</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs/>
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+		<failureEffect>
+                    <effectType>ContractScoreUpdate</effectType>
+                    <effectScaling>Inverted</effectScaling>
+                    <howMuch>-1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <description>Preserve 100% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>100</percentage>
+            <timeLimit>0</timeLimit>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </objective>
+	<objective>
+            <associatedForceNames>
+                <associatedForceName>Attached Liaison</associatedForceName>
+                <associatedForceName>Player</associatedForceName>
+                <associatedForceName>Allied Force</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs/>
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails/>
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimit>0</timeLimit>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </objective>
+        </objectives>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariotemplates/Defend Grounded Dropship.xml
+++ b/MekHQ/data/scenariotemplates/Defend Grounded Dropship.xml
@@ -146,7 +146,9 @@
                     <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails/>
+            <additionalDetails>
+                <additionalDetail>If the dropship cannot be deployed, this objective may be ignored.</additionalDetail>
+            </additionalDetails>
             <description>Protect the following units:</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>

--- a/MekHQ/data/scenariotemplates/Destroy Grounded Dropship.xml
+++ b/MekHQ/data/scenariotemplates/Destroy Grounded Dropship.xml
@@ -138,7 +138,9 @@
                     <howMuch>1</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails/>
+            <additionalDetails>
+                <additionalDetail>If the dropship cannot be deployed, this objective may be ignored.</additionalDetail>
+            </additionalDetails>
             <description>Destroy or cripple the following unit(s):</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>

--- a/MekHQ/data/scenariotemplates/Harass.xml
+++ b/MekHQ/data/scenariotemplates/Harass.xml
@@ -3,6 +3,8 @@
     <name>Harass</name>
     <shortBriefing>Harass a superior enemy force.</shortBriefing>
     <detailedBriefing>Prevent 50% of the hostile force from reaching the opposite map edge.</detailedBriefing>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes/>
         <allowRotation>true</allowRotation>
@@ -38,6 +40,7 @@
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -66,6 +69,7 @@
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>SameEdge</syncDeploymentType>
@@ -95,6 +99,7 @@
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
@@ -105,7 +110,9 @@
     </scenarioForces>
     <scenarioObjectives>
         <scenarioObjective>
-            <associatedForceNames/>
+            <associatedForceNames>
+                <associatedForceName>Primary Opfor</associatedForceName>
+            </associatedForceNames>
             <associatedUnitIDs/>
             <successEffects>
                 <successEffect>

--- a/MekHQ/data/scenariotemplates/Recon.xml
+++ b/MekHQ/data/scenariotemplates/Recon.xml
@@ -111,6 +111,7 @@
             <additionalDetails>
                 <additionalDetail>Scans may be conducted by weapons fire, TAG, spotting or physical attacks.</additionalDetail>
                 <additionalDetail>If the scan action requires a roll, it must be possible.</additionalDetail>
+                <additionalDetail>Note: This objective should be tracked manually outside of MegaMek.</additionalDetail>
             </additionalDetails>
             <description>Scan the following enemy unit(s) and force(s):</description>
             <destinationEdge>NONE</destinationEdge>

--- a/MekHQ/docs/AtB Stuff/stratcon-faq.txt
+++ b/MekHQ/docs/AtB Stuff/stratcon-faq.txt
@@ -64,7 +64,7 @@ Might be a hostile facility or three on the track. Better do some recon and take
 
 
 How do I capture a hostile facility?
-You'll need to complete the 'capture' objective in an attack scenario on it, without completing the 'destroy' objective. Meaning, you'll need to leave the facility turrets intact (though disabling them via crew kills, equipment destruction or ammo depletion is fine), while routing any mobile enemy ground units
+You'll need to complete the 'capture' objective in an attack scenario on it, without completing the 'destroy' objective. Meaning, you'll need to leave (by default, 75% of) the facility turrets intact (though disabling them via crew kills, equipment destruction or ammo depletion is fine), while routing any mobile enemy ground units (usually, crippling 75% of all non-aerospace units will do the trick). 
 
 
 How do I manually deploy units to a track?
@@ -77,3 +77,11 @@ You've probably got them deployed to a StratCon track. Wait for them to come bac
 
 I want to design my own scenarios, how do I do that?
 Use the Scenario Template Editor to put together a scenario template. I recommend using the Briefing Room -> Add Scenario -> Generate From Template mechanism to test the template out. Now, go to your data\scenariomodifiers directory and create (if it doesn't exist already) a file called UserScenarioManifest.xml. It should be formatted exactly like ScenarioManifest. Make sure not to overlap with the ID numbers or file names in ScenarioManifest, as that "may cause unpredictable behavior". Now that you've got your scenario in the UserScenarioManifest file, it'll be added to the pool of scenarios StratCon draws from when generating battles.
+
+
+Do I use BV or unit count to determine whether I've completed an objective?
+You can use either, that's entirely up to you. Maybe even both! 
+
+
+How do I determine if I control the battlefield after a battle?
+By default, crippling or destroying 50% of the opposition (not including aerospace units on ground maps) will grant you control of the battlefield for salvage, search & rescue or any other purposes. The exception being a hostile facility, which requires crippling or destroying 75% of the opposition (again, not including aerospace units on ground maps) to gain battlefield control.


### PR DESCRIPTION
A bunch of data fixes:
- employer unit scenario modifiers (integrated/house/liaison) no longer make reference to loss of contract score
- ground employer unit scenario modifiers now have associated objectives like their air counterparts
- Harass scenario objective actually linked to force that needs to be harassed
- Clarifying text added to grounded dropship scenarios for situations where the DS cannot be deployed (we basically assume it's powered down off-map somewhere in that case)
- Clarifying text added to recon scenario to tell the player to track the objective manually
- Update to the FAQ regarding facility capture, battlefield control and BV vs unit count objective tracking.