### PR TITLE
Stratcon fix batch #2

### DIFF
--- a/MekHQ/data/scenariomodifiers/EnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyDropship.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>An enemy dropship has been grounded in this area, but it's weapons are still active so pay attention.</additionalBriefingText>
+	<additionalBriefingText>An enemy dropship has been detected in the area.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>An enemy dropship has been grounded in this area, but it's weapons are still active so pay attention.</additionalBriefingText>
+	<additionalBriefingText>An enemy dropship has been grounded in this area, but its weapons are still active so pay attention.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariotemplates/Irregular Forces.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Forces.xml
@@ -170,7 +170,7 @@
             <additionalDetails/>
             <description>Destroy, cripple or force the withdrawal of the following forces and units:</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Destroy</objectiveCriterion>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
             <percentage>50</percentage>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>

--- a/MekHQ/data/scenariotemplates/Low Atmo - Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low Atmo - Escort.xml
@@ -3,6 +3,8 @@
     <name>Low Atmo - Escort</name>
     <shortBriefing>Escort allied dropship.</shortBriefing>
     <detailedBriefing>Escort designated dropship to its destination.</detailedBriefing>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes/>
         <allowRotation>true</allowRotation>
@@ -41,6 +43,7 @@
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -69,6 +72,7 @@
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
@@ -89,7 +93,7 @@
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones/>
-                <destinationZone>4</destinationZone>
+                <destinationZone>5</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -98,6 +102,7 @@
                 <generationOrder>4</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>SameEdge</syncDeploymentType>

--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -1,15 +1,15 @@
 supportPoint.text=Support Point
 supportPointConvert.text=Will convert VP from SP
-reinforcementRoll.Text=<span color="red">Reinforement Roll</span>
+reinforcementRoll.Text=<span color="red">Reinforcement Roll</span>
 fromChainedScenario.text=Lance already deployed
-lanceInFightRole.text=Lance in Fight role
+lanceInFightRole.text=Fight-Role Reinforcement Roll
 
 lblDefensiveMinefieldCount.text=Defensive Minefield Count: %d
 lblSelectIndividualUnits.text=Select individual units (%d max)
 
 lblDefensivePostureInstructions.Text=This lance is on a defensive deployment and you may deploy additional infantry, battle armor, or minefields.
 lblLeadershipInstructions.Text=The force commander's leadership allows the deployment of additional auxiliary units - choose from the list below.
-lblFCLeadershipAvailable.Text=<html>Force commander's leadership: %d%s%s
+lblFCLeadershipAvailable.Text=<html>Force commander's leadership: %d%s%s</html>
 lblLeaderUnitsUsed.Text=<br/>%d units already assigned
 lblLeadershipReinforcementsUnavailable.Text=<br/>Leadership reinforcements unavailable
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -171,6 +171,11 @@ public class AtBDynamicScenario extends AtBScenario {
     public int getMapY() {
         return getMapSizeY();
     }
+    
+    @Override
+    public void setMapSize() {
+        AtBDynamicScenarioFactory.setScenarioMapSize(this);
+    }
 
     /**
      * Adds a bot force to this scenario.

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -802,7 +802,7 @@ public class AtBDynamicScenarioFactory {
      *
      * @param scenario The scenario to process.
      */
-    private static void setScenarioMapSize(AtBDynamicScenario scenario) {
+    public static void setScenarioMapSize(AtBDynamicScenario scenario) {
         int mapSizeX;
         int mapSizeY;
         ScenarioTemplate template = scenario.getTemplate();

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -150,9 +150,12 @@ public class StratconPanel extends JPanel implements ActionListener {
         
         StratconScenario scenario = getSelectedScenario();
         
-        if (scenario == null) {
+        // can't stack more than one force on hex 
+        // can't "deploy" a force to a scenario (have to reinforce instead)
+        if ((scenario == null) && 
+                !currentTrack.getAssignedCoordForces().containsKey(coords)) {
             menuItemManageForceAssignments = new JMenuItem();
-            menuItemManageForceAssignments.setText("Manage Force Assignments");
+            menuItemManageForceAssignments.setText("Manage Force Assignment");
             menuItemManageForceAssignments.setActionCommand(RCLICK_COMMAND_MANAGE_FORCES);
             menuItemManageForceAssignments.addActionListener(this);
             rightClickMenu.add(menuItemManageForceAssignments);

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -435,7 +435,7 @@ public class StratconScenarioWizard extends JDialog {
             costBuilder.append(resourceMap.getString("fromChainedScenario.text"));
             break;
         case FightLance:
-            costBuilder.append("lanceInFightRole.text");
+            costBuilder.append(resourceMap.getString("lanceInFightRole.text"));
             break;
         default:
             costBuilder.append("Error: Invalid Reinforcement Type");

--- a/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
+++ b/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
@@ -23,6 +23,7 @@ import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -86,6 +87,7 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
                 StratconRulesManager.getAvailableForceIDs(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX, 
                         campaign, ownerPanel.getCurrentTrack(), false, null));
         
+        availableForceList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         availableForceList.setModel(lanceModel);
         availableForceList.setCellRenderer(new ScenarioWizardLanceRenderer(campaign));
         


### PR DESCRIPTION
- Fixes a couple of modifier/scenario descriptions, objectives and force destinations.
- Fixes some text tokens
- Prevents map size rerolls from generating tiny maps
- Prevents stacking multiple forces on a single hex - it can still happen with reinforcements, but I a) want to prevent multiple scenarios from spawning in a single hex and b) want to prevent the player from stacking all their forces on top of an allied facility for "free" reinforcement.
