### PR TITLE
StratCon data fixes round 3

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedArtyGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedArtyGarrison.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>This facility is defended by an additional force of allied artillery who have been unable to clear the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/AlliedArtySupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedArtySupport.xml
@@ -1,31 +1,35 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Allied artillery units will support your deployment with indirect fire.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>
-<actualDeploymentZone>-1</actualDeploymentZone>
-<allowAeroBombs>false</allowAeroBombs>
-<allowedUnitType>1</allowedUnitType>
-<arrivalTurn>0</arrivalTurn>
-<canReinforceLinked>false</canReinforceLinked>
-<contributesToBV>false</contributesToBV>
-<contributesToMapSize>false</contributesToMapSize>
-<contributesToUnitCount>false</contributesToUnitCount>
-<deployOffboard>true</deployOffboard>
-<deploymentZones>
-<deploymentZone>9</deploymentZone>
-</deploymentZones>
-<destinationZone>4</destinationZone>
-<fixedUnitCount>-1</fixedUnitCount>
-<forceAlignment>1</forceAlignment>
-<forceMultiplier>1.0</forceMultiplier>
-<forceName>Allied Artillery</forceName>
-<generationMethod>3</generationMethod>
-<generationOrder>3</generationOrder>
-<maxWeightClass>4</maxWeightClass>
-<retreatThreshold>0</retreatThreshold>
-<startingAltitude>0</startingAltitude>
-<syncDeploymentType>None</syncDeploymentType>
-<useArtillery>true</useArtillery>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>1</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>false</contributesToBV>
+		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToUnitCount>false</contributesToUnitCount>
+		<deployOffboard>true</deployOffboard>
+		<deploymentZones>
+			<deploymentZone>9</deploymentZone>
+		</deploymentZones>
+		<destinationZone>4</destinationZone>
+		<fixedUnitCount>-1</fixedUnitCount>
+		<forceAlignment>1</forceAlignment>
+		<forceMultiplier>1.0</forceMultiplier>
+		<forceName>Allied Artillery</forceName>
+		<generationMethod>3</generationMethod>
+		<generationOrder>3</generationOrder>
+		<maxWeightClass>4</maxWeightClass>
+		<retreatThreshold>0</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<syncDeploymentType>None</syncDeploymentType>
+		<useArtillery>true</useArtillery>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/AlliedGroundSupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedGroundSupport.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Additional allied ground units are en route.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/AlliedMechGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMechGarrison.xml
@@ -1,31 +1,35 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>This facility is guarded by a lance of allied mechs who will fight alongside us in its defense.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>
-<actualDeploymentZone>-1</actualDeploymentZone>
-<allowAeroBombs>false</allowAeroBombs>
-<allowedUnitType>0</allowedUnitType>
-<arrivalTurn>0</arrivalTurn>
-<canReinforceLinked>false</canReinforceLinked>
-<contributesToBV>true</contributesToBV>
-<contributesToMapSize>true</contributesToMapSize>
-<contributesToUnitCount>false</contributesToUnitCount>
-<deployOffboard>false</deployOffboard>
-<deploymentZones>
-<deploymentZone>10</deploymentZone>
-</deploymentZones>
-<destinationZone>4</destinationZone>
-<fixedUnitCount>-1</fixedUnitCount>
-<forceAlignment>1</forceAlignment>
-<forceMultiplier>1.0</forceMultiplier>
-<forceName>Allied Mech Garrison</forceName>
-<generationMethod>3</generationMethod>
-<generationOrder>1</generationOrder>
-<maxWeightClass>4</maxWeightClass>
-<retreatThreshold>75</retreatThreshold>
-<startingAltitude>0</startingAltitude>
-<syncDeploymentType>None</syncDeploymentType>
-<useArtillery>false</useArtillery>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>0</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>true</contributesToBV>
+		<contributesToMapSize>true</contributesToMapSize>
+		<contributesToUnitCount>false</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+		<deploymentZones>
+			<deploymentZone>10</deploymentZone>
+		</deploymentZones>
+		<destinationZone>4</destinationZone>
+		<fixedUnitCount>-1</fixedUnitCount>
+		<forceAlignment>1</forceAlignment>
+		<forceMultiplier>1.0</forceMultiplier>
+		<forceName>Allied Mech Garrison</forceName>
+		<generationMethod>3</generationMethod>
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>
+		<retreatThreshold>75</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<syncDeploymentType>None</syncDeploymentType>
+		<useArtillery>false</useArtillery>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/AlliedMechReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMechReinforcements.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Additional allied 'Mechs are approaching the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/AlliedReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedReinforcements.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Additional allied ground forces are approaching the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/AlliedTankGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTankGarrison.xml
@@ -1,31 +1,35 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>This facility has a garrison of tanks, which will fight alongside your force in the facility's defense.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>
-<actualDeploymentZone>-1</actualDeploymentZone>
-<allowAeroBombs>false</allowAeroBombs>
-<allowedUnitType>1</allowedUnitType>
-<arrivalTurn>0</arrivalTurn>
-<canReinforceLinked>false</canReinforceLinked>
-<contributesToBV>true</contributesToBV>
-<contributesToMapSize>true</contributesToMapSize>
-<contributesToUnitCount>false</contributesToUnitCount>
-<deployOffboard>false</deployOffboard>
-<deploymentZones>
-<deploymentZone>10</deploymentZone>
-</deploymentZones>
-<destinationZone>4</destinationZone>
-<fixedUnitCount>-1</fixedUnitCount>
-<forceAlignment>1</forceAlignment>
-<forceMultiplier>1.0</forceMultiplier>
-<forceName>Allied Tank Garrison</forceName>
-<generationMethod>3</generationMethod>
-<generationOrder>1</generationOrder>
-<maxWeightClass>4</maxWeightClass>
-<retreatThreshold>75</retreatThreshold>
-<startingAltitude>0</startingAltitude>
-<syncDeploymentType>None</syncDeploymentType>
-<useArtillery>false</useArtillery>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>1</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>true</contributesToBV>
+		<contributesToMapSize>true</contributesToMapSize>
+		<contributesToUnitCount>false</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+		<deploymentZones>
+			<deploymentZone>10</deploymentZone>
+		</deploymentZones>
+		<destinationZone>4</destinationZone>
+		<fixedUnitCount>-1</fixedUnitCount>
+		<forceAlignment>1</forceAlignment>
+		<forceMultiplier>1.0</forceMultiplier>
+		<forceName>Allied Tank Garrison</forceName>
+		<generationMethod>3</generationMethod>
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>
+		<retreatThreshold>75</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<syncDeploymentType>None</syncDeploymentType>
+		<useArtillery>false</useArtillery>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/AlliedTankReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTankReinforcements.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Additional allied ground armor forces are approaching the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/AlliedTurrets.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTurrets.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>This location is defended by additional fixed turrets.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/BadIntelGround.xml
+++ b/MekHQ/data/scenariomodifiers/BadIntelGround.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Recon underestimated enemy strength, and additional enemy units are present.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyArty.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyArty.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>A hostile artillery battery is on the field.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyArtyGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyArtyGarrison.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>This facility is defended by an additional force of enemy artillery who have been unable to clear the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyHotDrop.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyHotDrop.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Enemy dropship has been detected in the area. Telemetry indicates it's at least partially loaded. Expect additional hostile units to be deployed via airdrop.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyMechGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyMechGarrison.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>This facility is defended by an additional force of enemy mechs.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyMechReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyMechReinforcements.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Additional hostile mechs are approaching the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyReinforcements.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Additional enemy ground forces have been detected approaching the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyTankGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyTankGarrison.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>This facility is defended by an additional lance of enemy armor.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyTankReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyTankReinforcements.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Additional hostile ground armor forces are approaching the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyTurrets.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyTurrets.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>This location is defended by additional fixed turrets.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
@@ -1,30 +1,34 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>An enemy dropship has been grounded in this area, but its weapons are still active so pay attention.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>
-<actualDeploymentZone>-1</actualDeploymentZone>
-<allowAeroBombs>false</allowAeroBombs>
-<allowedUnitType>11</allowedUnitType>
-<arrivalTurn>0</arrivalTurn>
-<canReinforceLinked>false</canReinforceLinked>
-<contributesToBV>false</contributesToBV>
-<contributesToMapSize>false</contributesToMapSize>
-<contributesToUnitCount>false</contributesToUnitCount>
-<deployOffboard>false</deployOffboard>
-<deploymentZones/>
-<destinationZone>4</destinationZone>
-<fixedUnitCount>1</fixedUnitCount>
-<forceAlignment>2</forceAlignment>
-<forceMultiplier>1.0</forceMultiplier>
-<forceName>Opfor Grounded Dropship</forceName>
-<generationMethod>3</generationMethod>
-<generationOrder>3</generationOrder>
-<maxWeightClass>4</maxWeightClass>
-<retreatThreshold>50</retreatThreshold>
-<startingAltitude>0</startingAltitude>
-<syncDeploymentType>SameEdge</syncDeploymentType>
-<syncedForceName>Primary Opfor</syncedForceName>
-<useArtillery>false</useArtillery>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>11</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>false</contributesToBV>
+		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToUnitCount>false</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+		<deploymentZones/>
+			<destinationZone>4</destinationZone>
+		<fixedUnitCount>1</fixedUnitCount>
+		<forceAlignment>2</forceAlignment>
+		<forceMultiplier>1.0</forceMultiplier>
+		<forceName>Opfor Grounded Dropship</forceName>
+		<generationMethod>3</generationMethod>
+		<generationOrder>3</generationOrder>
+		<maxWeightClass>4</maxWeightClass>
+		<retreatThreshold>50</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<syncDeploymentType>SameEdge</syncDeploymentType>
+		<syncedForceName>Primary Opfor</syncedForceName>
+		<useArtillery>false</useArtillery>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>The house commanding officer will deploy alongside your units. Keep them alive.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Your force will be deployed as part of an integrated unit. Keep the allied units alive.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/LiaisonGround.xml
+++ b/MekHQ/data/scenariomodifiers/LiaisonGround.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>The employer's liaison will deploy alongside your force in a battlemech, under your command. Keep them alive.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/LocalGarrisonInfantry.xml
+++ b/MekHQ/data/scenariomodifiers/LocalGarrisonInfantry.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Planetary garrison infantry have been reported in the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/LocalGarrisonTurrets.xml
+++ b/MekHQ/data/scenariomodifiers/LocalGarrisonTurrets.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Fixed defences have been reported in the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/PiratesIncomingGround.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesIncomingGround.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Unidentified ground forces have been detected approaching the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/PiratesPresentGround.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesPresentGround.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>Unidentified ground forces have been detected in the area.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
@@ -1,5 +1,9 @@
 <AtBScenarioModifier>
 	<additionalBriefingText>To compensate for the presence of a large opposing force, allied units will be working alongside us on this operation.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/SearchAndRescue.xml
+++ b/MekHQ/data/scenariomodifiers/SearchAndRescue.xml
@@ -1,4 +1,8 @@
 <AtBScenarioModifier>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
 	<additionalBriefingText>Minor detention facility reported here. Rescue targets from designated buildings.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
@@ -28,26 +32,30 @@
 		</objectiveLinkedForces>
 		<syncDeploymentType>None</syncDeploymentType>
 	</forceDefinition>
-	<scenarioObjective>
-            <associatedForceNames>
-                <associatedForceName>Designated Facilities</associatedForceName>
-            </associatedForceNames>
-            <associatedUnitIDs/>
-            <successEffects>
-                <successEffect>
-                    <effectType>SupportPointUpdate</effectType>
-                    <effectScaling>Linear</effectScaling>
-                    <howMuch>1</howMuch>
-                </successEffect>
-            </successEffects>
-            <failureEffects/>
-            <additionalDetails/>
-            <description>Extract from or do not destroy units from the following force(s) for additional support points:</description>
-            <destinationEdge>NONE</destinationEdge>
-            <fixedAmount>1</fixedAmount>
-            <objectiveCriterion>Capture</objectiveCriterion>
-            <percentage>1</percentage>
-            <timeLimitAtMost>true</timeLimitAtMost>
-            <timeLimitType>None</timeLimitType>
-        </scenarioObjective>
+	<objectives>
+		<objective>
+			<associatedForceNames>
+				<associatedForceName>Designated Facilities</associatedForceName>
+			</associatedForceNames>
+			<successEffects>
+				<successEffect>
+					<effectType>SupportPointUpdate</effectType>
+					<effectScaling>Linear</effectScaling>
+					<howMuch>1</howMuch>
+				</successEffect>
+			</successEffects>
+			<description>Extract from, or, leave intact while maintaining battlefield control, units from the following force(s) for additional support points:</description>
+			<additionalDetails>
+				<additionalDetail>
+					1 support point will be awarded per intact unit remaining.
+				</additionalDetail>
+			</additionalDetails>
+			<destinationEdge>NONE</destinationEdge>
+			<fixedAmount>1</fixedAmount>
+			<objectiveCriterion>Capture</objectiveCriterion>
+			<percentage>1</percentage>
+			<timeLimitAtMost>true</timeLimitAtMost>
+			<timeLimitType>None</timeLimitType>
+		</objective>
+        </objectives>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariotemplates/Irregular Forces.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Forces.xml
@@ -168,7 +168,7 @@
             </successEffects>
             <failureEffects/>
             <additionalDetails/>
-            <description>Destroy, cripple or force the withdrawal of the following forces and units:</description>
+            <description>Destroy, cripple or force the withdrawal of 50% of the following forces and units:</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
             <percentage>50</percentage>

--- a/MekHQ/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/MekHQ/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -20,8 +20,8 @@
     <objectiveParameters>
         <objectiveParameter>
 		<objectiveType>AnyScenarioVictory</objectiveType>
-		<objectiveScenarioModifiers>															<objectiveScenarioModifier>OverwhelmingReinforcementsGround.xml</objectiveScenarioModifier>
-			<objectiveScenarioModifier>OverwhelmingReinforcementsAir.xml</objectiveScenarioModifier>
+		<objectiveScenarioModifiers>										<objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
+			<objectiveScenarioModifier>OverwhelmingEnemyAirReinforcements.xml</objectiveScenarioModifier>
 		</objectiveScenarioModifiers>
         </objectiveParameter>
     </objectiveParameters>


### PR DESCRIPTION
- Ground scenario modifiers have had their allowed terrain type explicitly set so they don't show up for aerospace scenarios.
- Search & Rescue scenario now properly adds objectives and rewards to scenario
- Updated Irregular Forces briefing text
- Guerilla warfare contract definition has proper "fixed" scenario modifiers