### PR TITLE
fix multiple issues generating fixed objective scenarios

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -977,6 +977,13 @@ public class Campaign implements Serializable, ITechManager {
     //endregion Missions/Contracts
 
     /**
+     * Adds scenario to existing mission, generating a report.
+     */
+    public void addScenario(Scenario s, Mission m) {
+        addScenario(s, m, false);
+    }
+    
+    /**
      * Add scenario to an existing mission. This method will also assign the scenario an id, provided
      * that it is a new scenario. It then adds the scenario to the scenarioId hash.
      *
@@ -987,15 +994,16 @@ public class Campaign implements Serializable, ITechManager {
      *
      * @param s - the Scenario to add
      * @param m - the mission to add the new scenario to
+     * @param suppressReport - whether or not to suppress the campaign report
      */
-    public void addScenario(Scenario s, Mission m) {
+    public void addScenario(Scenario s, Mission m, boolean suppressReport) {
         final boolean newScenario = s.getId() == Scenario.S_DEFAULT_ID;
         final int id = newScenario ? ++lastScenarioId : s.getId();
         s.setId(id);
         m.addScenario(s);
         scenarios.put(id, s);
 
-        if (newScenario) {
+        if (newScenario && !suppressReport) {
             addReport(MessageFormat.format(
                     resources.getString("newAtBMission.format"),
                     s.getName(), MekHQ.getMekHQOptions().getDisplayFormattedDate(s.getDate())));

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2444,8 +2444,8 @@ public class AtBDynamicScenarioFactory {
      * owners of the contract's location at the current date.
      */
     private static boolean isPlanetOwner(AtBContract contract, LocalDate currentDate, String factionCode) {
-        if (contract == null || contract.getSystem() == null ||
-                contract.getSystem().getFactions(currentDate) == null) {
+        if ((contract == null) || (contract.getSystem() == null) ||
+                (contract.getSystem().getFactions(currentDate) == null)) {
             return false;
         }
         

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -327,7 +327,7 @@ public class AtBDynamicScenarioFactory {
         }
 
         String parentFactionType = AtBConfiguration.getParentFactionType(factionCode);
-        boolean isPlanetOwner = contract.getSystem().getFactions(currentDate).contains(factionCode);
+        boolean isPlanetOwner = isPlanetOwner(contract, currentDate, factionCode);
         boolean usingAerospace = forceTemplate.getAllowedUnitType() == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX ||
                 forceTemplate.getAllowedUnitType() == UnitType.CONV_FIGHTER ||
                 forceTemplate.getAllowedUnitType() == UnitType.AERO;
@@ -2437,5 +2437,18 @@ public class AtBDynamicScenarioFactory {
         for (Entity entity : scenario.getAlliesPlayer()) {
             csu.upgradeCrew(entity);
         }
+    }
+    
+    /**
+     * Highly paranoid function that will check if the given faction is one of the
+     * owners of the contract's location at the current date.
+     */
+    private static boolean isPlanetOwner(AtBContract contract, LocalDate currentDate, String factionCode) {
+        if (contract == null || contract.getSystem() == null ||
+                contract.getSystem().getFactions(currentDate) == null) {
+            return false;
+        }
+        
+        return contract.getSystem().getFactions(currentDate).contains(factionCode);
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -152,6 +152,10 @@ public class Mission implements Serializable, MekHqXmlSerializable {
     public List<Scenario> getScenarios() {
         return scenarios;
     }
+    
+    public List<Scenario> getVisibleScenarios() {
+        return getScenarios().stream().filter(scenario -> !scenario.isCloaked()).collect(Collectors.toList()); 
+    }
 
     public List<Scenario> getCurrentScenarios() {
         return getScenarios().stream().filter(scenario -> scenario.getStatus().isCurrent()).collect(Collectors.toList());

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -67,6 +67,7 @@ public class Scenario implements Serializable {
     private int id = S_DEFAULT_ID;
     private int missionId;
     private ForceStub stub;
+    private boolean cloaked;
 
     //allow multiple loot objects for meeting different mission objectives
     private List<Loot> loots;
@@ -145,6 +146,17 @@ public class Scenario implements Serializable {
 
     public void setScenarioObjectives(List<ScenarioObjective> scenarioObjectives) {
         this.scenarioObjectives = scenarioObjectives;
+    }
+
+    /**
+     * This indicates that the scenario should not be displayed in the briefing tab.
+     */
+    public boolean isCloaked() {
+        return cloaked;
+    }
+
+    public void setCloaked(boolean cloaked) {
+        this.cloaked = cloaked;
     }
 
     public Map<UUID, List<UUID>> getPlayerTransportLinkages() {
@@ -329,6 +341,8 @@ public class Scenario implements Serializable {
         if (null != date) {
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "date", MekHqXmlUtil.saveFormattedDate(date));
         }
+        
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "cloaked", isCloaked());
     }
 
     protected void writeToXmlEnd(PrintWriter pw1, int indent) {
@@ -403,6 +417,8 @@ public class Scenario implements Serializable {
                     retVal.stub = ForceStub.generateInstanceFromXML(wn2);
                 } else if (wn2.getNodeName().equalsIgnoreCase("date")) {
                     retVal.date = MekHqXmlUtil.parseDate(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("cloaked")) {
+                    retVal.cloaked = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("loots")) {
                     NodeList nl2 = wn2.getChildNodes();
                     for (int y = 0; y < nl2.getLength(); y++) {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -275,6 +275,7 @@ public class StratconContractInitializer {
             scenario.setActionDate(null);
             scenario.setReturnDate(null);
             scenario.setStrategicObjective(true);
+            scenario.getBackingScenario().setCloaked(true);
             
             // apply objective mods
             if (objectiveModifiers != null) {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -25,6 +25,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.ResolveScenarioTracker;
 import mekhq.campaign.againstTheBot.enums.AtBLanceRole;
 import mekhq.campaign.event.NewDayEvent;
+import mekhq.campaign.event.ScenarioChangedEvent;
 import mekhq.campaign.event.StratconDeploymentEvent;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.Lance;
@@ -225,6 +226,16 @@ public class StratconRulesManager {
 
         processForceDeployment(coords, forceID, campaign, track, sticky);
 
+        // we may stumble on a fixed objective scenario - in that case assign the force to it and finalize
+        // we also will not be encountering any of the other stuff so bug out afterwards
+        StratconScenario revealedScenario = track.getScenario(coords);
+        if (revealedScenario != null) {
+            revealedScenario.addPrimaryForce(forceID);
+            AtBDynamicScenarioFactory.finalizeScenario(revealedScenario.getBackingScenario(), contract, campaign);
+            commitPrimaryForces(campaign, revealedScenario, track);
+            return;
+        }
+        
         // don't create a scenario on top of allied facilities
         StratconFacility facility = track.getFacility(coords);
         boolean isNonAlliedFacility = (facility != null) && (facility.getOwner() != ForceAlignment.Allied);
@@ -325,13 +336,29 @@ public class StratconRulesManager {
 
     /**
      * Process the deployment of a force to the given coordinates on the given track.
+     * This does not include assigning the force to any scenarios
      */
     public static void processForceDeployment(StratconCoords coords, int forceID, Campaign campaign,
-            StratconTrackState track, boolean sticky) {
+            StratconTrackState track, boolean sticky) {        
+        // plan of action:
+        // reveal deployed coordinates
+        // reveal facility in deployed coordinates (and all adjacent coordinates for scout lances)
+        // reveal scenario in deployed coordinates (and all adjacent coordinates for scout lances)
+        
         track.getRevealedCoords().add(coords);
+        
         StratconFacility facility = track.getFacility(coords);
         if (facility != null) {
             facility.setVisible(true);
+        }
+                
+        StratconScenario scenario = track.getScenario(coords);
+        // if we're deploying on top of a scenario and it's "cloaked"
+        // then we have to activate it
+        if ((scenario != null) && scenario.getBackingScenario().isCloaked()) {
+            scenario.getBackingScenario().setCloaked(false);
+            setScenarioDates(0, track, campaign, scenario); // must be called before commitPrimaryForces
+            MekHQ.triggerEvent(new ScenarioChangedEvent(scenario.getBackingScenario()));
         }
 
         if (campaign.getLances().get(forceID).getRole() == AtBLanceRole.SCOUTING) {
@@ -341,6 +368,15 @@ public class StratconRulesManager {
                 facility = track.getFacility(checkCoords);
                 if (facility != null) {
                     facility.setVisible(true);
+                }
+                
+                scenario = track.getScenario(checkCoords);
+                // if we've revealed a scenario and it's "cloaked"
+                // we have to activate it
+                if ((scenario != null) && scenario.getBackingScenario().isCloaked()) {
+                    scenario.getBackingScenario().setCloaked(false);
+                    setScenarioDates(0, track, campaign, scenario);
+                    MekHQ.triggerEvent(new ScenarioChangedEvent(scenario.getBackingScenario()));
                 }
 
                 track.getRevealedCoords().add(coords.translate(direction));
@@ -626,7 +662,9 @@ public class StratconRulesManager {
         // with the campaign, so that the stratcon - backing scenario association is maintained
         // registering the scenario with the campaign should be done after setting
         // dates, otherwise, the report messages for new scenarios look weird
-        campaign.addScenario(backingScenario, contract);
+        // also, suppress the "new scenario" report if not generating a scenario
+        // for a specific force, as this indicates a contract initialization
+        campaign.addScenario(backingScenario, contract, forceID == Force.FORCE_NONE);
         scenario.setBackingScenarioID(backingScenario.getId());
 
         if (forceID > Force.FORCE_NONE) {
@@ -777,11 +815,19 @@ public class StratconRulesManager {
      * Worker function that sets scenario deploy/battle/return dates based on the track's properties and
      * current campaign date
      */
-    private static void setScenarioDates(StratconTrackState track, Campaign campaign, StratconScenario scenario) {
+    private static void setScenarioDates(StratconTrackState track, Campaign campaign, StratconScenario scenario)    {
+        int deploymentDay = track.getDeploymentTime() < 7 ? Compute.randomInt(7 - track.getDeploymentTime()) : 0;
+        setScenarioDates(deploymentDay, track, campaign, scenario);
+    }
+        
+    /**
+     * Worker function that sets scenario deploy/battle/return dates based on the track's properties and
+     * current campaign date. Takes a fixed deployment day of X days from campaign's today date.
+     */
+    private static void setScenarioDates(int deploymentDay, StratconTrackState track, Campaign campaign, StratconScenario scenario) {    
         // set up deployment day, battle day, return day here
         // safety code to prevent attempts to generate random int with upper bound of 0
         // which is apparently illegal
-        int deploymentDay = track.getDeploymentTime() < 7 ? Compute.randomInt(7 - track.getDeploymentTime()) : 0;
         int battleDay = deploymentDay
                 + (track.getDeploymentTime() > 0 ? Compute.randomInt(track.getDeploymentTime()) : 0);
         int returnDay = deploymentDay + track.getDeploymentTime();
@@ -1434,7 +1480,8 @@ public class StratconRulesManager {
                     // loop through scenarios - if we haven't deployed in time,
                     // fail it and apply consequences
                     for (StratconScenario scenario : track.getScenarios().values()) {
-                        if (scenario.getDeploymentDate().isBefore(ev.getCampaign().getLocalDate()) &&
+                        if ((scenario.getDeploymentDate() != null) &&
+                                scenario.getDeploymentDate().isBefore(ev.getCampaign().getLocalDate()) &&
                                 scenario.getPrimaryForceIDs().isEmpty()) {
                             processIgnoredScenario(scenario, campaignState);
                         }
@@ -1459,7 +1506,7 @@ public class StratconRulesManager {
         List<StratconScenario> cleanupList = new ArrayList<>();
 
         for (StratconScenario scenario : track.getScenarios().values()) {
-            if (scenario.getDeploymentDate() == null) {
+            if ((scenario.getDeploymentDate() == null) && !scenario.isStrategicObjective()) {
                 cleanupList.add(scenario);
             }
         }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -904,7 +904,7 @@ public final class BriefingTab extends CampaignGuiTab {
     public void refreshScenarioTableData() {
         Mission m = getCampaign().getMission(selectedMission);
         if (null != m) {
-            scenarioModel.setData(m.getScenarios());
+            scenarioModel.setData(m.getVisibleScenarios());
         } else {
             scenarioModel.setData(new ArrayList<Scenario>());
         }
@@ -931,6 +931,7 @@ public final class BriefingTab extends CampaignGuiTab {
             if (ev.getScenario().getId() == selectedScenario) {
                 scenarioViewScheduler.schedule();
             }
+            scenarioDataScheduler.schedule();
         }
     }
 

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -49,6 +49,7 @@ import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconCoords;
 import mekhq.campaign.stratcon.StratconFacility;
 import mekhq.campaign.stratcon.StratconScenario;
+import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
 import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.gui.stratcon.StratconScenarioWizard;
 import mekhq.gui.stratcon.TrackForceAssignmentUI;
@@ -150,10 +151,9 @@ public class StratconPanel extends JPanel implements ActionListener {
         
         StratconScenario scenario = getSelectedScenario();
         
-        // can't stack more than one force on hex 
-        // can't "deploy" a force to a scenario (have to reinforce instead)
-        if ((scenario == null) && 
-                !currentTrack.getAssignedCoordForces().containsKey(coords)) {
+        // display "Manage Force Assignment" if
+        // there is not a force already on the hex
+        if (!currentTrack.getAssignedCoordForces().containsKey(coords)) {
             menuItemManageForceAssignments = new JMenuItem();
             menuItemManageForceAssignments.setText("Manage Force Assignment");
             menuItemManageForceAssignments.setActionCommand(RCLICK_COMMAND_MANAGE_FORCES);
@@ -161,7 +161,10 @@ public class StratconPanel extends JPanel implements ActionListener {
             rightClickMenu.add(menuItemManageForceAssignments);
         }
         
-        if (scenario != null) {
+        // display "Manage Scenario" if
+        // there is already a scenario on the hex that hasn't been resolved
+        if ((scenario != null) &&
+                (scenario.getCurrentState() != ScenarioState.UNRESOLVED)) {
             menuItemManageScenario = new JMenuItem();
             menuItemManageScenario.setText("Manage Scenario");
             menuItemManageScenario.setActionCommand(RCLICK_COMMAND_MANAGE_SCENARIO);
@@ -353,9 +356,12 @@ public class StratconPanel extends JPanel implements ActionListener {
                 StratconScenario scenario = currentTrack.getScenario(currentCoords);
                 
                 // if there's a scenario here that has a deployment/battle date
+                // or if there's a scenario here and the hex has been revealed
                 // or if there's a scenario here and we've gm-revealed everything
                 if ((scenario != null) &&
-                        ((scenario.getDeploymentDate() != null) || currentTrack.isGmRevealed())) {
+                        ((scenario.getDeploymentDate() != null) ||
+                         (scenario.isStrategicObjective() && currentTrack.getRevealedCoords().contains(currentCoords)) ||
+                                currentTrack.isGmRevealed())) {
                     g2D.setColor(Color.RED);
                     g2D.drawPolygon(scenarioMarker);
                     g2D.drawPolygon(scenarioMarker2);

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -445,9 +445,9 @@ public class ContractMarketDialog extends JDialog {
             campaign.getFinances().credit(selectedContract.getTotalAdvanceAmount(), Transaction.C_CONTRACT,
                     "Advance monies for " + selectedContract.getName(), campaign.getLocalDate());
             
-            selectedContract.acceptContract(campaign);
-            
             campaign.addMission(selectedContract);
+            // must be invoked after campaign.addMission to ensure presence of mission ID
+            selectedContract.acceptContract(campaign);
             contractMarket.removeContract(selectedContract);
             ((DefaultTableModel) tableContracts.getModel()).removeRow(tableContracts
                     .convertRowIndexToModel(tableContracts.getSelectedRow()));

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -529,14 +529,17 @@ public class NewAtBContractDialog extends NewContractDialog {
 
         contract.calculatePartsAvailabilityLevel(campaign);
 
+        campaign.getFinances().credit(contract.getTotalAdvanceAmount(), Transaction.C_CONTRACT,
+                "Advance monies for " + contract.getName(), campaign.getLocalDate());
+        campaign.addMission(contract);
+        
+        // note that the contract must be initialized after the mission is added to the campaign
+        // to ensure presence of mission ID
         if (campaign.getCampaignOptions().getUseStratCon()) {
             StratconContractInitializer.initializeCampaignState(contract, campaign,
                     StratconContractDefinition.getContractDefinition(contract.getMissionType()));
         }
-
-        campaign.getFinances().credit(contract.getTotalAdvanceAmount(), Transaction.C_CONTRACT,
-                "Advance monies for " + contract.getName(), campaign.getLocalDate());
-        campaign.addMission(contract);
+        
         setVisible(false);
     }
 


### PR DESCRIPTION
This fixes #2603 and a nightmarish tangle of issues discovered while testing that fix.

- Introduces a mechanism to specify whether a StratCon scenario should be displayed in the briefing tab.
- Introduces a mechanism to prevent a scenario generation report from being displayed in the campaign log.
- Fixes a logic error which would result in fixed objective scenarios being generated but then getting eliminated immediately upon contract start.
- Fixes an error preventing "add a force" modifiers from being applied to fixed objective scenarios due to missing mission ID
- Updated right click menu logic to prevent information leakage about unrevealed fixed objective scenarios