### PR TITLE
fix exception thrown when deploying unit not in a force

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -235,7 +235,9 @@ public class AtBGameThread extends GameThread {
                     }
                     entity.setDeployRound(deploymentRound);
                     Force force = campaign.getForceFor(unit);
-                    entity.setForceString(force.getFullMMName());
+                    if (force != null) {
+                        entity.setForceString(force.getFullMMName());
+                    }
                     entities.add(entity);
                 }
                 client.sendAddEntity(entities);


### PR DESCRIPTION
StratCon will occasionally have a situation where you're deploying a unit to MegaMek without it being in the TO&E, this accounts for that possibility.