### PR TITLE
one more fix for the stratcon tab right click menu

### DIFF
--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -151,9 +151,10 @@ public class StratconPanel extends JPanel implements ActionListener {
         
         StratconScenario scenario = getSelectedScenario();
         
-        // display "Manage Force Assignment" if
-        // there is not a force already on the hex
-        if (!currentTrack.getAssignedCoordForces().containsKey(coords)) {
+        // display "Manage Force Assignment" if there is not a force already on the hex
+        // except if there is already a non-cloaked scenario here.
+        if (!currentTrack.getAssignedCoordForces().containsKey(coords) &&
+                (scenario == null || scenario.getBackingScenario().isCloaked())) {
             menuItemManageForceAssignments = new JMenuItem();
             menuItemManageForceAssignments.setText("Manage Force Assignment");
             menuItemManageForceAssignments.setActionCommand(RCLICK_COMMAND_MANAGE_FORCES);
@@ -162,9 +163,8 @@ public class StratconPanel extends JPanel implements ActionListener {
         }
         
         // display "Manage Scenario" if
-        // there is already a scenario on the hex that hasn't been resolved
-        if ((scenario != null) &&
-                (scenario.getCurrentState() != ScenarioState.UNRESOLVED)) {
+        // there is already a visible scenario on the hex
+        if ((scenario != null) && !scenario.getBackingScenario().isCloaked()) {
             menuItemManageScenario = new JMenuItem();
             menuItemManageScenario.setText("Manage Scenario");
             menuItemManageScenario.setActionCommand(RCLICK_COMMAND_MANAGE_SCENARIO);

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -49,7 +49,6 @@ import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconCoords;
 import mekhq.campaign.stratcon.StratconFacility;
 import mekhq.campaign.stratcon.StratconScenario;
-import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
 import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.gui.stratcon.StratconScenarioWizard;
 import mekhq.gui.stratcon.TrackForceAssignmentUI;
@@ -154,7 +153,7 @@ public class StratconPanel extends JPanel implements ActionListener {
         // display "Manage Force Assignment" if there is not a force already on the hex
         // except if there is already a non-cloaked scenario here.
         if (!currentTrack.getAssignedCoordForces().containsKey(coords) &&
-                (scenario == null || scenario.getBackingScenario().isCloaked())) {
+                ((scenario == null) || scenario.getBackingScenario().isCloaked())) {
             menuItemManageForceAssignments = new JMenuItem();
             menuItemManageForceAssignments.setText("Manage Force Assignment");
             menuItemManageForceAssignments.setActionCommand(RCLICK_COMMAND_MANAGE_FORCES);


### PR DESCRIPTION
The intended logic is explained in the updated comments. Basically, I want the "assign force to this track" menu item to show up if there aren't any forces currently assigned to that hex and there aren't any visible scenarios on it. If there *is* a visible scenario on the hex, then we should always be getting the "manage scenario" menu item.