### PR TITLE
fix bait and switch behavior for non-integrated scenarios

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -34,6 +34,7 @@ import org.w3c.dom.NodeList;
 
 import megamek.common.Entity;
 import megamek.common.annotations.Nullable;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Lance;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
@@ -411,6 +412,8 @@ public class AtBDynamicScenario extends AtBScenario {
         // in its current state
         if ((template != null) && getStatus().isCurrent()) {
             template.Serialize(pw1);
+            
+            MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "finalized", isFinalized());
         }
 
         super.writeToXmlEnd(pw1, indent);
@@ -425,6 +428,8 @@ public class AtBDynamicScenario extends AtBScenario {
 
             if (wn2.getNodeName().equalsIgnoreCase(ScenarioTemplate.ROOT_XML_ELEMENT_NAME)) {
                 template = ScenarioTemplate.Deserialize(wn2);
+            } else if (wn2.getNodeName().equalsIgnoreCase("finalized")) {
+                setFinalized(Boolean.parseBoolean(wn2.getTextContent().trim()));
             }
         }
 


### PR DESCRIPTION
When assigning a force to a scenario that's already had opposition generated, the scenario would occasionally mysteriously re-generate the opposition. This is undesirable, because, under house and better command clause, you're supposed to be able to assign lances after seeing the opposition.

Turns out, it would only happen when loading a save - the "finalized" flag wasn't being preserved. Note that it's not relevant once the scenario has been played out.