### PR TITLE
Strategic objective tracking improvements

### DIFF
--- a/MekHQ/data/stratconcontractdefinitions/DiversionaryRaid.xml
+++ b/MekHQ/data/stratconcontractdefinitions/DiversionaryRaid.xml
@@ -19,6 +19,7 @@
 	</deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
+		<objectiveCount>-1</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
         </objectiveParameter>
     </objectiveParameters>

--- a/MekHQ/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/MekHQ/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -19,6 +19,7 @@
 	</deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
+		<objectiveCount>-1</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
 		<objectiveScenarioModifiers>										<objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
 			<objectiveScenarioModifier>OverwhelmingEnemyAirReinforcements.xml</objectiveScenarioModifier>

--- a/MekHQ/data/stratconcontractdefinitions/PirateHunting.xml
+++ b/MekHQ/data/stratconcontractdefinitions/PirateHunting.xml
@@ -26,6 +26,7 @@
 		<objectiveCount>-0.3</objectiveCount>
         </objectiveParameter>
 	<objectiveParameter>
+		<objectiveCount>-0.3</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
 		<objectiveScenarios>
                 	<objectiveScenario>Destroy Grounded Dropship.xml</objectiveScenario>

--- a/MekHQ/data/stratconcontractdefinitions/RiotDuty.xml
+++ b/MekHQ/data/stratconcontractdefinitions/RiotDuty.xml
@@ -22,6 +22,7 @@
 		<objectiveCount>-0.5</objectiveCount>
         </objectiveParameter>
 	<objectiveParameter>
+		<objectiveCount>-0.5</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
 		<objectiveScenarios>
                 	<objectiveScenario>Irregular Forces.xml</objectiveScenario>

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -315,6 +315,8 @@ public class AtBGameThread extends GameThread {
                     }
                     swingGui.getBots().put(name, botClient);
 
+                    // chill out while bot is created and connects to megamek
+                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
                     configureBot(botClient, bf);
                     
                     // we need to wait until the game has actually started to do transport loading

--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -108,6 +108,8 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
     }
 
     /**
+     * TODO: This is dumb and we should just use EntityListFile.writeEntityList.
+     * 
      * Contents copied from megamek.common.EntityListFile.saveTo(...) Modified
      * to support saving to/from XML for our purposes in MekHQ TODO: Some of
      * this may want to be back-ported into entity itself in MM and then
@@ -160,6 +162,8 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
          if (tgtEnt instanceof Infantry) {
              retVal.append(String.format("\" %s=\"%d", MULParser.INF_SQUAD_NUM, ((Infantry) tgtEnt).getSquadN()));
          }
+
+         retVal.append(String.format("\" %s=\"%d", MULParser.ALTITUDE, tgtEnt.getAltitude()));
 
         retVal.append("\">\n");
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
@@ -186,7 +186,7 @@ public class StratconCampaignState {
     public void decrementStrategicObjectiveCompletedCount(int decrement) {
         completedStrategicObjectiveCount -= decrement;
     }
-    
+
     public void useSupportPoint() {
         supportPoints--;
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
@@ -53,8 +53,6 @@ public class StratconCampaignState {
     private double globalOpforBVMultiplier;
     private int supportPoints;
     private int victoryPoints;
-    private int pendingStrategicObjectiveCount;
-    private int completedStrategicObjectiveCount;
     private String briefingText; 
     private boolean strategicObjectivesBehaveAsVPs;
     
@@ -149,42 +147,6 @@ public class StratconCampaignState {
 
     public void setGlobalScenarioModifiers(List<String> globalScenarioModifiers) {
         this.globalScenarioModifiers = globalScenarioModifiers;
-    }
-
-    public int getPendingStrategicObjectiveCount() {
-        return pendingStrategicObjectiveCount;
-    }
-
-    public void setPendingStrategicObjectiveCount(int pendingStrategicObjectiveCount) {
-        this.pendingStrategicObjectiveCount = pendingStrategicObjectiveCount;
-    }
-    
-    public void incrementPendingStrategicObjectiveCount(int increment) {
-        pendingStrategicObjectiveCount += increment;
-    }
-    
-    public void incrementPendingStrategicObjectiveCount() {
-        pendingStrategicObjectiveCount++;
-    }
-    
-    public int getStrategicObjectiveCompletedCount() {
-        return completedStrategicObjectiveCount;
-    }
-    
-    public void incrementStrategicObjectiveCompletedCount() {
-        completedStrategicObjectiveCount++;
-    }
-    
-    public void decrementStrategicObjectiveCompletedCount() {
-        completedStrategicObjectiveCount--;
-    }
-    
-    public void incrementStrategicObjectiveCompletedCount(int increment) {
-        completedStrategicObjectiveCount += increment;
-    }
-    
-    public void decrementStrategicObjectiveCompletedCount(int decrement) {
-        completedStrategicObjectiveCount -= decrement;
     }
 
     public void useSupportPoint() {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
@@ -106,6 +106,11 @@ public class StratconContractDefinition {
         SpecificScenarioVictory,
         
         /**
+         * Victory in scenarios designated as "required" (usually per contract command clause)
+         */
+        RequiredScenarioVictory,
+        
+        /**
          * Control of allied facilities generated at contract start time
          * Each track will be seeded with some number of allied facilities
          * They must not be destroyed and the player must have control of them at the end-of-contract date 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -35,6 +35,7 @@ import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.mission.atb.AtBScenarioModifier;
 import mekhq.campaign.stratcon.StratconContractDefinition.ObjectiveParameters;
+import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
 
 /**
  * This class handles StratCon state initialization when a contract is signed.
@@ -98,6 +99,8 @@ public class StratconContractInitializer {
             for (int x = 0; x < trackObjects.size(); x++) {
                 int numObjects = trackObjects.get(x);
                 
+                List<StratconStrategicObjective> generatedObjectives = new ArrayList<>();
+                
                 switch (objectiveParams.objectiveType) {
                     case SpecificScenarioVictory:
                         initializeObjectiveScenarios(campaign, contract, campaignState.getTrack(x), numObjects,
@@ -115,8 +118,10 @@ public class StratconContractInitializer {
                         if (objectiveParams.objectiveScenarioModifiers != null) {
                             campaignState.getGlobalScenarioModifiers().addAll(objectiveParams.objectiveScenarioModifiers);
                         }
-                    break;
+                        break;
                 }
+                
+                
             }
         }
         
@@ -226,12 +231,20 @@ public class StratconContractInitializer {
             StratconCoords coords = getUnoccupiedCoords(trackState);
             
             trackState.addFacility(coords, sf);
+            
+            StratconStrategicObjective sso = new StratconStrategicObjective();
+            sso.setObjectiveCoords(coords);
+            
             if (sf.getOwner() == ForceAlignment.Allied) {
                 trackState.getRevealedCoords().add(coords);
                 sf.setVisible(true);
+                sso.setObjectiveType(StrategicObjectiveType.AlliedFacilityControl);
             } else {
                 sf.setVisible(false);
+                sso.setObjectiveType(StrategicObjectiveType.HostileFacilityControl);
             }
+            
+            trackState.addStrategicObjective(sso);
         }
     }
     
@@ -285,6 +298,11 @@ public class StratconContractInitializer {
             }
             
             trackState.addScenario(scenario);
+
+            StratconStrategicObjective sso = new StratconStrategicObjective();
+            sso.setObjectiveCoords(coords);
+            sso.setObjectiveType(StrategicObjectiveType.SpecificScenarioVictory);
+            trackState.addStrategicObjective(sso);
         }
     }
     

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -99,8 +99,6 @@ public class StratconContractInitializer {
             for (int x = 0; x < trackObjects.size(); x++) {
                 int numObjects = trackObjects.get(x);
                 
-                List<StratconStrategicObjective> generatedObjectives = new ArrayList<>();
-                
                 switch (objectiveParams.objectiveType) {
                     case SpecificScenarioVictory:
                         initializeObjectiveScenarios(campaign, contract, campaignState.getTrack(x), numObjects,
@@ -115,6 +113,13 @@ public class StratconContractInitializer {
                         initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Opposing, true);
                         break;
                     case AnyScenarioVictory:
+                        // set up a "win X scenarios" objective
+                        // todo: objective updates for scenario victory objective types
+                        StratconStrategicObjective sso = new StratconStrategicObjective();
+                        sso.setDesiredObjectiveCount(numObjects);
+                        sso.setObjectiveType(StrategicObjectiveType.AnyScenarioVictory);
+                        campaignState.getTrack(x).addStrategicObjective(sso);
+                        
                         if (objectiveParams.objectiveScenarioModifiers != null) {
                             campaignState.getGlobalScenarioModifiers().addAll(objectiveParams.objectiveScenarioModifiers);
                         }
@@ -302,6 +307,7 @@ public class StratconContractInitializer {
             StratconStrategicObjective sso = new StratconStrategicObjective();
             sso.setObjectiveCoords(coords);
             sso.setObjectiveType(StrategicObjectiveType.SpecificScenarioVictory);
+            sso.setDesiredObjectiveCount(1);
             trackState.addStrategicObjective(sso);
         }
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -245,7 +245,8 @@ public class StratconRulesManager {
 
         if (isNonAlliedFacility || spawnScenario) {
             StratconScenario scenario = setupScenario(coords, forceID, campaign, contract, track);
-            setScenarioDates(0, track, campaign, scenario); // we deploy immediately in this case, since it's an 
+            // we deploy immediately in this case, since we deployed the force manually 
+            setScenarioDates(0, track, campaign, scenario);  
             AtBDynamicScenarioFactory.finalizeScenario(scenario.getBackingScenario(), contract, campaign);
             commitPrimaryForces(campaign, scenario, track);
         }
@@ -1045,7 +1046,7 @@ public class StratconRulesManager {
         // contracts at a time
         return u.getCampaign().getActiveAtBContracts().stream().
             anyMatch(contract ->
-                contract.getStratconCampaignState() != null &&
+                (contract.getStratconCampaignState()) != null &&
                 contract.getStratconCampaignState().isForceDeployedHere(u.getForceId()));
     }
 
@@ -1260,8 +1261,7 @@ public class StratconRulesManager {
 
                     // this must be done before removing the scenario from the track
                     // in case any objectives are linked to the scenario's coordinates
-                    updateStrategicObjectives(victory, scenario, track, campaignState);
-                    //updateStrategicObjectiveCount(victory, scenario, facility, campaignState);
+                    updateStrategicObjectives(victory, scenario, track);
 
                     if ((facility != null) && (facility.getOwnershipChangeScore() > 0)) {
                         switchFacilityOwner(facility);
@@ -1281,7 +1281,7 @@ public class StratconRulesManager {
      * scenario, track and campaign state. For example, "win scenario A" or "win X scenarios".
      */
     private static void updateStrategicObjectives(boolean victory, StratconScenario scenario, 
-            StratconTrackState track, StratconCampaignState campaignState) {
+            StratconTrackState track) {
         
         // first, we check if this scenario is associated with any specific scenario objectives
         StratconStrategicObjective specificObjective = track.getObjectivesByCoords().get(scenario.getCoords());
@@ -1293,8 +1293,7 @@ public class StratconRulesManager {
         // "any scenario victory" is not linked to any specific coordinates, so we have to
         // search through the track's objectives and update those.
         for (StratconStrategicObjective objective : track.getStrategicObjectives()) {
-            if ((objective.getObjectiveType() == StrategicObjectiveType.AnyScenarioVictory) &&
-                    victory) {
+            if ((objective.getObjectiveType() == StrategicObjectiveType.AnyScenarioVictory) && victory) {
                 objective.incrementCurrentObjectiveCount();
             }
         }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -40,6 +40,7 @@ import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.mission.atb.AtBScenarioModifier;
 import mekhq.campaign.mission.atb.AtBScenarioModifier.EventTiming;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
 import mekhq.campaign.stratcon.StratconFacility.FacilityType;
 import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
 import mekhq.campaign.unit.Unit;
@@ -244,6 +245,7 @@ public class StratconRulesManager {
 
         if (isNonAlliedFacility || spawnScenario) {
             StratconScenario scenario = setupScenario(coords, forceID, campaign, contract, track);
+            setScenarioDates(0, track, campaign, scenario); // we deploy immediately in this case, since it's an 
             AtBDynamicScenarioFactory.finalizeScenario(scenario.getBackingScenario(), contract, campaign);
             commitPrimaryForces(campaign, scenario, track);
         }
@@ -719,6 +721,9 @@ public class StratconRulesManager {
                     continue;
                 }
 
+                modifier.setAdditionalBriefingText(
+                        "(from " + facility.getDisplayableName() + ") " +
+                        modifier.getAdditionalBriefingText());
                 scenario.getBackingScenario().addScenarioModifier(modifier);
             }
         }
@@ -1253,9 +1258,10 @@ public class StratconRulesManager {
                         campaignState.updateVictoryPoints(victory ? 1 : -1);
                     }
 
-                    // this must be done before updating ownership change to avoid
-                    // updating SO counts in the wrong direction.
-                    updateStrategicObjectiveCount(victory, scenario, facility, campaignState);
+                    // this must be done before removing the scenario from the track
+                    // in case any objectives are linked to the scenario's coordinates
+                    updateStrategicObjectives(victory, scenario, track, campaignState);
+                    //updateStrategicObjectiveCount(victory, scenario, facility, campaignState);
 
                     if ((facility != null) && (facility.getOwnershipChangeScore() > 0)) {
                         switchFacilityOwner(facility);
@@ -1266,6 +1272,30 @@ public class StratconRulesManager {
                     track.removeScenario(scenario);
                     break;
                 }
+            }
+        }
+    }
+    
+    /**
+     * Worker function that updates strategic objectives relevant to the passed in
+     * scenario, track and campaign state. For example, "win scenario A" or "win X scenarios".
+     */
+    private static void updateStrategicObjectives(boolean victory, StratconScenario scenario, 
+            StratconTrackState track, StratconCampaignState campaignState) {
+        
+        // first, we check if this scenario is associated with any specific scenario objectives
+        StratconStrategicObjective specificObjective = track.getObjectivesByCoords().get(scenario.getCoords());
+        if (victory && (specificObjective != null) && 
+                (specificObjective.getObjectiveType() == StrategicObjectiveType.SpecificScenarioVictory)) {
+            specificObjective.incrementCurrentObjectiveCount();
+        }
+        
+        // "any scenario victory" is not linked to any specific coordinates, so we have to
+        // search through the track's objectives and update those.
+        for (StratconStrategicObjective objective : track.getStrategicObjectives()) {
+            if ((objective.getObjectiveType() == StrategicObjectiveType.AnyScenarioVictory) &&
+                    victory) {
+                objective.incrementCurrentObjectiveCount();
             }
         }
     }
@@ -1297,53 +1327,6 @@ public class StratconRulesManager {
             facility.setOwner(ForceAlignment.Opposing);
         } else {
             facility.setOwner(ForceAlignment.Allied);
-        }
-    }
-
-    /**
-     * Worker function that contains logic for updating strategic objective counts
-     * in a given campaign.
-     */
-    private static void updateStrategicObjectiveCount(boolean victory,
-            StratconScenario scenario, StratconFacility facility, StratconCampaignState campaignState) {
-        // if neither the scenario nor facility are strategic objectives,
-        // then we are done here.
-        if (((scenario == null) || !scenario.isStrategicObjective()) &&
-                ((facility == null) || !facility.isStrategicObjective())) {
-            return;
-        }
-
-        // simple situation - if the strategic objective items simply increase VP count
-        // then we do that here
-        if (campaignState.strategicObjectivesBehaveAsVPs()) {
-            campaignState.updateVictoryPoints(victory ? 1 : -1);
-        } else {
-            // if a victory and the scenario is a strategic objective, SO++
-            // if a victory and facility is a strategic objective:
-            //      for allied facilities, do nothing
-            //      for hostile facilities, SO++
-            // if defeat and facility is a strategic objective:
-            //      for allied facilities, SO--
-            //      for hostile facilities, nothing
-            // the basic idea is that you're supposed to *hold* allied facilities
-            // and *seize* hostile facilities
-
-            if ((scenario != null) && scenario.isStrategicObjective() && victory) {
-                campaignState.incrementStrategicObjectiveCompletedCount();
-                return;
-            }
-
-            if (facility == null) {
-                return;
-            }
-
-            boolean alliedFacility = facility.getOwner() == ForceAlignment.Allied;
-
-            if (facility.isStrategicObjective() && alliedFacility && !victory) {
-                campaignState.decrementStrategicObjectiveCompletedCount();
-            } else if (facility.isStrategicObjective() && !alliedFacility && victory) {
-                campaignState.incrementStrategicObjectiveCompletedCount();
-            }
         }
     }
 
@@ -1406,10 +1389,6 @@ public class StratconRulesManager {
                     // then it'll get captured, and the player will possibly lose a SO
                     if (localFacility.getOwner() == ForceAlignment.Allied) {
                         localFacility.setOwner(ForceAlignment.Opposing);
-
-                        if (localFacility.isStrategicObjective()) {
-                            campaignState.decrementStrategicObjectiveCompletedCount();
-                        }
                     }
 
                     return true;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1046,7 +1046,7 @@ public class StratconRulesManager {
         // contracts at a time
         return u.getCampaign().getActiveAtBContracts().stream().
             anyMatch(contract ->
-                (contract.getStratconCampaignState()) != null &&
+                (contract.getStratconCampaignState() != null) &&
                 contract.getStratconCampaignState().isForceDeployedHere(u.getForceId()));
     }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1039,7 +1039,9 @@ public class StratconRulesManager {
         // this is a little inefficient, but probably there aren't too many active AtB
         // contracts at a time
         return u.getCampaign().getActiveAtBContracts().stream().
-            anyMatch(contract -> contract.getStratconCampaignState().isForceDeployedHere(u.getForceId()));
+            anyMatch(contract ->
+                contract.getStratconCampaignState() != null &&
+                contract.getStratconCampaignState().isForceDeployedHere(u.getForceId()));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
@@ -38,6 +38,10 @@ public class StratconStrategicObjective {
     public void setCurrentObjectiveCount(int currentObjectiveCount) {
         this.currentObjectiveCount = currentObjectiveCount;
     }
+    
+    public void incrementCurrentObjectiveCount() {
+        currentObjectiveCount++;
+    }
 
     public int getDesiredObjectiveCount() {
         return desiredObjectiveCount;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
@@ -1,14 +1,32 @@
+/*
+ * Copyright (c) 2019 The Megamek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package mekhq.campaign.stratcon;
 
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
 
+/**
+ * This class is a data structure storing data relating to StratCon strategic objectives
+ * and also handles some small amount of "business logic"
+ */
 public class StratconStrategicObjective {
-    /*public enum StrategicObjectiveState {
-        InProgress,
-        Failed,
-        Succeeded
-    }*/
     
     private StratconCoords objectiveCoords;
     private StrategicObjectiveType objectiveType;
@@ -51,6 +69,9 @@ public class StratconStrategicObjective {
         this.desiredObjectiveCount = desiredObjectiveCount;
     }
 
+    /**
+     * Given the track that this objective is on, is it complete?
+     */
     public boolean isObjectiveCompleted(StratconTrackState trackState) {
         switch (getObjectiveType()) {
             case AnyScenarioVictory:

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
@@ -1,11 +1,19 @@
 package mekhq.campaign.stratcon;
 
+import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
 
 public class StratconStrategicObjective {
+    /*public enum StrategicObjectiveState {
+        InProgress,
+        Failed,
+        Succeeded
+    }*/
+    
     private StratconCoords objectiveCoords;
     private StrategicObjectiveType objectiveType;
-    //private Boolean objectiveCompleted;
+    private int currentObjectiveCount;
+    private int desiredObjectiveCount;
     
     public StratconCoords getObjectiveCoords() {
         return objectiveCoords;
@@ -21,5 +29,43 @@ public class StratconStrategicObjective {
     
     public void setObjectiveType(StrategicObjectiveType objectiveType) {
         this.objectiveType = objectiveType;
+    }
+    
+    public int getCurrentObjectiveCount() {
+        return currentObjectiveCount;
+    }
+
+    public void setCurrentObjectiveCount(int currentObjectiveCount) {
+        this.currentObjectiveCount = currentObjectiveCount;
+    }
+
+    public int getDesiredObjectiveCount() {
+        return desiredObjectiveCount;
+    }
+
+    public void setDesiredObjectiveCount(int desiredObjectiveCount) {
+        this.desiredObjectiveCount = desiredObjectiveCount;
+    }
+
+    public boolean isObjectiveCompleted(StratconTrackState trackState) {
+        switch (getObjectiveType()) {
+            case AnyScenarioVictory:
+            case SpecificScenarioVictory:
+                // this is set once qualifying scenarios are completed
+                return getCurrentObjectiveCount() >= getDesiredObjectiveCount();
+            case AlliedFacilityControl:
+                // this is "ok" if the facility exists and is under allied control
+                StratconFacility alliedFacility = trackState.getFacility(getObjectiveCoords());
+                return (alliedFacility != null) && (alliedFacility.getOwner() == ForceAlignment.Allied);
+            case HostileFacilityControl:
+            case FacilityDestruction:
+                // these are "ok" if the facility no longer exists or is under allied control
+                // we assume that we can slag a facility at any time if we control it
+                StratconFacility hostileFacility = trackState.getFacility(getObjectiveCoords());
+                return (hostileFacility == null) || (hostileFacility.getOwner() == ForceAlignment.Allied);
+            default:
+                // we shouldn't be here, but just in case
+                return false;
+        }
     }
 }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
@@ -1,0 +1,25 @@
+package mekhq.campaign.stratcon;
+
+import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
+
+public class StratconStrategicObjective {
+    private StratconCoords objectiveCoords;
+    private StrategicObjectiveType objectiveType;
+    //private Boolean objectiveCompleted;
+    
+    public StratconCoords getObjectiveCoords() {
+        return objectiveCoords;
+    }
+    
+    public void setObjectiveCoords(StratconCoords objectiveCoords) {
+        this.objectiveCoords = objectiveCoords;
+    }
+    
+    public StrategicObjectiveType getObjectiveType() {
+        return objectiveType;
+    }
+    
+    public void setObjectiveType(StrategicObjectiveType objectiveType) {
+        this.objectiveType = objectiveType;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -201,6 +201,15 @@ public class StratconTrackState {
     public void setGmRevealed(boolean gmRevealed) {
         this.gmRevealed = gmRevealed;
     }
+    
+    /**
+     * Convenience function that determins if there are any forces
+     * deployed to the given coordinates.
+     */
+    public boolean areAnyForceDeployedTo(StratconCoords coords) {
+        return getAssignedCoordForces().containsKey(coords) &&
+                getAssignedCoordForces().get(coords).size() > 0;
+    }
 
     /**
      * Handles the assignment of a force to the given coordinates on this track on the given date.

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -57,9 +57,6 @@ public class StratconTrackState {
     private Set<Integer> stickyForces;
     private Map<Integer, String> assignedForceReturnDatesForStorage;
     private Set<StratconCoords> revealedCoords;
-    
-    @XmlElementWrapper(name = "strategicObjectives")
-    @XmlElement(name = "strategicObjective")
     private List<StratconStrategicObjective> strategicObjectives;
 
     // don't serialize this
@@ -382,6 +379,8 @@ public class StratconTrackState {
         stickyForces.remove(forceID);
     }
 
+    @XmlElementWrapper(name = "instantiatedObjectives")
+    @XmlElement(name = "instantiatedObjective")
     public List<StratconStrategicObjective> getStrategicObjectives() {
         return strategicObjectives;
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -208,7 +208,7 @@ public class StratconTrackState {
      */
     public boolean areAnyForceDeployedTo(StratconCoords coords) {
         return getAssignedCoordForces().containsKey(coords) &&
-                getAssignedCoordForces().get(coords).size() > 0;
+                (getAssignedCoordForces().get(coords).size() > 0);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -15,8 +15,10 @@
 package mekhq.campaign.stratcon;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -55,6 +57,10 @@ public class StratconTrackState {
     private Set<Integer> stickyForces;
     private Map<Integer, String> assignedForceReturnDatesForStorage;
     private Set<StratconCoords> revealedCoords;
+    
+    @XmlElementWrapper(name = "strategicObjectives")
+    @XmlElement(name = "strategicObjective")
+    private List<StratconStrategicObjective> strategicObjectives;
 
     // don't serialize this
     private transient Map<Integer, StratconScenario> backingScenarioMap;
@@ -72,6 +78,7 @@ public class StratconTrackState {
         setAssignedForceReturnDatesForStorage(new HashMap<>());
         revealedCoords = new HashSet<>();
         stickyForces = new HashSet<>();
+        strategicObjectives = new ArrayList<>();
     }
     
     public String getDisplayableName() {
@@ -373,5 +380,17 @@ public class StratconTrackState {
     
     public void removeStickyForce(int forceID) {
         stickyForces.remove(forceID);
+    }
+
+    public List<StratconStrategicObjective> getStrategicObjectives() {
+        return strategicObjectives;
+    }
+
+    public void setStrategicObjectives(List<StratconStrategicObjective> strategicObjectives) {
+        this.strategicObjectives = strategicObjectives;
+    }
+    
+    public void addStrategicObjective(StratconStrategicObjective strategicObjective) {
+        getStrategicObjectives().add(strategicObjective);
     }
 }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -61,6 +61,7 @@ public class StratconTrackState {
 
     // don't serialize this
     private transient Map<Integer, StratconScenario> backingScenarioMap;
+    private transient Map<StratconCoords, StratconStrategicObjective> specificStrategicObjectives;
     
     private int scenarioOdds;
     private int deploymentTime;
@@ -349,6 +350,21 @@ public class StratconTrackState {
         }
         
         return backingScenarioMap;
+    }
+    
+    /**
+     * Returns (and possibly initializes, if necessary) a map between
+     * coordinates and strategic objectives
+     */
+    public Map<StratconCoords, StratconStrategicObjective> getObjectivesByCoords() {
+        if (specificStrategicObjectives == null) {
+            specificStrategicObjectives = new HashMap<>();
+            for (StratconStrategicObjective objective : strategicObjectives) {
+                specificStrategicObjectives.put(objective.getObjectiveCoords(), objective);
+            }
+        }
+        
+        return specificStrategicObjectives;
     }
     
     /**

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -152,7 +152,7 @@ public class StratconPanel extends JPanel implements ActionListener {
         
         // display "Manage Force Assignment" if there is not a force already on the hex
         // except if there is already a non-cloaked scenario here.
-        if (!currentTrack.getAssignedCoordForces().containsKey(coords) &&
+        if (!currentTrack.areAnyForceDeployedTo(coords) &&
                 ((scenario == null) || scenario.getBackingScenario().isCloaked())) {
             menuItemManageForceAssignments = new JMenuItem();
             menuItemManageForceAssignments.setText("Manage Force Assignment");

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -195,6 +195,7 @@ public class StratconTab extends CampaignGuiTab {
     
     private String buildStrategicObjectiveText(StratconCampaignState campaignState) {
         StringBuilder sb = new StringBuilder();
+        sb.append("<html>");
         
 //        for (//StratconTrackState )
         // loop through all tracks
@@ -242,6 +243,7 @@ public class StratconTab extends CampaignGuiTab {
             }
         }
         
+        sb.append("</html>");
         return sb.toString();
     }
     

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -36,6 +36,7 @@ import mekhq.campaign.event.StratconDeploymentEvent;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Contract;
 import mekhq.campaign.stratcon.StratconCampaignState;
+import mekhq.campaign.stratcon.StratconStrategicObjective;
 import mekhq.campaign.stratcon.StratconTrackState;
 
 /**
@@ -175,6 +176,7 @@ public class StratconTab extends CampaignGuiTab {
         if (!campaignState.strategicObjectivesBehaveAsVPs()) {
             sb.append("<br/>Strategic Objectives: ").append(campaignState.getStrategicObjectiveCompletedCount())
                 .append("/").append(campaignState.getPendingStrategicObjectiveCount());
+            sb.append("<span style='background-color: #245250;'>Click me</span>");
         }
         
         sb.append("<br/>Victory Points: ").append(campaignState.getVictoryPoints())
@@ -184,6 +186,58 @@ public class StratconTab extends CampaignGuiTab {
             .append("</html>");
         
         campaignStatusText.setText(sb.toString());
+    }
+    
+    private String buildStrategicObjectiveText(StratconCampaignState campaignState) {
+        StringBuilder sb = new StringBuilder();
+        
+//        for (//StratconTrackState )
+        // loop through all tracks
+        // for each track, loop through all objectives
+        // for each objective, grab the coordinates
+        // if !revealed, "locate and"
+        // if specific scenario "engage hostile forces"
+        // if hostile facility "capture or destroy [facility name]"
+        // if allied facility "maintain control of [facility name]"
+        // if revealed, " on track [current track] at coordinates [coords]
+        for (StratconTrackState track : campaignState.getTracks()) {
+            for (StratconStrategicObjective objective : track.getStrategicObjectives()) {
+                boolean coordsRevealed = track.getRevealedCoords().contains(objective.getObjectiveCoords());
+                
+                if (!coordsRevealed) {
+                    sb.append("Locate and ");
+                }
+                
+                switch (objective.getObjectiveType()) {
+                    case SpecificScenarioVictory:
+                        sb.append("engage hostile forces");
+                        break;
+                    case HostileFacilityControl:
+                        sb.append("capture or destroy facility");
+                        break;
+                    case AlliedFacilityControl:
+                        sb.append("maintain control of facility");
+                        break;
+                    default:
+                        break;
+                }
+                
+                // need to add:
+                // global (campaign-state level) "keep VP count above 0" for liaison/house/integrated
+                // global (campaign-state level) "win X scenarios" for AnyScenarioVictory objective type
+                //      this probably means that StratconStrategicObjective needs "in progress/completed/failed" flag
+                // evaluate current state of facility control and "do X" objective
+                
+                if (coordsRevealed) {
+                    sb.append(" at ").append(objective.getObjectiveCoords().toFriendlyString())
+                        .append(" on track ").append(track.getDisplayableName());
+                }
+                
+                sb.append("<br/>");
+            }
+        }
+        
+        return sb.toString();
     }
     
     /**

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -55,8 +55,8 @@ public class StratconTab extends CampaignGuiTab {
     private JLabel infoPanelText;
     private JLabel campaignStatusText;
     private JLabel objectiveStatusText;
-    JScrollPane expandedObjectivePanel;
-    boolean objectivesCollapsed = true;
+    private JScrollPane expandedObjectivePanel;
+    private boolean objectivesCollapsed = true;
 
     /**
      * Creates an instance of the StratconTab.
@@ -83,7 +83,8 @@ public class StratconTab extends CampaignGuiTab {
         objectiveStatusText = new JLabel();
         objectiveStatusText.setHorizontalAlignment(SwingConstants.LEFT);
         objectiveStatusText.setVerticalAlignment(SwingConstants.TOP);
-        objectiveStatusText.addMouseListener(new MouseAdapter() { 
+        objectiveStatusText.addMouseListener(new MouseAdapter() {
+            @Override
             public void mousePressed(MouseEvent me) { 
                 TrackDropdownItem currentTDI = (TrackDropdownItem) cboCurrentTrack.getSelectedItem();
                 StratconCampaignState campaignState = currentTDI.contract.getStratconCampaignState();
@@ -310,22 +311,22 @@ public class StratconTab extends CampaignGuiTab {
                 
                 switch (objective.getObjectiveType()) {
                     case SpecificScenarioVictory:
-                        sb.append(coordsRevealed ? "E" : "e");
-                        sb.append("ngage and defeat hostile forces");
+                        sb.append(coordsRevealed ? "E" : "e")
+                            .append("ngage and defeat hostile forces");
                         break;
                     case HostileFacilityControl:
-                        sb.append(coordsRevealed ? "C" : "c");
-                        sb.append("apture or destroy designated facility");
+                        sb.append(coordsRevealed ? "C" : "c")
+                            .append("apture or destroy designated facility");
                         break;
                     case AlliedFacilityControl:
-                        sb.append(coordsRevealed ? "M" : "m");
-                        sb.append("aintain control of designated facility");
+                        sb.append(coordsRevealed ? "M" : "m")
+                            .append("aintain control of designated facility");
                         break;
                     case AnyScenarioVictory:
                         sb.append("Engage and defeat hostile forces in ")
-                        .append(objective.getCurrentObjectiveCount()).append("/")
-                        .append(objective.getDesiredObjectiveCount())
-                        .append(" scenarios on ").append(track.getDisplayableName());
+                            .append(objective.getCurrentObjectiveCount()).append("/")
+                            .append(objective.getDesiredObjectiveCount())
+                            .append(" scenarios on ").append(track.getDisplayableName());
                         break;
                     default:
                         break;

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -51,6 +51,7 @@ public class StratconTab extends CampaignGuiTab {
     private JComboBox<TrackDropdownItem> cboCurrentTrack;
     private JLabel infoPanelText;
     private JLabel campaignStatusText;
+    private JLabel objectiveStatusText;
 
     /**
      * Creates an instance of the StratconTab.
@@ -68,6 +69,7 @@ public class StratconTab extends CampaignGuiTab {
         
         infoPanelText = new JLabel();
         campaignStatusText = new JLabel();
+        objectiveStatusText = new JLabel();
         
         setLayout(new GridLayout());
         stratconPanel = new StratconPanel(getCampaignGui(), infoPanelText);
@@ -93,6 +95,7 @@ public class StratconTab extends CampaignGuiTab {
         
         infoPanel.add(new JLabel("Current Campaign Status:"));
         infoPanel.add(campaignStatusText);        
+        infoPanel.add(objectiveStatusText);
 
         JLabel lblCurrentTrack = new JLabel("Current Track:");
         infoPanel.add(lblCurrentTrack);
@@ -186,6 +189,8 @@ public class StratconTab extends CampaignGuiTab {
             .append("</html>");
         
         campaignStatusText.setText(sb.toString());
+        
+        objectiveStatusText.setText(buildStrategicObjectiveText(campaignState));
     }
     
     private String buildStrategicObjectiveText(StratconCampaignState campaignState) {


### PR DESCRIPTION
Multiple improvements to strategic objective tracking, as well as several bug fixes:

- Starting altitude for generated units is now preserved across saves
- Taking a break between adding a bot and trying to change its settings to avoid "can't connect client" errors and issues sending settings over
- Strategic objectives are now explicitly set at contract initialization, in the basic form of [Type] [At coordinates (optional)]. This enables explicit tracking of objectives and much more detailed display.
- Don't apply "global" scenario modifiers once per track to reduce "Allied Trainees" and "Overwhelming Enemy Reinforcements" spam; apply them only once instead.