### PR TITLE
2625: Properly Clear Tech Units on Person removal/retirement

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -416,6 +416,10 @@ public class Campaign implements Serializable, ITechManager {
         return forces;
     }
 
+    public List<Force> getAllForces() {
+        return new ArrayList<>(forceIds.values());
+    }
+
     public void importLance(Lance l) {
         lances.put(l.getForceId(), l);
     }
@@ -982,7 +986,7 @@ public class Campaign implements Serializable, ITechManager {
     public void addScenario(Scenario s, Mission m) {
         addScenario(s, m, false);
     }
-    
+
     /**
      * Add scenario to an existing mission. This method will also assign the scenario an id, provided
      * that it is a new scenario. It then adds the scenario to the scenarioId hash.
@@ -3541,7 +3545,7 @@ public class Campaign implements Serializable, ITechManager {
             u.remove(person, true);
         }
         removeAllPatientsFor(person);
-        removeAllTechJobsFor(person);
+        person.removeAllTechJobs(this);
         removeKillsFor(person.getId());
         getRetirementDefectionTracker().removePerson(person);
 
@@ -3627,30 +3631,6 @@ public class Campaign implements Serializable, ITechManager {
                     && p.getDoctorId().equals(doctor.getId())) {
                 p.setDoctorId(null, getCampaignOptions()
                         .getNaturalHealingWaitingPeriod());
-            }
-        }
-    }
-
-    public void removeAllTechJobsFor(Person tech) {
-        if (tech == null || tech.getId() == null) {
-            return;
-        }
-        getHangar().forEachUnit(u -> {
-            if (tech.equals(u.getTech())) {
-                u.removeTech();
-            }
-            if ((u.getRefit() != null) && tech.equals(u.getRefit().getTech())) {
-                u.getRefit().setTech(null);
-            }
-        });
-        for (Part p : getParts()) {
-            if (tech.equals(p.getTech())) {
-                p.setTech(null);
-            }
-        }
-        for (Force f : forceIds.values()) {
-            if (tech.getId().equals(f.getTechID())) {
-                f.setTechID(null);
             }
         }
     }
@@ -4377,10 +4357,6 @@ public class Campaign implements Serializable, ITechManager {
         this.rankSystem = rankSystem;
     }
     //endregion Ranks
-
-    public ArrayList<Force> getAllForces() {
-        return new ArrayList<>(forceIds.values());
-    }
 
     public void setFinances(Finances f) {
         finances = f;


### PR DESCRIPTION
This fixes #2625 by moving full tech removal to Person and standardizing the cases between the two.