### PR TITLE
Small unit contract init fix

### DIFF
--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -3,6 +3,8 @@
     <name>Convoy Escort</name>
     <shortBriefing>Protect an allied supply convoy.</shortBriefing>
     <detailedBriefing>Escort the allied convoy across the map or rout the attacking force.</detailedBriefing>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes/>
         <allowRotation>false</allowRotation>
@@ -36,6 +38,7 @@
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>SameEdge</syncDeploymentType>
@@ -65,6 +68,7 @@
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
@@ -99,6 +103,7 @@
                 <generationOrder>4</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -108,7 +113,9 @@
     </scenarioForces>
     <scenarioObjectives>
         <scenarioObjective>
-            <associatedForceNames/>
+            <associatedForceNames>
+                <associatedForceName>Convoy</associatedForceName>
+            </associatedForceNames>
             <associatedUnitIDs/>
             <successEffects>
                 <successEffect>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -90,7 +90,7 @@ public class StratconContractInitializer {
         for (ObjectiveParameters objectiveParams : contractDefinition.getObjectiveParameters()) {
             int objectiveCount = objectiveParams.objectiveCount > 0 ?
                     (int) objectiveParams.objectiveCount :
-                    (int) (-objectiveParams.objectiveCount * contract.getRequiredLances());
+                    (int) Math.max(1, -objectiveParams.objectiveCount * contract.getRequiredLances());
 
             List<Integer> trackObjects = trackObjectDistribution(objectiveCount, campaignState.getTracks().size());
 

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -267,7 +267,7 @@ public class StratconTab extends CampaignGuiTab {
         }
         
         // special logic for non-independent command clauses
-        if (campaignState.getContract().getCommandRights() <= Contract.COM_LIAISON) {
+        if (!campaignState.getContract().getCommandRights().isIndependent()) {
             desiredObjectives++;
             
             if (campaignState.getVictoryPoints() > 0) {
@@ -345,7 +345,7 @@ public class StratconTab extends CampaignGuiTab {
         }
         
         // special case text reminding player to complete required scenarios
-        if (campaignState.getContract().getCommandRights() <= Contract.COM_LIAISON) {
+        if (!campaignState.getContract().getCommandRights().isIndependent()) {
             if (campaignState.getVictoryPoints() > 0) {
                 sb.append("<span color='green'>");
             } else {

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
@@ -48,6 +48,7 @@ import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Contract;
+import mekhq.campaign.mission.enums.ContractCommandRights;
 import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
@@ -165,6 +166,7 @@ public class ContractMarketIntegrationTest {
         when(existing.getStartDate()).thenReturn(campaign.getLocalDate().minusDays(3000));
         when(existing.getEndingDate()).thenReturn(campaign.getLocalDate().plusDays(3000));
         when(existing.isActiveOn(campaign.getLocalDate(), false)).thenCallRealMethod();
+        when(existing.getCommandRights()).thenReturn(ContractCommandRights.INDEPENDENT);
         campaign.importMission(existing);
 
         ContractMarket market = new ContractMarket();


### PR DESCRIPTION
Three changes:
- compilation fix
- convoy escort objective properly lists force
- ensure minimum objective count for small unit sizes (objective count rounds to 0 sometimes).

Addresses #2633 