### PR TITLE
various StratCon fixes

### DIFF
--- a/MekHQ/data/scenariomodifiers/BadIntelAir.xml
+++ b/MekHQ/data/scenariomodifiers/BadIntelAir.xml
@@ -34,6 +34,7 @@
 		<objectiveLinkedForces>
 			<objectiveLinkedForce>Primary Opfor</objectiveLinkedForce>
 		</objectiveLinkedForces>
+		<startingAltitude>5</startingAltitude>
 		<syncDeploymentType>None</syncDeploymentType>
 		<syncedForceName />
 	</forceDefinition>

--- a/MekHQ/data/scenariomodifiers/FacilityHostileExtract.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityHostileExtract.xml
@@ -32,7 +32,7 @@
             <additionalDetails>
 		<additionalDetail>Extraction can be carried out by a unit with at least one free hand actuator, infantry or battle armor.</additionalDetail>
 		<additionalDetail>Extraction cannot be performed from destroyed buildings.</additionalDetail>
-		<additionalDetail>The extracting units may flee the battlefield, or the objective is automatically complete if routing the oppossing force.</additionalDetail>
+		<additionalDetail>The extracting units may flee the battlefield; alternately, the objective is automatically completed when routing the opposing force.</additionalDetail>
             </additionalDetails>
             <description>Extract assets from 75% of the buildings designated by turrets.</description>
             <destinationEdge>NONE</destinationEdge>

--- a/MekHQ/data/scenariomodifiers/FacilityHostileExtract.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityHostileExtract.xml
@@ -32,6 +32,7 @@
             <additionalDetails>
 		<additionalDetail>Extraction can be carried out by a unit with at least one free hand actuator, infantry or battle armor.</additionalDetail>
 		<additionalDetail>Extraction cannot be performed from destroyed buildings.</additionalDetail>
+		<additionalDetail>The extracting units may flee the battlefield, or the objective is automatically complete if routing the oppossing force.</additionalDetail>
             </additionalDetails>
             <description>Extract assets from 75% of the buildings designated by turrets.</description>
             <destinationEdge>NONE</destinationEdge>
@@ -39,7 +40,7 @@
             <percentage>75</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
             <timeLimitScaleFactor>2</timeLimitScaleFactor>
-            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
+            <timeLimitType>None</timeLimitType>
         </objective>
         </objectives>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/FacilityHostileRecon.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityHostileRecon.xml
@@ -30,9 +30,10 @@
                 </failureEffect>
             </failureEffects>
             <additionalDetails>
-			<additionalDetail>End a unit's turn within 4 hexes of one of the designated buildings and forego firing or physical attacks to conduct a scan.</additionalDetail>
-			<additionalDetail>Units with active probes, the improved sensors quirk or sensor geek SPA can fire and conduct physical attacks while scanning.</additionalDetail>
+			<additionalDetail>Scans may be conducted by moving a unit within three hexes of the target and foregoing all attacks.</additionalDetail>
+                <additionalDetail>Any kind of probe, improved sensors quirk or sensor geek SPA extends the range to five hexes, and the unit may attack as normal.</additionalDetail>
 			<additionalDetail>Scans cannot be conducted on destroyed buildings.</additionalDetail>
+			<additionalDetail>Note: This objective needs to be tracked outside of MegaMek.</additionalDetail>
 		</additionalDetails>
             <description>Scan the buildings designated by placed turrets.</description>
             <destinationEdge>NONE</destinationEdge>

--- a/MekHQ/data/scenariomodifiers/OverwhelmingEnemyAirReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/OverwhelmingEnemyAirReinforcements.xml
@@ -38,6 +38,7 @@
 		<objectiveLinkedForces>
                     <objectiveLinkedForce>Primary Opfor</objectiveLinkedForce>
                 </objectiveLinkedForces>
+		<startingAltitude>5</startingAltitude>
 		<syncDeploymentType>None</syncDeploymentType>
 		<syncedForceName />
 	</forceDefinition>

--- a/MekHQ/data/scenariomodifiers/PiratesIncomingAir.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesIncomingAir.xml
@@ -31,6 +31,7 @@
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>
 		<retreatThreshold>50</retreatThreshold>
+		<startingAltitude>5</startingAltitude>
 		<syncDeploymentType>None</syncDeploymentType>
 		<syncedForceName />
 	</forceDefinition>

--- a/MekHQ/data/scenariomodifiers/PiratesPresentAir.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesPresentAir.xml
@@ -31,6 +31,7 @@
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>
 		<retreatThreshold>50</retreatThreshold>
+		<startingAltitude>5</startingAltitude>
 		<syncDeploymentType>None</syncDeploymentType>
 		<syncedForceName />
 	</forceDefinition>

--- a/MekHQ/data/scenariotemplates/Destroy Grounded Dropship.xml
+++ b/MekHQ/data/scenariotemplates/Destroy Grounded Dropship.xml
@@ -169,8 +169,10 @@
                     <howMuch>2</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails/>
-            <description>Destroy, cripple or force to withdraw the following force(s) and unit(s):</description>
+            <additionalDetails>
+                <additionalDetail></additionalDetail>
+            </additionalDetails>
+            <description>Destroy, cripple or force to withdraw 50% of the following force(s) and unit(s):</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
             <percentage>50</percentage>

--- a/MekHQ/data/scenariotemplates/Recon.xml
+++ b/MekHQ/data/scenariotemplates/Recon.xml
@@ -109,8 +109,8 @@
                 </failureEffect>
             </failureEffects>
             <additionalDetails>
-                <additionalDetail>Scans may be conducted by weapons fire, TAG, spotting or physical attacks.</additionalDetail>
-                <additionalDetail>If the scan action requires a roll, it must be possible.</additionalDetail>
+                <additionalDetail>Scans may be conducted by moving a unit within three hexes of the target and foregoing all attacks.</additionalDetail>
+                <additionalDetail>Any kind of probe, improved sensors quirk or sensor geek SPA extends the range to five hexes, and the unit may attack as normal.</additionalDetail>
                 <additionalDetail>Note: This objective should be tracked manually outside of MegaMek.</additionalDetail>
             </additionalDetails>
             <description>Scan the following enemy unit(s) and force(s):</description>

--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -54,8 +54,9 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
     private static DocumentBuilderFactory UNSAFE_DOCUMENT_BUILDER_FACTORY;
 
     /**
-     * USE WITH CARE. Creates a DocumentBuilder safe from XML external entities
-     * attacks, but unsafe from XML entity expansion attacks.
+     * USE WITH CARE. Creates a DocumentBuilder safe from XML external entities attacks, but unsafe from
+     * XML entity expansion attacks.
+     * 
      * @return A DocumentBuilder less safe to use to read untrusted XML.
      */
     public static DocumentBuilder newUnsafeDocumentBuilder() throws ParserConfigurationException {
@@ -110,13 +111,11 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
     /**
      * TODO: This is dumb and we should just use EntityListFile.writeEntityList.
      * 
-     * Contents copied from megamek.common.EntityListFile.saveTo(...) Modified
-     * to support saving to/from XML for our purposes in MekHQ TODO: Some of
-     * this may want to be back-ported into entity itself in MM and then
-     * re-factored out of EntityListFile.
+     * Contents copied from megamek.common.EntityListFile.saveTo(...) Modified to support saving to/from
+     * XML for our purposes in MekHQ TODO: Some of this may want to be back-ported into entity itself in
+     * MM and then re-factored out of EntityListFile.
      *
-     * @param tgtEnt
-     *            The entity to serialize to XML.
+     * @param tgtEnt The entity to serialize to XML.
      * @return A string containing the XML representation of the entity.
      */
     public static String writeEntityToXmlString(Entity tgtEnt, int indentLvl, List<Entity> list) {
@@ -129,12 +128,10 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
         StringBuilder retVal = new StringBuilder();
 
         // Start writing this entity to the file.
-        retVal.append(MekHqXmlUtil.indentStr(indentLvl))
-                .append("<entity chassis=\"").append(escape(tgtEnt.getChassis()))
-                .append("\" model=\"").append(escape(tgtEnt.getModel()))
-                .append("\" type=\"").append(escape(tgtEnt.getMovementModeAsString()))
-                .append("\" commander=\"").append(tgtEnt.isCommander())
-                .append("\" externalId=\"").append(tgtEnt.getExternalIdAsString());
+        retVal.append(MekHqXmlUtil.indentStr(indentLvl)).append("<entity chassis=\"")
+                .append(escape(tgtEnt.getChassis())).append("\" model=\"").append(escape(tgtEnt.getModel()))
+                .append("\" type=\"").append(escape(tgtEnt.getMovementModeAsString())).append("\" commander=\"")
+                .append(tgtEnt.isCommander()).append("\" externalId=\"").append(tgtEnt.getExternalIdAsString());
 
         if (tgtEnt.countQuirks() > 0) {
             retVal.append("\" quirks=\"").append(escape(tgtEnt.getQuirkList("::")));
@@ -147,23 +144,32 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
             retVal.append("\" c3UUID=\"").append(tgtEnt.getC3UUIDAsString());
         }
 
-         if (!tgtEnt.getCamouflage().hasDefaultCategory()) {
-             retVal.append("\" camoCategory=\"").append(escape(tgtEnt.getCamouflage().getCategory()));
-         }
+        if (!tgtEnt.getCamouflage().hasDefaultCategory()) {
+            retVal.append("\" camoCategory=\"").append(escape(tgtEnt.getCamouflage().getCategory()));
+        }
 
-         if (!tgtEnt.getCamouflage().hasDefaultFilename()) {
-             retVal.append("\" camoFileName=\"").append(escape(tgtEnt.getCamouflage().getFilename()));
-         }
+        if (!tgtEnt.getCamouflage().hasDefaultFilename()) {
+            retVal.append("\" camoFileName=\"").append(escape(tgtEnt.getCamouflage().getFilename()));
+        }
 
-         if (tgtEnt.getDeployRound() > 0) {
-             retVal.append(String.format("\" %s=\"%d", MULParser.DEPLOYMENT, tgtEnt.getDeployRound()));
-         }
+        if (tgtEnt.getDeployRound() > 0) {
+            retVal.append(String.format("\" %s=\"%d", MULParser.DEPLOYMENT, tgtEnt.getDeployRound()));
+        }
 
-         if (tgtEnt instanceof Infantry) {
-             retVal.append(String.format("\" %s=\"%d", MULParser.INF_SQUAD_NUM, ((Infantry) tgtEnt).getSquadN()));
-         }
+        if (tgtEnt instanceof Infantry) {
+            retVal.append(String.format("\" %s=\"%d", MULParser.INF_SQUAD_NUM, ((Infantry) tgtEnt).getSquadN()));
+        }
 
-         retVal.append(String.format("\" %s=\"%d", MULParser.ALTITUDE, tgtEnt.getAltitude()));
+        retVal.append(String.format("\" %s=\"%d", MULParser.ALTITUDE, tgtEnt.getAltitude()));
+
+        if (tgtEnt.isOffBoard()) {
+            retVal.append("\" offboard=\"");
+            retVal.append(String.valueOf(tgtEnt.isOffBoard()));
+            retVal.append("\" offboard_distance=\"");
+            retVal.append(String.valueOf(tgtEnt.getOffBoardDistance()));
+            retVal.append("\" offboard_direction=\"");
+            retVal.append(String.valueOf(tgtEnt.getOffBoardDirection().getValue()));
+        }
 
         retVal.append("\">\n");
 
@@ -188,13 +194,16 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
             Aero a = (Aero) tgtEnt;
 
             // SI
-            retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1)).append("<structural integrity=\"").append(a.getSI()).append("\"/>\n");
+            retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1)).append("<structural integrity=\"").append(a.getSI())
+                    .append("\"/>\n");
 
             // Heat sinks
-            retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1)).append("<heat sinks=\"").append(a.getHeatSinks()).append("\"/>\n");
+            retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1)).append("<heat sinks=\"").append(a.getHeatSinks())
+                    .append("\"/>\n");
 
             // Fuel
-            retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1)).append("<fuel left=\"").append(a.getFuel()).append("\"/>\n");
+            retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1)).append("<fuel left=\"").append(a.getFuel())
+                    .append("\"/>\n");
 
             // TODO: dropship docking collars, bays
 
@@ -203,12 +212,12 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
                 Jumpship j = (Jumpship) a;
 
                 // KF integrity
-                retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1))
-                        .append("<KF integrity=\"").append(j.getKFIntegrity()).append("\"/>\n");
+                retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1)).append("<KF integrity=\"")
+                        .append(j.getKFIntegrity()).append("\"/>\n");
 
                 // KF sail integrity
-                retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1))
-                        .append("<sail integrity=\"").append(j.getSailIntegrity()).append("\"/>\n");
+                retVal.append(MekHqXmlUtil.indentStr(indentLvl + 1)).append("<sail integrity=\"")
+                        .append(j.getSailIntegrity()).append("\"/>\n");
             }
 
             // Crits
@@ -221,7 +230,7 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
         }
 
         // Add the locations of this entity (if any are needed).
-        String loc = EntityListFile.getLocString(tgtEnt, indentLvl+1);
+        String loc = EntityListFile.getLocString(tgtEnt, indentLvl + 1);
 
         if (null != loc) {
             retVal.append(loc);
@@ -295,11 +304,10 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
     }
 
     /**
-     * Contents copied from megamek.common.EntityListFile.getAeroCritString(...)
-     * Modified to support saving to/from XML for our purposes in MekHQ
+     * Contents copied from megamek.common.EntityListFile.getAeroCritString(...) Modified to support
+     * saving to/from XML for our purposes in MekHQ
      *
-     * @param a
-     *            The Aero unit to generate a crit string for.
+     * @param a The Aero unit to generate a crit string for.
      * @return The generated crit string.
      */
     private static String getAeroCritString(Aero a, int indentLvl) {
@@ -369,12 +377,10 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
     }
 
     /**
-     * Contents copied from
-     * megamek.common.EntityListFile.getTurretLockedString(...) Modified to
-     * support saving to/from XML for our purposes in MekHQ
+     * Contents copied from megamek.common.EntityListFile.getTurretLockedString(...) Modified to support
+     * saving to/from XML for our purposes in MekHQ
      *
-     * @param e
-     *            The tank to generate a turret-locked string for.
+     * @param e The tank to generate a turret-locked string for.
      * @return The generated string.
      */
     private static String getTurretLockedString(Tank e, int indentLvl) {
@@ -386,11 +392,10 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
     }
 
     /**
-     * Contents copied from megamek.common.EntityListFile.getMovementString(...)
-     * Modified to support saving to/from XML for our purposes in MekHQ
+     * Contents copied from megamek.common.EntityListFile.getMovementString(...) Modified to support
+     * saving to/from XML for our purposes in MekHQ
      *
-     * @param e
-     *            The tank to generate a movement string for.
+     * @param e The tank to generate a movement string for.
      * @return The generated string.
      */
     private static String getMovementString(Tank e, int indentLvl) {
@@ -398,10 +403,10 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
         boolean im = false;
 
         // This can throw an NPE for no obvious reason.
-        // Okay, fine.  If the tank doesn't even *have* an object related to this...
+        // Okay, fine. If the tank doesn't even *have* an object related to this...
         // Lets assume it's fully mobile, as any other fact hasn't been recorded.
         try {
-             im = e.isImmobile();
+            im = e.isImmobile();
         } catch (NullPointerException ex) {
             // Ignore - just don't completely fail out.
         }
@@ -425,53 +430,46 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
     }
 
     /**
-     * Contents copied from megamek.common.EntityListFile.getTankCritString(...)
-     * Modified to support saving to/from XML for our purposes in MekHQ
+     * Contents copied from megamek.common.EntityListFile.getTankCritString(...) Modified to support
+     * saving to/from XML for our purposes in MekHQ
      *
-     * @param e
-     *            The tank to generate a movement string for.
+     * @param e The tank to generate a movement string for.
      * @return The generated string.
      */
-     private static String getTankCritString(Tank e, int indentLvl) {
+    private static String getTankCritString(Tank e, int indentLvl) {
 
-         String retVal = MekHqXmlUtil.indentStr(indentLvl) + "<tcriticals";
-         String critVal = "";
+        String retVal = MekHqXmlUtil.indentStr(indentLvl) + "<tcriticals";
+        String critVal = "";
 
-         // crits
-         if (e.getSensorHits() > 0) {
-         critVal = critVal.concat(" sensors=\"");
-         critVal = critVal.concat(Integer.toString(e.getSensorHits()));
-         critVal = critVal.concat("\"");
-         }
-         if (e.isEngineHit()) {
-         critVal = critVal.concat(" engine=\"");
-         critVal = critVal.concat("hit");
-         critVal = critVal.concat("\"");
-         }
+        // crits
+        if (e.getSensorHits() > 0) {
+            critVal = critVal.concat(" sensors=\"");
+            critVal = critVal.concat(Integer.toString(e.getSensorHits()));
+            critVal = critVal.concat("\"");
+        }
+        if (e.isEngineHit()) {
+            critVal = critVal.concat(" engine=\"");
+            critVal = critVal.concat("hit");
+            critVal = critVal.concat("\"");
+        }
 
-         /* crew are handled as a Person object in MekHq...
-         if (e.isDriverHit()) {
-         critVal = critVal.concat(" driver=\"");
-         critVal = critVal.concat("hit");
-         critVal = critVal.concat("\"");
-         }
-
-         if (e.isCommanderHit()) {
-         critVal = critVal.concat(" commander=\"");
-         critVal = critVal.concat("hit");
-         critVal = critVal.concat("\"");
-         }
+        /*
+         * crew are handled as a Person object in MekHq... if (e.isDriverHit()) { critVal =
+         * critVal.concat(" driver=\""); critVal = critVal.concat("hit"); critVal = critVal.concat("\""); }
+         * 
+         * if (e.isCommanderHit()) { critVal = critVal.concat(" commander=\""); critVal =
+         * critVal.concat("hit"); critVal = critVal.concat("\""); }
          */
 
-         if (!critVal.equals("")) {
-         // then add beginning and end
-         retVal = retVal.concat(critVal);
-         retVal = retVal.concat("/>\n");
-         } else {
-         return critVal;
-         }
+        if (!critVal.equals("")) {
+            // then add beginning and end
+            retVal = retVal.concat(critVal);
+            retVal = retVal.concat("/>\n");
+        } else {
+            return critVal;
+        }
 
-         return retVal;
+        return retVal;
 
     }
 
@@ -482,22 +480,18 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
     }
 
     /**
-     * Parses the given node as if it was a .mul file and returns the first
-     * entity it contains.
+     * Parses the given node as if it was a .mul file and returns the first entity it contains.
      * <p>
-     * In theme with {@link MULParser}, this method fails silently and returns
-     * {@code null} if the input can't be parsed; if it can be parsed and
-     * contains more than one entity, an {@linkplain IllegalArgumentException}
-     * is thrown.
+     * In theme with {@link MULParser}, this method fails silently and returns {@code null} if the input
+     * can't be parsed; if it can be parsed and contains more than one entity, an
+     * {@linkplain IllegalArgumentException} is thrown.
      *
-     * @param element
-     *        the xml tag to parse
+     * @param element the xml tag to parse
      *
-     * @return the first entity parsed from the given element, or {@code null}
-     *         if anything is wrong with the input
+     * @return the first entity parsed from the given element, or {@code null} if anything is wrong with
+     *         the input
      *
-     * @throws IllegalArgumentException
-     *         if the given element parses to multiple entities
+     * @throws IllegalArgumentException if the given element parses to multiple entities
      */
     public static Entity parseSingleEntityMul(Element element) {
         MekHQ.getLogger().trace(MekHqXmlUtil.class, "Executing getEntityFromXmlString(Node)...");
@@ -507,14 +501,16 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
         List<Entity> entities = prs.getEntities();
 
         switch (entities.size()) {
-            case 0:
-                return null;
-            case 1:
-                Entity entity = entities.get(0);
-                MekHQ.getLogger().trace(MekHqXmlUtil.class, "Returning " + entity + " from getEntityFromXmlString(String)...");
-                return entity;
-            default:
-                throw new IllegalArgumentException("More than one entity contained in XML string!  Expecting a single entity.");
+        case 0:
+            return null;
+        case 1:
+            Entity entity = entities.get(0);
+            MekHQ.getLogger().trace(MekHqXmlUtil.class,
+                    "Returning " + entity + " from getEntityFromXmlString(String)...");
+            return entity;
+        default:
+            throw new IllegalArgumentException(
+                    "More than one entity contained in XML string!  Expecting a single entity.");
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2295,8 +2295,8 @@ public class AtBDynamicScenarioFactory {
     }
 
     /**
-     * Helper function that puts the units in the given list at the given altitude, and
-     * VTOLs at the elevation. Use with caution, as may lead to splattering.
+     * Helper function that puts the units in the given list at the given altitude. 
+     * Use with caution, as may lead to splattering or aerospace units starting on the ground.
      * @param entityList The entity list to process.
      * @param startingAltitude Starting altitude.
      */
@@ -2311,8 +2311,6 @@ public class AtBDynamicScenarioFactory {
                     ((IAero) entity).land();
                 }
             }
-
-            entity.setElevation(startingAltitude);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -150,11 +150,6 @@ public class StratconRulesManager {
 
                 StratconScenario scenario = setupScenario(scenarioCoords, randomForceID, campaign, contract, track);
                 generatedScenarios.add(scenario);
-
-                // if we're auto-assigning lances, deploy the force to the track as well
-                if (autoAssignLances) {
-                    processForceDeployment(scenarioCoords, randomForceID, campaign, track, false);
-                }
             }
         }
 
@@ -181,6 +176,10 @@ public class StratconRulesManager {
                 track.addScenario(scenario);
             } else {
                 commitPrimaryForces(campaign, scenario, track);
+                // if we're auto-assigning lances, deploy all assigned forces to the track as well
+                for (int forceID : scenario.getPrimaryForceIDs()) {
+                    processForceDeployment(scenario.getCoords(), forceID, campaign, track, false);
+                }
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -924,7 +924,7 @@ public class StratconRulesManager {
      * scenario d) if attempting to deploy as reinforcements, haven't already failed to deploy
      */
     public static List<Integer> getAvailableForceIDs(int unitType, Campaign campaign, StratconTrackState currentTrack,
-            boolean reinforcements, @Nullable StratconScenario currentScenario) {
+            boolean reinforcements, @Nullable StratconScenario currentScenario, StratconCampaignState campaignState) {
         List<Integer> retVal = new ArrayList<>();
 
         Set<Integer> forcesInTracks = new HashSet<>();
@@ -951,9 +951,12 @@ public class StratconRulesManager {
             }
 
             int primaryUnitType = force.getPrimaryUnitType(campaign);
+            boolean noReinforcementRestriction = !reinforcements || (reinforcements 
+                    && (getReinforcementType(force.getId(), currentTrack, campaign, campaignState) != ReinforcementEligibilityType.None));
             if (!force.isDeployed() && (force.getScenarioId() <= 0) && !force.getUnits().isEmpty()
                     && !forcesInTracks.contains(force.getId())
-                    && forceCompositionMatchesDeclaredUnitType(primaryUnitType, unitType, reinforcements)) {
+                    && forceCompositionMatchesDeclaredUnitType(primaryUnitType, unitType, reinforcements)
+                    && noReinforcementRestriction) {
                 retVal.add(force.getId());
             }
         }
@@ -980,7 +983,8 @@ public class StratconRulesManager {
             if ((isEligibleInfantry || isEligibleGunEmplacement)
                     && !u.isDeployed()
                     && !u.isMothballed()
-                    && u.isFunctional()) {
+                    && (u.checkDeployment() == null)
+                    && !isUnitDeployedToStratCon(u)) {
 
                 // this is a little inefficient, but probably there aren't too many active AtB
                 // contracts at a time
@@ -1028,7 +1032,8 @@ public class StratconRulesManager {
                     forceCompositionMatchesDeclaredUnitType(u.getEntity().getUnitType(), generalUnitType, true);
 
             if (validUnitType && !u.isDeployed() && !u.isMothballed()
-                    && u.isFunctional() && (u.getEntity().calculateBattleValue() < lowestBV)
+                    && (u.getEntity().calculateBattleValue() < lowestBV)
+                    && (u.checkDeployment() == null)
                     && !isUnitDeployedToStratCon(u)) {
                 retVal.add(u);
             }
@@ -1119,18 +1124,7 @@ public class StratconRulesManager {
      * Determines what rules to use when deploying a force for reinforcements to the given track.
      */
     public static ReinforcementEligibilityType getReinforcementType(int forceID, StratconTrackState trackState,
-            Campaign campaign) {
-        // if the force is currently deployed to the track, it'll be able to deploy "for free"
-        if (trackState.isForceDeployed(forceID)) {
-            return ReinforcementEligibilityType.ChainedScenario;
-        }
-
-        // if the force is in 'fight' stance, it'll be able to deploy using 'fight lance' rules
-        if (campaign.getLances().containsKey(forceID)
-                && (campaign.getLances().get(forceID).getRole() == AtBLanceRole.FIGHTING)) {
-            return ReinforcementEligibilityType.FightLance;
-        }
-
+            Campaign campaign, StratconCampaignState campaignState) {
         // if the force is deployed elsewhere, it cannot be deployed as reinforcements
         for (AtBContract contract : campaign.getActiveAtBContracts()) {
             for (StratconTrackState track : contract.getStratconCampaignState().getTracks()) {
@@ -1139,10 +1133,67 @@ public class StratconRulesManager {
                 }
             }
         }
+        
+        // TODO: If the force has completed a scenario which allows it, 
+        // it can deploy "for free" (ReinforcementEligibilityType.ChainedScenario)
+        
+        // if the force is in 'fight' stance, it'll be able to deploy using 'fight lance' rules
+        if (campaign.getLances().containsKey(forceID)
+                && (campaign.getLances().get(forceID).getRole() == AtBLanceRole.FIGHTING)) {
+            return ReinforcementEligibilityType.FightLance;
+        }
 
         // otherwise, the force requires support points / vps to deploy
-        return ReinforcementEligibilityType.SupportPoint;
+        if ((campaignState.getSupportPoints() > 0) ||
+                (campaignState.getVictoryPoints() > 0)) {
+            return ReinforcementEligibilityType.SupportPoint;
+        }
+        
+        /// if we don't have any of these things, it can't be deployed
+        return ReinforcementEligibilityType.None;
     }
+    
+    /**
+     * Can any force be manually deployed to the given coordinates on the given track
+     * for the given contract?
+     */
+    public static boolean canManuallyDeployAnyForce(StratconCoords coords,
+            StratconTrackState track, AtBContract contract) {
+        // Rules: can't manually deploy under integrated command
+        // can't manually deploy if there's already a force deployed there
+        //      exception: on allied facilities
+        // can't manually deploy if there's a non-cloaked scenario
+        
+        if (contract.getCommandRights().isIntegrated()) {
+            return false;
+        }
+        
+        StratconScenario scenario = track.getScenario(coords);
+        boolean nonCloakedOrNoscenario = (scenario == null) || scenario.getBackingScenario().isCloaked();
+        
+        StratconFacility facility = track.getFacility(coords);
+        boolean alliedFacility = (facility != null) && (facility.getOwner() == ForceAlignment.Allied);
+        
+        return (!track.areAnyForceDeployedTo(coords) || alliedFacility) && nonCloakedOrNoscenario;
+    }
+    
+    /**
+     * Can the given force be manually deployed to the given coordinates on the given track
+     */
+    public static boolean canManuallyDeployForce(StratconCoords coords, 
+            StratconTrackState track, AtBContract contract, Force force, AtBLanceRole forceRole) {        
+        // can't do it under integrated command clause, period
+        
+        // defend lances can stack up on allied facilities
+        
+        // can't deploy if a force has already been deployed to these coordinates
+        
+        // can't deploy if a scenario exists on these coordinates, unless it's invisible
+        
+        
+        return false;
+    }
+    
 
     /**
      * Given a track and the current campaign state, and if the player is deploying a force or not,
@@ -1459,6 +1510,12 @@ public class StratconRulesManager {
             if (campaignState != null) {
                 for (StratconTrackState track : campaignState.getTracks()) {
                     cleanupPhantomScenarios(track);
+                    
+                    // check if some of the forces have finished deployment
+                    // please do this before generating scenarios for track
+                    // to avoid unintentionally cleaning out integrated force deployments on
+                    // 0-deployment-length tracks
+                    processTrackForceReturnDates(track, ev.getCampaign().getLocalDate());
 
                     // loop through scenarios - if we haven't deployed in time,
                     // fail it and apply consequences
@@ -1474,9 +1531,6 @@ public class StratconRulesManager {
                     if (isMonday) {
                         generateScenariosForTrack(ev.getCampaign(), contract, track);
                     }
-
-                    // check if some of the forces have finished deployment
-                    processTrackForceReturnDates(track, ev.getCampaign().getLocalDate());
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1174,25 +1174,7 @@ public class StratconRulesManager {
         boolean alliedFacility = (facility != null) && (facility.getOwner() == ForceAlignment.Allied);
         
         return (!track.areAnyForceDeployedTo(coords) || alliedFacility) && nonCloakedOrNoscenario;
-    }
-    
-    /**
-     * Can the given force be manually deployed to the given coordinates on the given track
-     */
-    public static boolean canManuallyDeployForce(StratconCoords coords, 
-            StratconTrackState track, AtBContract contract, Force force, AtBLanceRole forceRole) {        
-        // can't do it under integrated command clause, period
-        
-        // defend lances can stack up on allied facilities
-        
-        // can't deploy if a force has already been deployed to these coordinates
-        
-        // can't deploy if a scenario exists on these coordinates, unless it's invisible
-        
-        
-        return false;
-    }
-    
+    }    
 
     /**
      * Given a track and the current campaign state, and if the player is deploying a force or not,

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -88,6 +88,7 @@ public class StratconScenario implements IStratconDisplayable {
      */
     public void addPrimaryForce(int forceID) {
         backingScenario.addForce(forceID, ScenarioForceTemplate.PRIMARY_FORCE_TEMPLATE_ID);
+        primaryForceIDs.add(forceID);
     }
     
     /**

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -48,6 +48,7 @@ import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconCoords;
 import mekhq.campaign.stratcon.StratconFacility;
+import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.gui.stratcon.StratconScenarioWizard;
@@ -152,8 +153,7 @@ public class StratconPanel extends JPanel implements ActionListener {
         
         // display "Manage Force Assignment" if there is not a force already on the hex
         // except if there is already a non-cloaked scenario here.
-        if (!currentTrack.areAnyForceDeployedTo(coords) &&
-                ((scenario == null) || scenario.getBackingScenario().isCloaked())) {
+        if (StratconRulesManager.canManuallyDeployAnyForce(coords, currentTrack, campaignState.getContract())) {
             menuItemManageForceAssignments = new JMenuItem();
             menuItemManageForceAssignments.setText("Manage Force Assignment");
             menuItemManageForceAssignments.setActionCommand(RCLICK_COMMAND_MANAGE_FORCES);

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -417,7 +417,7 @@ public class StratconScenarioWizard extends JDialog {
         StringBuilder costBuilder = new StringBuilder();
         costBuilder.append("(");
         
-        switch(StratconRulesManager.getReinforcementType(forceID, currentTrackState, campaign, currentCampaignState)) {
+        switch (StratconRulesManager.getReinforcementType(forceID, currentTrackState, campaign, currentCampaignState)) {
         case SupportPoint:
             costBuilder.append(resourceMap.getString("supportPoint.text"));
             if (currentCampaignState.getSupportPoints() <= 0) {

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -19,7 +19,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -294,7 +293,7 @@ public class StratconScenarioWizard extends JDialog {
                 StratconRulesManager.getAvailableForceIDs(forceTemplate.getAllowedUnitType(), 
                         campaign, currentTrackState,
                         (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS),
-                        currentScenario));
+                        currentScenario, currentCampaignState));
         
         JList<Force> availableForceList = new JList<>();
         availableForceList.setModel(lanceModel);
@@ -418,7 +417,7 @@ public class StratconScenarioWizard extends JDialog {
         StringBuilder costBuilder = new StringBuilder();
         costBuilder.append("(");
         
-        switch(StratconRulesManager.getReinforcementType(forceID, currentTrackState, campaign)) {
+        switch(StratconRulesManager.getReinforcementType(forceID, currentTrackState, campaign, currentCampaignState)) {
         case SupportPoint:
             costBuilder.append(resourceMap.getString("supportPoint.text"));
             if (currentCampaignState.getSupportPoints() <= 0) {
@@ -480,7 +479,8 @@ public class StratconScenarioWizard extends JDialog {
                 // if we are assigning reinforcements, pay the price if appropriate
                 if (currentScenario.getCurrentState() == ScenarioState.PRIMARY_FORCES_COMMITTED) {
                     ReinforcementEligibilityType reinforcementType = 
-                            StratconRulesManager.getReinforcementType(force.getId(), currentTrackState, campaign);
+                            StratconRulesManager.getReinforcementType(force.getId(), currentTrackState, 
+                                    campaign, currentCampaignState);
                     
                     // if we failed to deploy as reinforcements, move on to the next force
                     if (!StratconRulesManager.processReinforcementDeployment(reinforcementType, currentCampaignState, currentScenario, campaign)) {

--- a/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
+++ b/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
@@ -85,7 +85,7 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
         // if we're waiting to assign primary forces, we can only do so from the current track 
         lanceModel = new ScenarioWizardLanceModel(campaign, 
                 StratconRulesManager.getAvailableForceIDs(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX, 
-                        campaign, ownerPanel.getCurrentTrack(), false, null));
+                        campaign, ownerPanel.getCurrentTrack(), false, null, currentCampaignState));
         
         availableForceList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         availableForceList.setModel(lanceModel);

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -425,15 +425,15 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                 objectiveBuilder.append("\n");
             }
 
+            objectiveBuilder.append("\t");
+            objectiveBuilder.append(objective.getTimeLimitString());
+            objectiveBuilder.append("\n");
+            
             for (String detail : objective.getDetails()) {
                 objectiveBuilder.append("\t");
                 objectiveBuilder.append(detail);
                 objectiveBuilder.append("\n");
             }
-
-            objectiveBuilder.append("\t");
-            objectiveBuilder.append(objective.getTimeLimitString());
-            objectiveBuilder.append("\n");
 
             objectiveBuilder.append("\n");
         }

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
@@ -48,6 +48,7 @@ import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Contract;
+import mekhq.campaign.mission.enums.ContractCommandRights;
 import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
@@ -165,6 +166,7 @@ public class ContractMarketIntegrationTest {
         when(existing.getStartDate()).thenReturn(campaign.getLocalDate().minusDays(3000));
         when(existing.getEndingDate()).thenReturn(campaign.getLocalDate().plusDays(3000));
         when(existing.isActiveOn(campaign.getLocalDate(), false)).thenCallRealMethod();
+        when(existing.getCommandRights()).thenReturn(ContractCommandRights.INDEPENDENT);
         campaign.importMission(existing);
 
         ContractMarket market = new ContractMarket();


### PR DESCRIPTION
- Updated arrival altitude for aerospace fighter reinforcement modifiers (they were showing up on the ground)
- Standardized "recon" type scenarios to have the same criteria as Tukayyid scenarios 
- Various briefing text clarifications
- Store artillery offboard status between campaign saves
- On Integrated command, don't immediately and incorrectly undeploy lances after generating scenarios
- Adjusted manual force deployment rules (unlimited stacking on allied facilities, one per hex otherwise, no manual deployment under integrated command)
- Tighten up reinforcement restrictions (can't deploy units that can't actually deploy; can't double deploy units; can now only deploy fight lances or have to use a support point/VP)
- VTOLs no longer start on the ground