### PR TITLE
2529: Fixing refit display so it no longer includes the pilot's BV

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
@@ -150,7 +150,7 @@ public class ChooseRefitDialog extends JDialog {
         txtOldUnit.setBorder(BorderFactory.createCompoundBorder(
                  BorderFactory.createTitledBorder(resourceMap.getString("txtOldUnit.title")),
                  BorderFactory.createEmptyBorder(5,5,5,5)));
-        MechView mv = new MechView(unit.getEntity(), false, true);
+        MechView mv = new MechView(unit.getEntity(), false, true, true, true);
         txtOldUnit.setText("<div style='font: 12pt monospaced'>" + mv.getMechReadout() + "</div>");
         scrOldUnit = new JScrollPane(txtOldUnit);
         scrOldUnit.setMinimumSize(new java.awt.Dimension(300, 400));


### PR DESCRIPTION
This fixes #2529 and requires https://github.com/MegaMek/megamek/pull/2895