### PR TITLE
2534: Fixing Missing Clan Check For Endo Steel Location Repairs

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -111,49 +111,51 @@ public class MekLocation extends Part {
         //TODO: need to account for internal structure and myomer types
         //crap, no static report for location names?
         this.name = "Mech Location";
-        switch(loc) {
-        case(Mech.LOC_HEAD):
-            this.name = "Mech Head";
-            break;
-        case(Mech.LOC_CT):
-            this.name = "Mech Center Torso";
-            break;
-        case(Mech.LOC_LT):
-            this.name = "Mech Left Torso";
-            break;
-        case(Mech.LOC_RT):
-            this.name = "Mech Right Torso";
-            break;
-        case(Mech.LOC_LARM):
-            this.name = "Mech Left Arm";
-            if (forQuad) {
-                this.name = "Mech Front Left Leg";
-            }
-            break;
-        case(Mech.LOC_RARM):
-            this.name = "Mech Right Arm";
-            if (forQuad) {
-                this.name = "Mech Front Right Leg";
-            }
-            break;
-        case(Mech.LOC_LLEG):
-            this.name = "Mech Left Leg";
-            if (forQuad) {
-                this.name = "Mech Rear Left Leg";
-            }
-            break;
-        case(Mech.LOC_RLEG):
-            this.name = "Mech Right Leg";
-            if (forQuad) {
-                this.name = "Mech Rear Right Leg";
-            }
-            break;
+        switch (loc) {
+            case(Mech.LOC_HEAD):
+                this.name = "Mech Head";
+                break;
+            case(Mech.LOC_CT):
+                this.name = "Mech Center Torso";
+                break;
+            case(Mech.LOC_LT):
+                this.name = "Mech Left Torso";
+                break;
+            case(Mech.LOC_RT):
+                this.name = "Mech Right Torso";
+                break;
+            case(Mech.LOC_LARM):
+                this.name = "Mech Left Arm";
+                if (forQuad) {
+                    this.name = "Mech Front Left Leg";
+                }
+                break;
+            case(Mech.LOC_RARM):
+                this.name = "Mech Right Arm";
+                if (forQuad) {
+                    this.name = "Mech Front Right Leg";
+                }
+                break;
+            case(Mech.LOC_LLEG):
+                this.name = "Mech Left Leg";
+                if (forQuad) {
+                    this.name = "Mech Rear Left Leg";
+                }
+                break;
+            case(Mech.LOC_RLEG):
+                this.name = "Mech Right Leg";
+                if (forQuad) {
+                    this.name = "Mech Rear Right Leg";
+                }
+                break;
         }
+
         if (EquipmentType.T_STRUCTURE_ENDO_STEEL == structureType) {
-            this.name += " (" + EquipmentType.getStructureTypeName(structureType, isClan()) + ")";
+            this.name += " (" + EquipmentType.getStructureTypeName(structureType, clan) + ")";
         } else if (structureType != EquipmentType.T_STRUCTURE_STANDARD) {
             this.name += " (" + EquipmentType.getStructureTypeName(structureType) + ")";
         }
+
         if (tsm) {
             this.name += " (TSM)";
         }

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -113,9 +113,13 @@ public class MissingMekLocation extends MissingPart {
                 }
                 break;
         }
-        if (structureType != EquipmentType.T_STRUCTURE_STANDARD) {
+
+        if (EquipmentType.T_STRUCTURE_ENDO_STEEL == structureType) {
+            this.name += " (" + EquipmentType.getStructureTypeName(structureType, clan) + ")";
+        } else if (structureType != EquipmentType.T_STRUCTURE_STANDARD) {
             this.name += " (" + EquipmentType.getStructureTypeName(structureType) + ")";
         }
+
         if (tsm) {
             this.name += " (TSM)";
         }
@@ -197,25 +201,20 @@ public class MissingMekLocation extends MissingPart {
 
     @Override
     public boolean isAcceptableReplacement(Part part, boolean refit) {
-        if (loc == Mech.LOC_CT && !refit) {
+        if ((loc == Mech.LOC_CT) && !refit) {
             //you can't replace a center torso
             return false;
+        } else if (part instanceof MekLocation) {
+            MekLocation mekLoc = (MekLocation) part;
+            return (mekLoc.getLoc() == loc)
+                    && (mekLoc.getUnitTonnage() == getUnitTonnage())
+                    && (mekLoc.isTsm() == tsm)
+                    && (mekLoc.clan == clan)
+                    && (mekLoc.getStructureType() == structureType)
+                    && (!isArm() || (mekLoc.forQuad() == forQuad));
+        } else {
+            return false;
         }
-        if (part instanceof MekLocation) {
-            MekLocation mekLoc = (MekLocation)part;
-            /*if(mekLoc.getLoc() == Mech.LOC_HEAD && null != unit) {
-                //cockpit must either be none, or match
-                if(mekLoc.hasCockpit() && mekLoc.getCockpitType() != ((Mech)unit.getEntity()).getCockpitType()) {
-                    return false;
-                }
-            }*/
-            return mekLoc.getLoc() == loc
-                && mekLoc.getUnitTonnage() == getUnitTonnage()
-                && mekLoc.isTsm() == tsm
-                && mekLoc.getStructureType() == structureType
-                && (!isArm() || mekLoc.forQuad() == forQuad);
-        }
-        return false;
     }
 
     @Override


### PR DESCRIPTION
This fixes #2534. I also fixed a visual oddity between the two MekLocations, namely the missing IS/Clan for Endo Steel when replacing them. 