### PR TITLE
Preventing NONE Primary Role Hiring

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -22,7 +22,6 @@ import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.awt.event.KeyEvent;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
@@ -311,13 +310,7 @@ public enum PersonnelRole {
      * @return a list of roles that can be included in the personnel market
      */
     public static List<PersonnelRole> getMarketableRoles() {
-        final List<PersonnelRole> marketableRoles = new ArrayList<>();
-        for (final PersonnelRole role : values()) {
-            if (role.isMarketable()) {
-                marketableRoles.add(role);
-            }
-        }
-        return marketableRoles;
+        return Stream.of(values()).filter(PersonnelRole::isMarketable).collect(Collectors.toList());
     }
 
     /**
@@ -331,52 +324,28 @@ public enum PersonnelRole {
      * @return a list of roles that are considered to be vessel (as in spacecraft) crewmembers
      */
     public static List<PersonnelRole> getVesselRoles() {
-        final List<PersonnelRole> vesselRoles = new ArrayList<>();
-        for (final PersonnelRole role : values()) {
-            if (role.isVesselCrewmember()) {
-                vesselRoles.add(role);
-            }
-        }
-        return vesselRoles;
+        return Stream.of(values()).filter(PersonnelRole::isVesselCrewmember).collect(Collectors.toList());
     }
 
     /**
      * @return a list of roles that are considered to be techs
      */
     public static List<PersonnelRole> getTechRoles() {
-        final List<PersonnelRole> techRoles = new ArrayList<>();
-        for (final PersonnelRole role : values()) {
-            if (role.isTech()) {
-                techRoles.add(role);
-            }
-        }
-        return techRoles;
+        return Stream.of(values()).filter(PersonnelRole::isTech).collect(Collectors.toList());
     }
 
     /**
      * @return a list of all roles that are considered to be administrators
      */
     public static List<PersonnelRole> getAdministratorRoles() {
-        final List<PersonnelRole> administratorRoles = new ArrayList<>();
-        for (final PersonnelRole role : values()) {
-            if (role.isAdministrator()) {
-                administratorRoles.add(role);
-            }
-        }
-        return administratorRoles;
+        return Stream.of(values()).filter(PersonnelRole::isAdministrator).collect(Collectors.toList());
     }
 
     /**
      * @return the number of roles that are not tagged as marketable
      */
     public static int getUnmarketableCount() {
-        int unmarketable = 0;
-        for (final PersonnelRole role : values()) {
-            if (!role.isMarketable()) {
-                unmarketable++;
-            }
-        }
-        return unmarketable;
+        return Math.toIntExact(Stream.of(values()).filter(role -> !role.isMarketable()).count());
     }
     //endregion Static Methods
 

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -25,6 +25,8 @@ import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public enum PersonnelRole {
     //region Enum Declarations
@@ -316,6 +318,13 @@ public enum PersonnelRole {
             }
         }
         return marketableRoles;
+    }
+
+    /**
+     * @return a list of roles that are potential primary roles. Currently this is all bar NONE
+     */
+    public static List<PersonnelRole> getPrimaryRoles() {
+        return Stream.of(values()).filter(role -> !role.isNone()).collect(Collectors.toList());
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -832,7 +832,7 @@ public class CampaignGUI extends JPanel {
 
         JMenu menuHire = new JMenu(resourceMap.getString("menuHire.text"));
         menuHire.setMnemonic(KeyEvent.VK_H);
-        for (PersonnelRole role : PersonnelRole.values()) {
+        for (PersonnelRole role : PersonnelRole.getPrimaryRoles()) {
             JMenuItem miHire = new JMenuItem(role.getName(getCampaign().getFaction().isClan()));
             if (role.getMnemonic() != KeyEvent.VK_UNDEFINED) {
                 miHire.setMnemonic(role.getMnemonic());

--- a/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
@@ -111,8 +111,7 @@ public class HireBulkPersonnelDialog extends JDialog {
         getContentPane().add(new JLabel(resourceMap.getString("lblType.text")), newConstraints(0, 0));
 
         DefaultComboBoxModel<PersonTypeItem> personTypeModel = new DefaultComboBoxModel<>();
-        final PersonnelRole[] personnelRoles = PersonnelRole.values();
-        for (PersonnelRole personnelRole : personnelRoles) {
+        for (final PersonnelRole personnelRole : PersonnelRole.getPrimaryRoles()) {
             personTypeModel.addElement(new PersonTypeItem(personnelRole.getName(campaign.getFaction().isClan()), personnelRole));
         }
         choiceType.setModel(personTypeModel);


### PR DESCRIPTION
The NONE Role is supposed to be a secondary role only. This prevents you from hiring a person with NONE as a primary role.

The second commit refactors the personnel role methods into streams