### PR TITLE
2485: Default Subcontract Name, Briefing Tab Mission Tracking

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -426,8 +426,8 @@ public class ContractMarket implements Serializable {
         contract.calculateContract(campaign);
 
         contract.setName(String.format("%s - %s - %s %s",
-                campaign.getLocalDate().format(DateTimeFormatter.ofPattern("yyyy")), employer,
-                        contract.getSystem().getName(campaign.getLocalDate()),
+                contract.getStartDate().format(DateTimeFormatter.ofPattern("yyyy")), employer,
+                        contract.getSystem().getName(contract.getStartDate()),
                         AtBContract.missionTypeNames[contract.getMissionType()]));
 
         return contract;
@@ -514,6 +514,11 @@ public class ContractMarket implements Serializable {
         contract.calculatePaymentMultiplier(campaign);
         contract.calculatePartsAvailabilityLevel(campaign);
         contract.calculateContract(campaign);
+
+        contract.setName(String.format("%s - %s - %s Subcontract %s",
+                contract.getStartDate().format(DateTimeFormatter.ofPattern("yyyy")), contract.getEmployer(),
+                contract.getSystem().getName(parent.getStartDate()),
+                AtBContract.missionTypeNames[contract.getMissionType()]));
 
         return contract;
     }

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -152,9 +152,9 @@ public class Mission implements Serializable, MekHqXmlSerializable {
     public List<Scenario> getScenarios() {
         return scenarios;
     }
-    
+
     public List<Scenario> getVisibleScenarios() {
-        return getScenarios().stream().filter(scenario -> !scenario.isCloaked()).collect(Collectors.toList()); 
+        return getScenarios().stream().filter(scenario -> !scenario.isCloaked()).collect(Collectors.toList());
     }
 
     public List<Scenario> getCurrentScenarios() {
@@ -303,4 +303,9 @@ public class Mission implements Serializable, MekHqXmlSerializable {
         return retVal;
     }
     //endregion File I/O
+
+    @Override
+    public String toString() {
+        return getStatus().isCompleted() ? name + " (Complete)" : name;
+    }
 }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 - The MegaMek Team. All rights reserved.
+ * Copyright (c) 2017-2021 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -36,6 +36,7 @@ import javax.swing.*;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
+import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.common.Entity;
 import megamek.common.EntityListFile;
 import megamek.common.event.Subscribe;
@@ -98,7 +99,7 @@ public final class BriefingTab extends CampaignGuiTab {
     private JSplitPane splitScenario;
     private JSplitPane splitBrief;
     private JTable scenarioTable;
-    private JComboBox<String> choiceMission;
+    private MMComboBox<Mission> comboMission;
     private JScrollPane scrollMissionView;
     private JScrollPane scrollScenarioView;
     private JPanel panMissionButtons;
@@ -120,12 +121,10 @@ public final class BriefingTab extends CampaignGuiTab {
     private ScenarioTableModel scenarioModel;
     private TableRowSorter<ScenarioTableModel> scenarioSorter;
 
-    public int selectedMission;
     public int selectedScenario;
 
     BriefingTab(CampaignGUI gui, String tabName) {
         super(gui, tabName);
-        selectedMission = -1;
         selectedScenario = -1;
         MekHQ.registerHandler(this);
     }
@@ -156,8 +155,8 @@ public final class BriefingTab extends CampaignGuiTab {
         gridBagConstraints.weighty = 0.0;
         panMission.add(new JLabel(resourceMap.getString("lblMission.text")), gridBagConstraints);
 
-        choiceMission = new JComboBox<>();
-        choiceMission.addActionListener(ev -> changeMission());
+        comboMission = new MMComboBox<>("comboMission");
+        comboMission.addActionListener(ev -> changeMission());
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
@@ -165,7 +164,7 @@ public final class BriefingTab extends CampaignGuiTab {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 0.0;
-        panMission.add(choiceMission, gridBagConstraints);
+        panMission.add(comboMission, gridBagConstraints);
 
         panMissionButtons = new JPanel(new GridLayout(2, 3));
         gridBagConstraints = new GridBagConstraints();
@@ -334,43 +333,36 @@ public final class BriefingTab extends CampaignGuiTab {
                     : new NewContractDialog(getFrame(), true, getCampaign());
             ncd.setVisible(true);
             this.setVisible(false);
-            if (ncd.getContractId() != -1) {
-                selectedMission = ncd.getContractId();
-            }
+            comboMission.setSelectedItem(ncd.getContract());
         } else {
             CustomizeMissionDialog cmd = new CustomizeMissionDialog(getFrame(), true, null, getCampaign());
             cmd.setVisible(true);
             this.setVisible(false);
-            if (cmd.getMissionId() != -1) {
-                selectedMission = cmd.getMissionId();
-            }
+            comboMission.setSelectedItem(cmd.getMission());
         }
     }
 
     private void editMission() {
-        Mission mission = getCampaign().getMission(selectedMission);
-        if (null != mission) {
-            if (getCampaign().getCampaignOptions().getUseAtB() && (mission instanceof AtBContract)) {
-                CustomizeAtBContractDialog cmd = new CustomizeAtBContractDialog(getFrame(), true,
-                        (AtBContract) mission, getCampaign());
-                cmd.setVisible(true);
-                if (cmd.getMissionId() != -1) {
-                    selectedMission = cmd.getMissionId();
-                }
-            } else {
-                CustomizeMissionDialog cmd = new CustomizeMissionDialog(getFrame(), true, mission, getCampaign());
-                cmd.setVisible(true);
-                if (cmd.getMissionId() != -1) {
-                    selectedMission = cmd.getMissionId();
-                }
-            }
-            MekHQ.triggerEvent(new MissionChangedEvent(mission));
+        final Mission mission = comboMission.getSelectedItem();
+        if (mission == null) {
+            return;
         }
 
+        if (getCampaign().getCampaignOptions().getUseAtB() && (mission instanceof AtBContract)) {
+            CustomizeAtBContractDialog cmd = new CustomizeAtBContractDialog(getFrame(), true,
+                    (AtBContract) mission, getCampaign());
+            cmd.setVisible(true);
+            comboMission.setSelectedItem(cmd.getAtBContract());
+        } else {
+            CustomizeMissionDialog cmd = new CustomizeMissionDialog(getFrame(), true, mission, getCampaign());
+            cmd.setVisible(true);
+            comboMission.setSelectedItem(cmd.getMission());
+        }
+        MekHQ.triggerEvent(new MissionChangedEvent(mission));
     }
 
     private void completeMission() {
-        Mission mission = getCampaign().getMission(selectedMission);
+        final Mission mission = comboMission.getSelectedItem();
         if (mission == null) {
             return;
         } else if (mission.hasPendingScenarios()) {
@@ -429,14 +421,14 @@ public final class BriefingTab extends CampaignGuiTab {
             ((AtBContract) mission).checkForFollowup(getCampaign());
         }
 
-        List<Mission> missions = getCampaign().getSortedMissions();
-        selectedMission = missions.isEmpty() ? -1 : missions.get(0).getId();
+        final List<Mission> missions = getCampaign().getSortedMissions();
+        comboMission.setSelectedItem(missions.isEmpty() ? null : missions.get(0));
     }
 
     private void deleteMission() {
-        final Mission mission = getCampaign().getMission(selectedMission);
+        final Mission mission = comboMission.getSelectedItem();
         if (mission == null) {
-            MekHQ.getLogger().error("Cannot remove null mission with id " + selectedMission);
+            MekHQ.getLogger().error("Cannot remove null mission");
             return;
         }
         MekHQ.getLogger().debug("Attempting to Delete Mission, Mission ID: " + mission.getId());
@@ -445,8 +437,8 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
         getCampaign().removeMission(mission);
-        List<Mission> missions = getCampaign().getSortedMissions();
-        selectedMission = missions.isEmpty() ? -1 : missions.get(0).getId();
+        final List<Mission> missions = getCampaign().getSortedMissions();
+        comboMission.setSelectedItem(missions.isEmpty() ? null : missions.get(0));
         MekHQ.triggerEvent(new MissionRemovedEvent(mission));
     }
 
@@ -467,11 +459,13 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     private void addScenario() {
-        Mission m = getCampaign().getMission(selectedMission);
-        if (null != m) {
-            CustomizeScenarioDialog csd = new CustomizeScenarioDialog(getFrame(), true, null, m, getCampaign());
-            csd.setVisible(true);
+        final Mission mission = comboMission.getSelectedItem();
+        if (mission == null) {
+            return;
         }
+
+        CustomizeScenarioDialog csd = new CustomizeScenarioDialog(getFrame(), true, null, mission, getCampaign());
+        csd.setVisible(true);
         //need to update the scenario table and refresh the scroll view
         refreshScenarioTableData();
         scrollMissionView.revalidate();
@@ -789,22 +783,16 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     public void refreshMissions() {
-        choiceMission.removeAllItems();
-        List<Mission> missions = getCampaign().getSortedMissions();
-        for (Mission m : missions) {
-            String desc = m.getName();
-            if (m.getStatus().isCompleted()) {
-                desc += " (Complete)";
-            }
-            choiceMission.addItem(desc);
-            if (m.getId() == selectedMission) {
-                choiceMission.setSelectedItem(m.getName());
-            }
+        comboMission.removeAllItems();
+        final List<Mission> missions = getCampaign().getSortedMissions();
+        for (final Mission mission : missions) {
+            comboMission.addItem(mission);
         }
-        if ((choiceMission.getSelectedIndex() == -1) && !missions.isEmpty()) {
-            selectedMission = missions.get(0).getId();
-            choiceMission.setSelectedIndex(0);
+
+        if ((comboMission.getSelectedIndex() == -1) && !missions.isEmpty()) {
+            comboMission.setSelectedIndex(0);
         }
+
         changeMission();
         if (getCampaign().getCampaignOptions().getUseAtB()) {
             refreshLanceAssignments();
@@ -873,41 +861,31 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     public void changeMission() {
-        int idx = choiceMission.getSelectedIndex();
-        btnEditMission.setEnabled(false);
-        btnCompleteMission.setEnabled(false);
-        btnDeleteMission.setEnabled(false);
-        btnAddScenario.setEnabled(false);
-        btnGMGenerateScenarios.setEnabled(false);
-        List<Mission> missions = getCampaign().getSortedMissions();
-        if ((idx >= 0) && (idx < missions.size())) {
-            Mission m = missions.get(idx);
-            if (m != null) {
-                selectedMission = m.getId();
-                scrollMissionView.setViewportView(new MissionViewPanel(m, scenarioTable, getCampaignGui()));
-                // This odd code is to make sure that the scrollbar stays at the top
-                // I can't just call it here, because it ends up getting reset somewhere later
-                javax.swing.SwingUtilities.invokeLater(() -> scrollMissionView.getVerticalScrollBar().setValue(0));
-                btnEditMission.setEnabled(true);
-                btnCompleteMission.setEnabled(m.getStatus().isActive());
-                btnDeleteMission.setEnabled(true);
-                btnAddScenario.setEnabled(m.isActiveOn(getCampaign().getLocalDate()));
-                btnGMGenerateScenarios.setEnabled(m.isActiveOn(getCampaign().getLocalDate()) && getCampaign().isGM());
-            }
-        } else {
-            selectedMission = -1;
+        final Mission mission = comboMission.getSelectedItem();
+        if (mission == null) {
             scrollMissionView.setViewportView(null);
+            btnEditMission.setEnabled(false);
+            btnCompleteMission.setEnabled(false);
+            btnDeleteMission.setEnabled(false);
+            btnAddScenario.setEnabled(false);
+            btnGMGenerateScenarios.setEnabled(false);
+        } else {
+            scrollMissionView.setViewportView(new MissionViewPanel(mission, scenarioTable, getCampaignGui()));
+            // This odd code is to make sure that the scrollbar stays at the top
+            // I can't just call it here, because it ends up getting reset somewhere later
+            SwingUtilities.invokeLater(() -> scrollMissionView.getVerticalScrollBar().setValue(0));
+            btnEditMission.setEnabled(true);
+            btnCompleteMission.setEnabled(mission.getStatus().isActive());
+            btnDeleteMission.setEnabled(true);
+            btnAddScenario.setEnabled(mission.isActiveOn(getCampaign().getLocalDate()));
+            btnGMGenerateScenarios.setEnabled(mission.isActiveOn(getCampaign().getLocalDate()) && getCampaign().isGM());
         }
         refreshScenarioTableData();
     }
 
     public void refreshScenarioTableData() {
-        Mission m = getCampaign().getMission(selectedMission);
-        if (null != m) {
-            scenarioModel.setData(m.getVisibleScenarios());
-        } else {
-            scenarioModel.setData(new ArrayList<Scenario>());
-        }
+        final Mission mission = comboMission.getSelectedItem();
+        scenarioModel.setData((mission == null) ? new ArrayList<Scenario>() : mission.getVisibleScenarios());
         selectedScenario = -1;
         scenarioTable.setPreferredScrollableViewportSize(scenarioTable.getPreferredSize());
         scenarioTable.setFillsViewportHeight(true);
@@ -925,10 +903,13 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     @Subscribe
-    public void handle(ScenarioChangedEvent ev) {
-        if (ev.getScenario() != null && ev.getScenario().getMissionId() == selectedMission) {
+    public void handle(ScenarioChangedEvent evt) {
+        final Mission mission = comboMission.getSelectedItem();
+        if ((evt.getScenario() != null)
+                && (((mission == null) && (evt.getScenario().getMissionId() == -1))
+                || (mission != null) && (evt.getScenario().getMissionId() == mission.getId()))) {
             scenarioTable.repaint();
-            if (ev.getScenario().getId() == selectedScenario) {
+            if (evt.getScenario().getId() == selectedScenario) {
                 scenarioViewScheduler.schedule();
             }
             scenarioDataScheduler.schedule();
@@ -974,8 +955,9 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     @Subscribe
-    public void handle(MissionChangedEvent ev) {
-        if (ev.getMission().getId() == selectedMission) {
+    public void handle(MissionChangedEvent evt) {
+        final Mission mission = comboMission.getSelectedItem();
+        if ((mission != null) && (evt.getMission().getId() == mission.getId())) {
             changeMission();
         }
     }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -97,6 +97,10 @@ public class CustomizeAtBContractDialog extends JDialog {
         setUserPreferences();
     }
 
+    public AtBContract getAtBContract() {
+        return contract;
+    }
+
     private void initComponents() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.NewContractDialog", new EncodeControl());
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
@@ -547,9 +551,4 @@ public class CustomizeAtBContractDialog extends JDialog {
             cbEnemy.addFactionEntries(currentFactions, campaign.getGameYear());
         }
     }
-
-    public int getMissionId() {
-        return contract.getId();
-    }
-
 }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeMissionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeMissionDialog.java
@@ -34,24 +34,25 @@ import mekhq.gui.utilities.JSuggestField;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import megamek.client.ui.preferences.PreferencesNode;
 
+import javax.swing.*;
+
 /**
  * @author  Taharqa
  */
 public class CustomizeMissionDialog extends javax.swing.JDialog {
-	private static final long serialVersionUID = -8038099101234445018L;
+    private static final long serialVersionUID = -8038099101234445018L;
     private Mission mission;
     private Campaign campaign;
     private boolean newMission;
 
-    /** Creates new form NewTeamDialog */
-    public CustomizeMissionDialog(java.awt.Frame parent, boolean modal, Mission m, Campaign c) {
+    public CustomizeMissionDialog(JFrame parent, boolean modal, Mission m, Campaign c) {
         super(parent, modal);
-        if(null == m) {
-        	mission = new Mission("New Mission");
-        	newMission = true;
+        if (null == m) {
+            mission = new Mission("New Mission");
+            newMission = true;
         } else {
-        	mission = m;
-        	newMission = false;
+            mission = m;
+            newMission = false;
         }
         campaign = c;
         initComponents();
@@ -60,8 +61,12 @@ public class CustomizeMissionDialog extends javax.swing.JDialog {
         pack();
     }
 
+    public Mission getMission() {
+        return mission;
+    }
+
     private void initComponents() {
-    	 java.awt.GridBagConstraints gridBagConstraints;
+        java.awt.GridBagConstraints gridBagConstraints;
 
         txtName = new javax.swing.JTextField();
         lblName = new javax.swing.JLabel();
@@ -194,36 +199,30 @@ public class CustomizeMissionDialog extends javax.swing.JDialog {
         preferences.manage(new JWindowPreference(this));
     }
 
-    private void btnOKActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnHireActionPerformed
+    private void btnOKActionPerformed(java.awt.event.ActionEvent evt) {
+        mission.setName(txtName.getText());
+        mission.setType(txtType.getText());
 
-    	mission.setName(txtName.getText());
-    	mission.setType(txtType.getText());
-
-    	PlanetarySystem canonSystem = Systems.getInstance().getSystemByName(suggestPlanet.getText(),
+        PlanetarySystem canonSystem = Systems.getInstance().getSystemByName(suggestPlanet.getText(),
                 campaign.getLocalDate());
 
-    	if (canonSystem != null) {
-    	    mission.setSystemId(canonSystem.getId());
-    	} else {
-    	    mission.setSystemId(null);
-    	    mission.setLegacyPlanetName(suggestPlanet.getText());
-    	}
+        if (canonSystem != null) {
+            mission.setSystemId(canonSystem.getId());
+        } else {
+            mission.setSystemId(null);
+            mission.setLegacyPlanetName(suggestPlanet.getText());
+        }
 
-    	mission.setDesc(txtDesc.getText());
-    	if (newMission) {
-    		campaign.addMission(mission);
-    	}
-    	this.setVisible(false);
-    }
-
-    public int getMissionId() {
-    	return mission.getId();
+        mission.setDesc(txtDesc.getText());
+        if (newMission) {
+            campaign.addMission(mission);
+        }
+        this.setVisible(false);
     }
 
     private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnCloseActionPerformed
-    	this.setVisible(false);
+        this.setVisible(false);
     }
-    // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnClose;
     private javax.swing.JButton btnOK;
     private javax.swing.JLabel lblName;
@@ -232,9 +231,5 @@ public class CustomizeMissionDialog extends javax.swing.JDialog {
     private javax.swing.JTextField txtType;
     private MarkdownEditorPanel txtDesc;
     private javax.swing.JLabel lblPlanetName;
-	private JSuggestField suggestPlanet;
-
-
-    // End of variables declaration//GEN-END:variables
-
+    private JSuggestField suggestPlanet;
 }

--- a/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
@@ -94,6 +94,10 @@ public class NewContractDialog extends JDialog {
         setUserPreferences();
     }
 
+    public Contract getContract() {
+        return contract;
+    }
+
     protected void initComponents() {
         java.awt.GridBagConstraints gridBagConstraints;
 
@@ -711,26 +715,6 @@ public class NewContractDialog extends JDialog {
             btnDate.setText(MekHQ.getMekHQOptions().getDisplayFormattedDate(contract.getStartDate()));
         }
     }
-
-    public int getContractId() {
-        return contract.getId();
-    }
-
-    /*
-    private void refreshTotals() {
-        lblBaseAmount2.setText(formatter.format(contract.getBaseAmount()));
-        lblOverheadAmount2.setText("+" + formatter.format(contract.getOverheadAmount()));
-        lblSupportAmount2.setText("+" + formatter.format(contract.getSupportAmount()));
-        lblTransitAmount2.setText("+" + formatter.format(contract.getTransitAmount()));
-        lblTransportAmount2.setText("+" + formatter.format(contract.getTransportAmount()));
-        lblTotalAmount2.setText(formatter.format(contract.getTotalAmount()));
-        lblSignBonusAmount2.setText("+" + formatter.format(contract.getSigningBonusAmount()));
-        lblFeeAmount2.setText("-" + formatter.format(contract.getFeeAmount()));
-        lblTotalAmountPlus2.setText(formatter.format(contract.getTotalAmountPlusFeesAndBonuses()));
-        lblAdvanceMoney2.setText(formatter.format(contract.getTotalAdvanceAmount()));
-        lblMonthlyAmount2.setText(formatter.format(contract.getMonthlyPayOut()));
-        lblProfit2.setText(formatter.format(contract.getEstimatedTotalProfit(campaign)));
-    }*/
 
     private void btnCloseActionPerformed(ActionEvent evt) {
         if (!btnClose.equals(evt.getSource())) {


### PR DESCRIPTION
This fixes #2485 by adding a default subcontract name, adding an override of toString for Mission, and swapping the Briefing Tab to use the Mission objects instead of tracking using an id.

It also fixes a minor bug where the contract name would be dated using the wrong date, namely the current day instead of the start date.