### PR TITLE
Prevent expired contracts from disappearing outright; duplicate unit selection fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -174,6 +174,7 @@ public class StratconScenario implements IStratconDisplayable {
         
         if (this.isRequiredScenario()) {
             stateBuilder.append("<span color='red'>Deployment required by contract</span>").append(html ? "<br/>" : "");
+            stateBuilder.append("<span color='red'>-1 VP if lost/ignored; +1 VP if won</span>").append(html ? "<br/>" : "");
         }
         
         stateBuilder.append("Status: ")

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -159,7 +159,7 @@ public class StratconScenario implements IStratconDisplayable {
     public String getInfo(boolean html) {
         StringBuilder stateBuilder = new StringBuilder();
 
-        if (this.isStrategicObjective) {
+        if (isStrategicObjective()) {
             stateBuilder.append("<span color='red'>Contract objective located</span>").append(html ? "<br/>" : "");
         }
         
@@ -172,9 +172,9 @@ public class StratconScenario implements IStratconDisplayable {
                 .append(html ? "<br/>" : "");
         }
         
-        if (this.isRequiredScenario()) {
-            stateBuilder.append("<span color='red'>Deployment required by contract</span>").append(html ? "<br/>" : "");
-            stateBuilder.append("<span color='red'>-1 VP if lost/ignored; +1 VP if won</span>").append(html ? "<br/>" : "");
+        if (isRequiredScenario()) {
+            stateBuilder.append("<span color='red'>Deployment required by contract</span>").append(html ? "<br/>" : "")
+                .append("<span color='red'>-1 VP if lost/ignored; +1 VP if won</span>").append(html ? "<br/>" : "");
         }
         
         stateBuilder.append("Status: ")

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -21,6 +21,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.time.LocalDate;
 import java.util.Objects;
 
 import javax.swing.BoxLayout;
@@ -196,7 +197,9 @@ public class StratconTab extends CampaignGuiTab {
         }
         AtBContract currentContract = currentTDI.contract;
         
-        if (!currentContract.isActiveOn(getCampaignGui().getCampaign().getLocalDate())) {
+        LocalDate currentDate = getCampaignGui().getCampaign().getLocalDate();
+        
+        if (currentContract.getStartDate().isAfter(currentDate)) {
             campaignStatusText.setText("Contract has not started.");
             expandedObjectivePanel.setVisible(false);
             return;
@@ -210,6 +213,10 @@ public class StratconTab extends CampaignGuiTab {
             .append(currentContract.getMissionTypeName()).append(": ").append(currentContract.getName())
             .append("<br/>")
             .append(campaignState.getBriefingText());
+        
+        if (currentContract.getEndingDate().isBefore(currentDate)) {
+            sb.append("<br/>Contract term has expired!");
+        }
         
         sb.append("<br/>Victory Points: ").append(campaignState.getVictoryPoints())
             .append("<br/>Support Points: ").append(campaignState.getSupportPoints())
@@ -367,12 +374,10 @@ public class StratconTab extends CampaignGuiTab {
         cboCurrentTrack.removeAllItems();
         
         // track dropdown is populated with all tracks across all active contracts
-        for (Contract contract : getCampaignGui().getCampaign().getActiveContracts()) {
-            if ((contract instanceof AtBContract) && 
-            		contract.isActiveOn(getCampaignGui().getCampaign().getLocalDate()) && 
-            		(((AtBContract) contract).getStratconCampaignState() != null)) {
-                for (StratconTrackState track : ((AtBContract) contract).getStratconCampaignState().getTracks()) {
-                    TrackDropdownItem tdi = new TrackDropdownItem((AtBContract) contract, track);
+        for (AtBContract contract : getCampaignGui().getCampaign().getActiveAtBContracts(true)) {
+            if (contract.getStratconCampaignState() != null) {
+                for (StratconTrackState track : contract.getStratconCampaignState().getTracks()) {
+                    TrackDropdownItem tdi = new TrackDropdownItem(contract, track);
                     cboCurrentTrack.addItem(tdi);
                     
                     if ((currentTDI != null) && currentTDI.equals(tdi)) {

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -22,6 +22,7 @@ import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -579,6 +580,22 @@ public class StratconScenarioWizard extends JDialog {
             btnCommit.setEnabled(true);
         }
 
+        // go through the other unit lists in the wizard and deselect the selected units
+        // to avoid "issues" and "unpredictable behavior"
+        for (JList<Unit> unitList : availableUnitLists.values()) {
+            if (!changedList.equals(unitList)) {
+                unselectDuplicateUnits(unitList, changedList.getSelectedValuesList());
+            }
+        }
+        
+        if (!changedList.equals(availableInfantryUnits)) {
+            unselectDuplicateUnits(availableInfantryUnits, changedList.getSelectedValuesList());
+        }
+        
+        if (!changedList.equals(availableLeadershipUnits)) {
+            unselectDuplicateUnits(availableLeadershipUnits, changedList.getSelectedValuesList());
+        }
+        
         StringBuilder sb = new StringBuilder();
         sb.append("<html>");
 
@@ -590,6 +607,23 @@ public class StratconScenarioWizard extends JDialog {
 
         unitStatusLabel.setText(sb.toString());
         pack();
+    }
+    
+    /**
+     * Worker function that de-selects duplicate units.
+     * @param listToProcess
+     * @param selectedUnits
+     */
+    private void unselectDuplicateUnits(JList<Unit> listToProcess, List<Unit> selectedUnits) {
+        for (Unit selectedUnit : selectedUnits) {
+            for (int potentialClearIndex : listToProcess.getSelectedIndices()) {
+                Unit potentialClearTarget = listToProcess.getModel().getElementAt(potentialClearIndex);
+                
+                if (potentialClearTarget.getId().equals(selectedUnit.getId())) {
+                    listToProcess.removeSelectionInterval(potentialClearIndex, potentialClearIndex);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
A couple of changes:
- some descriptive text to indicate that a scenario will provide campaign VP
- expired contracts still show up in StratCon tab for now; updated text for expired contracts (partial fix for #2657)
- If a selected unit in the scenario wizard is selected in other unit lists, remove it from those. Fix for #2661