### PR TITLE
Ignorable Nag Dialogs

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -49,6 +49,13 @@ ProcurementTableMouseAdapter.GMAdded.report=<font color='Green'><b>GM Added %s</
 
 
 
+#### Base Components
+### AbstractMHQNagDialog
+chkIgnore.text=Do not bother me again
+chkIgnore.toolTipText=If selected this nag will no longer show until re-enabled under MekHQ Options.
+
+
+
 #### Dialog
 ### AddOrEditPersonnelEntryDialog Class
 AddOrEditPersonnelEntryDialog.AddEntry.title=Add Log Entry
@@ -70,6 +77,34 @@ chkSwapToRankSystem.toolTipText=This will swap you to having this rank system wh
 CustomRankSystemCreationDialog.BlankRankSystemCode.text=The entered rank system code cannot be blank.
 CustomRankSystemCreationDialog.BlankRankSystemName.text=The entered rank system name cannot be blank.
 CustomRankSystemCreationDialog.DuplicateCode.text=The entered rank system code cannot duplicate an existing code, as all rank systems must have a unique system code.
+
+### InsufficientAstechsNagDialog Class
+InsufficientAstechsNagDialog.title=Astech Shortage
+InsufficientAstechsNagDialog.text=You do not have enough astechs for your techs. You need %d more astech(s). Do you wish to proceed?
+
+### InsufficientAstechTimeNagDialog Class
+InsufficientAstechTimeNagDialog.title=Astech Shortage
+InsufficientAstechTimeNagDialog.text=You do not have enough remaining astech time for maintenance. You need %d more astech(s). Do you wish to proceed?
+
+### InsufficientMedicsNagDialog Class
+InsufficientMedicsNagDialog.title=Medic Shortage
+InsufficientMedicsNagDialog.text=You do not have enough medics for your doctors. You need %d more medic(s). Do you wish to proceed?
+
+### OutstandingScenariosNagDialog Class
+OutstandingScenariosNagDialog.title=Pending Battle
+OutstandingScenariosNagDialog.text=You have a pending battle. Failure to deploy will result in a defeat and a minor contract breach. \nDo you really wish to advance the day?
+
+### ShortDeploymentNagDialog Class
+ShortDeploymentNagDialog.title=Unmet Deployment Requirements
+ShortDeploymentNagDialog.text=You have not met the deployment levels required by your contracts. Do you really wish to advance the day?
+
+### UnmaintainedUnitsNagDialog Class
+UnmaintainedUnitsNagDialog.title=Unmaintained Units
+UnmaintainedUnitsNagDialog.text=You have unmaintained units. Do you really wish to advance the day?
+
+### UnresolvedStratConContactsNagDialog Class
+UnresolvedStratConContactsNagDialog.title=Unresolved StratCon Contacts
+UnresolvedStratConContactsNagDialog.text=You have unresolved contacts on the StratCon interface:\n%s\nAdvance day anyway?
 
 
 

--- a/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MekHqOptionsDialog.properties
@@ -83,6 +83,23 @@ optionWriteCustomsToXML.text=Write Custom Units to Campaign XML
 optionSaveMothballState.text=Save Unit State Before Mothballing
 optionSaveMothballState.toolTipText=This option allows you to disable saving of the unit's crew and force before being mothballed for restoration post-mothball.
 
+# Nag Tab
+nagTab.title=Nag Options
+optionUnmaintainedUnitsNag.text=Hide Unmaintained Units Nag
+optionUnmaintainedUnitsNag.toolTipText=This allows you to ignore the daily warning for when you have unmaintained units.
+optionInsufficientAstechsNag.text=Hide Insufficient Astechs Nag
+optionInsufficientAstechsNag.toolTipText=This allows you to ignore the daily warning for when you don't have enough astechs to support your techs.
+optionInsufficientAstechTimeNag.text=Hide Insufficient Astech Time Nag
+optionInsufficientAstechTimeNag.toolTipText=This allows you to ignore the daily warning for when you don't have enough astech time remaining for maintenance.
+optionInsufficientMedicsNag.text=Hide Insufficient Medics Nag
+optionInsufficientMedicsNag.toolTipText=This allows you to ignore the daily warning for when you don't have enough medics to support your doctors.
+optionShortDeploymentNag.text=Hide AtB Unmet Contract Lance Deployment Nag
+optionShortDeploymentNag.toolTipText=This allows you to ignore the weekly warning for not having enough lances assigned to an active AtB contract.
+optionUnresolvedStratConContactsNag.text=Hide StratCon Unresolved Contacts Nag
+optionUnresolvedStratConContactsNag.toolTipText=This allows you to ignore the daily warning for not having resolved all active contacts.
+optionOutstandingScenariosNag.text=Hide Outstanding Scenarios Nag
+optionOutstandingScenariosNag.toolTipText=This allows you to ignore the daily warning for having unfinished scenarios on the current day.
+
 #Miscellaneous Tab
 miscellaneousTab.title=Miscellaneous Options
 labelStartGameDelay.text=Delay Timer

--- a/MekHQ/src/mekhq/MekHQOptions.java
+++ b/MekHQ/src/mekhq/MekHQOptions.java
@@ -513,6 +513,16 @@ public final class MekHQOptions {
     }
     //endregion File Paths
 
+    //region Nag Tab
+    public boolean getNagDialogIgnore(final String key) {
+        return userPreferences.node(MekHqConstants.NAG_NODE).getBoolean(key, false);
+    }
+
+    public void setNagDialogIgnore(final String key, final boolean value) {
+        userPreferences.node(MekHqConstants.NAG_NODE).putBoolean(key, value);
+    }
+    //endregion Nag Tab
+
     //region Miscellaneous Options
     public int getStartGameDelay() {
         return userPreferences.node(MekHqConstants.MISCELLANEOUS_NODE).getInt(MekHqConstants.START_GAME_DELAY, 500);

--- a/MekHQ/src/mekhq/MekHqConstants.java
+++ b/MekHQ/src/mekhq/MekHqConstants.java
@@ -105,6 +105,17 @@ public final class MekHqConstants {
     public static final String INDIVIDUAL_RANK_SYSTEM_DIRECTORY_PATH = "individualRankSystemDirectoryPath";
     //endregion File Paths
 
+    //region Nag Tab
+    public static final String NAG_NODE = "mekhq/prefs/nags";
+    public static final String NAG_UNMAINTAINED_UNITS = "nagUnmaintainedUnits";
+    public static final String NAG_INSUFFICIENT_ASTECHS = "nagInsufficientAstechs";
+    public static final String NAG_INSUFFICIENT_ASTECH_TIME = "nagInsufficientAstechTime";
+    public static final String NAG_INSUFFICIENT_MEDICS = "nagInsufficientMedics";
+    public static final String NAG_SHORT_DEPLOYMENT = "nagShortDeployment";
+    public static final String NAG_UNRESOLVED_STRATCON_CONTACTS = "nagUnresolvedStratConContacts";
+    public static final String NAG_OUTSTANDING_SCENARIOS = "nagOutstandingScenarios";
+    //endregion Nag Tab
+
     //region Miscellaneous Options
     public static final String MISCELLANEOUS_NODE = "mekhq/prefs/miscellaneous";
     public static final String START_GAME_DELAY = "startGameDelay";

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2969,11 +2969,12 @@ public class Campaign implements Serializable, ITechManager {
     }
 
     /**
+     * TODO : I should be part of AtBContract, not Campaign
      * @param contract an active AtBContract
      * @return the current deployment deficit for the contract
      */
     public int getDeploymentDeficit(AtBContract contract) {
-        if (contract.isActiveOn(getLocalDate())) {
+        if (!contract.isActiveOn(getLocalDate()) || contract.getStartDate().isEqual(getLocalDate())) {
             // Do not check for deficits if the contract has not started or
             // it is the first day of the contract, as players won't have
             // had time to assign forces to the contract yet
@@ -4959,7 +4960,7 @@ public class Campaign implements Serializable, ITechManager {
             if (helpMod > 0) {
                 target.addModifier(helpMod, "shorthanded");
             }
-            
+
             // like repairs, per CamOps page 208 extra time gives a
             // reduction to the TN based on x2, x3, x4
             if (partWork.getUnit().getMaintenanceMultiplier() > 1) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -21,49 +21,29 @@
  */
 package mekhq.gui;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.io.*;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.time.DayOfWeek;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.List;
-import java.util.zip.GZIPOutputStream;
-
-import javax.swing.*;
-import javax.swing.UIManager.LookAndFeelInfo;
-import javax.xml.parsers.DocumentBuilder;
-
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
-import megamek.common.*;
-import megamek.common.options.OptionsConstants;
-import mekhq.MHQStaticDirectoryManager;
-import mekhq.MekHqConstants;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.personnel.ranks.RankSystem;
-import mekhq.campaign.personnel.ranks.Ranks;
-import mekhq.gui.dialog.*;
-import megamek.client.ui.preferences.JWindowPreference;
-import megamek.client.ui.preferences.PreferencesNode;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import chat.ChatClient;
 import megamek.client.generator.RandomUnitGenerator;
+import megamek.client.ui.preferences.JWindowPreference;
+import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.swing.GameOptionsDialog;
+import megamek.client.ui.swing.UnitLoadingDialog;
+import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
+import megamek.common.Dropship;
+import megamek.common.Entity;
+import megamek.common.Jumpship;
+import megamek.common.MULParser;
+import megamek.common.MechSummaryCache;
+import megamek.common.TechConstants;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.Subscribe;
 import megamek.common.loaders.EntityLoadingException;
+import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
 import megamek.common.util.EncodeControl;
 import mekhq.IconPackage;
+import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
+import mekhq.MekHqConstants;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.Version;
@@ -84,26 +64,98 @@ import mekhq.campaign.event.OptionsChangedEvent;
 import mekhq.campaign.event.OrganizationChangedEvent;
 import mekhq.campaign.event.PersonEvent;
 import mekhq.campaign.event.TransactionEvent;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.SpecialAbility;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.ranks.RankSystem;
+import mekhq.campaign.personnel.ranks.Ranks;
 import mekhq.campaign.report.CargoReport;
 import mekhq.campaign.report.HangarReport;
 import mekhq.campaign.report.PersonnelReport;
 import mekhq.campaign.report.RatingReport;
 import mekhq.campaign.report.Report;
 import mekhq.campaign.report.TransportReport;
-import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.campaign.universe.RandomFactionGenerator;
+import mekhq.gui.dialog.AdvanceDaysDialog;
+import mekhq.gui.dialog.BatchXPDialog;
+import mekhq.gui.dialog.CampaignExportWizard;
+import mekhq.gui.dialog.CampaignOptionsDialog;
+import mekhq.gui.dialog.ContractMarketDialog;
+import mekhq.gui.dialog.DataLoadingDialog;
+import mekhq.gui.dialog.GMToolsDialog;
+import mekhq.gui.dialog.HireBulkPersonnelDialog;
+import mekhq.gui.dialog.HistoricalDailyReportDialog;
+import mekhq.gui.dialog.InsufficientAstechTimeNagDialog;
+import mekhq.gui.dialog.InsufficientAstechsNagDialog;
+import mekhq.gui.dialog.InsufficientMedicsNagDialog;
+import mekhq.gui.dialog.MaintenanceReportDialog;
+import mekhq.gui.dialog.MassMothballDialog;
+import mekhq.gui.dialog.MekHQAboutBox;
+import mekhq.gui.dialog.MekHQUnitSelectorDialog;
+import mekhq.gui.dialog.MekHqOptionsDialog;
+import mekhq.gui.dialog.MercRosterDialog;
+import mekhq.gui.dialog.NewRecruitDialog;
+import mekhq.gui.dialog.NewsReportDialog;
+import mekhq.gui.dialog.OutstandingScenariosNagDialog;
+import mekhq.gui.dialog.PartsStoreDialog;
+import mekhq.gui.dialog.PersonnelMarketDialog;
+import mekhq.gui.dialog.PopupValueChoiceDialog;
+import mekhq.gui.dialog.RefitNameDialog;
+import mekhq.gui.dialog.ReportDialog;
+import mekhq.gui.dialog.RetirementDefectionDialog;
+import mekhq.gui.dialog.ScenarioTemplateEditorDialog;
+import mekhq.gui.dialog.ShipSearchDialog;
+import mekhq.gui.dialog.ShortDeploymentNagDialog;
+import mekhq.gui.dialog.UnitCostReportDialog;
+import mekhq.gui.dialog.UnitMarketDialog;
+import mekhq.gui.dialog.UnmaintainedUnitsNagDialog;
+import mekhq.gui.dialog.UnresolvedStratConContactsNagDialog;
 import mekhq.gui.model.PartsTableModel;
 import mekhq.io.FileType;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.swing.*;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.xml.parsers.DocumentBuilder;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.UUID;
+import java.util.Vector;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * The application's main frame.
@@ -1240,92 +1292,6 @@ public class CampaignGUI extends JPanel {
             NewsReportDialog nrd = new NewsReportDialog(frame, news);
             nrd.setVisible(true);
         }
-    }
-
-    public boolean nagShortMaintenance() {
-        if (!getCampaign().getCampaignOptions().checkMaintenance()) {
-            return false;
-        }
-        Vector<Unit> notMaintained = new Vector<>();
-        int totalAstechMinutesNeeded = 0;
-        for (Unit u : getCampaign().getHangar().getUnits()) {
-            if (u.isUnmaintained()) {
-                notMaintained.add(u);
-            } else if (u.isPresent() && (u.getEngineer() == null)) {
-                // only add astech minutes for non-crewed units who are present
-                totalAstechMinutesNeeded += (u.getMaintenanceTime() * 6);
-            }
-        }
-
-        if (notMaintained.size() > 0) {
-            if (JOptionPane.YES_OPTION != JOptionPane
-                    .showConfirmDialog(
-                            null,
-                            "You have unmaintained units. Do you really wish to advance the day?",
-                            "Unmaintained Units", JOptionPane.YES_NO_OPTION)) {
-                return true;
-            }
-        }
-
-        int minutesAvail = getCampaign().getPossibleAstechPoolMinutes();
-        if (getCampaign().isOvertimeAllowed()) {
-            minutesAvail += getCampaign().getPossibleAstechPoolOvertime();
-        }
-        if (minutesAvail < totalAstechMinutesNeeded) {
-            int needed = (int) Math.ceil((totalAstechMinutesNeeded - minutesAvail) / 480D);
-            return JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(null,
-                    "You do not have enough astechs to provide for full maintenance. You need "
-                            + needed + " more astech(s). Do you wish to proceed?",
-                    "Astech shortage", JOptionPane.YES_NO_OPTION);
-        }
-
-        return false;
-    }
-
-    public boolean nagShortDeployments() {
-        if (getCampaign().getLocalDate().getDayOfWeek() != DayOfWeek.SUNDAY) {
-            return false;
-        }
-        for (AtBContract contract : getCampaign().getActiveAtBContracts()) {
-            if (!getCampaign().getLocation().isOnPlanet()) {
-                continue;
-            }
-
-            if (getCampaign().getDeploymentDeficit(contract) > 0) {
-                return 0 != JOptionPane.showConfirmDialog(null,
-                        "You have not met the deployment levels required by contract. Do your really wish to advance the day?",
-                        "Unmet deployment requirements", JOptionPane.YES_NO_OPTION);
-            }
-        }
-        return false;
-    }
-
-    public boolean nagOutstandingScenarios() {
-        for (final AtBContract contract : getCampaign().getActiveAtBContracts(true)) {
-            for (final Scenario scenario : contract.getCurrentAtBScenarios()) {
-                if (getCampaign().getLocalDate().equals(scenario.getDate())) {
-                    return 0 != JOptionPane.showConfirmDialog(null,
-                            "You have a pending battle. Failure to deploy will result in a defeat and a minor contract breach. Do your really wish to advance the day?",
-                            "Pending battle", JOptionPane.YES_NO_OPTION);
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Displays a nag if the StratCon UI has unresolved hostile forces
-     */
-    public boolean nagUnresolvedStratconContacts() {
-        String nagText = StratconRulesManager.nagUnresolvedContacts(getCampaign());
-
-        if (!nagText.isEmpty()) {
-            return 0 != JOptionPane.showConfirmDialog(null,
-                    String.format("You have unresolved contacts on the StratCon interface:\n%s\nAdvance day anyway?", nagText),
-                    "Unresolved Stratcon Contacts", JOptionPane.YES_NO_OPTION);
-        }
-
-        return false;
     }
 
     private void hirePerson(final ActionEvent evt) {
@@ -2591,43 +2557,61 @@ public class CampaignGUI extends JPanel {
     private ActionScheduler fundsScheduler = new ActionScheduler(this::refreshFunds);
 
     @Subscribe
-    public void handleDayEnding(DayEndingEvent ev) {
+    public void handleDayEnding(DayEndingEvent evt) {
         // first check for overdue loan payments - don't allow advancement until
         // these are addressed
         if (getCampaign().checkOverDueLoans()) {
             refreshFunds();
             showOverdueLoansDialog();
-            ev.cancel();
+            evt.cancel();
             return;
         }
+
         if (getCampaign().checkRetirementDefections()) {
             showRetirementDefectionDialog();
-            ev.cancel();
+            evt.cancel();
             return;
         }
+
         if (getCampaign().checkYearlyRetirements()) {
             showRetirementDefectionDialog();
-            ev.cancel();
+            evt.cancel();
             return;
         }
-        if (nagShortMaintenance()) {
-            ev.cancel();
+
+        if (new UnmaintainedUnitsNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+            evt.cancel();
             return;
         }
+
+        if (new InsufficientAstechsNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+            evt.cancel();
+            return;
+        }
+
+        if (new InsufficientAstechTimeNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+            evt.cancel();
+            return;
+        }
+
+        if (new InsufficientMedicsNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+            evt.cancel();
+            return;
+        }
+
         if (getCampaign().getCampaignOptions().getUseAtB()) {
-            if (nagShortDeployments()) {
-                ev.cancel();
+            if (new ShortDeploymentNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+                evt.cancel();
                 return;
             }
 
-            if (getCampaign().getCampaignOptions().getUseStratCon() &&
-                    nagUnresolvedStratconContacts()) {
-                ev.cancel();
+            if (new UnresolvedStratConContactsNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+                evt.cancel();
                 return;
             }
 
-            if (nagOutstandingScenarios()) {
-                ev.cancel();
+            if (new OutstandingScenariosNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+                evt.cancel();
                 return;
             }
         }

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQNagDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQNagDialog.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.baseComponents;
+
+import megamek.client.ui.enums.DialogResult;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+
+import javax.swing.*;
+import java.awt.*;
+
+public abstract class AbstractMHQNagDialog extends AbstractMHQButtonDialog {
+    //region Variable Declarations
+    private final String key;
+    private final boolean show;
+    private String description;
+    private JCheckBox chkIgnore;
+    //endregion Variable Declarations
+
+    //region Constructors
+    protected AbstractMHQNagDialog(final JFrame frame, final String name, final String title,
+                                   final Campaign campaign, final String key) {
+        super(frame, name, title);
+        this.key = key;
+        this.show = checkNag(campaign);
+        setDescription("");
+        if (isShow()) {
+            initialize();
+        } else {
+            setResult(DialogResult.CONFIRMED);
+        }
+    }
+    //endregion Constructors
+
+    //region Getters
+    public String getKey() {
+        return key;
+    }
+
+    public boolean isShow() {
+        return show;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(final String description) {
+        this.description = description;
+    }
+
+    public JCheckBox getChkIgnore() {
+        return chkIgnore;
+    }
+
+    public void setChkIgnore(final JCheckBox chkIgnore) {
+        this.chkIgnore = chkIgnore;
+    }
+    //endregion Getters
+
+    //region Initialization
+    @Override
+    protected Container createCenterPane() {
+        // Create Panel Components
+        final JTextArea txtDescription = new JTextArea(getDescription());
+        txtDescription.setName("txtDescription");
+        txtDescription.setEditable(false);
+        txtDescription.setOpaque(false);
+
+        setChkIgnore(new JCheckBox(resources.getString("chkIgnore.text")));
+        getChkIgnore().setToolTipText(resources.getString("chkIgnore.toolTipText"));
+        getChkIgnore().setName("chkIgnore");
+
+        // Layout the UI
+        final JPanel panel = new JPanel();
+        panel.setName("nagPanel");
+        final GroupLayout layout = new GroupLayout(panel);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+        panel.setLayout(layout);
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup()
+                        .addComponent(txtDescription)
+                        .addComponent(getChkIgnore())
+        );
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                        .addComponent(txtDescription)
+                        .addComponent(getChkIgnore())
+        );
+
+        return panel;
+    }
+    //endregion Initialization
+
+    //region Button Actions
+    @Override
+    protected void okAction() {
+        super.okAction();
+        MekHQ.getMekHQOptions().setNagDialogIgnore(getKey(), getChkIgnore().isSelected());
+    }
+
+    @Override
+    protected void cancelAction() {
+        super.cancelAction();
+        MekHQ.getMekHQOptions().setNagDialogIgnore(getKey(), getChkIgnore().isSelected());
+    }
+    //endregion Button Actions
+
+    protected abstract boolean checkNag(final Campaign campaign);
+
+    @Override
+    public void setVisible(final boolean visible) {
+        super.setVisible(visible && isShow());
+    }
+}

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQNagDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQNagDialog.java
@@ -28,18 +28,19 @@ import java.awt.*;
 public abstract class AbstractMHQNagDialog extends AbstractMHQButtonDialog {
     //region Variable Declarations
     private final String key;
-    private final boolean show;
     private String description;
+    private final boolean show;
     private JCheckBox chkIgnore;
     //endregion Variable Declarations
 
     //region Constructors
     protected AbstractMHQNagDialog(final JFrame frame, final String name, final String title,
-                                   final Campaign campaign, final String key) {
+                                   final String description, final Campaign campaign,
+                                   final String key) {
         super(frame, name, title);
         this.key = key;
+        setDescription(description.isBlank() ? description : resources.getString(description));
         this.show = checkNag(campaign);
-        setDescription("");
         if (isShow()) {
             initialize();
         } else {
@@ -53,16 +54,16 @@ public abstract class AbstractMHQNagDialog extends AbstractMHQButtonDialog {
         return key;
     }
 
-    public boolean isShow() {
-        return show;
-    }
-
     public String getDescription() {
         return description;
     }
 
     public void setDescription(final String description) {
         this.description = description;
+    }
+
+    public boolean isShow() {
+        return show;
     }
 
     public JCheckBox getChkIgnore() {

--- a/MekHQ/src/mekhq/gui/dialog/InsufficientAstechTimeNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/InsufficientAstechTimeNagDialog.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import mekhq.MekHqConstants;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
+    //region Constructors
+    public InsufficientAstechTimeNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "InsufficientAstechTimeNagDialog", "InsufficientAstechTimeNagDialog.title",
+                campaign, MekHqConstants.NAG_INSUFFICIENT_ASTECH_TIME);
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag(Campaign campaign) {
+        if (!campaign.getCampaignOptions().checkMaintenance()) {
+            return false;
+        }
+
+        final int need = campaign.getHangar().getUnitsStream()
+                .filter(unit -> !unit.isUnmaintained() && unit.isPresent() && !unit.isSelfCrewed())
+                .mapToInt(unit -> unit.getMaintenanceTime() * 6).sum();
+
+        int available = campaign.getPossibleAstechPoolMinutes();
+        if (campaign.isOvertimeAllowed()) {
+            available += campaign.getPossibleAstechPoolOvertime();
+        }
+
+        if (available < need) {
+            final int astechsNeeded = (int) Math.ceil((need - available) / (double) Person.PRIMARY_ROLE_SUPPORT_TIME);
+            setDescription(String.format(resources.getString("InsufficientAstechTimeNagDialog.text"), astechsNeeded));
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/InsufficientAstechTimeNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/InsufficientAstechTimeNagDialog.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.dialog;
 
+import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -29,13 +30,14 @@ public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
     //region Constructors
     public InsufficientAstechTimeNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "InsufficientAstechTimeNagDialog", "InsufficientAstechTimeNagDialog.title",
-                campaign, MekHqConstants.NAG_INSUFFICIENT_ASTECH_TIME);
+                "", campaign, MekHqConstants.NAG_INSUFFICIENT_ASTECH_TIME);
     }
     //endregion Constructors
 
     @Override
     protected boolean checkNag(Campaign campaign) {
-        if (!campaign.getCampaignOptions().checkMaintenance()) {
+        if (MekHQ.getMekHQOptions().getNagDialogIgnore(getKey())
+                || !campaign.getCampaignOptions().checkMaintenance()) {
             return false;
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/InsufficientAstechTimeNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/InsufficientAstechTimeNagDialog.java
@@ -41,6 +41,9 @@ public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
             return false;
         }
 
+        // Units are only valid if the are maintained, present, and not self crewed (as the crew
+        // maintain it in that case). For each unit this is valid for, we need six astechs to assist
+        // the tech for the maintenance.
         final int need = campaign.getHangar().getUnitsStream()
                 .filter(unit -> !unit.isUnmaintained() && unit.isPresent() && !unit.isSelfCrewed())
                 .mapToInt(unit -> unit.getMaintenanceTime() * 6).sum();

--- a/MekHQ/src/mekhq/gui/dialog/InsufficientAstechsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/InsufficientAstechsNagDialog.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.dialog;
 
+import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
 import mekhq.gui.baseComponents.AbstractMHQNagDialog;
@@ -28,12 +29,16 @@ public class InsufficientAstechsNagDialog extends AbstractMHQNagDialog {
     //region Constructors
     public InsufficientAstechsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "InsufficientAstechsNagDialog", "InsufficientAstechsNagDialog.title",
-                campaign, MekHqConstants.NAG_INSUFFICIENT_ASTECHS);
+                "", campaign, MekHqConstants.NAG_INSUFFICIENT_ASTECHS);
     }
     //endregion Constructors
 
     @Override
     protected boolean checkNag(final Campaign campaign) {
+        if (MekHQ.getMekHQOptions().getNagDialogIgnore(getKey())) {
+            return false;
+        }
+
         final int need = campaign.getAstechNeed();
         if (need > 0) {
             setDescription(String.format(resources.getString("InsufficientAstechsNagDialog.text"), need));

--- a/MekHQ/src/mekhq/gui/dialog/InsufficientAstechsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/InsufficientAstechsNagDialog.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import mekhq.MekHqConstants;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class InsufficientAstechsNagDialog extends AbstractMHQNagDialog {
+    //region Constructors
+    public InsufficientAstechsNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "InsufficientAstechsNagDialog", "InsufficientAstechsNagDialog.title",
+                campaign, MekHqConstants.NAG_INSUFFICIENT_ASTECHS);
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag(final Campaign campaign) {
+        final int need = campaign.getAstechNeed();
+        if (need > 0) {
+            setDescription(String.format(resources.getString("InsufficientAstechsNagDialog.text"), need));
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/InsufficientMedicsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/InsufficientMedicsNagDialog.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import mekhq.MekHqConstants;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class InsufficientMedicsNagDialog extends AbstractMHQNagDialog {
+    //region Constructors
+    public InsufficientMedicsNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "InsufficientMedicsNagDialog", "InsufficientMedicsNagDialog.title",
+                campaign, MekHqConstants.NAG_INSUFFICIENT_MEDICS);
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag(final Campaign campaign) {
+        final int need = campaign.getMedicsNeed();
+        if (need > 0) {
+            setDescription(String.format(resources.getString("InsufficientMedicsNagDialog.text"), need));
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/InsufficientMedicsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/InsufficientMedicsNagDialog.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.dialog;
 
+import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
 import mekhq.gui.baseComponents.AbstractMHQNagDialog;
@@ -28,12 +29,16 @@ public class InsufficientMedicsNagDialog extends AbstractMHQNagDialog {
     //region Constructors
     public InsufficientMedicsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "InsufficientMedicsNagDialog", "InsufficientMedicsNagDialog.title",
-                campaign, MekHqConstants.NAG_INSUFFICIENT_MEDICS);
+                "", campaign, MekHqConstants.NAG_INSUFFICIENT_MEDICS);
     }
     //endregion Constructors
 
     @Override
     protected boolean checkNag(final Campaign campaign) {
+        if (MekHQ.getMekHQOptions().getNagDialogIgnore(getKey())) {
+            return false;
+        }
+
         final int need = campaign.getMedicsNeed();
         if (need > 0) {
             setDescription(String.format(resources.getString("InsufficientMedicsNagDialog.text"), need));

--- a/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHqOptionsDialog.java
@@ -21,6 +21,7 @@ package mekhq.gui.dialog;
 import megamek.client.ui.swing.ColourSelectorButton;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
+import mekhq.MekHqConstants;
 import mekhq.campaign.event.MekHQOptionsChangedEvent;
 import mekhq.gui.baseComponents.AbstractMHQButtonDialog;
 import mekhq.gui.enums.PersonnelFilterStyle;
@@ -106,6 +107,16 @@ public class MekHqOptionsDialog extends AbstractMHQButtonDialog {
     private JCheckBox optionSaveMothballState;
     //endregion Campaign XML Save
 
+    //region Nag Tab
+    private JCheckBox optionUnmaintainedUnitsNag;
+    private JCheckBox optionInsufficientAstechsNag;
+    private JCheckBox optionInsufficientAstechTimeNag;
+    private JCheckBox optionInsufficientMedicsNag;
+    private JCheckBox optionShortDeploymentNag;
+    private JCheckBox optionUnresolvedStratConContactsNag;
+    private JCheckBox optionOutstandingScenariosNag;
+    //endregion Nag Tab
+
     //region Miscellaneous
     private JSpinner optionStartGameDelay;
     //endregion Miscellaneous
@@ -134,6 +145,7 @@ public class MekHqOptionsDialog extends AbstractMHQButtonDialog {
         optionsTabbedPane.add(resources.getString("autosaveTab.title"), new JScrollPane(createAutosaveTab()));
         optionsTabbedPane.add(resources.getString("newDayTab.title"), new JScrollPane(createNewDayTab()));
         optionsTabbedPane.add(resources.getString("campaignXMLSaveTab.title"), new JScrollPane(createCampaignXMLSaveTab()));
+        optionsTabbedPane.add(resources.getString("nagTab.title"), new JScrollPane(createNagTab()));
         optionsTabbedPane.add(resources.getString("miscellaneousTab.title"), new JScrollPane(createMiscellaneousTab()));
 
         return optionsTabbedPane;
@@ -580,6 +592,69 @@ public class MekHqOptionsDialog extends AbstractMHQButtonDialog {
         return body;
     }
 
+    private JPanel createNagTab() {
+        // Create Panel Components
+        optionUnmaintainedUnitsNag = new JCheckBox(resources.getString("optionUnmaintainedUnitsNag.text"));
+        optionUnmaintainedUnitsNag.setToolTipText(resources.getString("optionUnmaintainedUnitsNag.toolTipText"));
+        optionUnmaintainedUnitsNag.setName("optionUnmaintainedUnitsNag");
+
+        optionInsufficientAstechsNag = new JCheckBox(resources.getString("optionInsufficientAstechsNag.text"));
+        optionInsufficientAstechsNag.setToolTipText(resources.getString("optionInsufficientAstechsNag.toolTipText"));
+        optionInsufficientAstechsNag.setName("optionInsufficientAstechsNag");
+
+        optionInsufficientAstechTimeNag = new JCheckBox(resources.getString("optionInsufficientAstechTimeNag.text"));
+        optionInsufficientAstechTimeNag.setToolTipText(resources.getString("optionInsufficientAstechTimeNag.toolTipText"));
+        optionInsufficientAstechTimeNag.setName("optionInsufficientAstechTimeNag");
+
+        optionInsufficientMedicsNag = new JCheckBox(resources.getString("optionInsufficientMedicsNag.text"));
+        optionInsufficientMedicsNag.setToolTipText(resources.getString("optionInsufficientMedicsNag.toolTipText"));
+        optionInsufficientMedicsNag.setName("optionInsufficientMedicsNag");
+
+        optionShortDeploymentNag = new JCheckBox(resources.getString("optionShortDeploymentNag.text"));
+        optionShortDeploymentNag.setToolTipText(resources.getString("optionShortDeploymentNag.toolTipText"));
+        optionShortDeploymentNag.setName("optionShortDeploymentNag");
+
+        optionUnresolvedStratConContactsNag = new JCheckBox(resources.getString("optionUnresolvedStratConContactsNag.text"));
+        optionUnresolvedStratConContactsNag.setToolTipText(resources.getString("optionUnresolvedStratConContactsNag.toolTipText"));
+        optionUnresolvedStratConContactsNag.setName("optionUnresolvedStratConContactsNag");
+
+        optionOutstandingScenariosNag = new JCheckBox(resources.getString("optionOutstandingScenariosNag.text"));
+        optionOutstandingScenariosNag.setToolTipText(resources.getString("optionOutstandingScenariosNag.toolTipText"));
+        optionOutstandingScenariosNag.setName("optionOutstandingScenariosNag");
+
+        // Layout the UI
+        final JPanel panel = new JPanel();
+        panel.setName("nagPanel");
+        final GroupLayout layout = new GroupLayout(panel);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+        panel.setLayout(layout);
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup()
+                        .addComponent(optionUnmaintainedUnitsNag)
+                        .addComponent(optionInsufficientAstechsNag)
+                        .addComponent(optionInsufficientAstechTimeNag)
+                        .addComponent(optionInsufficientMedicsNag)
+                        .addComponent(optionShortDeploymentNag)
+                        .addComponent(optionUnresolvedStratConContactsNag)
+                        .addComponent(optionOutstandingScenariosNag)
+        );
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                        .addComponent(optionUnmaintainedUnitsNag)
+                        .addComponent(optionInsufficientAstechsNag)
+                        .addComponent(optionInsufficientAstechTimeNag)
+                        .addComponent(optionInsufficientMedicsNag)
+                        .addComponent(optionShortDeploymentNag)
+                        .addComponent(optionUnresolvedStratConContactsNag)
+                        .addComponent(optionOutstandingScenariosNag)
+        );
+
+        return panel;
+    }
+
     private JPanel createMiscellaneousTab() {
         //region Create Graphical Components
         JLabel labelStartGameDelay = new JLabel(resources.getString("labelStartGameDelay.text"));
@@ -679,6 +754,14 @@ public class MekHqOptionsDialog extends AbstractMHQButtonDialog {
         MekHQ.getMekHQOptions().setWriteCustomsToXML(optionWriteCustomsToXML.isSelected());
         MekHQ.getMekHQOptions().setSaveMothballState(optionSaveMothballState.isSelected());
 
+        MekHQ.getMekHQOptions().setNagDialogIgnore(MekHqConstants.NAG_UNMAINTAINED_UNITS, optionUnmaintainedUnitsNag.isSelected());
+        MekHQ.getMekHQOptions().setNagDialogIgnore(MekHqConstants.NAG_INSUFFICIENT_ASTECHS, optionInsufficientAstechsNag.isSelected());
+        MekHQ.getMekHQOptions().setNagDialogIgnore(MekHqConstants.NAG_INSUFFICIENT_ASTECH_TIME, optionInsufficientAstechTimeNag.isSelected());
+        MekHQ.getMekHQOptions().setNagDialogIgnore(MekHqConstants.NAG_INSUFFICIENT_MEDICS, optionInsufficientMedicsNag.isSelected());
+        MekHQ.getMekHQOptions().setNagDialogIgnore(MekHqConstants.NAG_SHORT_DEPLOYMENT, optionShortDeploymentNag.isSelected());
+        MekHQ.getMekHQOptions().setNagDialogIgnore(MekHqConstants.NAG_UNRESOLVED_STRATCON_CONTACTS, optionUnresolvedStratConContactsNag.isSelected());
+        MekHQ.getMekHQOptions().setNagDialogIgnore(MekHqConstants.NAG_OUTSTANDING_SCENARIOS, optionOutstandingScenariosNag.isSelected());
+
         MekHQ.getMekHQOptions().setStartGameDelay((Integer) optionStartGameDelay.getValue());
 
         MekHQ.triggerEvent(new MekHQOptionsChangedEvent());
@@ -740,11 +823,19 @@ public class MekHqOptionsDialog extends AbstractMHQButtonDialog {
         optionWriteCustomsToXML.setSelected(MekHQ.getMekHQOptions().getWriteCustomsToXML());
         optionSaveMothballState.setSelected(MekHQ.getMekHQOptions().getSaveMothballState());
 
+        optionUnmaintainedUnitsNag.setSelected(MekHQ.getMekHQOptions().getNagDialogIgnore(MekHqConstants.NAG_UNMAINTAINED_UNITS));
+        optionInsufficientAstechsNag.setSelected(MekHQ.getMekHQOptions().getNagDialogIgnore(MekHqConstants.NAG_INSUFFICIENT_ASTECHS));
+        optionInsufficientAstechTimeNag.setSelected(MekHQ.getMekHQOptions().getNagDialogIgnore(MekHqConstants.NAG_INSUFFICIENT_ASTECH_TIME));
+        optionInsufficientMedicsNag.setSelected(MekHQ.getMekHQOptions().getNagDialogIgnore(MekHqConstants.NAG_INSUFFICIENT_MEDICS));
+        optionShortDeploymentNag.setSelected(MekHQ.getMekHQOptions().getNagDialogIgnore(MekHqConstants.NAG_SHORT_DEPLOYMENT));
+        optionUnresolvedStratConContactsNag.setSelected(MekHQ.getMekHQOptions().getNagDialogIgnore(MekHqConstants.NAG_UNRESOLVED_STRATCON_CONTACTS));
+        optionOutstandingScenariosNag.setSelected(MekHQ.getMekHQOptions().getNagDialogIgnore(MekHqConstants.NAG_OUTSTANDING_SCENARIOS));
+
         optionStartGameDelay.setValue(MekHQ.getMekHQOptions().getStartGameDelay());
     }
 
     //region Data Validation
-    private boolean validateDateFormat(String format) {
+    private boolean validateDateFormat(final String format) {
         try {
             LocalDate.now().format(DateTimeFormatter.ofPattern(format));
         } catch (Exception ignored) {

--- a/MekHQ/src/mekhq/gui/dialog/OutstandingScenariosNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/OutstandingScenariosNagDialog.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.dialog;
 
+import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
 import mekhq.gui.baseComponents.AbstractMHQNagDialog;
@@ -28,15 +29,16 @@ public class OutstandingScenariosNagDialog extends AbstractMHQNagDialog {
     //region Constructors
     public OutstandingScenariosNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "OutstandingScenariosNagDialog", "OutstandingScenariosNagDialog.title",
-                campaign, MekHqConstants.NAG_OUTSTANDING_SCENARIOS);
-        setDescription(resources.getString("OutstandingScenariosNagDialog.text"));
+                "OutstandingScenariosNagDialog.text", campaign,
+                MekHqConstants.NAG_OUTSTANDING_SCENARIOS);
     }
     //endregion Constructors
 
     @Override
     protected boolean checkNag(final Campaign campaign) {
-        return campaign.getActiveAtBContracts(true).stream()
-                .anyMatch(contract -> contract.getCurrentAtBScenarios().stream()
-                        .anyMatch(scenario -> scenario.getDate().isEqual(campaign.getLocalDate())));
+        return !MekHQ.getMekHQOptions().getNagDialogIgnore(getKey())
+                && campaign.getActiveAtBContracts(true).stream()
+                        .anyMatch(contract -> contract.getCurrentAtBScenarios().stream()
+                                .anyMatch(scenario -> scenario.getDate().isEqual(campaign.getLocalDate())));
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/OutstandingScenariosNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/OutstandingScenariosNagDialog.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import mekhq.MekHqConstants;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class OutstandingScenariosNagDialog extends AbstractMHQNagDialog {
+    //region Constructors
+    public OutstandingScenariosNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "OutstandingScenariosNagDialog", "OutstandingScenariosNagDialog.title",
+                campaign, MekHqConstants.NAG_OUTSTANDING_SCENARIOS);
+        setDescription(resources.getString("OutstandingScenariosNagDialog.text"));
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag(final Campaign campaign) {
+        return campaign.getActiveAtBContracts(true).stream()
+                .anyMatch(contract -> contract.getCurrentAtBScenarios().stream()
+                        .anyMatch(scenario -> scenario.getDate().isEqual(campaign.getLocalDate())));
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/OutstandingScenariosNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/OutstandingScenariosNagDialog.java
@@ -36,6 +36,8 @@ public class OutstandingScenariosNagDialog extends AbstractMHQNagDialog {
 
     @Override
     protected boolean checkNag(final Campaign campaign) {
+        // If this isn't ignored, check all active AtB contracts for current AtB scenarios whose
+        // date is today
         return !MekHQ.getMekHQOptions().getNagDialogIgnore(getKey())
                 && campaign.getActiveAtBContracts(true).stream()
                         .anyMatch(contract -> contract.getCurrentAtBScenarios().stream()

--- a/MekHQ/src/mekhq/gui/dialog/ShortDeploymentNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ShortDeploymentNagDialog.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import mekhq.MekHQ;
+import mekhq.MekHqConstants;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+import java.time.DayOfWeek;
+
+public class ShortDeploymentNagDialog extends AbstractMHQNagDialog {
+    //region Constructors
+    public ShortDeploymentNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "ShortDeploymentNagDialog", "ShortDeploymentNagDialog.title",
+                campaign, MekHqConstants.NAG_SHORT_DEPLOYMENT);
+        setDescription(resources.getString("ShortDeploymentNagDialog.text"));
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag(final Campaign campaign) {
+        if (MekHQ.getMekHQOptions().getNagDialogIgnore(getKey())
+                || !campaign.getLocation().isOnPlanet()
+                || (campaign.getLocalDate().getDayOfWeek() != DayOfWeek.SUNDAY)) {
+            return false;
+        }
+
+        return campaign.getActiveAtBContracts().stream()
+                .anyMatch(contract -> campaign.getDeploymentDeficit(contract) > 0);
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/ShortDeploymentNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ShortDeploymentNagDialog.java
@@ -30,8 +30,7 @@ public class ShortDeploymentNagDialog extends AbstractMHQNagDialog {
     //region Constructors
     public ShortDeploymentNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "ShortDeploymentNagDialog", "ShortDeploymentNagDialog.title",
-                campaign, MekHqConstants.NAG_SHORT_DEPLOYMENT);
-        setDescription(resources.getString("ShortDeploymentNagDialog.text"));
+                "ShortDeploymentNagDialog.text", campaign, MekHqConstants.NAG_SHORT_DEPLOYMENT);
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/UnmaintainedUnitsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnmaintainedUnitsNagDialog.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import mekhq.MekHqConstants;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
+    //region Constructors
+    public UnmaintainedUnitsNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "UnmaintainedUnitsNagDialog", "UnmaintainedUnitsNagDialog.title",
+                campaign, MekHqConstants.NAG_UNMAINTAINED_UNITS);
+        setDescription(resources.getString("UnmaintainedUnitsNagDialog.text"));
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag(final Campaign campaign) {
+        return campaign.getHangar().getUnitsStream().anyMatch(Unit::isUnmaintained);
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/UnmaintainedUnitsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnmaintainedUnitsNagDialog.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.dialog;
 
+import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
@@ -29,13 +30,13 @@ public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
     //region Constructors
     public UnmaintainedUnitsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "UnmaintainedUnitsNagDialog", "UnmaintainedUnitsNagDialog.title",
-                campaign, MekHqConstants.NAG_UNMAINTAINED_UNITS);
-        setDescription(resources.getString("UnmaintainedUnitsNagDialog.text"));
+                "UnmaintainedUnitsNagDialog.text", campaign, MekHqConstants.NAG_UNMAINTAINED_UNITS);
     }
     //endregion Constructors
 
     @Override
     protected boolean checkNag(final Campaign campaign) {
-        return campaign.getHangar().getUnitsStream().anyMatch(Unit::isUnmaintained);
+        return !MekHQ.getMekHQOptions().getNagDialogIgnore(getKey())
+                && campaign.getHangar().getUnitsStream().anyMatch(Unit::isUnmaintained);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/UnresolvedStratConContactsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnresolvedStratConContactsNagDialog.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import mekhq.MekHqConstants;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.stratcon.StratconRulesManager;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class UnresolvedStratConContactsNagDialog extends AbstractMHQNagDialog {
+    //region Constructors
+    public UnresolvedStratConContactsNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "UnresolvedStratConContactsNagDialog", "UnresolvedStratConContactsNagDialog.title",
+                campaign, MekHqConstants.NAG_UNRESOLVED_STRATCON_CONTACTS);
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag(final Campaign campaign) {
+        if (!campaign.getCampaignOptions().getUseStratCon()) {
+            return false;
+        }
+
+        final String text = StratconRulesManager.nagUnresolvedContacts(campaign);
+
+        if (text.isEmpty()) {
+            return false;
+        } else {
+            setDescription(String.format(resources.getString("UnresolvedStratConContactsNagDialog.text"), text));
+            return true;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/UnresolvedStratConContactsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/UnresolvedStratConContactsNagDialog.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.dialog;
 
+import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.stratcon.StratconRulesManager;
@@ -29,13 +30,14 @@ public class UnresolvedStratConContactsNagDialog extends AbstractMHQNagDialog {
     //region Constructors
     public UnresolvedStratConContactsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "UnresolvedStratConContactsNagDialog", "UnresolvedStratConContactsNagDialog.title",
-                campaign, MekHqConstants.NAG_UNRESOLVED_STRATCON_CONTACTS);
+                "", campaign, MekHqConstants.NAG_UNRESOLVED_STRATCON_CONTACTS);
     }
     //endregion Constructors
 
     @Override
     protected boolean checkNag(final Campaign campaign) {
-        if (!campaign.getCampaignOptions().getUseStratCon()) {
+        if (MekHQ.getMekHQOptions().getNagDialogIgnore(getKey())
+                || !campaign.getCampaignOptions().getUseStratCon()) {
             return false;
         }
 


### PR DESCRIPTION
This PR swaps our nag dialogs to the new AbstractMHQNagDialog, which is backed onto MekHQ Options to allow persistence in ignoring individual nags

It also fixes Campaign::getDeploymentDeficit.