### PR TITLE
Prototype TSM mods

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -413,10 +413,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     /**
      * Sets the number of hits on the part.
-     * 
+     *
      * NOTE: It is the caller's responsibilty to update the condition
      * of the part and any attached unit.
-     * 
+     *
      * @param hits The number of hits on the part.
      */
     public void setHits(int hits) {
@@ -991,6 +991,10 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                         && !getUnit().getTech().getOptions().booleanOption(PersonnelOptions.TECH_CLAN_TECH_KNOWLEDGE)) {
                     mods.addModifier(2, "Clan tech");
                 }
+            }
+
+            if (getUnit().hasPrototypeTSM()) {
+                mods.addModifier(1, "prototype TSM");
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -849,7 +849,11 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
 
     @Override
     public int getActualTime() {
-        return (int) Math.ceil(getBaseTime() * mode.timeMultiplier);
+        double time = getBaseTime() * mode.timeMultiplier;
+        if ((getUnit() != null) && (getUnit().hasPrototypeTSM())) {
+            time *= 2;
+        }
+        return (int) Math.ceil(time);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -935,9 +935,15 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             mods.append(unit.getSiteMod());
             if (unit.getEntity().hasQuirk("easy_maintain")) {
                 mods.addModifier(-1, "easy to maintain");
-            }
-            else if (unit.getEntity().hasQuirk("difficult_maintain")) {
+            } else if (unit.getEntity().hasQuirk("difficult_maintain")) {
                 mods.addModifier(1, "difficult to maintain");
+            }
+            if (unit.hasPrototypeTSM() &&
+                    ((this instanceof MekLocation)
+                    || (this instanceof MissingMekLocation)
+                    || (this instanceof MekActuator)
+                    || (this instanceof MissingMekActuator))) {
+                mods.addModifier(2, "prototype TSM");
             }
         }
         if (isClanTechBase() || (this instanceof MekLocation && this.getUnit() != null && this.getUnit().getEntity().isClan())) {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -599,7 +599,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 updateRefitClass(CLASS_F);
             } else if (nPart instanceof MissingMekLocation) {
                 replacingLocations = true;
-                if (((Mech)newUnit.getEntity()).hasTSM() != ((Mech)oldUnit.getEntity()).hasTSM()) {
+                if (((Mech) newUnit.getEntity()).hasTSM(true) != ((Mech) oldUnit.getEntity()).hasTSM(true)) {
                     updateRefitClass(CLASS_E);
                 } else {
                     updateRefitClass(CLASS_F);

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1015,6 +1015,9 @@ public class Refit extends Part implements IAcquisitionWork {
             // The cost is equal to 10 percent of the units base value (not modified for quality). (SO p189)
             cost = oldUnit.getBuyCost().multipliedBy(0.1);
         }
+        if (oldUnit.hasPrototypeTSM() || newUnit.hasPrototypeTSM()) {
+            time *= 2;
+        }
     }
 
     public void begin() throws EntityLoadingException, IOException {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1839,7 +1839,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         if (astechDaysMaintained > 0) {
             MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "astechDaysMaintained", astechDaysMaintained);
         }
-        
+
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "maintenanceMultiplier", maintenanceMultiplier);
 
         if (mothballTime > 0) {
@@ -1905,7 +1905,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     retVal.mothballTime = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("astechDaysMaintained")) {
                     retVal.astechDaysMaintained = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("maintenanceMultiplier")) { 
+                } else if (wn2.getNodeName().equalsIgnoreCase("maintenanceMultiplier")) {
                     retVal.maintenanceMultiplier = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("driverId")) {
                     retVal.drivers.add(new UnitPersonRef(UUID.fromString(wn2.getTextContent())));
@@ -4596,6 +4596,20 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     }
 
     /**
+     * Prototype TSM makes a unit harder to repair and maintain.
+     *
+     * @return Whether the unit has prototype TSM
+     */
+    public boolean hasPrototypeTSM() {
+        for (Mounted m : getEntity().getMisc()) {
+            if (m.getType().hasFlag(MiscType.F_TSM) && m.getType().hasFlag(MiscType.F_PROTOTYPE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns a personnel count for each marine platoon/squad assigned to this unit
      * @return The number of marines aboard
      */
@@ -4735,7 +4749,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
 
     public int getMaintenanceTime() {
         int retVal = 0;
-        
+
         if (getEntity() instanceof Mech) {
             switch (getEntity().getWeightClass()) {
                 case EntityWeightClass.WEIGHT_ULTRA_LIGHT:
@@ -4811,7 +4825,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     break;
             }
         }
-                
+
         // default value for retVal is zero, so anything that didn't fall into one of the
         // above classifications is self-maintaining, meaning zero.
         return retVal * getMaintenanceMultiplier();
@@ -4851,11 +4865,11 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
     public int getAstechsMaintained() {
         return (int) Math.floor((1.0 * astechDaysMaintained) / daysSinceMaintenance);
     }
-    
+
     public int getMaintenanceMultiplier() {
         return maintenanceMultiplier;
     }
-    
+
     public void setMaintenanceMultiplier(int value) {
         maintenanceMultiplier = value;
     }


### PR DESCRIPTION
Implements the modifiers to maintenance, repair, and replacement for a mech with prototype TSM due to its unstable nature and tendency to burst into flames. See IO, p. 104.

1. All maintenance rolls for a mech equipped with P-TSM are made at +1.
2. All repair and replacement tasks take twice as long (I didn't apply this to reloading ammo bins, as this should not directly involve the myomer).
3. Any repair or replacement involving internal structure, location replacement, or actuators is made at +2.

Depends on MegaMek/megamek#2923