### PR TITLE
contract objective update

### DIFF
--- a/MekHQ/data/scenariomodifiers/BadIntelAir.xml
+++ b/MekHQ/data/scenariomodifiers/BadIntelAir.xml
@@ -26,7 +26,7 @@
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>2</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Opfor Ground Reinforcements</forceName>
+		<forceName>Additional OpFor Aircraft</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>

--- a/MekHQ/data/scenariomodifiers/BadIntelGround.xml
+++ b/MekHQ/data/scenariomodifiers/BadIntelGround.xml
@@ -30,7 +30,7 @@
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>2</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Opfor Ground Reinforcements</forceName>
+		<forceName>Additional Opfor Ground Units</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>

--- a/MekHQ/data/stratconcontractdefinitions/CadreDuty.xml
+++ b/MekHQ/data/stratconcontractdefinitions/CadreDuty.xml
@@ -19,6 +19,7 @@
 	</deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
+		<objectiveCount>-1</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
 		<objectiveScenarioModifiers>
                 	<objectiveScenarioModifier>AlliedTraineesGround.xml</objectiveScenarioModifier>

--- a/MekHQ/data/stratconcontractdefinitions/DiversionaryRaid.xml
+++ b/MekHQ/data/stratconcontractdefinitions/DiversionaryRaid.xml
@@ -19,7 +19,6 @@
 	</deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
-		<objectiveCount>-1</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
         </objectiveParameter>
     </objectiveParameters>

--- a/MekHQ/data/stratconcontractdefinitions/DiversionaryRaid.xml
+++ b/MekHQ/data/stratconcontractdefinitions/DiversionaryRaid.xml
@@ -19,6 +19,7 @@
 	</deploymentTimes>
     <objectiveParameters>
         <objectiveParameter>
+		<objectiveCount>-1</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
         </objectiveParameter>
     </objectiveParameters>

--- a/MekHQ/data/stratconcontractdefinitions/FileFormat.txt
+++ b/MekHQ/data/stratconcontractdefinitions/FileFormat.txt
@@ -1,0 +1,77 @@
+The following is an example contract definition file:
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ScenarioTemplate>
+    <alliedFacilityCount>-0.3</alliedFacilityCount>
+    <briefing>Protect attached trainees.</briefing>
+    <contractTypeName>Cadre Duty</contractTypeName>
+    <hostileFacilityCount>0</hostileFacilityCount>
+	<scenarioOdds>
+		<scenarioOdds>10</scenarioOdds>
+		<scenarioOdds>10</scenarioOdds>
+		<scenarioOdds>10</scenarioOdds>
+		<scenarioOdds>10</scenarioOdds>
+	</scenarioOdds>
+	<deploymentTimes>
+		<deploymentTimes>0</deploymentTimes>
+		<deploymentTimes>1</deploymentTimes>
+		<deploymentTimes>2</deploymentTimes>
+		<deploymentTimes>3</deploymentTimes>
+	</deploymentTimes>
+    <objectiveParameters>
+	<objectiveParameter>
+		<objectiveType>AlliedFacilityControl</objectiveType>
+		<objectiveCount>-0.25</objectiveCount>
+        </objectiveParameter>
+	<objectiveParameter>
+		<objectiveCount>-0.25</objectiveCount>
+		<objectiveType>SpecificScenarioVictory</objectiveType>
+		<objectiveScenarios>
+                	<objectiveScenario>Irregular Forces.xml</objectiveScenario>
+		</objectiveScenarios>
+        </objectiveParameter>
+	<objectiveParameter>
+		<objectiveType>FacilityDestruction</objectiveType>
+		<objectiveCount>-0.25</objectiveCount>
+        </objectiveParameter>
+        <objectiveParameter>
+		<objectiveCount>-0.25</objectiveCount>
+		<objectiveType>AnyScenarioVictory</objectiveType>
+		<objectiveScenarioModifiers>
+                	<objectiveScenarioModifier>AlliedTraineesGround.xml</objectiveScenarioModifier>
+                	<objectiveScenarioModifier>AlliedTraineesAir.xml</objectiveScenarioModifier>
+		</objectiveScenarioModifiers>
+        </objectiveParameter>
+    </objectiveParameters>
+</ScenarioTemplate>
+
+Let's break it down.
+
+alliedFacilityCount - Decimal. The number of allied facilities to seed for the entire contract, split somewhat evenly among the tracks. Numbers less than zero indicate that the number of allied facilities should be scaled to the number of contract required lances. Avoid setting this too high, as the player will be swamped with allied reinforcements.
+
+briefing - a (preferably brief) text description of the contract.
+
+contractTypeName - the name of the contract
+
+hostileFacilityCount - Decimal. Exactly like alliedFacilityCount, except for hostile facilities. Avoid setting this too high, as the player will be swamped with hostile reinforcements.
+
+scenarioOdds - a list of base odds that a scenario will occur a) for a require lance on monday, b) when a lance is deployed to a hex on a track that does not have an allied facility. Picked randomly from the list for each track.
+
+deploymentTimes - a list of deployment times, in days, for when a force gets assigned to a scenario. Once assigned, a force (and any reinforcements, and, theoretically, in the future, any salvage) will not return for the specified number of days. Picked randomly from the list for each track. 
+
+globalScenarioModifiers/globalScenarioModifier - a list of all scenario modifier file names to apply to any scenario in this contract. Use sparingly.
+
+objectiveParameters - a list of objectives for the contract. Its child elements follow:
+
+objectiveCount - Decimal. How much of this particular objective to generate. A number less than zero indicates that it's a scaling multiplier to the number of contract required lances. Avoid setting this too low or too high, as it will lead to boredom or craziness due to either nothing to do or way too much to do.
+
+objectiveScenarios/objectiveScenario - a list of possible scenario file names pre-seeded for this particular objective, that need to be completed in order too meet this objective. Ignored AnyScenarioVictory objective type.
+
+objectivescenarioModifiers/objectiveScenarioModifier - a list of scenario modifiers file names to be applied to objective scenarios. Note that for AnyScenarioVictory, these modifiers will be applied to *all* scenarios, and thus this should be used sparingly.
+
+
+objectiveType - the class of objective. There are four types:
+AnyScenarioVictory - victory in any scenario. 
+SpecificScenarioVictory - victory in specific pre-seeded scenarios, from the list in objectiveScenarios.
+FacilityDestruction - drops some hostile facilities on the map, which the player must seize control over/destroy.
+AlliedFacilityControl - drops some allied facilities on the map, which the player must retain control over (it is possible to retake if they were captured).

--- a/MekHQ/data/stratconcontractdefinitions/PirateHunting.xml
+++ b/MekHQ/data/stratconcontractdefinitions/PirateHunting.xml
@@ -19,14 +19,14 @@
     <objectiveParameters>
         <objectiveParameter>
 		<objectiveType>FacilityDestruction</objectiveType>
-		<objectiveCount>-0.3</objectiveCount>
+		<objectiveCount>-0.33</objectiveCount>
         </objectiveParameter>
 	<objectiveParameter>
 		<objectiveType>AlliedFacilityControl</objectiveType>
-		<objectiveCount>-0.3</objectiveCount>
+		<objectiveCount>-0.33</objectiveCount>
         </objectiveParameter>
 	<objectiveParameter>
-		<objectiveCount>-0.3</objectiveCount>
+		<objectiveCount>-0.33</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
 		<objectiveScenarios>
                 	<objectiveScenario>Destroy Grounded Dropship.xml</objectiveScenario>

--- a/MekHQ/data/stratconcontractdefinitions/RiotDuty.xml
+++ b/MekHQ/data/stratconcontractdefinitions/RiotDuty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ScenarioTemplate>
-    <alliedFacilityCount>.3</alliedFacilityCount>
+    <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Defend designated facilities.</briefing>
     <contractTypeName>Riot Duty</contractTypeName>
     <hostileFacilityCount>0</hostileFacilityCount>

--- a/MekHQ/data/stratconcontractdefinitions/RiotDuty.xml
+++ b/MekHQ/data/stratconcontractdefinitions/RiotDuty.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ScenarioTemplate>
-    <alliedFacilityCount>0</alliedFacilityCount>
+    <alliedFacilityCount>.3</alliedFacilityCount>
     <briefing>Defend designated facilities.</briefing>
-    <contractTypeName>Garrison Duty</contractTypeName>
+    <contractTypeName>Riot Duty</contractTypeName>
     <hostileFacilityCount>0</hostileFacilityCount>
 	<scenarioOdds>
 		<scenarioOdds>10</scenarioOdds>
@@ -23,7 +23,7 @@
         </objectiveParameter>
 	<objectiveParameter>
 		<objectiveCount>-0.5</objectiveCount>
-		<objectiveType>AnyScenarioVictory</objectiveType>
+		<objectiveType>SpecificScenarioVictory</objectiveType>
 		<objectiveScenarios>
                 	<objectiveScenario>Irregular Forces.xml</objectiveScenario>
 		</objectiveScenarios>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
@@ -53,8 +53,7 @@ public class StratconCampaignState {
     private double globalOpforBVMultiplier;
     private int supportPoints;
     private int victoryPoints;
-    private String briefingText; 
-    private boolean strategicObjectivesBehaveAsVPs;
+    private String briefingText;
     
     // these are applied to any scenario generated in the campaign; use sparingly
     private List<String> globalScenarioModifiers = new ArrayList<>(); 
@@ -131,14 +130,6 @@ public class StratconCampaignState {
 
     public void setBriefingText(String briefingText) {
         this.briefingText = briefingText;
-    }
-
-    public boolean strategicObjectivesBehaveAsVPs() {
-        return strategicObjectivesBehaveAsVPs;
-    }
-
-    public void setStrategicObjectivesBehaveAsVPs(boolean strategicObjectivesBehaveAsVPs) {
-        this.strategicObjectivesBehaveAsVPs = strategicObjectivesBehaveAsVPs;
     }
 
     public List<String> getGlobalScenarioModifiers() {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
@@ -22,6 +22,7 @@ package mekhq.campaign.stratcon;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,9 +168,10 @@ public class StratconContractDefinition {
     private List<ObjectiveParameters> objectiveParameters;
     
     /**
-     * If true, strategic objective scenarios contribute to the VP count
+     * This is a list of scenario modifier names that apply to
+     * *every* mission generated in this contract. Use very sparingly.
      */
-    private boolean objectivesBehaveAsVPs;
+    private List<String> globalScenarioModifiers = new ArrayList<>();
     
     private List<Integer> scenarioOdds;
     
@@ -255,14 +257,6 @@ public class StratconContractDefinition {
         this.objectiveParameters = objectiveParameters;
     }
 
-    public boolean objectivesBehaveAsVPs() {
-        return objectivesBehaveAsVPs;
-    }
-
-    public void setObjectivesBehaveAsVPs(boolean objectivesBehaveAsVPs) {
-        this.objectivesBehaveAsVPs = objectivesBehaveAsVPs;
-    }
-
     @XmlElementWrapper(name = "scenarioOdds")
     @XmlElement(name = "scenarioOdds")
     public List<Integer> getScenarioOdds() {
@@ -281,6 +275,14 @@ public class StratconContractDefinition {
 
     public void setDeploymentTimes(List<Integer> deploymentTimes) {
         this.deploymentTimes = deploymentTimes;
+    }
+
+    public List<String> getGlobalScenarioModifiers() {
+        return globalScenarioModifiers;
+    }
+
+    public void setGlobalScenarioModifiers(List<String> globalScenarioModifiers) {
+        this.globalScenarioModifiers = globalScenarioModifiers;
     }
 
     /**
@@ -307,7 +309,7 @@ public class StratconContractDefinition {
          */
         @XmlElementWrapper(name = "objectiveScenarios")
         @XmlElement(name = "objectiveScenario")
-        List<String> objectiveScenarios;
+        List<String> objectiveScenarios = new ArrayList<>();
         
         /**
          * If a particular scenario being generated is a strategic objective, it will have
@@ -315,7 +317,7 @@ public class StratconContractDefinition {
          */
         @XmlElementWrapper(name = "objectiveScenarioModifiers")
         @XmlElement(name = "objectiveScenarioModifier")
-        List<String> objectiveScenarioModifiers;
+        List<String> objectiveScenarioModifiers = new ArrayList<>();
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCoords.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCoords.java
@@ -85,4 +85,9 @@ public class StratconCoords extends Coords {
         StratconCoords other = (StratconCoords) object;
         return (other.getX() == this.getX()) && (other.getY() == this.getY());
     }
+    
+    @Override
+    public String toString() {
+        return String.format("%s, %s", getX(), getY());
+    }
 }

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -38,7 +38,6 @@ import mekhq.campaign.event.MissionRemovedEvent;
 import mekhq.campaign.event.NewDayEvent;
 import mekhq.campaign.event.StratconDeploymentEvent;
 import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.Contract;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconStrategicObjective;
 import mekhq.campaign.stratcon.StratconTrackState;
@@ -339,11 +338,8 @@ public class StratconTab extends CampaignGuiTab {
                         break;
                 }
                 
-                // need to add:
-                // global (campaign-state level) "keep VP count above 0" for liaison/house/integrated
-                
                 if (coordsRevealed && displayCoordinateData) {
-                    sb.append(" at ").append(objective.getObjectiveCoords().toFriendlyString())
+                    sb.append(" at ").append(objective.getObjectiveCoords().toString())
                         .append(" on ").append(track.getDisplayableName());
                 }
                 


### PR DESCRIPTION
Change to behavior for contract objective scenario modifiers - now, they can be explicitly applied to the scenarios associated with the objective only. The exception being AnyScenarioVictory, where they'll get applied to any scenario in the contract.

Also, fix incorrect coordinate display, and some data fixes for a few contract types. Riot duty is actually riot duty now. Also, some code cleanup for unused code.