### PR TITLE
vtols off the ground; bombs expansion

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -318,7 +318,8 @@ public class AtBGameThread extends GameThread {
 
                     // we need to wait until the game has actually started to do transport loading
                     // This will load the bot's infantry into APCs
-                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
+                    // sometimes it needs more time?
+                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay() * 2);
                     if (scenario != null) {
                         AtBDynamicScenarioFactory.loadTransports(scenario, botClient);
                     }

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -25,8 +25,10 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -45,7 +47,6 @@ import megamek.common.UnitType;
 import megamek.common.logging.LogLevel;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.BotForce;
 import mekhq.campaign.personnel.Person;
@@ -77,6 +78,8 @@ public class AtBGameThread extends GameThread {
     private static final String LOAD_FTR_DIALOG_TITLE = "Load Fighters on Transport?";
     private static final String LOAD_GND_DIALOG_TEXT = "Would you like the ground units assigned to %s to deploy loaded into its bays?";
     private static final String LOAD_GND_DIALOG_TITLE = "Load Ground Units on Transport?";
+    
+    public static final int CLIENT_RETRY_COUNT = 1000;
 
 
     @Override
@@ -108,7 +111,7 @@ public class AtBGameThread extends GameThread {
 
             // if game is running, shouldn't do the following, so detect the
             // phase
-            for (int i = 0; (i < 1000) && (client.getGame().getPhase() == IGame.Phase.PHASE_UNKNOWN); i++) {
+            for (int i = 0; (i < CLIENT_RETRY_COUNT) && (client.getGame().getPhase() == IGame.Phase.PHASE_UNKNOWN); i++) {
                 Thread.sleep(50);
                 MekHQ.getLogger().error("Thread in unknown stage");
             }
@@ -320,7 +323,7 @@ public class AtBGameThread extends GameThread {
                     // This will load the bot's infantry into APCs
                     Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
                     if (scenario != null) {
-                        AtBDynamicScenarioFactory.loadTransports(scenario, botClient, bf);
+                        loadTransports(scenario, botClient, bf);
                     }
                 }
 
@@ -422,6 +425,56 @@ public class AtBGameThread extends GameThread {
             }
         } catch (Exception e) {
             MekHQ.getLogger().error(e);
+        }
+    }
+    
+    /**
+     * Handles loading transported units onto their transports once a megamek scenario has actually started;
+     */
+    private void loadTransports(AtBScenario scenario, Client client, BotForce botForce) {
+        Map<String, Integer> idMap = new HashMap<>();
+
+        // here we have to make sure that the server has loaded all the entities
+        // and sent the back to the client (which is the only way we know the former)
+        // before we attempt to load transports.
+        int entityCount = client.getGame().getEntitiesOwnedBy(client.getLocalPlayer());
+        int retryCount = 0;
+        while ((entityCount != botForce.getEntityList().size()) &&
+                (retryCount < AtBGameThread.CLIENT_RETRY_COUNT)) {
+            try {
+                Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
+            } catch (Exception ignored) {
+                
+            }
+            
+            retryCount++;
+            entityCount = client.getGame().getEntitiesOwnedBy(client.getLocalPlayer());
+        }
+        
+        List<Entity> clientEntities = client.getEntitiesVector();
+        // this is a bit inefficient, should really give the client/game the ability to look up an entity by external ID
+        for (Entity entity : clientEntities) {
+            if (entity.getOwnerId() == client.getLocalPlayerNumber()) {
+                idMap.put(entity.getExternalIdAsString(), entity.getId());
+            }
+        }
+
+        for (Entity potentialTransport : clientEntities) {
+            if ((potentialTransport.getOwnerId() == client.getLocalPlayerNumber()) &&
+                    scenario.getTransportLinkages().containsKey(potentialTransport.getExternalIdAsString())) {
+                for (String cargoID : scenario.getTransportLinkages().get(potentialTransport.getExternalIdAsString())) {
+                    Entity cargo = scenario.getExternalIDLookup().get(cargoID);
+
+                    // if the game contains the potential cargo unit
+                    // and the potential transport can actually load it, send the load command to the server
+                    if ((cargo != null) &&
+                            idMap.containsKey(cargo.getExternalIdAsString()) &&
+                            potentialTransport.canLoad(cargo, false)) {
+                        client.sendLoadEntity(idMap.get(cargo.getExternalIdAsString()),
+                                idMap.get(potentialTransport.getExternalIdAsString()), -1);
+                    }
+                }
+            }
         }
     }
 }

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -318,10 +318,9 @@ public class AtBGameThread extends GameThread {
 
                     // we need to wait until the game has actually started to do transport loading
                     // This will load the bot's infantry into APCs
-                    // sometimes it needs more time?
-                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay() * 2);
+                    Thread.sleep(MekHQ.getMekHQOptions().getStartGameDelay());
                     if (scenario != null) {
-                        AtBDynamicScenarioFactory.loadTransports(scenario, botClient);
+                        AtBDynamicScenarioFactory.loadTransports(scenario, botClient, bf);
                     }
                 }
 


### PR DESCRIPTION
Three changes:

- generated VTOLs no longer start at elevation 0
- only put 1 TAG on bombers, hook it up with other types of bombs for the rest of the space instead
- wait a little longer to load transports; this seems to be a thread timing issue
