### PR TITLE
prevent double deployment of forces and units

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -951,15 +951,41 @@ public class StratconRulesManager {
             int primaryUnitType = force.getPrimaryUnitType(campaign);
             boolean noReinforcementRestriction = !reinforcements || (reinforcements
                     && (getReinforcementType(force.getId(), currentTrack, campaign, campaignState) != ReinforcementEligibilityType.None));
-            if (!force.isDeployed() && (force.getScenarioId() <= 0) && !force.getUnits().isEmpty()
+            if ((force.getScenarioId() <= 0) && !force.getUnits().isEmpty()
                     && !forcesInTracks.contains(force.getId())
                     && forceCompositionMatchesDeclaredUnitType(primaryUnitType, unitType, reinforcements)
-                    && noReinforcementRestriction) {
+                    && noReinforcementRestriction
+                    && !subElementsDeployed(force, campaign)) {
                 retVal.add(force.getId());
             }
         }
 
         return retVal;
+    }
+    
+    /**
+     * Returns true if any sub-element (unit or sub-force) of this force is deployed.
+     */
+    private static boolean subElementsDeployed(Force force, Campaign campaign) {
+        if (force.isDeployed()) {
+            return true;
+        }
+        
+        for (UUID unitID : force.getUnits()) {
+            Unit unit = campaign.getUnit(unitID);
+            
+            if (unit.isDeployed()) {
+                return true;
+            }
+        }
+        
+        for (Force child : force.getSubForces()) {
+            if (subElementsDeployed(child, campaign)) {
+                return true;
+            }
+        }
+        
+        return false;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -955,7 +955,7 @@ public class StratconRulesManager {
                     && !forcesInTracks.contains(force.getId())
                     && forceCompositionMatchesDeclaredUnitType(primaryUnitType, unitType, reinforcements)
                     && noReinforcementRestriction
-                    && !subElementsDeployed(force, campaign)) {
+                    && !subElementsOrSelfDeployed(force, campaign)) {
                 retVal.add(force.getId());
             }
         }
@@ -966,7 +966,7 @@ public class StratconRulesManager {
     /**
      * Returns true if any sub-element (unit or sub-force) of this force is deployed.
      */
-    private static boolean subElementsDeployed(Force force, Campaign campaign) {
+    private static boolean subElementsOrSelfDeployed(Force force, Campaign campaign) {
         if (force.isDeployed()) {
             return true;
         }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -20,16 +20,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import mekhq.MekHQ;
 import mekhq.adapter.DateAdapter;
+import mekhq.campaign.event.DeploymentChangedEvent;
+import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.mission.ScenarioTemplate;
+import mekhq.campaign.unit.Unit;
 
 /**
  * Class that handles scenario metadata and interaction at the StratCon level
@@ -93,16 +96,31 @@ public class StratconScenario implements IStratconDisplayable {
     
     /**
      * Add a force to the backing scenario, trying to associate it with the given template.
+     * Does some scenario and force house-keeping, fires a deployment changed event.
      */
-    public void addForce(int forceID, String templateID) {
-        backingScenario.addForce(forceID, templateID);
+    public void addForce(Force force, String templateID) {
+        if (!getBackingScenario().getForceIDs().contains(force.getId())) {
+            backingScenario.addForce(force.getId(), templateID);
+            force.setScenarioId(getBackingScenarioID());
+            MekHQ.triggerEvent(new DeploymentChangedEvent(force, getBackingScenario()));
+        }
     }
     
     /**
      * Add an individual unit to the backing scenario, trying to associate it with the given template.
+     * Performs house keeping on the unit and scenario and invokes a deployment changed event.
      */
-    public void addUnit(UUID unitID, String templateID) {
-        backingScenario.addUnit(unitID, templateID);
+    public void addUnit(Unit unit, String templateID, boolean useLeadershipPoint) {
+        if (!backingScenario.containsPlayerUnit(unit.getId())) {
+            backingScenario.addUnit(unit.getId(), templateID);
+            unit.setScenarioId(getBackingScenarioID());
+            
+            if (useLeadershipPoint) {
+                useLeadershipPoint();
+            }
+            
+            MekHQ.triggerEvent(new DeploymentChangedEvent(unit, getBackingScenario()));
+        }
     }
 
     public List<Integer> getAssignedForces() {

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -22,7 +22,6 @@ import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -473,31 +472,22 @@ public class StratconScenarioWizard extends JDialog {
                     }
                 }
 
-                currentScenario.addForce(force.getId(), templateID);
-                force.setScenarioId(currentScenario.getBackingScenarioID());
-                MekHQ.triggerEvent(new DeploymentChangedEvent(force, currentScenario.getBackingScenario()));
+                currentScenario.addForce(force, templateID);
             }
         }
 
         for (String templateID : availableUnitLists.keySet()) {
             for (Unit unit : availableUnitLists.get(templateID).getSelectedValuesList()) {
-                currentScenario.addUnit(unit.getId(), templateID);
-                unit.setScenarioId(currentScenario.getBackingScenarioID());
-                MekHQ.triggerEvent(new DeploymentChangedEvent(unit, currentScenario.getBackingScenario()));
+                currentScenario.addUnit(unit, templateID, false);
             }
         }
 
         for (Unit unit : availableInfantryUnits.getSelectedValuesList()) {
-            currentScenario.addUnit(unit.getId(), ScenarioForceTemplate.PRIMARY_FORCE_TEMPLATE_ID);
-            unit.setScenarioId(currentScenario.getBackingScenarioID());
-            MekHQ.triggerEvent(new DeploymentChangedEvent(unit, currentScenario.getBackingScenario()));
+            currentScenario.addUnit(unit, ScenarioForceTemplate.PRIMARY_FORCE_TEMPLATE_ID, false);
         }
 
         for (Unit unit : availableLeadershipUnits.getSelectedValuesList()) {
-            currentScenario.addUnit(unit.getId(), ScenarioForceTemplate.PRIMARY_FORCE_TEMPLATE_ID);
-            unit.setScenarioId(currentScenario.getBackingScenarioID());
-            currentScenario.useLeadershipPoint();
-            MekHQ.triggerEvent(new DeploymentChangedEvent(unit, currentScenario.getBackingScenario()));
+            currentScenario.addUnit(unit, ScenarioForceTemplate.PRIMARY_FORCE_TEMPLATE_ID, true);
         }
 
         // every force that's been deployed to this scenario gets assigned to the track


### PR DESCRIPTION
Prevent situations where a force or a unit may theoretically be selected more than once on the StratCon scenario management UI. This would basically cause a freeze when starting a scenario.

Now, if a force has any of its sub-units or sub-elements deployed, it cannot be deployed itself.