### PR TITLE
Issue #2703: Defend against parts without campaigns after Refit

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -480,7 +480,8 @@ public class Refit extends Part implements IAcquisitionWork {
                 //its a new part
                 //dont actually add the part iself but rather its missing equivalent
                 //except in the case of armor, ammobins and the spacecraft cooling system
-                if (part instanceof Armor || part instanceof AmmoBin || part instanceof SpacecraftCoolingSystem) {
+                if (part instanceof Armor || part instanceof AmmoBin || part instanceof SpacecraftCoolingSystem
+                        || part instanceof TransportBayPart) {
                     newPartList.add(part);
                 } else {
                     Part mPart = part.getMissingPart();

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1482,6 +1482,10 @@ public class Refit extends Part implements IAcquisitionWork {
         }
 
         for (Part p : newParts) {
+            // CAW: after a refit some parts ended up NOT having a Campaign attached,
+            // see https://github.com/MegaMek/mekhq/issues/2703
+            p.setCampaign(getCampaign());
+
             if (p instanceof AmmoBin) {
                 //All large craft ammo got unloaded into the warehouse earlier, though the part IDs have now changed.
                 //Consider all LC ammobins empty and load them back up.


### PR DESCRIPTION
This is just a bit of defense-in-depth for a possible problem with parts not having a campaign after a refit (as in #2703). I could not reproduce the issue and honestly could not find a path in the Refit logic where a part would not have a campaign.

Also, do not try and using missing parts for Transport Bays.

Fixes #2687.