### PR TITLE
2707: Preventing text wrap in the person title JTable usages

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2583,7 +2583,7 @@ public class Person implements Serializable {
     }
 
     public String getHTMLTitle() {
-        return String.format("<html><div id=\"%s\">%s</div></html>", getId(), getFullTitle());
+        return String.format("<html><div id=\"%s\" style=\"white-space: nowrap;\">%s</div></html>", getId(), getFullTitle());
     }
 
     public String getFullTitle() {


### PR DESCRIPTION
This fixes #2707