### PR TITLE
Issue #2609: Show which parts are blocking repairs

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -21,11 +21,15 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.StringJoiner;
 
 import megamek.common.MiscType;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.enums.PartRepairType;
+import mekhq.campaign.parts.equipment.EquipmentPart;
+
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -678,7 +682,10 @@ public class MekLocation extends Part {
                 || (unit.getEntity().hasRearArmor(loc) && unit.getEntity().getArmorForReal(loc, true) > 0 )) {
             return "must salvage armor in this location first";
         }
+
         //you can only salvage a location that has nothing left on it
+        Set<Integer> equipmentSeen = new HashSet<>();
+        StringJoiner partsToSalvageOrScrap = new StringJoiner(", ");
         for (int i = 0; i < unit.getEntity().getNumberOfCriticals(loc); i++) {
             CriticalSlot slot = unit.getEntity().getCritical(loc, i);
             // ignore empty & non-hittable slots
@@ -701,14 +708,14 @@ public class MekLocation extends Part {
                     if (unit.findPart(p -> p instanceof MissingLandingGear) != null) {
                         continue;
                     } else {
-                        return "Landing gear in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first.";
+                        partsToSalvageOrScrap.add(String.format("Landing Gear (%s)", unit.getEntity().getLocationName(loc)));
                     }
                 // Skip Avionics if already gone
                 } else if (slot.getIndex() == LandAirMech.LAM_AVIONICS) {
                     if (unit.findPart(p -> p instanceof MissingAvionics) != null) {
                         continue;
                     } else {
-                        return "Avionics in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first.";
+                        partsToSalvageOrScrap.add(String.format("Avionics (%s)", unit.getEntity().getLocationName(loc)));
                     }
                 }
             }
@@ -717,21 +724,41 @@ public class MekLocation extends Part {
                 if ((slot.getMount() != null) && !slot.getMount().isDestroyed()) {
                     EquipmentType equipmentType = slot.getMount().getType();
                     if (equipmentType.hasFlag(MiscType.F_NULLSIG)) {
-                            return "Null-Signature System must be salvaged or scrapped first.";
+                        partsToSalvageOrScrap.add("Null-Signature System");
                     } else if (equipmentType.hasFlag(MiscType.F_VOIDSIG)) {
-                        return "Void-Signature System must be salvaged or scrapped first.";
+                        partsToSalvageOrScrap.add("Void-Signature System");
                     } else if (equipmentType.hasFlag(MiscType.F_CHAMELEON_SHIELD)) {
-                        return "Chameleon shield must be salvaged or scrapped first.";
+                        partsToSalvageOrScrap.add("Chameleon Shield");
                     }
                 }
             }
 
             if (slot.isRepairable()) {
-                return "Repairable parts in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first.";
+                String partName = "Repairable Part";
+
+                // Try to get a more specific name
+                int equipmentNum = unit.getEntity().getEquipmentNum(slot.getMount());
+                if (equipmentNum >= 0) {
+                    if (!equipmentSeen.add(equipmentNum)) {
+                        // We have already marked this part as needing to be salvaged/scrapped
+                        continue;
+                    }
+
+                    Part repairablePart = unit.findPart(p -> (p instanceof EquipmentPart) && (((EquipmentPart) p).getEquipmentNum() == equipmentNum));
+                    if (repairablePart != null) {
+                        partName = repairablePart.getName();
+                    }
+                }
+
+                partsToSalvageOrScrap.add(String.format("%s (%s)", partName, unit.getEntity().getLocationName(loc)));
             }
         }
+        
+        if (partsToSalvageOrScrap.length() == 0) {
+            return null;
+        }
 
-        return null;
+        return "The following parts must be salvaged or scrapped first: " + partsToSalvageOrScrap;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingAvionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingAvionics.java
@@ -21,6 +21,8 @@
 
 package mekhq.campaign.parts;
 
+import java.util.StringJoiner;
+
 import org.w3c.dom.Node;
 
 import megamek.common.Aero;
@@ -79,21 +81,26 @@ public class MissingAvionics extends MissingPart {
         if ((unit != null) && (unit.getEntity() instanceof LandAirMech)) {
             // Avionics are installed in the Head and both Torsos,
             // make sure they're not missing.
+            StringJoiner missingLocs = new StringJoiner(", ");
             for (Part part : unit.getParts()) {
                 if (part instanceof MissingMekLocation) {
                     switch (part.getLocation()) {
                         case Mech.LOC_HEAD:
-                            return "Cannot reinstall avionics with a missing Head.";
                         case Mech.LOC_LT:
-                            return "Cannot reinstall avionics with a missing Left Torso.";
                         case Mech.LOC_RT:
-                            return "Cannot reinstall avionics with a missing Right Torso.";
+                            missingLocs.add(unit.getEntity().getLocationName(part.getLocation()));
+                            break;
                         default:
                             break;
                     }
                 }
             }
+    
+            return missingLocs.length() == 0 
+                    ? null 
+                    : "Cannot reinstall avionics when missing: " + missingLocs;
         }
+
         return null;
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/MissingLandingGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingLandingGear.java
@@ -79,19 +79,24 @@ public class MissingLandingGear extends MissingPart {
         if ((unit != null) && (unit.getEntity() instanceof LandAirMech)) {
             // Landing Gear is installed in the CT and both Side Torsos,
             // make sure they're not missing.
+            StringJoiner missingLocs = new StringJoiner(", ");
             for (Part part : unit.getParts()) {
                 if (part instanceof MissingMekLocation) {
                     // The CT cannot be scrapped, so that check is elided.
                     switch (part.getLocation()) {
                         case Mech.LOC_LT:
-                            return "Cannot reinstall landing gear with a missing Left Torso.";
                         case Mech.LOC_RT:
-                            return "Cannot reinstall landing gear with a missing Right Torso.";
+                            missingLocs.add(unit.getEntity().getLocationName(part.getLocation()));
+                            break;
                         default:
                             break;
                     }
                 }
             }
+    
+            return missingLocs.length() == 0 
+                    ? null 
+                    : "Cannot reinstall landing gear when missing: " + missingLocs;
         }
         return null;
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingLandingGear.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingLandingGear.java
@@ -32,6 +32,8 @@ import megamek.common.Mech;
 import megamek.common.TechAdvancement;
 import mekhq.campaign.Campaign;
 
+import java.util.StringJoiner;
+
 import org.w3c.dom.Node;
 
 /**

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -21,6 +21,9 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringJoiner;
 
 import megamek.common.CriticalSlot;
 import megamek.common.EquipmentType;
@@ -33,6 +36,8 @@ import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 
 import mekhq.campaign.parts.enums.PartRepairType;
+import mekhq.campaign.parts.equipment.EquipmentPart;
+
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -232,8 +237,11 @@ public class MissingMekLocation extends MissingPart {
                 return "must replace right torso first";
             }
         }
+
         //there must be no usable equipment currently in the location
         //you can only salvage a location that has nothing left on it
+        Set<Integer> equipmentSeen = new HashSet<>();
+        StringJoiner partsToSalvageOrScrap = new StringJoiner(", ");
         for (int i = 0; i < unit.getEntity().getNumberOfCriticals(loc); i++) {
             CriticalSlot slot = unit.getEntity().getCritical(loc, i);
             // ignore empty & non-hittable slots
@@ -254,14 +262,14 @@ public class MissingMekLocation extends MissingPart {
                         if (unit.findPart(p -> p instanceof MissingLandingGear) != null) {
                             continue;
                         } else {
-                            return "Landing gear in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first.";
+                            partsToSalvageOrScrap.add(String.format("Landing Gear (%s)", unit.getEntity().getLocationName(loc)));
                         }
                     // Skip Avionics if already gone
                     } else if (slot.getIndex() == LandAirMech.LAM_AVIONICS) {
                         if (unit.findPart(p -> p instanceof MissingAvionics) != null) {
                             continue;
                         } else {
-                            return "Avionics in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first.";
+                            partsToSalvageOrScrap.add(String.format("Avionics (%s)", unit.getEntity().getLocationName(loc)));
                         }
                     }
                 }
@@ -269,20 +277,41 @@ public class MissingMekLocation extends MissingPart {
                 if ((slot.getMount() != null) && !slot.getMount().isDestroyed()) {
                     EquipmentType equipmentType = slot.getMount().getType();
                     if (equipmentType.hasFlag(MiscType.F_NULLSIG)) {
-                        return "Null-Signature System must be salvaged or scrapped first.";
+                        partsToSalvageOrScrap.add("Null-Signature System");
                     } else if (equipmentType.hasFlag(MiscType.F_VOIDSIG)) {
-                        return "Void-Signature System must be salvaged or scrapped first.";
+                        partsToSalvageOrScrap.add("Void-Signature System");
                     } else if (equipmentType.hasFlag(MiscType.F_CHAMELEON_SHIELD)) {
-                        return "Chameleon shield must be salvaged or scrapped first.";
+                        partsToSalvageOrScrap.add("Chameleon Shield");
                     }
                 }
             }
 
             if (slot.isRepairable()) {
-                return "Repairable parts in " + unit.getEntity().getLocationName(loc) + " must be salvaged or scrapped first.";
+                String partName = "Repairable Part";
+
+                // Try to get a more specific name
+                int equipmentNum = unit.getEntity().getEquipmentNum(slot.getMount());
+                if (equipmentNum >= 0) {
+                    if (!equipmentSeen.add(equipmentNum)) {
+                        // We have already marked this part as needing to be salvaged/scrapped
+                        continue;
+                    }
+
+                    Part repairablePart = unit.findPart(p -> (p instanceof EquipmentPart) && (((EquipmentPart) p).getEquipmentNum() == equipmentNum));
+                    if (repairablePart != null) {
+                        partName = repairablePart.getName();
+                    }
+                }
+
+                partsToSalvageOrScrap.add(String.format("%s (%s)", partName, unit.getEntity().getLocationName(loc)));
             }
         }
-        return null;
+
+        if (partsToSalvageOrScrap.length() == 0) {
+            return null;
+        }
+
+        return "The following parts must be salvaged or scrapped first: " + partsToSalvageOrScrap;
     }
 
     @Override

--- a/MekHQ/unittests/mekhq/campaign/parts/MissingMekLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MissingMekLocationTest.java
@@ -65,7 +65,10 @@ public class MissingMekLocationTest {
         }).when(unit).findPart(any());
 
         // We cannot repair this torso
-        assertNotNull(missing.checkFixable());
+        String message = missing.checkFixable();
+        assertNotNull(message);
+        assertTrue(message.contains("Avionics"));
+        assertTrue(message.contains("Landing Gear"));
 
         // Only missing landing gear, avionics are still good
         doAnswer(inv -> {
@@ -75,7 +78,9 @@ public class MissingMekLocationTest {
         }).when(unit).findPart(any());
 
         // We cannot repair this torso
-        assertNotNull(missing.checkFixable());
+        message = missing.checkFixable();
+        assertNotNull(message);
+        assertTrue(message.contains("Avionics"));
 
         // Only missing avionics, landing gear is still good
         doAnswer(inv -> {
@@ -85,7 +90,9 @@ public class MissingMekLocationTest {
         }).when(unit).findPart(any());
 
         // We cannot repair this torso
-        assertNotNull(missing.checkFixable());
+        message = missing.checkFixable();
+        assertNotNull(message);
+        assertTrue(message.contains("Landing Gear"));
 
         // Missing both Landing Gear and Avionics
         doAnswer(inv -> {
@@ -130,7 +137,9 @@ public class MissingMekLocationTest {
         }).when(unit).findPart(any());
 
         // We cannot repair this head
-        assertNotNull(missing.checkFixable());
+        String message = missing.checkFixable();
+        assertNotNull(message);
+        assertTrue(message.contains("Avionics"));
 
         // Missing avionics
         doAnswer(inv -> {


### PR DESCRIPTION
This is a quick attempt at explaining why a part is blocked for repairs. The logic here is to aggregate all of the parts which are blocking the repair and listing them (and their location if applicable). This should hopefully improve situations like #2609 where it is not clear why exactly the part is being blocked.

Fixes #2609.

_NOTE: I'm evaluating the unit tests to see if any of them can be extended to test this._