### PR TITLE
2717: Advance Days Dialog no longer based on modality

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -41,6 +41,7 @@ import java.util.List;
 public class AdvanceDaysDialog extends AbstractMHQDialog {
     //region Variable Declarations
     private final CampaignGUI gui;
+    private boolean running;
 
     private JSpinner spnDays;
     private JButton btnStartAdvancement;
@@ -64,6 +65,14 @@ public class AdvanceDaysDialog extends AbstractMHQDialog {
     //region Getters/Setters
     public CampaignGUI getGUI() {
         return gui;
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public void setRunning(final boolean running) {
+        this.running = running;
     }
 
     public JSpinner getSpnDays() {
@@ -274,8 +283,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialog {
             days = 1;
         }
 
-        setModal(true);
-
+        setRunning(true);
         boolean firstDay = true;
         final List<String> reports = new ArrayList<>();
         for (; days > 0; days--) {
@@ -294,7 +302,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialog {
             getGUI().getCampaign().fetchAndClearNewReports();
         }
 
-        setModal(false);
+        setRunning(false);
         getDailyLogPanel().appendLog(reports);
 
         // We couldn't advance all days for some reason,
@@ -310,7 +318,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialog {
 
     @Subscribe(priority = 1)
     public void reportOverride(final ReportEvent evt) {
-        if (isModal()) {
+        if (isRunning()) {
             evt.cancel();
         } else {
             getDailyLogPanel().refreshLog(getGUI().getCampaign().getCurrentReportHTML());

--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -287,19 +287,24 @@ public class AdvanceDaysDialog extends AbstractMHQDialog {
         boolean firstDay = true;
         final List<String> reports = new ArrayList<>();
         for (; days > 0; days--) {
-            if (!getGUI().getCampaign().newDay()) {
+            try {
+                if (!getGUI().getCampaign().newDay()) {
+                    break;
+                }
+
+                final String report = getGUI().getCampaign().getCurrentReportHTML();
+                if (firstDay) {
+                    getDailyLogPanel().refreshLog(report);
+                    firstDay = false;
+                } else {
+                    reports.add(resources.getString("HR.text"));
+                    reports.add(report);
+                }
+                getGUI().getCampaign().fetchAndClearNewReports();
+            } catch (Exception e) {
+                MekHQ.getLogger().error(e);
                 break;
             }
-
-            final String report = getGUI().getCampaign().getCurrentReportHTML();
-            if (firstDay) {
-                getDailyLogPanel().refreshLog(report);
-                firstDay = false;
-            } else {
-                reports.add(resources.getString("HR.text"));
-                reports.add(report);
-            }
-            getGUI().getCampaign().fetchAndClearNewReports();
         }
 
         setRunning(false);


### PR DESCRIPTION
This fixes #2717 by removing the modality changes from the advance days dialog and instead tracking using a single variable.