### PR TITLE
Assorted UI improvements

### DIFF
--- a/MekHQ/data/stratconcontractdefinitions/CadreDuty.xml
+++ b/MekHQ/data/stratconcontractdefinitions/CadreDuty.xml
@@ -3,6 +3,7 @@
     <contractTypeName>Cadre Duty</contractTypeName>
     <alliedFacilityCount>-0.3</alliedFacilityCount>
     <briefing>Protect attached trainees.</briefing>
+	<allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
 	<objectivesBehaveAsVPs>true</objectivesBehaveAsVPs>
 	<scenarioOdds>

--- a/MekHQ/data/stratconcontractdefinitions/GarrisonDuty.xml
+++ b/MekHQ/data/stratconcontractdefinitions/GarrisonDuty.xml
@@ -3,6 +3,7 @@
     <contractTypeName>Garrison Duty</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Defend designated facilities.</briefing>
+	<allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
 	<scenarioOdds>
 		<scenarioOdds>10</scenarioOdds>

--- a/MekHQ/data/stratconcontractdefinitions/RiotDuty.xml
+++ b/MekHQ/data/stratconcontractdefinitions/RiotDuty.xml
@@ -3,6 +3,7 @@
     <contractTypeName>Riot Duty</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Defend designated facilities.</briefing>
+	<allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
 	<scenarioOdds>
 		<scenarioOdds>10</scenarioOdds>

--- a/MekHQ/data/stratconcontractdefinitions/SecurityDuty.xml
+++ b/MekHQ/data/stratconcontractdefinitions/SecurityDuty.xml
@@ -3,6 +3,7 @@
     <contractTypeName>Security Duty</contractTypeName>
     <alliedFacilityCount>0</alliedFacilityCount>
     <briefing>Defend designated facilities.</briefing>
+	<allowEarlyVictory>false</allowEarlyVictory>
     <hostileFacilityCount>0</hostileFacilityCount>
 	<scenarioOdds>
 		<scenarioOdds>10</scenarioOdds>

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -188,7 +188,9 @@ public class Mission implements Serializable, MekHqXmlSerializable {
     }
 
     public boolean hasPendingScenarios() {
-        return getScenarios().stream().anyMatch(scenario -> scenario.getStatus().isCurrent());
+        // scenarios that are pending, but have not been revealed don't count
+        return getScenarios().stream().anyMatch(scenario -> 
+            (scenario.getStatus().isCurrent() && !scenario.isCloaked()));
     }
     //endregion Scenarios
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
@@ -54,6 +54,7 @@ public class StratconCampaignState {
     private int supportPoints;
     private int victoryPoints;
     private String briefingText;
+    private boolean allowEarlyVictory;
     
     // these are applied to any scenario generated in the campaign; use sparingly
     private List<String> globalScenarioModifiers = new ArrayList<>(); 
@@ -130,6 +131,14 @@ public class StratconCampaignState {
 
     public void setBriefingText(String briefingText) {
         this.briefingText = briefingText;
+    }
+
+    public boolean allowEarlyVictory() {
+        return allowEarlyVictory;
+    }
+
+    public void setAllowEarlyVictory(boolean allowEarlyVictory) {
+        this.allowEarlyVictory = allowEarlyVictory;
     }
 
     public List<String> getGlobalScenarioModifiers() {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
@@ -150,6 +150,8 @@ public class StratconContractDefinition {
      */
     private double hostileFacilityCount;
 
+    private boolean allowEarlyVictory;
+    
     /**
      * List of scenario IDs (file names) that are allowed for this contract type
      */
@@ -201,6 +203,14 @@ public class StratconContractDefinition {
      */
     public void setBriefing(String briefing) {
         this.briefing = briefing;
+    }
+
+    public boolean isAllowEarlyVictory() {
+        return allowEarlyVictory;
+    }
+
+    public void setAllowEarlyVictory(boolean allowEarlyVictory) {
+        this.allowEarlyVictory = allowEarlyVictory;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -49,7 +49,8 @@ public class StratconContractInitializer {
     public static void initializeCampaignState(AtBContract contract, Campaign campaign, StratconContractDefinition contractDefinition) {
         StratconCampaignState campaignState = new StratconCampaignState(contract);
         campaignState.setBriefingText(contractDefinition.getBriefing() + "<br/>" + contract.getCommandRights().getStratConText());
-
+        campaignState.setAllowEarlyVictory(contractDefinition.isAllowEarlyVictory());
+        
         // dependency: this is required here in order for scenario initialization to work properly
         contract.setStratconCampaignState(campaignState);
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -32,7 +32,6 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
 import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -304,7 +304,7 @@ public class StratconTab extends CampaignGuiTab {
                 boolean displayCoordinateData = objective.getObjectiveCoords() != null;
                 boolean objectiveCompleted = objective.isObjectiveCompleted(track);
 
-                if((objective.getObjectiveType() == StrategicObjectiveType.AlliedFacilityControl) && 
+                if ((objective.getObjectiveType() == StrategicObjectiveType.AlliedFacilityControl) && 
                         !campaignState.allowEarlyVictory()) {
                     sb.append("<span>");
                 } else if (objectiveCompleted) {

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -37,6 +37,7 @@ import mekhq.campaign.event.NewDayEvent;
 import mekhq.campaign.event.StratconDeploymentEvent;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.stratcon.StratconCampaignState;
+import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
 import mekhq.campaign.stratcon.StratconStrategicObjective;
 import mekhq.campaign.stratcon.StratconTrackState;
 
@@ -303,8 +304,11 @@ public class StratconTab extends CampaignGuiTab {
                 boolean displayCoordinateData = objective.getObjectiveCoords() != null;
                 boolean objectiveCompleted = objective.isObjectiveCompleted(track);
 
-                if (objectiveCompleted) {
-                    sb.append("<span color='green'>");
+                if((objective.getObjectiveType() == StrategicObjectiveType.AlliedFacilityControl) && 
+                        !campaignState.allowEarlyVictory()) {
+                    sb.append("<span>");
+                } else if (objectiveCompleted) {
+                    sb.append("<span color='green'>");                    
                 } else {
                     sb.append("<span color='red'>");
                 }
@@ -325,6 +329,10 @@ public class StratconTab extends CampaignGuiTab {
                     case AlliedFacilityControl:
                         sb.append(coordsRevealed ? "M" : "m")
                             .append("aintain control of designated facility");
+                        
+                        if (!campaignState.allowEarlyVictory()) {
+                            sb.append(" until " + campaignState.getContract().getEndingDate());
+                        }
                         break;
                     case AnyScenarioVictory:
                         sb.append("Engage and defeat hostile forces in ")

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -270,7 +270,9 @@ public class CustomizeScenarioDialog extends JDialog {
             JButton btnLoad = new JButton("Generate From Template");
             btnLoad.addActionListener(this::btnLoadActionPerformed);
             panBtn.add(btnLoad);
-        } else if ((mission instanceof AtBContract) && (scenario instanceof AtBDynamicScenario)) {
+        } else if ((mission instanceof AtBContract) && 
+                (scenario instanceof AtBDynamicScenario) &&
+                (scenario.getStatus().isCurrent())) {
             JButton btnFinalize = new JButton();
 
             if (((AtBDynamicScenario) scenario).getNumBots() > 0) {

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -1006,5 +1006,14 @@ public class MissionViewPanel extends JScrollablePanel {
         gridBagConstraints.fill = GridBagConstraints.BOTH;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlStats.add(txtDesc, gridBagConstraints);
+        
+        // for StratCon, contract score is irrelevant and only leads to confusion, so we
+        // do not display it in that situation
+        boolean showContractScore = 
+                !gui.getCampaign().getCampaignOptions().getUseStratCon() &&
+                (mission instanceof AtBContract) && (((AtBContract) mission).getStratconCampaignState() != null);
+        
+        lblScore.setVisible(showContractScore);
+        txtScore.setVisible(showContractScore);
     }
 }

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -972,25 +972,33 @@ public class MissionViewPanel extends JScrollablePanel {
             pnlStats.add(txtSharePct, gridBagConstraints);
         }
 
-        lblScore.setName("lblScore");
-        lblScore.setText(resourceMap.getString("lblScore.text"));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = y;
-        gridBagConstraints.fill = GridBagConstraints.NONE;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        pnlStats.add(lblScore, gridBagConstraints);
+        // for StratCon, contract score is irrelevant and only leads to confusion, so we
+        // do not display it in that situation
+        boolean showContractScore = 
+                !gui.getCampaign().getCampaignOptions().getUseStratCon() &&
+                (mission instanceof AtBContract) && (((AtBContract) mission).getStratconCampaignState() != null);
+        
+        if (showContractScore) {
+            lblScore.setName("lblScore");
+            lblScore.setText(resourceMap.getString("lblScore.text"));
+            gridBagConstraints = new GridBagConstraints();
+            gridBagConstraints.gridx = 0;
+            gridBagConstraints.gridy = y;
+            gridBagConstraints.fill = GridBagConstraints.NONE;
+            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+            pnlStats.add(lblScore, gridBagConstraints);
 
-        txtScore.setName("txtScore");
-        txtScore.setText(Integer.toString(contract.getScore()));
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = y++;
-        gridBagConstraints.weightx = 0.5;
-        gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        pnlStats.add(txtScore, gridBagConstraints);
+            txtScore.setName("txtScore");
+            txtScore.setText(Integer.toString(contract.getScore()));
+            gridBagConstraints = new GridBagConstraints();
+            gridBagConstraints.gridx = 1;
+            gridBagConstraints.gridy = y++;
+            gridBagConstraints.weightx = 0.5;
+            gridBagConstraints.insets = new Insets(0, 10, 0, 0);
+            gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+            pnlStats.add(txtScore, gridBagConstraints);
+        }
 
         txtDesc.setName("txtDesc");
         txtDesc.setEditable(false);
@@ -1006,14 +1014,5 @@ public class MissionViewPanel extends JScrollablePanel {
         gridBagConstraints.fill = GridBagConstraints.BOTH;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlStats.add(txtDesc, gridBagConstraints);
-        
-        // for StratCon, contract score is irrelevant and only leads to confusion, so we
-        // do not display it in that situation
-        boolean showContractScore = 
-                !gui.getCampaign().getCampaignOptions().getUseStratCon() &&
-                (mission instanceof AtBContract) && (((AtBContract) mission).getStratconCampaignState() != null);
-        
-        lblScore.setVisible(showContractScore);
-        txtScore.setVisible(showContractScore);
     }
 }


### PR DESCRIPTION
Three changes:
- Don't display "regenerate bot forces" button when editing completed scenarios
- Allow mission/contract completion when there are "cloaked" scenarios (useful for early contract completion on contracts with fixed objectives)
- For contracts that are defensive in nature, introduce an "allow early victory" flag. Currently, all that does is display a "hold until date on "hold this facility" objectives. 