### PR TITLE
251: Force Generator Unit Generation Empty Unit Table Parent Faction Fallback

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/UnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/UnitMarket.java
@@ -23,19 +23,16 @@ package mekhq.campaign.market;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
+import megamek.common.*;
 import mekhq.campaign.market.enums.UnitMarketMethod;
 import mekhq.campaign.market.enums.UnitMarketType;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import megamek.client.ratgenerator.MissionRole;
-import megamek.common.Compute;
-import megamek.common.EntityWeightClass;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.UnitType;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
@@ -46,7 +43,6 @@ import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.IUnitGenerator;
 import mekhq.campaign.universe.RandomFactionGenerator;
-import mekhq.campaign.universe.UnitGeneratorParameters;
 
 /**
  * Generates units available for sale.
@@ -164,26 +160,18 @@ public class UnitMarket implements Serializable {
             market = UnitMarketType.EMPLOYER;
         }
 
-        UnitGeneratorParameters params = new UnitGeneratorParameters();
-        params.setFaction(faction);
-        params.setYear(campaign.getGameYear());
-        params.setUnitType(unitType);
-        params.setQuality(quality);
-
         for (int i = 0; i < num; i++) {
-            params.setWeightClass(getRandomWeight(unitType, faction,
-                    campaign.getCampaignOptions().getRegionalMechVariations()));
-            params.clearMissionRoles();
+            final Collection<EntityMovementMode> movementModes = new ArrayList<>();
+            final Collection<MissionRole> missionRoles = new ArrayList<>();
 
-            MechSummary ms;
             if (unitType == UnitType.TANK) {
-                params.setMovementModes(IUnitGenerator.MIXED_TANK_VTOL);
-                params.addMissionRole(MissionRole.MIXED_ARTILLERY);
-
-            } else {
-                params.clearMovementModes();
+                movementModes.addAll(IUnitGenerator.MIXED_TANK_VTOL);
+                missionRoles.add(MissionRole.MIXED_ARTILLERY);
             }
-            ms = campaign.getUnitGenerator().generate(params);
+
+            MechSummary ms = campaign.getUnitGenerator().generate(faction, campaign.getGameYear(), unitType,
+                    getRandomWeight(unitType, faction, campaign.getCampaignOptions().getRegionalMechVariations()),
+                    quality, movementModes, missionRoles, null);
             if (ms != null) {
                 if (campaign.getCampaignOptions().limitByYear()
                         && (campaign.getGameYear() < ms.getYear())) {

--- a/MekHQ/src/mekhq/campaign/market/UnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/UnitMarket.java
@@ -171,7 +171,7 @@ public class UnitMarket implements Serializable {
 
             MechSummary ms = campaign.getUnitGenerator().generate(faction, campaign.getGameYear(), unitType,
                     getRandomWeight(unitType, faction, campaign.getCampaignOptions().getRegionalMechVariations()),
-                    quality, movementModes, missionRoles, null);
+                    quality, movementModes, missionRoles);
             if (ms != null) {
                 if (campaign.getCampaignOptions().limitByYear()
                         && (campaign.getGameYear() < ms.getYear())) {

--- a/MekHQ/src/mekhq/campaign/universe/AbstractUnitGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/AbstractUnitGenerator.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017-2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
 package mekhq.campaign.universe;
 
 import java.util.Collections;
@@ -16,9 +34,8 @@ import mekhq.campaign.rating.IUnitRating;
  * Base class for unit generators containing common functionality.
  * Currently, only turret-related code.
  * @author NickAragua
- *
  */
-public abstract class AbstractUnitGenerator {
+public abstract class AbstractUnitGenerator implements IUnitGenerator {
     private Map<Integer, String> ratRatingMappings = null;
     private TreeSet<Integer> turretRatYears = new TreeSet<>();
     private Map<Integer, Map<String, String>> turretRatNames = new HashMap<>();
@@ -48,6 +65,7 @@ public abstract class AbstractUnitGenerator {
      * @param currentYear The current year
      * @return List of turrets
      */
+    @Override
     public List<MechSummary> generateTurrets(int num, int skill, int quality, int currentYear) {
         int ratYear;
 
@@ -80,10 +98,10 @@ public abstract class AbstractUnitGenerator {
         // RAT for the current or previous year, use the earliest available.
         // If there are no turret RATs, return an empty list
         if (turretRatYears.isEmpty()) {
-            MekHQ.getLogger().warning(this, "No turret RATs found.");
+            MekHQ.getLogger().warning("No turret RATs found.");
             return Collections.emptyList();
         } else if (currentYear < turretRatYears.first()) {
-            MekHQ.getLogger().warning(this, "Earliest turret RAT is later than campaign year.");
+            MekHQ.getLogger().warning("Earliest turret RAT is later than campaign year.");
             ratYear = turretRatYears.first();
         } else {
             ratYear = turretRatYears.floor(currentYear);

--- a/MekHQ/src/mekhq/campaign/universe/IUnitGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/IUnitGenerator.java
@@ -1,7 +1,8 @@
 /*
  * IUnitGenerator.java
  *
- * Copyright (c) 2016 Carl Spain. All rights reserved.
+ * Copyright (c) 2016 - Carl Spain. All rights reserved.
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -18,74 +19,73 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.universe;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Predicate;
 
+import megamek.client.ratgenerator.MissionRole;
 import megamek.common.EntityMovementMode;
 import megamek.common.MechSummary;
 import megamek.common.UnitType;
+import megamek.common.annotations.Nullable;
 
 /**
  * Common interface to interact with various methods for generating units.
  *
  * @author Neoancient
- *
  */
 public interface IUnitGenerator {
-
-    /*
+    /**
      * For convenience in generating traditional ground + vtol units.
      */
-    final static EnumSet<EntityMovementMode> MIXED_TANK_VTOL = EnumSet.of(EntityMovementMode.TRACKED,
+    EnumSet<EntityMovementMode> MIXED_TANK_VTOL = EnumSet.of(EntityMovementMode.TRACKED,
             EntityMovementMode.WHEELED, EntityMovementMode.HOVER, EntityMovementMode.WIGE,
             EntityMovementMode.VTOL);
 
     /**
      * For convenience in generating infantry units.
      */
-    final static EnumSet<EntityMovementMode> ALL_INFANTRY_MODES = EnumSet.of(EntityMovementMode.INF_JUMP,
+    EnumSet<EntityMovementMode> ALL_INFANTRY_MODES = EnumSet.of(EntityMovementMode.INF_JUMP,
             EntityMovementMode.INF_LEG, EntityMovementMode.INF_MOTORIZED, EntityMovementMode.INF_UMU,
             EntityMovementMode.TRACKED, EntityMovementMode.WHEELED, EntityMovementMode.HOVER);
-    
-    final static EnumSet<EntityMovementMode> ALL_BATTLE_ARMOR_MODES = EnumSet.of(EntityMovementMode.INF_JUMP,
+
+    EnumSet<EntityMovementMode> ALL_BATTLE_ARMOR_MODES = EnumSet.of(EntityMovementMode.INF_JUMP,
             EntityMovementMode.INF_LEG, EntityMovementMode.INF_UMU, EntityMovementMode.VTOL);
 
     /**
      * For convenience in generating infantry units, the minimum tonnage of a foot infantry platoon.
      */
-    final static double FOOT_PLATOON_INFANTRY_WEIGHT = 3.0;
-    
+    double FOOT_PLATOON_INFANTRY_WEIGHT = 3.0;
+
     /**
      * For convenience in generating battle armor, minimum tonnage of a battle armor squad.
      */
-    final static double BATTLE_ARMOR_MIN_WEIGHT = 4.0;
-    
+    double BATTLE_ARMOR_MIN_WEIGHT = 4.0;
+
     /**
-     * For convenience in generating battle armor/infantry, when the tonnage does not matter 
-     * (a dedicated dropship bay, battle armor riding on a mech, etc)
+     * For convenience in generating battle armor/infantry, when the tonnage does not matter
+     * (a dedicated DropShip bay, battle armor riding on a 'Mech, etc)
      */
-    final static double NO_WEIGHT_LIMIT = -1.0;
+    double NO_WEIGHT_LIMIT = -1.0;
 
     /**
      * Convenience function to let us know whether a unit type supports weight class selection.
      * @param unitType The unit type to check.
      * @return Whether or not the unit type supports weight class selection.
      */
-    static boolean unitTypeSupportsWeightClass(int unitType) {
-        return unitType == UnitType.AERO || unitType == UnitType.MEK || unitType == UnitType.TANK;
+    static boolean unitTypeSupportsWeightClass(final int unitType) {
+        return (unitType == UnitType.AERO) || (unitType == UnitType.MEK) || (unitType == UnitType.TANK);
     }
 
     /**
-     *
      * @param unitType UnitType constant
      * @return true if the generator supports the unit type
      */
-    boolean isSupportedUnitType(int unitType);
+    boolean isSupportedUnitType(final int unitType);
 
     /**
      * Generate a single unit.
@@ -95,9 +95,12 @@ public interface IUnitGenerator {
      * @param weightClass EntityWeightClass constant, or -1 for unspecified
      * @param year The year of the campaign date
      * @param quality Index of equipment rating, with zero being the lowest quality.
-     * @return A unit that matches the criteria
+     * @return A unit that matches the criteria, or null if none can be generated
      */
-    MechSummary generate(String faction, int unitType, int weightClass, int year, int quality);
+    default @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                           final int year, final int quality) {
+        return generate(faction, unitType, weightClass, year, quality, null);
+    }
 
     /**
      * Generate a single unit.
@@ -110,11 +113,67 @@ public interface IUnitGenerator {
      * @param filter All generated units return true when the filter function is applied.
      * @return A unit that matches the criteria
      */
-    MechSummary generate(String faction, int unitType, int weightClass, int year, int quality,
-            Predicate<MechSummary> filter);
+    default @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                           final int year, final int quality, @Nullable Predicate<MechSummary> filter) {
+        return generate(faction, unitType, weightClass, year, quality, new ArrayList<>(), filter);
+    }
 
     /**
+     * Generate a unit using additional parameters specific to the generation method.
      *
+     * @param faction Faction shortname
+     * @param unitType UnitType constant
+     * @param weightClass EntityWeightClass constant, or -1 for unspecified
+     * @param year The year of the campaign date
+     * @param quality Index of equipment rating, with zero being the lowest quality.
+     * @param movementModes A collection of various movement modes
+     * @param filter All generated units return true when the filter function is applied.
+     * @return A unit that matches the criteria
+     */
+    default @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                           final int year, final int quality,
+                                           final Collection<EntityMovementMode> movementModes,
+                                           @Nullable Predicate<MechSummary> filter) {
+        return generate(faction, unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
+    }
+
+    /**
+     * Generate a unit using additional parameters specific to the generation method.
+     *
+     * @param faction Faction shortname
+     * @param unitType UnitType constant
+     * @param weightClass EntityWeightClass constant, or -1 for unspecified
+     * @param year The year of the campaign date
+     * @param quality Index of equipment rating, with zero being the lowest quality.
+     * @param movementModes A collection of various movement modes
+     * @param missionRoles A collection of various mission roles
+     * @return A unit that matches the criteria
+     */
+    default @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                           final int year, final int quality,
+                                           final Collection<EntityMovementMode> movementModes,
+                                           final Collection<MissionRole> missionRoles) {
+        return generate(faction, unitType, weightClass, year, quality, movementModes, missionRoles, null);
+    }
+
+    /**
+     * Generate a unit using additional parameters specific to the generation method.
+     *
+     * @param faction Faction shortname
+     * @param unitType UnitType constant
+     * @param weightClass EntityWeightClass constant, or -1 for unspecified
+     * @param year The year of the campaign date
+     * @param quality Index of equipment rating, with zero being the lowest quality.
+     * @param movementModes A collection of various movement modes
+     * @param missionRoles A collection of various mission roles
+     * @param filter All generated units return true when the filter function is applied.
+     * @return A unit that matches the criteria
+     */
+    @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass, final int year,
+                                   final int quality, final Collection<EntityMovementMode> movementModes,
+                                   final Collection<MissionRole> missionRoles, @Nullable Predicate<MechSummary> filter);
+
+    /**
      * Generates a list of units.
      *
      * @param count The number of units to generate
@@ -125,11 +184,12 @@ public interface IUnitGenerator {
      * @param quality Index of equipment rating, with zero being the lowest quality.
      * @return A list of units matching the criteria.
      */
-    List<MechSummary> generate(int count, String faction, int unitType, int weightClass,
-            int year, int quality);
+    default List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                       final int year, final int quality) {
+        return generate(count, faction, unitType, weightClass, year, quality, null);
+    }
 
     /**
-     *
      * Generates a list of units with an additional test function.
      *
      * @param count The number of units to generate
@@ -141,27 +201,12 @@ public interface IUnitGenerator {
      * @param filter All generated units return true when the filter function is applied.
      * @return A list of units matching the criteria.
      */
-
-    List<MechSummary> generate(int count, String faction, int unitType, int weightClass,
-            int year, int quality, Predicate<MechSummary> filter);
-
-    /**
-     * Generate a unit using additional parameters specific to the generation method.
-     *
-     * @param faction Faction shortname
-     * @param unitType UnitType constant
-     * @param weightClass EntityWeightClass constant, or -1 for unspecified
-     * @param year The year of the campaign date
-     * @param quality Index of equipment rating, with zero being the lowest quality.
-     * @param movementModes A collection of various movement modes
-     * @return A unit that matches the criteria
-     */
-    MechSummary generate(String faction, int unitType, int weightClass,
-            int year, int quality, Collection<EntityMovementMode> movementModes,
-            Predicate<MechSummary> filter);
+    default List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                       final int year, final int quality, @Nullable Predicate<MechSummary> filter) {
+        return generate(count, faction, unitType, weightClass, year, quality, new ArrayList<>(), filter);
+    }
 
     /**
-     *
      * Generates a list of units using additional parameters specific to the generation method.
      *
      * @param count The number of units to generate
@@ -174,26 +219,71 @@ public interface IUnitGenerator {
      * @param filter All generated units return true when the filter function is applied.
      * @return A list of units matching the criteria.
      */
-    List<MechSummary> generate(int count, String faction, int unitType, int weightClass,
-            int year, int quality, Collection<EntityMovementMode> movementModes,
-            Predicate<MechSummary> filter);
+    default List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                       final int year, final int quality,
+                                       final Collection<EntityMovementMode> movementModes,
+                                       @Nullable Predicate<MechSummary> filter) {
+        return generate(count, faction, unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
+    }
 
     /**
-     * Generates the given count of units, for the given faction, using the given set of parameters.
-     * Note that some of the properties of the parameters may be ignored for generation mechanisms that aren't the RAT Generator
+     * Generates a list of units using additional parameters specific to the generation method.
+     *
+     * @param count The number of units to generate
+     * @param faction Faction shortname
+     * @param unitType UnitType constant
+     * @param weightClass EntityWeightClass constant, or -1 for unspecified
+     * @param year The year of the campaign date
+     * @param quality Index of equipment rating, with zero being the lowest quality.
+     * @param movementModes A collection of various movement modes
+     * @param missionRoles A collection of various mission roles
+     * @return A list of units matching the criteria.
+     */
+    default @Nullable List<MechSummary> generate(final int count, final String faction, final int unitType,
+                                                 final int weightClass, final int year, final int quality,
+                                                 final Collection<EntityMovementMode> movementModes,
+                                                 final Collection<MissionRole> missionRoles) {
+        return generate(count, faction, unitType, weightClass, year, quality, movementModes, missionRoles, null);
+    }
+
+    /**
+     * Generates a list of units using additional parameters specific to the generation method.
+     *
+     * @param count The number of units to generate
+     * @param faction Faction shortname
+     * @param unitType UnitType constant
+     * @param weightClass EntityWeightClass constant, or -1 for unspecified
+     * @param year The year of the campaign date
+     * @param quality Index of equipment rating, with zero being the lowest quality.
+     * @param movementModes A collection of various movement modes
+     * @param missionRoles A collection of various mission roles
+     * @param filter All generated units return true when the filter function is applied.
+     * @return A list of units matching the criteria.
+     */
+    @Nullable List<MechSummary> generate(final int count, final String faction, final int unitType,
+                                         final int weightClass, final int year, final int quality,
+                                         final Collection<EntityMovementMode> movementModes,
+                                         final Collection<MissionRole> missionRoles,
+                                         @Nullable Predicate<MechSummary> filter);
+
+    /**
+     * Generates a single unit to be used in an OpFor using the given set of parameters.
+     * Note that some of the properties of the parameters may be ignored for generation mechanisms that aren't the RAT
+     * Generator
+     * @param parameters data structure containing unit generation parameters
+     * @return The generated unit, or null if none are generated.
+     */
+    @Nullable MechSummary generate(final UnitGeneratorParameters parameters);
+
+    /**
+     * Generates the given count of units to be used in an OpFor using the given set of parameters.
+     * Note that some of the properties of the parameters may be ignored for generation mechanisms that aren't the RAT
+     * Generator
      * @param count How many to generate
      * @param parameters data structure containing unit generation parameters
-     * @return List of generated units. Empty if none generated.
+     * @return List of generated units. Empty if none are generated.
      */
-    List<MechSummary> generate(int count, UnitGeneratorParameters parameters);
-
-    /**
-     * Generates a single unit, for the given faction, using the given set of parameters.
-     * Note that some of the properties of the parameters may be ignored for generation mechanisms that aren't the RAT Generator
-     * @param parameters data structure containing unit generation parameters
-     * @return Generated units. Null if none generated.
-     */
-    MechSummary generate(UnitGeneratorParameters parameters);
+    List<MechSummary> generate(final int count, final UnitGeneratorParameters parameters);
 
     /**
      * Generates a list of turrets given a skill level, quality and year
@@ -203,5 +293,5 @@ public interface IUnitGenerator {
      * @param currentYear The current year
      * @return List of turrets
      */
-    List<MechSummary> generateTurrets(int num, int skill, int quality, int currentYear);
+    List<MechSummary> generateTurrets(final int num, final int skill, final int quality, final int currentYear);
 }

--- a/MekHQ/src/mekhq/campaign/universe/IUnitGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/IUnitGenerator.java
@@ -13,11 +13,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.universe;
 

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -23,7 +23,9 @@ package mekhq.campaign.universe;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import megamek.client.ratgenerator.*;
@@ -142,7 +144,7 @@ public class RATGeneratorConnector extends AbstractUnitGenerator {
      * This finds a unit table for OpFor generation. It falls back using the parent faction to try to ensure there are
      * units in the unit table, so an OpFor is generated.
      * @param unitParameters the base parameters to find the table using.
-     * @return the unit table to generate using
+     * @return the unit table to use in generating OpFor mech summaries
      */
     private UnitTable findOpForTable(final UnitGeneratorParameters unitParameters) {
         final UnitTable.Parameters parameters = unitParameters.getRATGeneratorParameters();
@@ -151,7 +153,7 @@ public class RATGeneratorConnector extends AbstractUnitGenerator {
             // Do Parent Factions Fallbacks to try to ensure units can be generated, at a maximum of 10
             List<String> factions = parameters.getFaction().getParentFactions();
             for (int i = 0; (i < 10) && !factions.isEmpty(); i++) {
-                final List<String> parentFactions = new ArrayList<>();
+                final Set<String> parentFactions = new HashSet<>();
                 for (final String factionCode : factions) {
                     // Use the current Parent Faction
                     parameters.setFaction(RATGenerator.getInstance().getFaction(factionCode));

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -34,10 +34,10 @@ import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 
 /**
- * Provides access to RATGenerator through IUnitGenerator interface.
+ * Provides access to RATGenerator through the AbstractUnitGenerator and thus the IUnitGenerator interface.
  * @author Neoancient
  */
-public class RATGeneratorConnector extends AbstractUnitGenerator implements IUnitGenerator {
+public class RATGeneratorConnector extends AbstractUnitGenerator {
     /**
      * Initialize RATGenerator and load the data for the current game year
      */

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -1,7 +1,8 @@
 /*
  * RATGeneratorConnector.java
  *
- * Copyright (c) 2016 Carl Spain. All rights reserved.
+ * Copyright (c) 2016 - Carl Spain. All rights reserved.
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -12,11 +13,11 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.universe;
 
@@ -33,16 +34,18 @@ import megamek.client.ratgenerator.UnitTable;
 import megamek.common.EntityMovementMode;
 import megamek.common.MechSummary;
 import megamek.common.UnitType;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 
 /**
  * Provides access to RATGenerator through IUnitGenerator interface.
- *
  * @author Neoancient
  */
 public class RATGeneratorConnector extends AbstractUnitGenerator implements IUnitGenerator {
-    /* Initialize RATGenerator and load the data for the current game year */
-    public RATGeneratorConnector(int year) {
+    /**
+     * Initialize RATGenerator and load the data for the current game year
+     */
+    public RATGeneratorConnector(final int year) {
         while (!RATGenerator.getInstance().isInitialized()) {
             try {
                 Thread.sleep(50);
@@ -53,36 +56,35 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
         RATGenerator.getInstance().loadYear(year);
     }
 
-    private UnitTable findTable(String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes) {
-        FactionRecord fRec = Factions.getInstance().getFactionRecordOrFallback(faction);
-        if(fRec == null) {
+    private @Nullable UnitTable findTable(final String faction, final int unitType, final int weightClass,
+                                          final int year, final int quality,
+                                          final Collection<EntityMovementMode> movementModes) {
+        final FactionRecord factionRecord = Factions.getInstance().getFactionRecordOrFallback(faction);
+        if (factionRecord == null) {
             return null;
         }
-
-        String rating = getFactionSpecificRating(fRec, quality);
-
-        ArrayList<Integer> wcs = new ArrayList<>();
+        final String rating = getFactionSpecificRating(factionRecord, quality);
+        final List<Integer> weightClasses = new ArrayList<>();
         if (weightClass >= 0) {
-            wcs.add(weightClass);
+            weightClasses.add(weightClass);
         }
-
-        return UnitTable.findTable(fRec, unitType, year, rating, wcs, ModelRecord.NETWORK_NONE, movementModes, new ArrayList<>(), 2, fRec);
+        return UnitTable.findTable(factionRecord, unitType, year, rating, weightClasses, ModelRecord.NETWORK_NONE,
+                movementModes, new ArrayList<>(), 2, factionRecord);
     }
 
     /**
      * Helper function that extracts the string-based unit rating from the given int-based unit-rating
      * for the given faction.
-     * @param fRec Faction record
+     * @param factionRecord Faction record
      * @param quality Unit quality number
      * @return Unit quality string
      */
-    public static String getFactionSpecificRating(FactionRecord fRec, int quality) {
+    public static String getFactionSpecificRating(final FactionRecord factionRecord, final int quality) {
         String rating = null;
-        if (fRec.getRatingLevels().size() != 1) {
-            List<String> ratings = fRec.getRatingLevelSystem();
+        if (factionRecord.getRatingLevels().size() != 1) {
+            final List<String> ratings = factionRecord.getRatingLevelSystem();
             rating = ratings.get(Math.min(quality, ratings.size() - 1));
         }
-
         return rating;
     }
 
@@ -90,89 +92,83 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
      * @see mekhq.campaign.universe.IUnitGenerator#isSupportedUnitType(int)
      */
     @Override
-    public boolean isSupportedUnitType(int unitType) {
-        return unitType != UnitType.GUN_EMPLACEMENT
-                && unitType != UnitType.SPACE_STATION;
+    public boolean isSupportedUnitType(final int unitType) {
+        return (unitType != UnitType.GUN_EMPLACEMENT) && (unitType != UnitType.SPACE_STATION);
     }
 
     /* (non-Javadoc)
      * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int)
      */
     @Override
-    public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality) {
-        UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
-                EnumSet.noneOf(EntityMovementMode.class));
-        return (ut == null)? null : ut.generateUnit();
+    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                          final int year, final int quality) {
+        return generate(faction, unitType, weightClass, year, quality, null);
     }
 
     /* (non-Javadoc)
      * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int, java.util.function.Predicate)
      */
     @Override
-    public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality, Predicate<MechSummary> filter) {
-        UnitTable ut = findTable(faction, unitType, weightClass, year, quality, EnumSet.noneOf(EntityMovementMode.class));
-        return (ut == null)? null : ut.generateUnit(filter == null?null : filter::test);
+    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                          final int year, final int quality,
+                                          final @Nullable Predicate<MechSummary> filter) {
+        return generate(faction, unitType, weightClass, year, quality, EnumSet.noneOf(EntityMovementMode.class), filter);
     }
 
     @Override
-    public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Predicate<MechSummary> filter) {
-        UnitTable ut = findTable(faction, unitType, weightClass, year, quality, movementModes);
-        return (ut == null)? null : ut.generateUnit(filter == null?null : filter::test);
+    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                          final int year, final int quality,
+                                          final Collection<EntityMovementMode> movementModes,
+                                          final @Nullable Predicate<MechSummary> filter) {
+        final UnitTable table = findTable(faction, unitType, weightClass, year, quality, movementModes);
+        return (table == null) ? null : table.generateUnit((filter == null) ? null : filter::test);
     }
 
     /* (non-Javadoc)
      * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int)
      */
     @Override
-    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality) {
-        UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
-                EnumSet.noneOf(EntityMovementMode.class));
-        return ut == null? new ArrayList<>() : ut.generateUnits(count);
+    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                      final int year, final int quality) {
+        return generate(count, faction, unitType, weightClass, year, quality, null);
     }
 
     /* (non-Javadoc)
      * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int, java.util.function.Predicate)
      */
     @Override
-    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality,
-            Predicate<MechSummary> filter) {
-        UnitTable ut = findTable(faction, unitType, weightClass, year, quality,
-                EnumSet.noneOf(EntityMovementMode.class));
-        return ut == null? new ArrayList<>() : ut.generateUnits(count,
-                filter == null? null : filter::test);
+    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                      final int year, final int quality, final @Nullable Predicate<MechSummary> filter) {
+        return generate(count, faction, unitType, weightClass, year, quality, EnumSet.noneOf(EntityMovementMode.class), filter);
     }
 
     @Override
-    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Predicate<MechSummary> filter) {
-        UnitTable ut = findTable(faction, unitType, weightClass, year, quality, movementModes);
-        return ut == null? new ArrayList<>() : ut.generateUnits(count,
-                filter == null? null : filter::test);
+    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                      final int year, final int quality,
+                                      final Collection<EntityMovementMode> movementModes,
+                                      final @Nullable Predicate<MechSummary> filter) {
+        final UnitTable table = findTable(faction, unitType, weightClass, year, quality, movementModes);
+        return (table == null) ? new ArrayList<>() : table.generateUnits(count, (filter == null) ? null : filter::test);
     }
 
     /**
      * Generates a list of mech summaries from a RAT determined by the given faction, quality and other parameters.
-     * Note that for the purposes of this implementation, any faction record or unit quality are ignored.
      * @param count How many units to generate
      * @param parameters RATGenerator parameters
      */
     @Override
-    public List<MechSummary> generate(int count, UnitGeneratorParameters parameters) {
-        UnitTable ut = UnitTable.findTable(parameters.getRATGeneratorParameters());
-
-        return ut == null ? new ArrayList<MechSummary>() :
-            ut.generateUnits(count, parameters.getFilter() == null ? null : ms -> parameters.getFilter().test(ms));
+    public List<MechSummary> generate(final int count, final UnitGeneratorParameters parameters) {
+        final UnitTable table = UnitTable.findTable(parameters.getRATGeneratorParameters());
+        return table.generateUnits(count, (parameters.getFilter() == null) ? null : ms -> parameters.getFilter().test(ms));
     }
 
     /**
      * Generates a single mech summary from a RAT determined by the given faction, quality and other parameters.
-     * Note that for the purposes of this implementation, any faction record or unit quality are ignored.
      * @param parameters RATGenerator parameters
      */
     @Override
-    public MechSummary generate(UnitGeneratorParameters parameters) {
-        UnitTable ut = UnitTable.findTable(parameters.getRATGeneratorParameters());
-
-        return ut == null ? null :
-            ut.generateUnit(parameters.getFilter() == null ? null : ms -> parameters.getFilter().test(ms));
+    public MechSummary generate(final UnitGeneratorParameters parameters) {
+        final UnitTable table = UnitTable.findTable(parameters.getRATGeneratorParameters());
+        return table.generateUnit((parameters.getFilter() == null) ? null : ms -> parameters.getFilter().test(ms));
     }
 }

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -27,10 +27,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Predicate;
 
-import megamek.client.ratgenerator.FactionRecord;
-import megamek.client.ratgenerator.ModelRecord;
-import megamek.client.ratgenerator.RATGenerator;
-import megamek.client.ratgenerator.UnitTable;
+import megamek.client.ratgenerator.*;
 import megamek.common.EntityMovementMode;
 import megamek.common.MechSummary;
 import megamek.common.UnitType;
@@ -58,7 +55,8 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
 
     private @Nullable UnitTable findTable(final String faction, final int unitType, final int weightClass,
                                           final int year, final int quality,
-                                          final Collection<EntityMovementMode> movementModes) {
+                                          final Collection<EntityMovementMode> movementModes,
+                                          final Collection<MissionRole> missionRoles) {
         final FactionRecord factionRecord = Factions.getInstance().getFactionRecordOrFallback(faction);
         if (factionRecord == null) {
             return null;
@@ -69,7 +67,7 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
             weightClasses.add(weightClass);
         }
         return UnitTable.findTable(factionRecord, unitType, year, rating, weightClasses, ModelRecord.NETWORK_NONE,
-                movementModes, new ArrayList<>(), 2, factionRecord);
+                movementModes, missionRoles, 2, factionRecord);
     }
 
     /**
@@ -120,7 +118,16 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
                                           final int year, final int quality,
                                           final Collection<EntityMovementMode> movementModes,
                                           final @Nullable Predicate<MechSummary> filter) {
-        final UnitTable table = findTable(faction, unitType, weightClass, year, quality, movementModes);
+        return generate(faction,unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
+    }
+
+    @Override
+    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                          final int year, final int quality,
+                                          final Collection<EntityMovementMode> movementModes,
+                                          final Collection<MissionRole> missionRoles,
+                                          final @Nullable Predicate<MechSummary> filter) {
+        final UnitTable table = findTable(faction, unitType, weightClass, year, quality, movementModes, missionRoles);
         return (table == null) ? null : table.generateUnit((filter == null) ? null : filter::test);
     }
 
@@ -147,28 +154,76 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
                                       final int year, final int quality,
                                       final Collection<EntityMovementMode> movementModes,
                                       final @Nullable Predicate<MechSummary> filter) {
-        final UnitTable table = findTable(faction, unitType, weightClass, year, quality, movementModes);
+        return generate(count, faction, unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
+    }
+
+    @Override
+    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                      final int year, final int quality,
+                                      final Collection<EntityMovementMode> movementModes,
+                                      final Collection<MissionRole> missionRoles,
+                                      final @Nullable Predicate<MechSummary> filter) {
+        final UnitTable table = findTable(faction, unitType, weightClass, year, quality, movementModes, missionRoles);
         return (table == null) ? new ArrayList<>() : table.generateUnits(count, (filter == null) ? null : filter::test);
     }
 
     /**
      * Generates a list of mech summaries from a RAT determined by the given faction, quality and other parameters.
+     * We force a fallback to try to ensure that something is generated if the parents have any possible units to generate,
+     * as that is the normally expected behaviour for MekHQ OpFor generation.
      * @param count How many units to generate
      * @param parameters RATGenerator parameters
      */
     @Override
     public List<MechSummary> generate(final int count, final UnitGeneratorParameters parameters) {
-        final UnitTable table = UnitTable.findTable(parameters.getRATGeneratorParameters());
+        final UnitTable table = findOpForTable(parameters);
         return table.generateUnits(count, (parameters.getFilter() == null) ? null : ms -> parameters.getFilter().test(ms));
     }
 
     /**
      * Generates a single mech summary from a RAT determined by the given faction, quality and other parameters.
+     * We force a fallback to try to ensure that something is generated if the parents have any possible units to generate,
+     * as that is the normally expected behaviour for MekHQ OpFor generation.
      * @param parameters RATGenerator parameters
      */
     @Override
-    public MechSummary generate(final UnitGeneratorParameters parameters) {
-        final UnitTable table = UnitTable.findTable(parameters.getRATGeneratorParameters());
+    public @Nullable MechSummary generate(final UnitGeneratorParameters parameters) {
+        final UnitTable table = findOpForTable(parameters);
         return table.generateUnit((parameters.getFilter() == null) ? null : ms -> parameters.getFilter().test(ms));
+    }
+
+    /**
+     * This finds a unit table for OpFor generation. It falls back using the parent faction to try to ensure there are
+     * units in the unit table, so an OpFor is generated.
+     * @param unitParameters the base parameters to find the table using.
+     * @return the unit table to generate using
+     */
+    private UnitTable findOpForTable(final UnitGeneratorParameters unitParameters) {
+        final UnitTable.Parameters parameters = unitParameters.getRATGeneratorParameters();
+        UnitTable table = UnitTable.findTable(parameters);
+        if (!table.hasUnits()) {
+            // Do Parent Factions Fallbacks to try to ensure units can be generated, at a maximum of 10
+            List<String> factions = parameters.getFaction().getParentFactions();
+            for (int i = 0; (i < 10) && !factions.isEmpty(); i++) {
+                final List<String> parentFactions = new ArrayList<>();
+                for (final String factionCode : factions) {
+                    // Use the current Parent Faction
+                    parameters.setFaction(RATGenerator.getInstance().getFaction(factionCode));
+
+                    // Get the table for the new Parent Faction
+                    table = UnitTable.findTable(parameters);
+
+                    // Check if this one has units, returning if it does
+                    if (table.hasUnits()) {
+                        return table;
+                    }
+
+                    // Save the Potential Parent Factions
+                    parentFactions.addAll(parameters.getFaction().getParentFactions());
+                }
+                factions = new ArrayList<>(parentFactions);
+            }
+        }
+        return table;
     }
 }

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -23,7 +23,6 @@ package mekhq.campaign.universe;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -94,67 +93,14 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
         return (unitType != UnitType.GUN_EMPLACEMENT) && (unitType != UnitType.SPACE_STATION);
     }
 
-    /* (non-Javadoc)
-     * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int)
-     */
-    @Override
-    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
-                                          final int year, final int quality) {
-        return generate(faction, unitType, weightClass, year, quality, null);
-    }
-
-    /* (non-Javadoc)
-     * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int, java.util.function.Predicate)
-     */
-    @Override
-    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
-                                          final int year, final int quality,
-                                          final @Nullable Predicate<MechSummary> filter) {
-        return generate(faction, unitType, weightClass, year, quality, EnumSet.noneOf(EntityMovementMode.class), filter);
-    }
-
-    @Override
-    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
-                                          final int year, final int quality,
-                                          final Collection<EntityMovementMode> movementModes,
-                                          final @Nullable Predicate<MechSummary> filter) {
-        return generate(faction,unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
-    }
-
     @Override
     public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
                                           final int year, final int quality,
                                           final Collection<EntityMovementMode> movementModes,
                                           final Collection<MissionRole> missionRoles,
-                                          final @Nullable Predicate<MechSummary> filter) {
+                                          @Nullable Predicate<MechSummary> filter) {
         final UnitTable table = findTable(faction, unitType, weightClass, year, quality, movementModes, missionRoles);
         return (table == null) ? null : table.generateUnit((filter == null) ? null : filter::test);
-    }
-
-    /* (non-Javadoc)
-     * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int)
-     */
-    @Override
-    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
-                                      final int year, final int quality) {
-        return generate(count, faction, unitType, weightClass, year, quality, null);
-    }
-
-    /* (non-Javadoc)
-     * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int, java.util.function.Predicate)
-     */
-    @Override
-    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
-                                      final int year, final int quality, final @Nullable Predicate<MechSummary> filter) {
-        return generate(count, faction, unitType, weightClass, year, quality, EnumSet.noneOf(EntityMovementMode.class), filter);
-    }
-
-    @Override
-    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
-                                      final int year, final int quality,
-                                      final Collection<EntityMovementMode> movementModes,
-                                      final @Nullable Predicate<MechSummary> filter) {
-        return generate(count, faction, unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
     }
 
     @Override
@@ -162,7 +108,7 @@ public class RATGeneratorConnector extends AbstractUnitGenerator implements IUni
                                       final int year, final int quality,
                                       final Collection<EntityMovementMode> movementModes,
                                       final Collection<MissionRole> missionRoles,
-                                      final @Nullable Predicate<MechSummary> filter) {
+                                      @Nullable Predicate<MechSummary> filter) {
         final UnitTable table = findTable(faction, unitType, weightClass, year, quality, movementModes, missionRoles);
         return (table == null) ? new ArrayList<>() : table.generateUnits(count, (filter == null) ? null : filter::test);
     }

--- a/MekHQ/src/mekhq/campaign/universe/RATManager.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATManager.java
@@ -349,66 +349,48 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
      * @see mekhq.campaign.universe.IUnitGenerator#isSupportedUnitType(int)
      */
     @Override
-    public boolean isSupportedUnitType(int unitType) {
-        return unitType == UnitType.MEK
-                || unitType == UnitType.TANK
-                || unitType == UnitType.AERO
-                || unitType == UnitType.DROPSHIP
-                || unitType == UnitType.INFANTRY
-                || unitType == UnitType.BATTLE_ARMOR
-                || unitType == UnitType.PROTOMEK;
-    }
-
-    /* (non-Javadoc)
-     * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int)
-     */
-    @Override
-    public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality) {
-        return generate(faction, unitType, weightClass, year, quality, null);
+    public boolean isSupportedUnitType(final int unitType) {
+        return (unitType == UnitType.MEK)
+                || (unitType == UnitType.TANK)
+                || (unitType == UnitType.AERO)
+                || (unitType == UnitType.DROPSHIP)
+                || (unitType == UnitType.INFANTRY)
+                || (unitType == UnitType.BATTLE_ARMOR)
+                || (unitType == UnitType.PROTOMEK);
     }
 
     /* (non-Javadoc)
      * @see mekhq.campaign.universe.IUnitGenerator#generate(java.lang.String, int, int, int, int, java.util.function.Predicate)
      */
     @Override
-    public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality, Predicate<MechSummary> filter) {
-        List<MechSummary> list = generate(1, faction, unitType, weightClass, year, quality, filter);
-        if (list.size() > 0) {
-            return list.get(0);
-        }
-        return null;
-    }
-
-    @Override
-    public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Predicate<MechSummary> filter) {
-        return generate(faction, unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
-    }
-
-    @Override
-    public @Nullable MechSummary generate(String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Collection<MissionRole> missionRoles, Predicate<MechSummary> filter) {
-        List<MechSummary> list = generate(1, faction, unitType, weightClass, year, quality, movementModes, filter);
+    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                          final int year, final int quality, @Nullable Predicate<MechSummary> filter) {
+        final List<MechSummary> list = generate(1, faction, unitType, weightClass, year, quality, filter);
         return list.isEmpty() ? null : list.get(0);
     }
 
-    /* (non-Javadoc)
-     * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int)
-     */
     @Override
-    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality) {
-        return generate(count, faction, unitType, weightClass, year, quality, null);
+    public @Nullable MechSummary generate(final String faction, final int unitType, final int weightClass,
+                                          final int year, final int quality,
+                                          final Collection<EntityMovementMode> movementModes,
+                                          final Collection<MissionRole> missionRoles,
+                                          @Nullable Predicate<MechSummary> filter) {
+        final List<MechSummary> list = generate(1, faction, unitType, weightClass, year, quality, movementModes, filter);
+        return list.isEmpty() ? null : list.get(0);
     }
 
     /* (non-Javadoc)
      * @see mekhq.campaign.universe.IUnitGenerator#generate(int, java.lang.String, int, int, int, int, java.util.function.Predicate)
      */
     @Override
-    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality, Predicate<MechSummary> filter) {
-        RAT rat = findRAT(faction, unitType, weightClass, year, quality);
+    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                      final int year, final int quality, @Nullable Predicate<MechSummary> filter) {
+        final RAT rat = findRAT(faction, unitType, weightClass, year, quality);
         if (rat != null) {
             if (unitType == UnitType.TANK) {
-                filter = filter != null ? filter.and(RATManager::isTank) : RATManager::isTank;
+                filter = (filter != null) ? filter.and(RATManager::isTank) : RATManager::isTank;
             } else if (unitType == UnitType.VTOL) {
-                filter = filter != null ? filter.and(RATManager::isVTOL) : RATManager::isVTOL;
+                filter = (filter != null) ? filter.and(RATManager::isVTOL) : RATManager::isVTOL;
             }
             return RandomUnitGenerator.getInstance().generate(count, rat.ratName, filter);
         }
@@ -424,28 +406,33 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
     }
 
     @Override
-    public List<MechSummary> generate(int count, String faction, int unitType,
-            int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes,
-            Predicate<MechSummary> filter) {
-        return generate(count, faction, unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
-    }
-
-    @Override
-    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Collection<MissionRole> missionRoles, Predicate<MechSummary> filter) {
-        RAT rat = findRAT(faction, unitType, weightClass, year, quality);
+    public List<MechSummary> generate(final int count, final String faction, final int unitType, final int weightClass,
+                                      final int year, final int quality,
+                                      final Collection<EntityMovementMode> movementModes,
+                                      final Collection<MissionRole> missionRoles,
+                                      @Nullable Predicate<MechSummary> filter) {
+        final RAT rat = findRAT(faction, unitType, weightClass, year, quality);
         if (rat != null) {
             if (!movementModes.isEmpty()) {
-                Predicate<MechSummary> moveFilter = ms ->
+                final Predicate<MechSummary> moveFilter = ms ->
                         movementModes.contains(EntityMovementMode.getMode(ms.getUnitSubType()));
-                if (filter == null) {
-                    filter = moveFilter;
-                } else {
-                    filter = filter.and(moveFilter);
-                }
+                filter = (filter == null) ? moveFilter : filter.and(moveFilter);
             }
             return RandomUnitGenerator.getInstance().generate(count, rat.ratName, filter);
         }
         return new ArrayList<>();
+    }
+
+    /**
+     * Generates a single unit, for the given faction, using the given set of parameters.
+     * Note that some of the properties of the parameters may be ignored for generation mechanisms that aren't the RAT Generator
+     * @param parameters data structure containing unit generation parameters
+     * @return Generated units. Null if none generated.
+     */
+    @Override
+    public @Nullable MechSummary generate(final UnitGeneratorParameters parameters) {
+        return generate(parameters.getFaction(), parameters.getUnitType(), parameters.getWeightClass(),
+                parameters.getYear(), parameters.getQuality(), parameters.getMovementModes(), parameters.getFilter());
     }
 
     /**
@@ -456,20 +443,8 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
      * @param parameters RATGenerator parameters (some are ignored)
      */
     @Override
-    public List<MechSummary> generate(int count, UnitGeneratorParameters parameters) {
+    public List<MechSummary> generate(final int count, final UnitGeneratorParameters parameters) {
         return generate(count, parameters.getFaction(), parameters.getUnitType(), parameters.getWeightClass(),
-                parameters.getYear(), parameters.getQuality(), parameters.getMovementModes(), parameters.getFilter());
-    }
-
-    /**
-     * Generates a single unit, for the given faction, using the given set of parameters.
-     * Note that some of the properties of the parameters may be ignored for generation mechanisms that aren't the RAT Generator
-     * @param parameters data structure containing unit generation parameters
-     * @return Generated units. Null if none generated.
-     */
-    @Override
-    public @Nullable MechSummary generate(UnitGeneratorParameters parameters) {
-        return generate(parameters.getFaction(), parameters.getUnitType(), parameters.getWeightClass(),
                 parameters.getYear(), parameters.getQuality(), parameters.getMovementModes(), parameters.getFilter());
     }
 

--- a/MekHQ/src/mekhq/campaign/universe/RATManager.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATManager.java
@@ -37,6 +37,8 @@ import java.util.function.Predicate;
 
 import javax.xml.parsers.DocumentBuilder;
 
+import megamek.client.ratgenerator.MissionRole;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHqConstants;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -379,11 +381,13 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
 
     @Override
     public MechSummary generate(String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Predicate<MechSummary> filter) {
+        return generate(faction, unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
+    }
+
+    @Override
+    public @Nullable MechSummary generate(String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Collection<MissionRole> missionRoles, Predicate<MechSummary> filter) {
         List<MechSummary> list = generate(1, faction, unitType, weightClass, year, quality, movementModes, filter);
-        if (list.size() > 0) {
-            return list.get(0);
-        }
-        return null;
+        return list.isEmpty() ? null : list.get(0);
     }
 
     /* (non-Javadoc)
@@ -423,11 +427,16 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
     public List<MechSummary> generate(int count, String faction, int unitType,
             int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes,
             Predicate<MechSummary> filter) {
+        return generate(count, faction, unitType, weightClass, year, quality, movementModes, new ArrayList<>(), filter);
+    }
+
+    @Override
+    public List<MechSummary> generate(int count, String faction, int unitType, int weightClass, int year, int quality, Collection<EntityMovementMode> movementModes, Collection<MissionRole> missionRoles, Predicate<MechSummary> filter) {
         RAT rat = findRAT(faction, unitType, weightClass, year, quality);
         if (rat != null) {
             if (!movementModes.isEmpty()) {
                 Predicate<MechSummary> moveFilter = ms ->
-                    movementModes.contains(EntityMovementMode.getMode(ms.getUnitSubType()));
+                        movementModes.contains(EntityMovementMode.getMode(ms.getUnitSubType()));
                 if (filter == null) {
                     filter = moveFilter;
                 } else {
@@ -436,7 +445,7 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
             }
             return RandomUnitGenerator.getInstance().generate(count, rat.ratName, filter);
         }
-        return new ArrayList<MechSummary>();
+        return new ArrayList<>();
     }
 
     /**
@@ -459,7 +468,7 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
      * @return Generated units. Null if none generated.
      */
     @Override
-    public MechSummary generate(UnitGeneratorParameters parameters) {
+    public @Nullable MechSummary generate(UnitGeneratorParameters parameters) {
         return generate(parameters.getFaction(), parameters.getUnitType(), parameters.getWeightClass(),
                 parameters.getYear(), parameters.getQuality(), parameters.getMovementModes(), parameters.getFilter());
     }

--- a/MekHQ/src/mekhq/campaign/universe/RATManager.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATManager.java
@@ -1,7 +1,8 @@
 /*
  * RATManager.java
  *
- * Copyright (c) 2016 Carl Spain. All rights reserved.
+ * Copyright (c) 2016 - Carl Spain. All Rights Reserved.
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -63,13 +64,13 @@ import mekhq.campaign.event.OptionsChangedEvent;
  *
  * @author Neoancient
  */
-public class RATManager extends AbstractUnitGenerator implements IUnitGenerator {
+public class RATManager extends AbstractUnitGenerator {
     // allRATs.get(collectionName).get(era); eras are sorted from latest to earliest
-    private Map<String, LinkedHashMap<Integer, List<RAT>>> allRATs;
-    private ArrayList<String> selectedCollections;
+    private final Map<String, LinkedHashMap<Integer, List<RAT>>> allRATs;
+    private final ArrayList<String> selectedCollections;
 
     private static Map<String, List<Integer>> allCollections = null;
-    private static Map<String, String> fileNames = new HashMap<>();
+    private static final Map<String, String> fileNames = new HashMap<>();
 
     private boolean canIgnoreEra = false;
 
@@ -465,7 +466,7 @@ public class RATManager extends AbstractUnitGenerator implements IUnitGenerator 
         public static RAT createFromXml(Node node) {
             RAT retVal = new RAT();
             if (node.getAttributes().getNamedItem("name") == null) {
-                MekHQ.getLogger().error(RATManager.class, "name attribute missing");
+                MekHQ.getLogger().error("Name attribute missing");
                 return null;
             }
             retVal.ratName = node.getAttributes().getNamedItem("name").getTextContent();

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -194,7 +194,7 @@ public class AtBEventProcessor {
         }
         final String faction = getRecruitFaction(campaign);
         MechSummary ms = campaign.getUnitGenerator().generate(faction, unitType, weight, campaign.getGameYear(),
-                IUnitRating.DRAGOON_F, movementModes, missionRoles, null);
+                IUnitRating.DRAGOON_F, movementModes, missionRoles);
         Entity en;
         if (null != ms) {
             if (Factions.getInstance().getFaction(faction).isClan() && ms.getName().matches(".*Platoon.*")) {

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -20,6 +20,7 @@ package mekhq.module.atb;
 
 import java.time.DayOfWeek;
 import java.util.ArrayList;
+import java.util.Collection;
 
 import megamek.client.ratgenerator.MissionRole;
 import megamek.common.Compute;
@@ -46,7 +47,6 @@ import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.IUnitGenerator;
 import mekhq.campaign.universe.RandomFactionGenerator;
-import mekhq.campaign.universe.UnitGeneratorParameters;
 
 /**
  * Main engine of the Against the Bot campaign system.
@@ -145,8 +145,8 @@ public class AtBEventProcessor {
     }
 
     private void addRecruitUnit(Person p) {
-        UnitGeneratorParameters params = new UnitGeneratorParameters();
-
+        final Collection<EntityMovementMode> movementModes = new ArrayList<>();
+        final Collection<MissionRole> missionRoles = new ArrayList<>();
         int unitType;
         switch (p.getPrimaryRole()) {
             case MECHWARRIOR:
@@ -168,8 +168,8 @@ public class AtBEventProcessor {
                 unitType = UnitType.INFANTRY;
                 // infantry will have a 1/3 chance of being field guns
                 if (Compute.d6() <= 2) {
-                    params.getMissionRoles().add(MissionRole.FIELD_GUN);
-                    params.getMovementModes().addAll(IUnitGenerator.ALL_INFANTRY_MODES);
+                    movementModes.addAll(IUnitGenerator.ALL_INFANTRY_MODES);
+                    missionRoles.add(MissionRole.FIELD_GUN);
                 }
                 break;
             default:
@@ -192,17 +192,10 @@ public class AtBEventProcessor {
                 weight = EntityWeightClass.WEIGHT_HEAVY;
             }
         }
+        final String faction = getRecruitFaction(campaign);
+        MechSummary ms = campaign.getUnitGenerator().generate(faction, unitType, weight, campaign.getGameYear(),
+                IUnitRating.DRAGOON_F, movementModes, missionRoles, null);
         Entity en;
-
-        String faction = getRecruitFaction(campaign);
-
-        params.setFaction(faction);
-        params.setUnitType(unitType);
-        params.setWeightClass(weight);
-        params.setYear(campaign.getGameYear());
-        params.setQuality(IUnitRating.DRAGOON_F);
-
-        MechSummary ms = campaign.getUnitGenerator().generate(params);
         if (null != ms) {
             if (Factions.getInstance().getFaction(faction).isClan() && ms.getName().matches(".*Platoon.*")) {
                 String name = "Clan " + ms.getName().replaceAll("Platoon", "Point");


### PR DESCRIPTION
This fixes #251 and a common source of bug reports by adding a fallback system for force generator unit generation, with the goal of preventing empty OpFors. To do this I reserved two of the generation methods for OpFor generation and removed the two non-OpFor generation method uses.
To review: The second commit is the generation change, while the other three are a mixture of code cleanup and standardization.  (I was originally considering doing a full campaign options setup, but decided the bugfix should be merged in the nearer future.)