### PR TITLE
Mekhq potato cleanup

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -32,7 +32,6 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
@@ -1483,7 +1482,7 @@ public class StratconRulesManager {
             
             if ((track.getAssignedForceReturnDates().get(forceID).equals(date)
                     || track.getAssignedForceReturnDates().get(forceID).isBefore(date))
-                    && (force != null) && !force.isDeployed()
+                    && (force != null) && !track.getBackingScenariosMap().containsKey(force.getScenarioId())
                     && !track.getStickyForces().contains(forceID)) {
                 forcesToUndeploy.add(forceID);
             }

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -269,20 +269,20 @@ public class StratconPanel extends JPanel implements ActionListener {
             
             // since we have the possibility of scrolling, we need to convert the on-screen clicked coordinates
             // to on-board coordinates. Thankfully, SwingUtilities provides the main computational ability for that
-            Point actualPanelPoint = SwingUtilities.convertPoint(this, translatedClickedPoint, this.getParent());
-            translatedClickedPoint.translate((int) -(actualPanelPoint.getX() - translatedClickedPoint.getX()), 
-                                                (int) -(actualPanelPoint.getY() - translatedClickedPoint.getY()));
+            translatedClickedPoint = SwingUtilities.convertPoint(this, translatedClickedPoint, this.getParent());
+            translatedClickedPoint.translate((int) getVisibleRect().getX(), (int) getVisibleRect().getY());
+            translatedClickedPoint.translate(0, -HEX_Y_RADIUS);
             
-            // now we translate to the starting point of where we're drawing and then go down a hex
-            translatedClickedPoint.translate((int) g2D.getTransform().getTranslateX(), (int) g2D.getTransform().getTranslateY());
-            translatedClickedPoint.translate(0, HEX_Y_RADIUS * -2);
+            // useful for graphics coords debugging
+            //g2D.setColor(Color.ORANGE);
+            //g2D.drawString(translatedClickedPoint.getX() + ", " + translatedClickedPoint.getY(), (int) clickedPoint.getX(), (int) clickedPoint.getY());
         }
 
         for (int x = 0; x < currentTrack.getWidth(); x++) {            
             for (int y = 0; y < currentTrack.getHeight(); y++) {
                 if (drawHexType == DrawHexType.Outline) {
                     g2D.setColor(new Color(0, 0, 0));
-                    g2D.drawPolygon(graphHex);                    
+                    g2D.drawPolygon(graphHex);
                 } else if (drawHexType == DrawHexType.Hex) {
                     
                     if (currentTrack.coordsRevealed(x, y) || currentTrack.isGmRevealed()) {
@@ -291,6 +291,11 @@ public class StratconPanel extends JPanel implements ActionListener {
                         g2D.setColor(Color.DARK_GRAY);
                     }
                     g2D.fillPolygon(graphHex);
+                    
+                    // useful for graphics coords debugging
+                    //g2D.setColor(Color.pink);
+                    //g2D.drawString(graphHex.getBounds().getX() + ", " + graphHex.getBounds().getY(), (int) graphHex.getBounds().getX(), (int) graphHex.getBounds().getY());
+                    //g2D.setColor(Color.DARK_GRAY);
                     
                     if ((translatedClickedPoint != null) && graphHex.contains(translatedClickedPoint)) {
                         g2D.setColor(Color.WHITE);

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -27,7 +27,6 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 
 import megamek.common.event.Subscribe;

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -27,6 +27,7 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 
 import megamek.common.event.Subscribe;
@@ -102,7 +103,8 @@ public class StratconTab extends CampaignGuiTab {
         // TODO: lance role assignment UI here?
 
         initializeInfoPanel();
-        this.add(infoPanel);
+        JScrollPane infoScrollPane = new JScrollPane(infoPanel);
+        this.add(infoScrollPane);
 
         MekHQ.registerHandler(this);
     }


### PR DESCRIPTION
Three changes:
- fix clicked hex detection on StratCon map when viewing anything other than top left corner when map doesn't fit on single screen
- added scroll pane in case info panel has more data than can be displayed
- do not un-deploy force from track if it's assigned to a scenario on the track until the scenario is resolved one way or another