### PR TITLE
Fixing Campaign::getTargetForMaintenance IDE Potential NPE False Positive

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4860,13 +4860,7 @@ public class Campaign implements Serializable, ITechManager {
         }
         int helpMod;
         if (null != partWork.getUnit() && partWork.getUnit().isSelfCrewed()) {
-            int hits;
-            if (null != partWork.getUnit().getEntity().getCrew()) {
-                hits = partWork.getUnit().getEntity().getCrew().getHits();
-            } else {
-                hits = 6;
-            }
-            helpMod = getShorthandedModForCrews(hits);
+            helpMod = getShorthandedModForCrews(partWork.getUnit().getEntity().getCrew());
         } else {
             int helpers = getAvailableAstechs(minutes, isOvertime);
             helpMod = getShorthandedMod(helpers, false);
@@ -4929,8 +4923,7 @@ public class Campaign implements Serializable, ITechManager {
             // size
             final int helpMod;
             if (partWork.getUnit().isSelfCrewed()) {
-                helpMod = getShorthandedModForCrews((partWork.getUnit().getEntity().getCrew() == null)
-                        ? 6 : partWork.getUnit().getEntity().getCrew().getHits());
+                helpMod = getShorthandedModForCrews(partWork.getUnit().getEntity().getCrew());
             } else {
                 helpMod = getShorthandedMod(partWork.getUnit().getAstechsMaintained(), false);
             }
@@ -5328,18 +5321,19 @@ public class Campaign implements Serializable, ITechManager {
         return helpMod;
     }
 
-    public int getShorthandedModForCrews(int hits) {
-        int helpMod = 0;
+    public int getShorthandedModForCrews(final @Nullable Crew crew) {
+        final int hits = (crew == null) ? 5 : crew.getHits();
         if (hits >= 5) {
-            helpMod = 4;
+            return 4;
         } else if (hits == 4) {
-            helpMod = 3;
+            return  3;
         } else if (hits == 3) {
-            helpMod = 2;
+            return 2;
         } else if (hits > 0) {
-            helpMod = 1;
+            return 1;
+        } else {
+            return 0;
         }
-        return helpMod;
     }
 
     public int getMedicsPerDoctor() {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4927,19 +4927,14 @@ public class Campaign implements Serializable, ITechManager {
             // "astech days" used over
             // the cycle and take the average per day rounding down as our team
             // size
-            int helpMod = 0;
-            if (null != partWork.getUnit() && partWork.getUnit().isSelfCrewed()) {
-                int hits = 0;
-                if (null != partWork.getUnit().getEntity().getCrew()) {
-                    hits = partWork.getUnit().getEntity().getCrew().getHits();
-                } else {
-                    hits = 6;
-                }
-                helpMod = getShorthandedModForCrews(hits);
+            final int helpMod;
+            if (partWork.getUnit().isSelfCrewed()) {
+                helpMod = getShorthandedModForCrews((partWork.getUnit().getEntity().getCrew() == null)
+                        ? 6 : partWork.getUnit().getEntity().getCrew().getHits());
             } else {
-                int helpers = partWork.getUnit().getAstechsMaintained();
-                helpMod = getShorthandedMod(helpers, false);
+                helpMod = getShorthandedMod(partWork.getUnit().getAstechsMaintained(), false);
             }
+
             if (helpMod > 0) {
                 target.addModifier(helpMod, "shorthanded");
             }


### PR DESCRIPTION
This fixes an IDE warning for a potential NPE (false positive, partWork.getUnit() is previously null checked, but better to clean up) and simplifies the code around the if statement.