### PR TITLE
fixes for multiple stratcon issues; objective display improvement

### DIFF
--- a/MekHQ/data/scenariomodifiers/EnemyArty.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyArty.xml
@@ -27,9 +27,6 @@
 		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>
-		<objectiveLinkedForces>
-			<objectiveLinkedForce>Primary Opfor</objectiveLinkedForce>
-		</objectiveLinkedForces>
 		<retreatThreshold>50</retreatThreshold>
 		<startingAltitude>0</startingAltitude>
 		<syncDeploymentType>None</syncDeploymentType>

--- a/MekHQ/data/scenariotemplates/Pursuit.xml
+++ b/MekHQ/data/scenariotemplates/Pursuit.xml
@@ -3,6 +3,8 @@
     <name>Pursuit</name>
     <shortBriefing>Escape superior pursuing enemy force.</shortBriefing>
     <detailedBriefing>Reach the far edge of the map or destroy 50% of the pursuing force.</detailedBriefing>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes/>
         <allowRotation>true</allowRotation>
@@ -13,97 +15,6 @@
         <useStandardAtBSizing>false</useStandardAtBSizing>
         <widthScalingIncrement>1</widthScalingIncrement>
     </mapParameters>
-    <scenarioForces>
-        <entry>
-            <key>Player</key>
-            <value>
-                <actualDeploymentZone>-1</actualDeploymentZone>
-                <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>-1</arrivalTurn>
-                <canReinforceLinked>false</canReinforceLinked>
-                <contributesToBV>true</contributesToBV>
-                <contributesToMapSize>true</contributesToMapSize>
-                <contributesToUnitCount>true</contributesToUnitCount>
-                <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>11</deploymentZone>
-                </deploymentZones>
-                <destinationZone>5</destinationZone>
-                <fixedUnitCount>0</fixedUnitCount>
-                <forceAlignment>0</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
-                <forceName>Player</forceName>
-                <generationMethod>0</generationMethod>
-                <generationOrder>1</generationOrder>
-                <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>0</minWeightClass>
-                <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
-                <useArtillery>false</useArtillery>
-            </value>
-        </entry>
-        <entry>
-            <key>Primary Opfor</key>
-            <value>
-                <actualDeploymentZone>-1</actualDeploymentZone>
-                <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>-1</arrivalTurn>
-                <canReinforceLinked>false</canReinforceLinked>
-                <contributesToBV>false</contributesToBV>
-                <contributesToMapSize>false</contributesToMapSize>
-                <contributesToUnitCount>false</contributesToUnitCount>
-                <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>11</deploymentZone>
-                </deploymentZones>
-                <destinationZone>6</destinationZone>
-                <fixedUnitCount>0</fixedUnitCount>
-                <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
-                <forceName>Primary Opfor</forceName>
-                <generationMethod>1</generationMethod>
-                <generationOrder>5</generationOrder>
-                <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
-                <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
-                <useArtillery>false</useArtillery>
-            </value>
-        </entry>
-        <entry>
-            <key>Reinforcements</key>
-            <value>
-                <actualDeploymentZone>-1</actualDeploymentZone>
-                <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>-3</arrivalTurn>
-                <canReinforceLinked>true</canReinforceLinked>
-                <contributesToBV>false</contributesToBV>
-                <contributesToMapSize>false</contributesToMapSize>
-                <contributesToUnitCount>false</contributesToUnitCount>
-                <deployOffboard>false</deployOffboard>
-                <deploymentZones/>
-                <destinationZone>5</destinationZone>
-                <fixedUnitCount>0</fixedUnitCount>
-                <forceAlignment>0</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
-                <forceName>Reinforcements</forceName>
-                <generationMethod>0</generationMethod>
-                <generationOrder>1</generationOrder>
-                <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
-                <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
-                <useArtillery>false</useArtillery>
-            </value>
-        </entry>
-    </scenarioForces>
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
@@ -164,4 +75,98 @@
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
+    <scenarioForces>
+        <entry>
+            <key>Player</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>-1</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>true</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>true</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>11</deploymentZone>
+                </deploymentZones>
+                <destinationZone>6</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>0</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Player</forceName>
+                <generationMethod>0</generationMethod>
+                <generationOrder>1</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces/>
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Primary Opfor</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>-1</arrivalTurn>
+                <canReinforceLinked>false</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>false</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>11</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>2.0</forceMultiplier>
+                <forceName>Primary Opfor</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>5</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>1</minWeightClass>
+                <objectiveLinkedForces/>
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>Reinforcements</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>-3</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>false</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones/>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>0</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Reinforcements</forceName>
+                <generationMethod>0</generationMethod>
+                <generationOrder>1</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>1</minWeightClass>
+                <objectiveLinkedForces/>
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+    </scenarioForces>
 </ScenarioTemplate>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1422,9 +1422,14 @@ public class StratconRulesManager {
 
         // first, we check if this scenario is associated with any specific scenario objectives
         StratconStrategicObjective specificObjective = track.getObjectivesByCoords().get(scenario.getCoords());
-        if (victory && (specificObjective != null) &&
+        if ((specificObjective != null) &&
                 (specificObjective.getObjectiveType() == StrategicObjectiveType.SpecificScenarioVictory)) {
-            specificObjective.incrementCurrentObjectiveCount();
+            
+            if (victory) {
+                specificObjective.incrementCurrentObjectiveCount();
+            } else {
+                specificObjective.setCurrentObjectiveCount(StratconStrategicObjective.OBJECTIVE_FAILED);
+            }
         }
 
         // "any scenario victory" is not linked to any specific coordinates, so we have to
@@ -1542,6 +1547,12 @@ public class StratconRulesManager {
                     if (closestAlliedFacilityCoords != null) {
                         StratconCoords newCoords = scenario.getCoords()
                                 .translate(scenario.getCoords().direction(closestAlliedFacilityCoords));
+                        
+                        boolean objectiveMoved = track.moveObjective(scenario.getCoords(), newCoords);
+                        if (!objectiveMoved) {
+                            track.failObjective(scenario.getCoords());
+                        }
+                        
                         scenario.setCoords(newCoords);
 
                         int daysForward = Math.max(1, track.getDeploymentTime());
@@ -1563,6 +1574,7 @@ public class StratconRulesManager {
                         scenario.setCurrentState(ScenarioState.UNRESOLVED);
                         return false;
                     } else {
+                        track.failObjective(scenario.getCoords());
                         // TODO: if there's no allied facilities here, add its forces to track
                         // reinforcement pool
                         return true;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
@@ -27,6 +27,7 @@ import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType
  * and also handles some small amount of "business logic"
  */
 public class StratconStrategicObjective {
+    public static final int OBJECTIVE_FAILED = -1;
     
     private StratconCoords objectiveCoords;
     private StrategicObjectiveType objectiveType;
@@ -69,6 +70,29 @@ public class StratconStrategicObjective {
         this.desiredObjectiveCount = desiredObjectiveCount;
     }
 
+    public boolean isObjectiveFailed(StratconTrackState trackState) {
+        switch (getObjectiveType()) {
+        case AnyScenarioVictory:
+        case SpecificScenarioVictory:
+            // you can fail this if the scenario goes away somehow
+            return getCurrentObjectiveCount() == OBJECTIVE_FAILED;
+        case AlliedFacilityControl:
+            // you can fail this by having the facility destroyed
+            StratconFacility alliedFacility = trackState.getFacility(getObjectiveCoords());
+            return alliedFacility == null;
+        case HostileFacilityControl:
+            // you can fail this by having the facility destroyed
+            StratconFacility hostileFacility = trackState.getFacility(getObjectiveCoords());
+            return hostileFacility == null;
+        case FacilityDestruction:
+            // you can't really permanently fail this
+            return false;
+        default:
+            // we shouldn't be here, but just in case
+            return false;
+    }
+    }
+    
     /**
      * Given the track that this objective is on, is it complete?
      */

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconStrategicObjective.java
@@ -72,25 +72,25 @@ public class StratconStrategicObjective {
 
     public boolean isObjectiveFailed(StratconTrackState trackState) {
         switch (getObjectiveType()) {
-        case AnyScenarioVictory:
-        case SpecificScenarioVictory:
-            // you can fail this if the scenario goes away somehow
-            return getCurrentObjectiveCount() == OBJECTIVE_FAILED;
-        case AlliedFacilityControl:
-            // you can fail this by having the facility destroyed
-            StratconFacility alliedFacility = trackState.getFacility(getObjectiveCoords());
-            return alliedFacility == null;
-        case HostileFacilityControl:
-            // you can fail this by having the facility destroyed
-            StratconFacility hostileFacility = trackState.getFacility(getObjectiveCoords());
-            return hostileFacility == null;
-        case FacilityDestruction:
-            // you can't really permanently fail this
-            return false;
-        default:
-            // we shouldn't be here, but just in case
-            return false;
-    }
+            case AnyScenarioVictory:
+            case SpecificScenarioVictory:
+                // you can fail this if the scenario goes away somehow
+                return getCurrentObjectiveCount() == OBJECTIVE_FAILED;
+            case AlliedFacilityControl:
+                // you can fail this by having the facility destroyed
+                StratconFacility alliedFacility = trackState.getFacility(getObjectiveCoords());
+                return alliedFacility == null;
+            case HostileFacilityControl:
+                // you can fail this by having the facility destroyed
+                StratconFacility hostileFacility = trackState.getFacility(getObjectiveCoords());
+                return hostileFacility == null;
+            case FacilityDestruction:
+                // you can't really permanently fail this
+                return false;
+            default:
+                // we shouldn't be here, but just in case
+                return false;
+        }
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -390,9 +390,9 @@ public class StratconTrackState {
             getObjectivesByCoords().put(destination, objective);
             objective.setObjectiveCoords(destination);
             return true;
+        } else {        
+            return false;
         }
-        
-        return false;
     }
     
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -377,6 +377,34 @@ public class StratconTrackState {
     }
     
     /**
+     * Moves a strategic objectives from the source to the destination coordinates.
+     * @return True if the operation succeeded, false if it failed
+     */
+    public boolean moveObjective(StratconCoords source, StratconCoords destination) {
+        // safety: don't move it if it's not there; logic prevents two objectives in the same coords
+        if (getObjectivesByCoords().containsKey(source) &&
+                !getObjectivesByCoords().containsKey(destination)) {
+            StratconStrategicObjective objective = getObjectivesByCoords().get(source);
+            // gotta get the cache
+            getObjectivesByCoords().remove(source);
+            getObjectivesByCoords().put(destination, objective);
+            objective.setObjectiveCoords(destination);
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Convenience method to fail an objective at the given coordinates.
+     */
+    public void failObjective(StratconCoords coords) {
+        if (getObjectivesByCoords().containsKey(coords)) {
+            getObjectivesByCoords().get(coords).setCurrentObjectiveCount(StratconStrategicObjective.OBJECTIVE_FAILED);
+        }
+    }
+    
+    /**
      * Convenience method - returns true if the force with the given ID is currently deployed to this track
      */
     public boolean isForceDeployed(int forceID) {

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -48,6 +48,10 @@ import mekhq.campaign.stratcon.StratconTrackState;
 public class StratconTab extends CampaignGuiTab {
     private static final long serialVersionUID = 8179754409939346465L;
 
+    private static final String OBJECTIVE_FAILED = "x";
+    private static final String OBJECTIVE_COMPLETED = "&#10003;";
+    private static final String OBJECTIVE_IN_PROGRESS = "o";
+    
     private StratconPanel stratconPanel;
     private JPanel infoPanel;
     private JComboBox<TrackDropdownItem> cboCurrentTrack;
@@ -291,6 +295,8 @@ public class StratconTab extends CampaignGuiTab {
     private String buildStrategicObjectiveText(StratconCampaignState campaignState) {
         StringBuilder sb = new StringBuilder();
 
+        boolean contractIsActive = campaignState.getContract().isActiveOn(getCampaignGui().getCampaign().getLocalDate());
+        
         // loop through all tracks
         // for each track, loop through all objectives
         // for each objective, grab the coordinates
@@ -306,16 +312,19 @@ public class StratconTab extends CampaignGuiTab {
                 boolean objectiveCompleted = objective.isObjectiveCompleted(track);
                 boolean objectiveFailed = objective.isObjectiveFailed(track);
 
+                // special case: allied facilities can get lost at any point in time
                 if ((objective.getObjectiveType() == StrategicObjectiveType.AlliedFacilityControl) && 
                         !campaignState.allowEarlyVictory()) {
-                    sb.append("<span>o");
+                    sb.append("<span color='orange'>").append(OBJECTIVE_IN_PROGRESS);
                 } else if (objectiveCompleted) {
-                    sb.append("<span color='green'>&#10003; ");                    
+                    sb.append("<span color='green'>").append(OBJECTIVE_COMPLETED);                    
                 } else if (objectiveFailed) {
-                    sb.append("<span color='red'>x ");
+                    sb.append("<span color='red'>").append(OBJECTIVE_FAILED);
                 } else {
-                    sb.append("<span color='orange'>o ");
+                    sb.append("<span color='orange'>").append(OBJECTIVE_IN_PROGRESS);
                 }
+                
+                sb.append(" ");
 
                 if (!coordsRevealed && displayCoordinateData) {
                     sb.append("Locate and ");
@@ -357,14 +366,16 @@ public class StratconTab extends CampaignGuiTab {
         }
 
         // special case text reminding player to complete required scenarios
-        if (!campaignState.getContract().getCommandRights().isIndependent()) {
-            if (campaignState.getVictoryPoints() > 0) {
-                sb.append("<span color='green'>");
+        if (!campaignState.getContract().getCommandRights().isIndependent()) {            
+            if (contractIsActive) {
+                sb.append("<span color='orange'>").append(OBJECTIVE_IN_PROGRESS);
+            } else if (campaignState.getVictoryPoints() > 0) {
+                sb.append("<span color='green'>").append(OBJECTIVE_COMPLETED);
             } else {
-                sb.append("<span color='red'>");
+                sb.append("<span color='red'>").append(OBJECTIVE_FAILED);
             }
 
-            sb.append("Maintain victory point count above 0 by completing required scenarios")
+            sb.append(" Maintain victory point count above 0 by completing required scenarios")
                 .append("</span><br/>");
         }
 

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -295,8 +295,6 @@ public class StratconTab extends CampaignGuiTab {
     private String buildStrategicObjectiveText(StratconCampaignState campaignState) {
         StringBuilder sb = new StringBuilder();
 
-        boolean contractIsActive = campaignState.getContract().isActiveOn(getCampaignGui().getCampaign().getLocalDate());
-        
         // loop through all tracks
         // for each track, loop through all objectives
         // for each objective, grab the coordinates
@@ -366,7 +364,9 @@ public class StratconTab extends CampaignGuiTab {
         }
 
         // special case text reminding player to complete required scenarios
-        if (!campaignState.getContract().getCommandRights().isIndependent()) {            
+        if (!campaignState.getContract().getCommandRights().isIndependent()) {
+            boolean contractIsActive = campaignState.getContract().isActiveOn(getCampaignGui().getCampaign().getLocalDate());
+            
             if (contractIsActive) {
                 sb.append("<span color='orange'>").append(OBJECTIVE_IN_PROGRESS);
             } else if (campaignState.getVictoryPoints() > 0) {

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -304,14 +304,17 @@ public class StratconTab extends CampaignGuiTab {
                 boolean coordsRevealed = track.getRevealedCoords().contains(objective.getObjectiveCoords());
                 boolean displayCoordinateData = objective.getObjectiveCoords() != null;
                 boolean objectiveCompleted = objective.isObjectiveCompleted(track);
+                boolean objectiveFailed = objective.isObjectiveFailed(track);
 
                 if ((objective.getObjectiveType() == StrategicObjectiveType.AlliedFacilityControl) && 
                         !campaignState.allowEarlyVictory()) {
-                    sb.append("<span>");
+                    sb.append("<span>o");
                 } else if (objectiveCompleted) {
-                    sb.append("<span color='green'>");                    
+                    sb.append("<span color='green'>&#10003; ");                    
+                } else if (objectiveFailed) {
+                    sb.append("<span color='red'>x ");
                 } else {
-                    sb.append("<span color='red'>");
+                    sb.append("<span color='orange'>o ");
                 }
 
                 if (!coordsRevealed && displayCoordinateData) {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -917,9 +917,10 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 for (final Mission mission : gui.getCampaign().getActiveMissions()) {
                     missionMenu = new JMenu(mission.getName());
                     for (final Scenario scenario : mission.getCurrentScenarios()) {
-                        if (gui.getCampaign().getCampaignOptions().getUseAtB()
+                        if (scenario.isCloaked()
+                                || (gui.getCampaign().getCampaignOptions().getUseAtB()
                                 && (scenario instanceof AtBScenario)
-                                && !((AtBScenario) scenario).canDeployForces(forces, gui.getCampaign())) {
+                                && !((AtBScenario) scenario).canDeployForces(forces, gui.getCampaign()))) {
                             continue;
                         }
                         menuItem = new JMenuItem(scenario.getName());


### PR DESCRIPTION
- Pursuit scenario had the opfor set to run for the opposite edge even though it's the player's goal to get to the opposite edge
- Objective scenarios can sometimes move, but the objective wouldn't go with them
- Now possible to completely fail a facility capture/control objective if the facility is destroyed
- Prevent being able to deploy to invisible objective scenarios from the TO&E
- To help with color-blind users:
o indicates an in-progress objective (not complete, not failed, colored orange)
x indicates a failed objective (no way to complete, red colored)
checkmark indicates a completed objective (green colored)