### PR TITLE
2558: Adding Custom Messages for Dependant Joining/Departing the Force

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -9,7 +9,8 @@ PlanetaryAcquisitionFactionLimit.NEUTRAL.text=Neutral or Allied Factions
 PlanetaryAcquisitionFactionLimit.ALLIED.text=Allied Factions
 PlanetaryAcquisitionFactionLimit.SELF.text=Own Faction Only
 
-# Unsorted Campaign Resources
+## Unsorted Campaign Resources
+dependentLeavesForce.text=%s is no longer travelling with the force, and is thus no longer dependent on it.
 bonusPartLog.text=Bonus part used to acquire 1x
 newAtBMission.format=New scenario "{0}" will occur on {1}.
 atbMissionToday.format=Scenario "{0}" is today, deploy a force from your TOE!

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -11,6 +11,7 @@ PlanetaryAcquisitionFactionLimit.SELF.text=Own Faction Only
 
 ## Unsorted Campaign Resources
 dependentLeavesForce.text=%s is no longer travelling with the force, and is thus no longer dependent on it.
+dependentJoinsForce.text=%s has started travelling with the force, and is now dependent on it.
 bonusPartLog.text=Bonus part used to acquire 1x
 newAtBMission.format=New scenario "{0}" will occur on {1}.
 atbMissionToday.format=Scenario "{0}" is today, deploy a force from your TOE!

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3155,8 +3155,8 @@ public class Campaign implements Serializable, ITechManager {
             int change = numPersonnel * (roll - 5) / 100;
             if (change < 0) {
                 if (!getCampaignOptions().getDependentsNeverLeave()) {
-                    while ((change < 0) && (dependents.size() > 0)) {
-                        removePerson(Utilities.getRandomItem(dependents).getId());
+                    while ((change < 0) && !dependents.isEmpty()) {
+                        removePerson(Utilities.getRandomItem(dependents)); // TODO : different log format for here
                         change++;
                     }
                 }
@@ -3511,22 +3511,20 @@ public class Campaign implements Serializable, ITechManager {
         MekHQ.triggerEvent(new UnitRemovedEvent(unit));
     }
 
-    public void removePerson(UUID id) {
-        removePerson(id, true);
+    public void removePerson(final @Nullable Person person) {
+        removePerson(person, true);
     }
 
-    public void removePerson(UUID id, boolean log) {
-        Person person = getPerson(id);
-
+    public void removePerson(final @Nullable Person person, final boolean log) {
         if (person == null) {
             return;
         }
 
         person.getGenealogy().clearGenealogy();
 
-        Unit u = person.getUnit();
-        if (null != u) {
-            u.remove(person, true);
+        final Unit unit = person.getUnit();
+        if (unit != null) {
+            unit.remove(person, true);
         }
         removeAllPatientsFor(person);
         person.removeAllTechJobs(this);
@@ -3537,7 +3535,7 @@ public class Campaign implements Serializable, ITechManager {
             addReport(person.getFullTitle() + " has been removed from the personnel roster.");
         }
 
-        personnel.remove(id);
+        personnel.remove(person.getId());
 
         // Deal with Astech Pool Minutes
         if (person.getPrimaryRole().isAstech()) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3156,7 +3156,11 @@ public class Campaign implements Serializable, ITechManager {
             if (change < 0) {
                 if (!getCampaignOptions().getDependentsNeverLeave()) {
                     while ((change < 0) && !dependents.isEmpty()) {
-                        removePerson(Utilities.getRandomItem(dependents)); // TODO : different log format for here
+                        final Person person = Utilities.getRandomItem(dependents);
+                        addReport(String.format(resources.getString("dependentLeavesForce.text"),
+                                person.getFullTitle()));
+                        removePerson(person, false);
+                        dependents.remove(person);
                         change++;
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3167,8 +3167,10 @@ public class Campaign implements Serializable, ITechManager {
             } else {
                 if (getCampaignOptions().canAtBAddDependents()) {
                     for (int i = 0; i < change; i++) {
-                        Person p = newDependent(false);
-                        recruitPerson(p);
+                        final Person person = newDependent(false);
+                        recruitPerson(person, PrisonerStatus.FREE, true, false);
+                        addReport(String.format(resources.getString("dependentJoinsForce.text"),
+                                person.getFullTitle()));
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -1412,7 +1412,7 @@ public class ResolveScenarioTracker {
             }
 
             if (status.toRemove()) {
-                campaign.removePerson(pid, false);
+                campaign.removePerson(person, false);
             }
         }
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -683,7 +683,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         resourceMap.getString("freeQ.text"),
                         JOptionPane.YES_NO_OPTION)) {
                     for (Person person : people) {
-                        gui.getCampaign().removePerson(person.getId());
+                        gui.getCampaign().removePerson(person);
                     }
                 }
                 break;
@@ -710,7 +710,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     gui.getCampaign().addReport(String.format(resourceMap.getString("ransomReport.format"), people.length, total.toAmountAndSymbolString()));
                     gui.getCampaign().addFunds(total, resourceMap.getString("ransom.text"), Transaction.C_MISC);
                     for (Person person : people) {
-                        gui.getCampaign().removePerson(person.getId(), false);
+                        gui.getCampaign().removePerson(person, false);
                     }
                 }
                 break;
@@ -737,14 +737,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         resourceMap.getString("removeQ.text"),
                         JOptionPane.YES_NO_OPTION)) {
                     for (Person person : people) {
-                        gui.getCampaign().removePerson(person.getId());
+                        gui.getCampaign().removePerson(person);
                     }
                 }
                 break;
             }
             case CMD_SACK: {
                 boolean showDialog = false;
-                ArrayList<UUID> toRemove = new ArrayList<>();
+                List<Person> toRemove = new ArrayList<>();
                 for (Person person : people) {
                     if (gui.getCampaign().getRetirementDefectionTracker()
                             .removeFromCampaign(
@@ -758,7 +758,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                     gui.getCampaign(), null)) {
                         showDialog = true;
                     } else {
-                        toRemove.add(person.getId());
+                        toRemove.add(person);
                     }
                 }
                 if (showDialog) {
@@ -773,8 +773,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                     .removePayout(person);
                         }
                     } else {
-                        for (UUID id : toRemove) {
-                            gui.getCampaign().removePerson(id);
+                        for (final Person person : toRemove) {
+                            gui.getCampaign().removePerson(person);
                         }
                     }
                 } else {
@@ -788,7 +788,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             null, question, resourceMap.getString("removeQ.text"),
                             JOptionPane.YES_NO_OPTION)) {
                         for (Person person : people) {
-                            gui.getCampaign().removePerson(person.getId());
+                            gui.getCampaign().removePerson(person);
                         }
                     }
                 }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -532,7 +532,7 @@ public class CampaignExportWizard extends JDialog {
         // overwrite any people with the same ID.
         for (Person person : personList.getSelectedValuesList()) {
             if (destinationCampaign.getPerson(person.getId()) != null) {
-                destinationCampaign.removePerson(person.getId());
+                destinationCampaign.removePerson(person);
             }
 
             destinationCampaign.importPerson(person);
@@ -587,7 +587,7 @@ public class CampaignExportWizard extends JDialog {
             }
 
             for (Person person : personList.getSelectedValuesList()) {
-                sourceCampaign.removePerson(person.getId(), true);
+                sourceCampaign.removePerson(person, true);
             }
 
             if (money > 0) {


### PR DESCRIPTION
This fixes #2558 and a bug where the same dependent can be selected for removal twice.
Commit 1 swaps removePerson to use the object instead of the id, commits 2-3 adds the new custom messages.