### PR TITLE
fixed reset settings

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -124,7 +124,7 @@ public class AtBGameThread extends GameThread {
 
                 MapSettings mapSettings = MapSettings.getInstance();
                 mapSettings.setBoardSize(scenario.getMapX(), scenario.getMapY());
-                mapSettings.setMapSize(1,  1); 
+                mapSettings.setMapSize(1, 1); 
                 mapSettings.getBoardsSelectedVector().clear();
                 
 
@@ -150,6 +150,9 @@ public class AtBGameThread extends GameThread {
                         mapSettings.setMedium(MapSettings.MEDIUM_ATMOSPHERE);
                     }
                     
+                    // duplicate code, but getting a new instance of map settings resets the size parameters
+                    mapSettings.setBoardSize(scenario.getMapX(), scenario.getMapY());
+                    mapSettings.setMapSize(1, 1); 
                     mapSettings.getBoardsSelectedVector().add(MapSettings.BOARD_GENERATED);
                 }
                 


### PR DESCRIPTION
Turns out, when going to a generated map, getting a new instance of the settings also reset the map size. Who knew.