### PR TITLE
Fixing Unit Market Migration

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -3457,7 +3457,7 @@ public class CampaignOptions implements Serializable {
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "allowOpforLocalUnits", allowOpforLocalUnits);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "opforAeroChance", opforAeroChance);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "opforLocalUnitChance", opforLocalUnitChance);
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "fixedMapChance", fixedMapChance);        
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "fixedMapChance", fixedMapChance);
 
         //Mass Repair/Salvage Options
         MekHqXmlUtil.writeSimpleXmlTag(pw1, ++indent, "massRepairUseRepair", massRepairUseRepair());
@@ -4211,7 +4211,7 @@ public class CampaignOptions implements Serializable {
         }
 
         // Fixing Old Data
-        if (version.isLowerThan("0.49.0") && retVal.getUseAtB()) {
+        if (version.isLowerThan("0.49.3") && retVal.getUseAtB()) {
             retVal.setUnitMarketMethod(UnitMarketMethod.ATB_MONTHLY);
             retVal.setContractMarketMethod(ContractMarketMethod.ATB_MONTHLY);
         }

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/UnitMarketOffer.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/UnitMarketOffer.java
@@ -150,7 +150,7 @@ public class UnitMarketOffer {
                     retVal.setUnitType(Integer.parseInt(wn3.getTextContent().trim()));
                 } else if (wn3.getNodeName().equalsIgnoreCase("unit")) {
                     retVal.setUnit(MechSummaryCache.getInstance().getMech(wn3.getTextContent().trim()));
-                } else if (wn3.getNodeName().equalsIgnoreCase("pct") // Legacy, 0.49.X removal
+                } else if (wn3.getNodeName().equalsIgnoreCase("pct") // Legacy, 0.49.3 removal
                         || wn3.getNodeName().equalsIgnoreCase("percent")) {
                     retVal.setPercent(Integer.parseInt(wn3.getTextContent().trim()));
                 } else if (wn3.getNodeName().equalsIgnoreCase("transitDuration")) {
@@ -161,7 +161,7 @@ public class UnitMarketOffer {
             MekHQ.getLogger().error(e);
         }
 
-        if (version.isLowerThan("0.49.0")) {
+        if (version.isLowerThan("0.49.3")) {
             retVal.setTransitDuration(campaign.getCampaignOptions().getInstantUnitMarketDelivery()
                     ? 0 : campaign.calculatePartTransitTime(Compute.d6(2) - 2));
         }


### PR DESCRIPTION
This ensures the unit market migrates on post-0.48 saves, as the code was originally written before 0.49.0.