### PR TITLE
2838: Turrets now generate with the proper faction and thus names

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -33,6 +33,7 @@ import megamek.client.generator.enums.SkillGeneratorType;
 import megamek.client.generator.skillGenerators.AbstractSkillGenerator;
 import megamek.client.generator.skillGenerators.TaharqaSkillGenerator;
 import megamek.common.MechSummaryCache;
+import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
@@ -336,6 +337,7 @@ public class AtBDynamicScenarioFactory {
                         String.format("Invalid force alignment %d", forceTemplate.getForceAlignment()));
         }
 
+        final Faction faction = Factions.getInstance().getFaction(factionCode);
         String parentFactionType = AtBConfiguration.getParentFactionType(factionCode);
         boolean isPlanetOwner = isPlanetOwner(contract, currentDate, factionCode);
         boolean usingAerospace = forceTemplate.getAllowedUnitType() == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX ||
@@ -390,7 +392,7 @@ public class AtBDynamicScenarioFactory {
             // some special cases that don't fit into the regular RAT generation mechanism
             // gun emplacements use a separate set of rats
             if (actualUnitType == UnitType.GUN_EMPLACEMENT) {
-                generatedLance = generateTurrets(4, skill, quality, campaign);
+                generatedLance = generateTurrets(4, skill, quality, campaign, faction);
             // atb civilians use a separate rat
             } else if (actualUnitType == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_CIVILIANS) {
                 generatedLance = generateCivilianUnits(4, campaign);
@@ -508,11 +510,13 @@ public class AtBDynamicScenarioFactory {
      * @param skill    The skill level of the turret operators
      * @param quality  The quality level of the turrets
      * @param campaign The campaign for which the turrets are being generated.
+     * @param faction  The faction to generate turrets for
      */
-    public static List<Entity> generateTurrets(int num, SkillLevel skill, int quality, Campaign campaign) {
-        int currentYear = campaign.getGameYear();
-        List<MechSummary> msl = campaign.getUnitGenerator().generateTurrets(num, skill, quality, currentYear);
-        return msl.stream().map(ms -> createEntityWithCrew("IND", skill, campaign, ms)).collect(Collectors.toCollection(ArrayList::new));
+    public static List<Entity> generateTurrets(int num, SkillLevel skill, int quality, Campaign campaign, Faction faction) {
+        return campaign.getUnitGenerator().generateTurrets(num, skill, quality, campaign.getGameYear()).stream()
+                .map(ms -> createEntityWithCrew(faction, skill, campaign, ms))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -1314,9 +1318,20 @@ public class AtBDynamicScenarioFactory {
      * @param skill the {@link SkillLevel} for the average crew skill level
      * @param campaign The campaign instance
      * @param ms Which entity to generate
-     * @return An crewed entity
+     * @return A crewed entity
      */
-    public static Entity createEntityWithCrew(String factionCode, SkillLevel skill, Campaign campaign, MechSummary ms) {
+    public static @Nullable Entity createEntityWithCrew(String factionCode, SkillLevel skill, Campaign campaign, MechSummary ms) {
+        return createEntityWithCrew(Factions.getInstance().getFaction(factionCode), skill, campaign, ms);
+    }
+
+    /**
+     * @param faction the Faction the crew is a part of
+     * @param skill the {@link SkillLevel} for the average crew skill level
+     * @param campaign The campaign instance
+     * @param ms Which entity to generate
+     * @return A crewed entity
+     */
+    public static @Nullable Entity createEntityWithCrew(Faction faction, SkillLevel skill, Campaign campaign, MechSummary ms) {
         Entity en;
         try {
             en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
@@ -1328,12 +1343,10 @@ public class AtBDynamicScenarioFactory {
         en.setOwner(campaign.getPlayer());
         en.setGame(campaign.getGame());
 
-        Faction faction = Factions.getInstance().getFaction(factionCode);
-
         RandomNameGenerator rng = RandomNameGenerator.getInstance();
         rng.setChosenFaction(faction.getNameGenerator());
         Gender gender = RandomGenderGenerator.generate();
-        String[] crewNameArray = rng.generateGivenNameSurnameSplit(gender, faction.isClan(), factionCode);
+        String[] crewNameArray = rng.generateGivenNameSurnameSplit(gender, faction.isClan(), faction.getShortName());
         String crewName = crewNameArray[0];
         crewName += !StringUtil.isNullOrEmpty(crewNameArray[1]) ?  " " + crewNameArray[1] : "";
 
@@ -1358,7 +1371,7 @@ public class AtBDynamicScenarioFactory {
                 case UnitType.TANK:
                 case UnitType.VTOL:
                     // The Vehicle Phenotype is unique to Clan Hell's Horses
-                    if (factionCode.equals("CHH")) {
+                    if (faction.getShortName().equals("CHH")) {
                         phenotype = Phenotype.VEHICLE;
                     }
                     break;
@@ -1377,14 +1390,14 @@ public class AtBDynamicScenarioFactory {
                 case UnitType.JUMPSHIP:
                 case UnitType.WARSHIP:
                     // The Naval Phenotype is unique to Clan Snow Raven and the Raven Alliance
-                    if (factionCode.equals("CSR") || factionCode.equals("RA")) {
+                    if (faction.getShortName().equals("CSR") || faction.getShortName().equals("RA")) {
                         phenotype = Phenotype.NAVAL;
                     }
                     break;
             }
 
             if (phenotype != Phenotype.NONE) {
-                String bloodname = Bloodname.randomBloodname(factionCode, phenotype,
+                String bloodname = Bloodname.randomBloodname(faction.getShortName(), phenotype,
                         campaign.getGameYear()).getName();
                 crewName += " " + bloodname;
                 innerMap.put(Crew.MAP_BLOODNAME, bloodname);

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -41,10 +41,7 @@ import mekhq.campaign.mission.enums.AtBLanceRole;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.unit.Unit;
-import mekhq.campaign.universe.Factions;
-import mekhq.campaign.universe.Planet;
-import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.campaign.universe.Systems;
+import mekhq.campaign.universe.*;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -1283,10 +1280,11 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      * @param skill     The skill level of the turret operators
      * @param quality   The quality level of the turrets
      * @param campaign  The campaign for which the turrets are being generated.
+     * @param faction   The faction the turrets are being generated for
      */
-    protected void addTurrets(List<Entity> list, int num, SkillLevel skill, int quality,
-                              Campaign campaign) {
-        list.addAll(AtBDynamicScenarioFactory.generateTurrets(num, skill, quality, campaign));
+    protected void addTurrets(List<Entity> list, int num, SkillLevel skill, int quality, Campaign campaign,
+                              Faction faction) {
+        list.addAll(AtBDynamicScenarioFactory.generateTurrets(num, skill, quality, campaign, faction));
     }
 
     /**
@@ -1393,7 +1391,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         // don't bother spawning turrets if there won't be anything to put them on
         if (spawnTurrets && isTurretAppropriateTerrain) {
             // skill level is 0-4 where 0 is "ultra-green" and 4 is "elite badass" and drives the number of extra units
-            addTurrets(scrubs,  campaign.getCampaignOptions().getSkillLevel() + 1, contract.getEnemySkill(), contract.getEnemyQuality(), campaign);
+            addTurrets(scrubs,  campaign.getCampaignOptions().getSkillLevel() + 1, contract.getEnemySkill(),
+                    contract.getEnemyQuality(), campaign, contract.getEnemy());
         }
 
         if (spawnConventionalInfantry && isInfantryAppropriateTerrain) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -137,10 +137,10 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
 
         if (isAttacker()) {
             addTurrets(turretForce, 6, getContract(campaign).getEnemySkill(), getContract(campaign).getEnemyQuality(),
-                    campaign);
+                    campaign, getContract(campaign).getEnemy());
         } else {
             addTurrets(turretForce, 6, getContract(campaign).getAllySkill(), getContract(campaign).getAllyQuality(),
-                    campaign);
+                    campaign, getContract(campaign).getEmployerFaction());
         }
 
         addBotForce(new BotForce(BASE_TURRET_FORCE_ID, isAttacker() ? 2 : 1, defenderStart, defenderHome, turretForce));


### PR DESCRIPTION
This fixes part of #2838, namely that turrets now generate their crew with the proper faction.