### PR TITLE
lowercase stratcon scenario template path

### DIFF
--- a/MekHQ/src/mekhq/MekHqConstants.java
+++ b/MekHQ/src/mekhq/MekHqConstants.java
@@ -153,7 +153,7 @@ public final class MekHqConstants {
     public static final String STRATCON_PRIMARY_PLAYER_FORCE_MODS = "./data/scenariomodifiers/primaryPlayerForceModifiers.xml";
     public static final String STRATCON_SCENARIO_MANIFEST = "./data/scenariotemplates/ScenarioManifest.xml";
     public static final String STRATCON_USER_SCENARIO_MANIFEST = "./data/scenariotemplates/UserScenarioManifest.xml";
-    public static final String STRATCON_SCENARIO_TEMPLATE_PATH = "./data/ScenarioTemplates/";
+    public static final String STRATCON_SCENARIO_TEMPLATE_PATH = "./data/scenariotemplates/";
     public static final String STRATCON_FACILITY_MANIFEST = "./data/stratconfacilities/facilitymanifest.xml";
     public static final String STRATCON_USER_FACILITY_MANIFEST = "./data/stratconfacilities/userfacilitymanifest.xml";
     public static final String STRATCON_FACILITY_PATH = "./data/stratconfacilities/";


### PR DESCRIPTION
Very simple fix for issue #2747 .
Case sensitive file systems were unable to find the stratcon scenario template files.