### PR TITLE
prevent out of bounds array access

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -465,7 +465,14 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 "Cliffs", "Mountain-medium", "Mountain-high"} //mountains
         };
 
-        map = maps[terrainType][Compute.d6() - 1];
+        int actualTerrainType = terrainType;
+        
+        // we want to make sure the terrain type we pick is in bounds, 
+        if ((terrainType < 0) || (terrainType >= maps.length)) {
+            actualTerrainType = Compute.randomInt(maps.length);
+        }
+        
+        map = maps[actualTerrainType][Compute.d6() - 1];
     }
 
     public boolean canRerollTerrain() {


### PR DESCRIPTION
For aerospace/space scenarios the terrain type is out of bounds of the array above the changed code. We don't actually want to change the terrain type, but we want to avoid array out of bounds exceptions. This would manifest in aerospace scenarios failing to appear on the stratcon map.