### PR TITLE
2867: Making the default unit market type the Open market instead of the Employer Market

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -136,7 +136,7 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
 
         if (faction == null) {
             faction = campaign.getFaction();
-            market = UnitMarketType.EMPLOYER;
+            market = UnitMarketType.OPEN;
         }
 
         for (int i = 0; i < num; i++) {


### PR DESCRIPTION
This fixes #2867 