### PR TITLE
Proposed fix for #2873 - saving the part new flag correctly

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -681,10 +681,12 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                 .append("</daysToArrival>")
                 .append(NL);
         }
-        if (brandNew) {
+        if (!brandNew) {
+        	//The default value for Part.brandNew is true.  Only store the tag if the value is false.
+        	//The lack of tag in the save file will ALWAYS result in TRUE.
             builder.append(level1)
                 .append("<brandNew>")
-                .append(true)
+                .append(false)
                 .append("</brandNew>")
                 .append(NL);
         }


### PR DESCRIPTION
When saving the parts list for GM added units, the tag is only saved
when the 'brandNew' property is TRUE and leave the tag out if the
property is FALSE.  Because the default constructor sets the property to
TRUE, false values re never saved and loaded.

Fixes #2873 