### PR TITLE
Fixed #2878 Missing Bay Door on reload.

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
@@ -72,10 +72,15 @@ public class MissingBayDoor extends MissingPart {
             unit.addPart(actualReplacement);
             campaign.getQuartermaster().addPart(actualReplacement, 0);
             replacement.decrementQuantity();
+
+            // Calling 'remove()' has the side effect of setting this.parentPart to null.
+            // Issue #2878
+            Part _parentPart = parentPart;
             remove(false);
-            if (null != parentPart) {
-                parentPart.addChildPart(actualReplacement);
-                parentPart.updateConditionFromPart();
+            
+            if (null != _parentPart) {
+                _parentPart.addChildPart(actualReplacement);
+                _parentPart.updateConditionFromPart();
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBayDoor.java
@@ -74,13 +74,13 @@ public class MissingBayDoor extends MissingPart {
             replacement.decrementQuantity();
 
             // Calling 'remove()' has the side effect of setting this.parentPart to null.
-            // Issue #2878
-            Part _parentPart = parentPart;
+            // Issue #2878 - Missing Bay Door on reload.
+            Part parentReference = parentPart;
             remove(false);
             
-            if (null != _parentPart) {
-                _parentPart.addChildPart(actualReplacement);
-                _parentPart.updateConditionFromPart();
+            if (null != parentReference) {
+                parentReference.addChildPart(actualReplacement);
+                parentReference.updateConditionFromPart();
             }
         }
     }


### PR DESCRIPTION
Fixes #2878 

Found and fixed an issue that occurs when a dropship bay door is scrapped and repaired.  The `MissingBayDoor::fix()` method was removing itself prior to adding the actual part.  The side-effect of the `remove()` function is that is renders `this.parentPart` null therefore unable to complete the critical next step of linking the child/parent relationship to the actual part.

I could have just moved the `remove` method below setting the actual part relationship, but thought this side effect needed to be documented here to make the reader of this code aware of the side effect.

The impact of the original code was that the bay door was being added, but the Transport Bay containing the door did not reference it nor did the new fixed bay door reference the transport bay.  As a result, whenever the file is reloaded, it looks like the bay door is missing. (because it's orphaned).