### PR TITLE
Monday Training XP Assignment on New Day instead of AtB Scenario Generation

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -203,11 +203,6 @@ public class AtBScenarioFactory {
                         continue;
                     }
 
-                    // Assign training experience
-                    if (lance.getRole().isTraining()) {
-                        c.awardTrainingXP(lance);
-                    }
-
                     // Don't generate scenarios for contracts with morale below the morale limit of Low
                     if (contract.getMoraleLevel().isVeryLow() || contract.getMoraleLevel().isRout()) {
                         continue;


### PR DESCRIPTION
This fixes training XP not being assigned in StratCon and it being assigned when GM generating scenarios. I also cleaned up a bit of the code to remove an unnecessary method and cast.