### PR TITLE
Ransom is no longer automatically selected at 100% salvage rights

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -660,7 +660,6 @@ public class ResolveScenarioWizardDialog extends JDialog {
             ransomed.setName("ransomed");
             ransomed.getAccessibleContext().setAccessibleName(resourceMap.getString("lblRansom.text"));
             ransomed.setEnabled(!tracker.usesSalvageExchange());
-            ransomed.setSelected(!tracker.usesSalvageExchange() && (maxSalvagePct >= 100));
             ransomed.addItemListener(evt -> checkSalvageRights());
             ransomUnitBoxes.add(ransomed);
             gridBagConstraints.gridx = gridx++;


### PR DESCRIPTION
This fixes a copy-paste error I made when implementing the ransom options, which was raised on Discord.