### PR TITLE
2918: AtBContract End Date Display Does Not Update on Contract Extension

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -714,7 +714,7 @@ public class AtBContract extends Contract implements Serializable {
         }
 
         final int extension;
-        final int roll = 1;//Compute.d6();
+        final int roll = Compute.d6();
         if (roll == 1) {
             extension = Math.max(1, getLength() / 2);
         } else if (roll == 2) {


### PR DESCRIPTION
This fixes #2918.

To Review:
Commit 1 is a code cleanup/refactor on AtBContract::contractExtended and removes an unused static method about creating a new contract when extending one.
The rest are the bugfix.