### PR TITLE
Startup: Rename Origin Force Node With Campaign Name

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -5504,6 +5504,9 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
     private void updateOptions() {
         try {
             campaign.setName(txtName.getText());
+            if (isStartup()) {
+                getCampaign().getForces().setName(getCampaign().getName());
+            }
             campaign.setLocalDate(date);
             // Ensure that the MegaMek year GameOption matches the campaign year
             campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());


### PR DESCRIPTION
This renames the origin force node from "My Campaign" to whatever you set for your campaign name when you first create a campaign.