### PR TITLE
actually replace VTOL rotor instead of eating the part

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingRotor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingRotor.java
@@ -87,6 +87,16 @@ public class MissingRotor extends MissingPart {
 		// TODO Auto-generated method stub
 		return 0;
 	}
+	
+	@Override
+    public void fix() {
+	    if (null != unit && unit.getEntity() instanceof VTOL) {
+	        int maxIsVal = unit.getEntity().getOInternal(VTOL.LOC_ROTOR);
+	        unit.getEntity().setInternal(maxIsVal, VTOL.LOC_ROTOR);
+	    }
+	    
+        super.fix();
+    }
 
 	@Override
 	public void updateConditionFromPart() {

--- a/MekHQ/src/mekhq/campaign/parts/MissingRotor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingRotor.java
@@ -90,7 +90,7 @@ public class MissingRotor extends MissingPart {
 	
 	@Override
     public void fix() {
-	    if (null != unit && unit.getEntity() instanceof VTOL) {
+	    if ((null != unit) && (unit.getEntity() instanceof VTOL)) {
 	        int maxIsVal = unit.getEntity().getOInternal(VTOL.LOC_ROTOR);
 	        unit.getEntity().setInternal(maxIsVal, VTOL.LOC_ROTOR);
 	    }


### PR DESCRIPTION
Replacing a destroyed rotor needs to set the internal structure properly instead of just swallowing the replacement part and not doing anything. Fixes #2866 