### PR TITLE
Migrating to MavenCentral from JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ allprojects {
         maven {
             url 'https://github.com/MegaMek/mavenrepo/raw/master'
         }
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://jitpack.io'
         }


### PR DESCRIPTION
JCenter is shutting down in February.