### PR TITLE
Adding temporary fallback for JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ allprojects {
         maven {
             url 'https://jitpack.io'
         }
+		jcenter()
     }
 }
 


### PR DESCRIPTION
This should fix the issues with the nightly build and some people's builds as raised in the comments at https://github.com/MegaMek/mekhq/pull/2967