### PR TITLE
MM 3289: Removing IPlayer Interface

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.20.1'
+    testImplementation 'org.mockito:mockito-core:4.1.0'
 }
 
 mainClassName = 'mekhq.MekHQ'

--- a/MekHQ/testresources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/MekHQ/testresources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -16,42 +16,15 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.parts;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.ParserConfigurationException;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
-
+import megamek.Version;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
-import megamek.common.IPlayer;
+import megamek.common.Player;
 import megamek.common.loaders.EntityLoadingException;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.CampaignOptions;
-import mekhq.campaign.Hangar;
-import mekhq.campaign.Quartermaster;
-import mekhq.campaign.Warehouse;
+import mekhq.campaign.*;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.market.ShoppingList;
 import mekhq.campaign.parts.equipment.AmmoBin;
@@ -60,6 +33,25 @@ import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitTestUtilities;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RefitTest {
     @Test
@@ -83,7 +75,7 @@ public class RefitTest {
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
-        IPlayer mockPlayer = mock(IPlayer.class);
+        Player mockPlayer = mock(Player.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 
@@ -123,7 +115,7 @@ public class RefitTest {
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
-        IPlayer mockPlayer = mock(IPlayer.class);
+        Player mockPlayer = mock(Player.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 
@@ -210,7 +202,7 @@ public class RefitTest {
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getLocustLCT1V();
-        IPlayer mockPlayer = mock(IPlayer.class);
+        Player mockPlayer = mock(Player.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 
@@ -328,7 +320,7 @@ public class RefitTest {
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
-        IPlayer mockPlayer = mock(IPlayer.class);
+        Player mockPlayer = mock(Player.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 
@@ -413,7 +405,7 @@ public class RefitTest {
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getJavelinJVN10N();
-        IPlayer mockPlayer = mock(IPlayer.class);
+        Player mockPlayer = mock(Player.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 
@@ -533,7 +525,7 @@ public class RefitTest {
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getFleaFLE4();
-        IPlayer mockPlayer = mock(IPlayer.class);
+        Player mockPlayer = mock(Player.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 
@@ -645,7 +637,7 @@ public class RefitTest {
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getFleaFLE4();
-        IPlayer mockPlayer = mock(IPlayer.class);
+        Player mockPlayer = mock(Player.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 
@@ -773,7 +765,7 @@ public class RefitTest {
 
         // Create the original entity backing the unit
         Entity oldEntity = UnitTestUtilities.getHeavyTrackedApcMg();
-        IPlayer mockPlayer = mock(IPlayer.class);
+        Player mockPlayer = mock(Player.class);
         when(mockPlayer.getName()).thenReturn("Test Player");
         oldEntity.setOwner(mockPlayer);
 

--- a/MekHQ/unittests/mekhq/campaign/universe/FactionBorderTrackerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/FactionBorderTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 The MegaMek Team. All rights reserved.
+ * Copyright (c) 2018 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -10,17 +10,15 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.universe;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,18 +29,19 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 public class FactionBorderTrackerTest {
 
     private Faction factionUs;
     private Faction factionThem;
-    
+
     @Before
     public void init() {
         factionUs = createFaction("us", false, false);
         factionThem = createFaction("them", false, false);
     }
-    
+
     // Builds a sample universe with a faction "us" with one planet at (0, 0) and faction
     // "them" with planets on a 4x3 grid with 2 ly distance between adjacent planets
     private FactionBorderTracker buildTestTracker() {
@@ -53,7 +52,7 @@ public class FactionBorderTrackerTest {
             }
         }
         systems.add(createSystem(0, 0, factionUs));
-        
+
         FactionBorderTracker tracker = new FactionBorderTracker() {
             @Override
             protected Collection<PlanetarySystem> getSystemList() {
@@ -62,7 +61,7 @@ public class FactionBorderTrackerTest {
         };
         return tracker;
     }
-    
+
     private Faction createFaction(final String key, final boolean periphery, final boolean clan) {
         Faction faction = mock(Faction.class);
         when(faction.getShortName()).thenReturn(key);
@@ -70,14 +69,14 @@ public class FactionBorderTrackerTest {
         when(faction.isClan()).thenReturn(clan);
         return faction;
     }
-    
+
     private PlanetarySystem createSystem(final double x, final double y, Faction owner) {
         PlanetarySystem system = mock(PlanetarySystem.class);
         when(system.getX()).thenReturn(x);
         when(system.getY()).thenReturn(y);
         String id = String.format("%f, %f", x, y);
         when(system.getId()).thenReturn(id);
-        when(system.getFactionSet(any())).thenReturn(Collections.singleton(owner));
+        when(system.getFactionSet(ArgumentMatchers.any())).thenReturn(Collections.singleton(owner));
         return system;
     }
 
@@ -85,9 +84,9 @@ public class FactionBorderTrackerTest {
     public void testFactionBorderTrackerAllPlanets() throws InterruptedException {
         FactionBorderTracker tracker = buildTestTracker();
         tracker.setDefaultBorderSize(1, 1, 1);
-        
+
         List<PlanetarySystem> border = tracker.getBorderSystems(factionUs, factionThem);
-        
+
         assertEquals(tracker.getBorders(factionUs).getSystems().size(), 1);
         assertEquals(tracker.getBorders(factionThem).getSystems().size(), 12);
         assertEquals(border.size(), 2);
@@ -102,9 +101,9 @@ public class FactionBorderTrackerTest {
         FactionBorderTracker tracker = buildTestTracker();
         tracker.setDefaultBorderSize(1, 1, 1);
         tracker.setRegionRadius(1.1);
-        
+
         List<PlanetarySystem> border = tracker.getBorderSystems(factionUs, factionThem);
-        
+
         assertEquals(tracker.getBorders(factionUs).getSystems().size(), 1);
         assertEquals(tracker.getBorders(factionThem).getSystems().size(), 2);
         assertEquals(border.size(), 2);
@@ -116,9 +115,9 @@ public class FactionBorderTrackerTest {
         tracker.setDefaultBorderSize(1, 1, 1);
         tracker.setRegionRadius(10);
         tracker.setRegionCenter(50, 0);
-        
+
         List<PlanetarySystem> border = tracker.getBorderSystems(factionUs, factionThem);
-        
+
         assertEquals(tracker.getBorders(factionUs), null);
         assertEquals(tracker.getBorders(factionThem), null);
         assertEquals(border.size(), 0);
@@ -131,7 +130,7 @@ public class FactionBorderTrackerTest {
         Faction clan = createFaction("clan", false, true);
         FactionBorderTracker tracker = buildTestTracker();
         tracker.setDefaultBorderSize(1, 2, 3);
-        
+
         assertEquals(tracker.getBorderSize(is), 1, RegionPerimeter.EPSILON);
         assertEquals(tracker.getBorderSize(periphery), 2, RegionPerimeter.EPSILON);
         assertEquals(tracker.getBorderSize(clan), 3, RegionPerimeter.EPSILON);
@@ -143,14 +142,14 @@ public class FactionBorderTrackerTest {
         FactionBorderTracker tracker = buildTestTracker();
         tracker.setDefaultBorderSize(1, 2, 3);
         tracker.setBorderSize(is, 30);
-        
+
         assertEquals(tracker.getBorderSize(is), 30, RegionPerimeter.EPSILON);
     }
 
     @Test
     public void testHexRegionContainsReturnsFalseOutsideBoundingRect() {
         FactionBorderTracker.RegionHex hex = new FactionBorderTracker.RegionHex(0, 0, 1.0);
-        
+
         assertFalse(hex.contains(0, 2));
         assertFalse(hex.contains(0, -2));
         assertFalse(hex.contains(2, 0.5));
@@ -160,7 +159,7 @@ public class FactionBorderTrackerTest {
     @Test
     public void testHexRegionContainsReturnsTrueInnerBoundingRect() {
         FactionBorderTracker.RegionHex hex = new FactionBorderTracker.RegionHex(0, 0, 1.0);
-        
+
         assertTrue(hex.contains(0.25, 0.5));
         assertTrue(hex.contains(0.25, -0.5));
         assertTrue(hex.contains(-0.25, 0.5));
@@ -170,7 +169,7 @@ public class FactionBorderTrackerTest {
     @Test
     public void testHexRegionContainsNearSides() {
         FactionBorderTracker.RegionHex hex = new FactionBorderTracker.RegionHex(0, 0, 1.0);
-        
+
         assertTrue(hex.contains(0.9, 0.1));
         assertFalse(hex.contains(0.9, 0.9));
     }

--- a/MekHQ/unittests/mekhq/campaign/universe/FactionBordersTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/FactionBordersTest.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.universe;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +29,7 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 public class FactionBordersTest {
 
@@ -55,7 +55,7 @@ public class FactionBordersTest {
         when(system.getY()).thenReturn(y);
         String id = String.format("%f, %f", x, y);
         when(system.getId()).thenReturn(id);
-        when(system.getFactionSet(any())).thenReturn(Collections.singleton(owner));
+        when(system.getFactionSet(ArgumentMatchers.any())).thenReturn(Collections.singleton(owner));
         return system;
     }
 


### PR DESCRIPTION
This contains the MekHQ changes required to remove the IPlayer interface, and updates Mockito to 4.1.0 (required to fix a Mockito bug that came up in testing)