### PR TITLE
prevent NPE when scaling stratcon objectives

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -659,7 +659,9 @@ public class AtBDynamicScenarioFactory {
         int primaryUnitCount = 0;
 
         for (int forceID : scenario.getPlayerForceTemplates().keySet()) {
-            if (scenario.getPlayerForceTemplates().get(forceID).getContributesToUnitCount()) {
+            ScenarioForceTemplate forceTemplate = scenario.getPlayerForceTemplates().get(forceID);
+            
+            if ((forceTemplate != null) && forceTemplate.getContributesToUnitCount()) {
                 primaryUnitCount += campaign.getForce(forceID).getAllUnits(true).size();
             }
         }


### PR DESCRIPTION
Sometimes, for some reason, a player force template ID maps to null, so we account for that possibility here. Fixes #2981