### PR TITLE
display lance role in lance assignment UIs

### DIFF
--- a/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceRenderer.java
+++ b/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceRenderer.java
@@ -24,6 +24,7 @@ import javax.swing.*;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
+import mekhq.campaign.force.Lance;
 
 /**
  * Handles rendering of individual lances in the StratCon scenario wizard.
@@ -50,7 +51,13 @@ public class ScenarioWizardLanceRenderer extends JLabel implements ListCellRende
         setForeground(foreground);
         setBackground(background);
 
-        setText(String.format("%s (BV: %d)", value.getName(), value.getTotalBV(campaign)));
+        Lance lance = campaign.getLances().get(value.getId());
+        String roleString = "";
+        if (lance != null) {
+            roleString = lance.getRole().toString() + ", ";
+        }
+        
+        setText(String.format("%s (%sBV: %d)", value.getName(), roleString, value.getTotalBV(campaign)));
 
         return this;
     }


### PR DESCRIPTION
Implements #2970 by adding the lance role, if it exists, to the lance descriptive text when deploying lances to a track or a scenario.