### PR TITLE
Log4j 2 Swapover

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.joda:joda-money:1.0.1'
     implementation 'org.apache.commons:commons-text:1.4'
     implementation 'org.apache.commons:commons-csv:1.4'
+    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
     implementation 'javax.vecmath:vecmath:1.5.2'
     implementation 'com.atlassian.commonmark:commonmark:0.13.0'
 

--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.joda:joda-money:1.0.1'
     implementation 'org.apache.commons:commons-text:1.4'
     implementation 'org.apache.commons:commons-csv:1.4'
-    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
     implementation 'javax.vecmath:vecmath:1.5.2'
     implementation 'com.atlassian.commonmark:commonmark:0.13.0'
 

--- a/MekHQ/resources/log4j2.xml
+++ b/MekHQ/resources/log4j2.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration status="info">
+    <Properties>
+        <Property name="layout">%d{ABSOLUTE} %-5p [%logger{36}] {%t}%n%l - %m%n%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console">
+            <PatternLayout pattern="${layout}" />
+        </Console>
+        <File name="MegaMekLog" fileName="logs/megamek.log" append="false">
+            <PatternLayout pattern="${layout}"/>
+        </File>
+        <File name="MegaMekLabLog" fileName="logs/megameklab.log" append="false">
+            <PatternLayout pattern="${layout}"/>
+        </File>
+        <File name="MekHQLog" fileName="logs/mekhq.log" append="false">
+            <PatternLayout pattern="${layout}"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="megamek" level="info" additivity="false" >
+            <AppenderRef ref="MegaMekLog" />
+        </Logger>
+        <Logger name="megamek/client/bot" level="error" additivity="false" >
+            <AppenderRef ref="MegaMekLog" />
+        </Logger>
+        <Logger name="megameklab" level="info" additivity="false" >
+            <AppenderRef ref="MegaMekLabLog" />
+        </Logger>
+        <Logger name="mekhq" level="info" additivity="false" >
+            <AppenderRef ref="MekHQLog" />
+        </Logger>
+
+        <Root level="info">
+            <AppenderRef ref="MekHQLog" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/MekHQ/src/chat/ChatClient.java
+++ b/MekHQ/src/chat/ChatClient.java
@@ -4,18 +4,13 @@ package chat;
  * Code taken from http://introcs.cs.princeton.edu/java/84network/
  */
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.Socket;
-
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
 
 public class ChatClient extends JPanel implements ActionListener {
 	private static final long serialVersionUID = -7447573101863923187L;
@@ -41,7 +36,7 @@ public class ChatClient extends JPanel implements ActionListener {
             out    = new Out(socket);
             in     = new In(socket);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         this.screenName = screenName;
 
@@ -53,7 +48,7 @@ public class ChatClient extends JPanel implements ActionListener {
 //                    in.close();
 //                    try                   { socket.close();        }
 //                    catch (Exception e) {
-//                        MekHQ.getLogger().error(getClass(), "windowClosing", e);
+//                        LogManager.getLogger().error(getClass(), "windowClosing", e);
 //                    }
                 }
             }
@@ -97,8 +92,8 @@ public class ChatClient extends JPanel implements ActionListener {
         try {
             socket.close();
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
-        MekHQ.getLogger().error("Closed client socket");
+        LogManager.getLogger().error("Closed client socket");
     }
 }

--- a/MekHQ/src/chat/ChatServer.java
+++ b/MekHQ/src/chat/ChatServer.java
@@ -4,7 +4,7 @@ package chat;
  * Code taken from http://introcs.cs.princeton.edu/java/84network/
  */
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -24,12 +24,12 @@ public class ChatServer {
         // thread that broadcasts messages to clients
         connectionListener.start();
 
-        MekHQ.getLogger().error("ChatServer started");
+        LogManager.getLogger().error("ChatServer started");
 
         while (true) {
             // wait for next client connection request
             Socket clientSocket = serverSocket.accept();
-            MekHQ.getLogger().error("Created socket with client");
+            LogManager.getLogger().error("Created socket with client");
 
             // listen to client in a separate thread
             Connection connection = new Connection(clientSocket);

--- a/MekHQ/src/chat/Connection.java
+++ b/MekHQ/src/chat/Connection.java
@@ -4,7 +4,7 @@ package chat;
  * Code taken from http://introcs.cs.princeton.edu/java/84network/
  */
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.net.Socket;
 
@@ -32,9 +32,9 @@ public class Connection extends Thread {
         try {
             socket.close();
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
-        MekHQ.getLogger().error("closing socket");
+        LogManager.getLogger().error("closing socket");
     }
 
 
@@ -56,7 +56,7 @@ public class Connection extends Thread {
             try {
                 wait();
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         message = s;

--- a/MekHQ/src/chat/ConnectionListener.java
+++ b/MekHQ/src/chat/ConnectionListener.java
@@ -1,6 +1,6 @@
 package chat;
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Vector;
 
@@ -37,7 +37,7 @@ public class ConnectionListener extends Thread {
             try {
                 Thread.sleep(100);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/chat/In.java
+++ b/MekHQ/src/chat/In.java
@@ -1,6 +1,6 @@
 package chat;
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -58,7 +58,7 @@ public final class In {
             scanner = new Scanner(new BufferedInputStream(is), charsetName);
             scanner.useLocale(usLocale);
         } catch (IOException e) {
-            MekHQ.getLogger().error("Could not open " + socket);
+            LogManager.getLogger().error("Could not open " + socket);
         }
     }
 
@@ -72,7 +72,7 @@ public final class In {
             scanner            = new Scanner(new BufferedInputStream(is), charsetName);
             scanner.useLocale(usLocale);
         } catch (IOException e) {
-            MekHQ.getLogger().error("Could not open " + url);
+            LogManager.getLogger().error("Could not open " + url);
         }
     }
 
@@ -84,7 +84,7 @@ public final class In {
             scanner = new Scanner(file, charsetName);
             scanner.useLocale(usLocale);
         } catch (IOException e) {
-            MekHQ.getLogger().error("Could not open " + file);
+            LogManager.getLogger().error("Could not open " + file);
         }
     }
 
@@ -114,7 +114,7 @@ public final class In {
             scanner            = new Scanner(new BufferedInputStream(is), charsetName);
             scanner.useLocale(usLocale);
         } catch (IOException e) {
-            MekHQ.getLogger().error("Could not open " + s);
+            LogManager.getLogger().error("Could not open " + s);
         }
     }
 

--- a/MekHQ/src/chat/Out.java
+++ b/MekHQ/src/chat/Out.java
@@ -1,6 +1,6 @@
 package chat;
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -24,7 +24,7 @@ public class Out {
         try {
             out = new PrintWriter(socket.getOutputStream(), true);
         } catch (IOException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -33,7 +33,7 @@ public class Out {
         try {
             out = new PrintWriter(new FileOutputStream(s), true);
         } catch (IOException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -25,13 +25,13 @@ import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.Princess;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.common.*;
-import megamek.common.logging.LogLevel;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.BotForce;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.io.File;
@@ -87,7 +87,7 @@ public class AtBGameThread extends GameThread {
         try {
             client.connect();
         } catch (Exception ex) {
-            MekHQ.getLogger().error("MegaMek client failed to connect to server", ex);
+            LogManager.getLogger().error("MegaMek client failed to connect to server", ex);
             return;
         }
 
@@ -99,11 +99,11 @@ public class AtBGameThread extends GameThread {
             // if game is running, shouldn't do the following, so detect the phase
             for (int i = 0; (i < CLIENT_RETRY_COUNT) && client.getGame().getPhase().isUnknown(); i++) {
                 Thread.sleep(50);
-                MekHQ.getLogger().warning("Client has not finished initialization, and is currently in an unknown phase.");
+                LogManager.getLogger().warn("Client has not finished initialization, and is currently in an unknown phase.");
             }
 
             if ((client.getGame() != null) && client.getGame().getPhase().isLounge()) {
-                MekHQ.getLogger().info("Thread in lounge");
+                LogManager.getLogger().info("Thread in lounge");
 
                 client.getLocalPlayer().setCamouflage(app.getCampaign().getCamouflage().clone());
                 client.getLocalPlayer().setColour(app.getCampaign().getColour());
@@ -134,7 +134,7 @@ public class AtBGameThread extends GameThread {
                     try (InputStream is = new FileInputStream(mapgenFile)) {
                         mapSettings = MapSettings.getInstance(is);
                     } catch (FileNotFoundException ex) {
-                        MekHQ.getLogger().error("Could not load map file data/mapgen/" + scenario.getMap() + ".xml", ex);
+                        LogManager.getLogger().error("Could not load map file data/mapgen/" + scenario.getMap() + ".xml", ex);
                     }
 
                     if (scenario.getTerrainType() == AtBScenario.TER_LOW_ATMO) {
@@ -311,12 +311,12 @@ public class AtBGameThread extends GameThread {
                         }
                         name += append;
                     }
-                    Princess botClient = new Princess(name, client.getHost(), client.getPort(), LogLevel.ERROR);
+                    Princess botClient = new Princess(name, client.getHost(), client.getPort());
                     botClient.setBehaviorSettings(bf.getBehaviorSettings());
                     try {
                         botClient.connect();
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Could not connect with Bot name " + bf.getName(), e);
+                        LogManager.getLogger().error("Could not connect with Bot name " + bf.getName(), e);
                     }
                     swingGui.getBots().put(name, botClient);
 
@@ -377,7 +377,7 @@ public class AtBGameThread extends GameThread {
                 Thread.sleep(50);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         } finally {
             client.die();
             client = null;
@@ -404,7 +404,7 @@ public class AtBGameThread extends GameThread {
                 sleep(50);
             }
             if (null == botClient.getLocalPlayer()) {
-                MekHQ.getLogger().error("Could not configure bot " + botClient.getName());
+                LogManager.getLogger().error("Could not configure bot " + botClient.getName());
             } else {
                 botClient.getLocalPlayer().setTeam(botForce.getTeam());
                 botClient.getLocalPlayer().setStartingPos(botForce.getStart());
@@ -427,7 +427,7 @@ public class AtBGameThread extends GameThread {
                 botClient.sendAddEntity(entities);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -23,6 +23,7 @@ import megamek.common.preference.PreferenceManager;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 
 import java.awt.*;
 import java.io.IOException;
@@ -89,7 +90,7 @@ class GameThread extends Thread implements CloseClientListener {
         try {
             client.connect();
         } catch (Exception ex) {
-            MekHQ.getLogger().error("MegaMek client failed to connect to server", ex);
+            LogManager.getLogger().error("MegaMek client failed to connect to server", ex);
             return;
         }
 
@@ -101,11 +102,11 @@ class GameThread extends Thread implements CloseClientListener {
             // if game is running, shouldn't do the following, so detect the phase
             for (int i = 0; (i < 1000) && client.getGame().getPhase().isUnknown(); i++) {
                 Thread.sleep(50);
-                MekHQ.getLogger().warning("Client has not finished initialization, and is currently in an unknown phase.");
+                LogManager.getLogger().warn("Client has not finished initialization, and is currently in an unknown phase.");
             }
 
             if ((client.getGame() != null) && client.getGame().getPhase().isLounge()) {
-                MekHQ.getLogger().info("Thread in lounge");
+                LogManager.getLogger().info("Thread in lounge");
                 client.getLocalPlayer().setCamouflage(app.getCampaign().getCamouflage().clone());
 
                 if (started) {
@@ -132,7 +133,7 @@ class GameThread extends Thread implements CloseClientListener {
                 Thread.sleep(50);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         finally {
             client.die();
@@ -157,13 +158,13 @@ class GameThread extends Thread implements CloseClientListener {
         try {
             WeaponOrderHandler.saveWeaponOrderFile();
         } catch (IOException e) {
-            MekHQ.getLogger().error("Error saving custom weapon orders!", e);
+            LogManager.getLogger().error("Error saving custom weapon orders!", e);
         }
 
         try {
             QuirksHandler.saveCustomQuirksList();
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error saving quirks override!", e);
+            LogManager.getLogger().error("Error saving quirks override!", e);
         }
 
         stop = true;

--- a/MekHQ/src/mekhq/MHQStaticDirectoryManager.java
+++ b/MekHQ/src/mekhq/MHQStaticDirectoryManager.java
@@ -28,6 +28,7 @@ import megamek.common.util.fileUtils.ImageFileFactory;
 import mekhq.campaign.force.Force;
 import mekhq.gui.enums.LayeredForceIcon;
 import mekhq.io.AwardFileFactory;
+import org.apache.logging.log4j.LogManager;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -77,7 +78,7 @@ public class MHQStaticDirectoryManager extends MMStaticDirectoryManager {
                 forceIconDirectory = new DirectoryItems(new File("data/images/force"), // TODO : remove inline file path
                         new ImageFileFactory());
             } catch (Exception e) {
-                MegaMek.getLogger().error("Could not parse the force icon directory!", e);
+                LogManager.getLogger().error("Could not parse the force icon directory!", e);
             }
         }
     }
@@ -96,7 +97,7 @@ public class MHQStaticDirectoryManager extends MMStaticDirectoryManager {
                 awardIconDirectory = new DirectoryItems(new File("data/images/awards"), // TODO : remove inline file path
                         new AwardFileFactory());
             } catch (Exception e) {
-                MegaMek.getLogger().error("Could not parse the award icon directory!", e);
+                LogManager.getLogger().error("Could not parse the award icon directory!", e);
             }
         }
     }
@@ -205,7 +206,7 @@ public class MHQStaticDirectoryManager extends MMStaticDirectoryManager {
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             } finally {
                 if (null != g2d) {
                     g2d.dispose();
@@ -214,7 +215,7 @@ public class MHQStaticDirectoryManager extends MMStaticDirectoryManager {
                     try {
                         base = (BufferedImage) getForceIcons().getItem("", "empty.png");
                     } catch (Exception e) {
-                        MekHQ.getLogger().error(e);
+                        LogManager.getLogger().error(e);
                     }
                 }
                 retVal = base;
@@ -229,7 +230,7 @@ public class MHQStaticDirectoryManager extends MMStaticDirectoryManager {
                 }
                 retVal = scaledImage;
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -21,56 +21,19 @@
  */
 package mekhq;
 
-import java.awt.*;
-import java.awt.event.KeyEvent;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.io.*;
-import java.text.NumberFormat;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.ResourceBundle;
-
-import javax.swing.*;
-import javax.swing.text.DefaultEditorKit;
-
 import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.generator.RandomUnitGenerator;
 import megamek.client.ui.preferences.MMPreferences;
+import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.swing.ButtonOrderPreferences;
 import megamek.client.ui.swing.gameConnectionDialogs.ConnectDialog;
 import megamek.client.ui.swing.gameConnectionDialogs.HostDialog;
-import megamek.common.event.EventBus;
-import megamek.common.event.GameBoardChangeEvent;
-import megamek.common.event.GameBoardNewEvent;
-import megamek.common.event.GameCFREvent;
-import megamek.common.event.GameEndEvent;
-import megamek.common.event.GameEntityChangeEvent;
-import megamek.common.event.GameEntityNewEvent;
-import megamek.common.event.GameEntityNewOffboardEvent;
-import megamek.common.event.GameEntityRemoveEvent;
-import megamek.common.event.GameListener;
-import megamek.common.event.GameMapQueryEvent;
-import megamek.common.event.GameNewActionEvent;
-import megamek.common.event.GamePhaseChangeEvent;
-import megamek.common.event.GamePlayerChangeEvent;
-import megamek.common.event.GamePlayerChatEvent;
-import megamek.common.event.GamePlayerConnectedEvent;
-import megamek.common.event.GamePlayerDisconnectedEvent;
-import megamek.common.event.GameReportEvent;
-import megamek.common.event.GameSettingsChangeEvent;
-import megamek.common.event.GameTurnChangeEvent;
-import megamek.common.event.GameVictoryEvent;
-import megamek.common.event.MMEvent;
-import megamek.common.logging.DefaultMmLogger;
-import megamek.common.logging.LogLevel;
-import megamek.common.logging.MMLogger;
+import megamek.common.event.*;
 import megamek.common.preference.PreferenceManager;
-import megamek.common.util.EncodeControl;
 import megamek.server.Server;
+import megameklab.com.MegaMekLab;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignController;
 import mekhq.campaign.ResolveScenarioTracker;
@@ -87,19 +50,26 @@ import mekhq.gui.dialog.ResolveScenarioWizardDialog;
 import mekhq.gui.dialog.RetirementDefectionDialog;
 import mekhq.gui.preferences.StringPreference;
 import mekhq.gui.utilities.ObservableString;
-import megamek.client.ui.preferences.PreferencesNode;
 import mekhq.service.AutosaveService;
 import mekhq.service.IAutosaveService;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.text.DefaultEditorKit;
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.*;
+import java.text.NumberFormat;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
 
 /**
  * The main class of the application.
  */
 public class MekHQ implements GameListener {
-    // TODO : This is intended as a debug/production type thing.
-    // TODO : So it should be backed down to 1 for releases...
-    // TODO : It's intended for 1 to be critical, 3 to be typical, and 5 to be
-    // debug/informational.
-    public static int VERBOSITY_LEVEL = 5;
     public static final String PREFERENCES_FILE = "mmconf/mekhq.preferences";
     public static final String DEFAULT_LOG_FILE_NAME = "mekhqlog.txt";
 
@@ -107,7 +77,6 @@ public class MekHQ implements GameListener {
 
     private static ObservableString selectedTheme;
 
-    private static MMLogger logger = null;
     private static MMPreferences preferences = null;
     private static MekHQOptions mekHQOptions = new MekHQOptions();
 
@@ -134,51 +103,6 @@ public class MekHQ implements GameListener {
     private IconPackage iconPackage = new IconPackage();
 
     private final IAutosaveService autosaveService;
-
-    /**
-     * Converts the MekHQ {@link #VERBOSITY_LEVEL} to {@link LogLevel}.
-     *
-     * @param verbosity The MekHQ verbosity to be converted.
-     * @return The equivalent LogLevel.
-     */
-    private static LogLevel verbosityToLogLevel(final int verbosity) {
-        if (verbosity < 0) {
-            return LogLevel.OFF;
-        }
-        switch (verbosity) {
-            case 0:
-                return LogLevel.FATAL;
-            case 1:
-                return LogLevel.ERROR;
-            case 2:
-                return LogLevel.WARNING;
-            case 3:
-                return LogLevel.INFO;
-            case 4:
-                return LogLevel.DEBUG;
-            case 5:
-                return LogLevel.TRACE;
-        }
-        return LogLevel.INFO;
-    }
-
-    /**
-     * @param logger The logger to be used.
-     */
-    public static void setLogger(final MMLogger logger) {
-        MekHQ.logger = logger;
-    }
-
-    /**
-     * @return The logger that will handle log file output. Will return the
-     *         {@link DefaultMmLogger} if a different logger has not been set.
-     */
-    public static MMLogger getLogger() {
-        if (null == logger) {
-            logger = DefaultMmLogger.getInstance();
-        }
-        return logger;
-    }
 
     public static MMPreferences getPreferences() {
         if (preferences == null) {
@@ -245,6 +169,8 @@ public class MekHQ implements GameListener {
         UIManager.installLookAndFeel("Flat Dark", "com.formdev.flatlaf.FlatDarkLaf");
         UIManager.installLookAndFeel("Flat Darcula", "com.formdev.flatlaf.FlatDarculaLaf");
 
+        MegaMek.showInfo();
+        MegaMekLab.showInfo();
         showInfo();
 
         // Setup user preferences
@@ -321,15 +247,8 @@ public class MekHQ implements GameListener {
         System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name", "MekHQ");
 
-        // We need to reset both the MekHQ and MegaMek log files for now, as we route
-        // output to them
-        // both
         String logFileNameMHQ = PreferenceManager.getClientPreferences().getLogDirectory() + File.separator
                 + DEFAULT_LOG_FILE_NAME;
-        String logFileNameMM = PreferenceManager.getClientPreferences().getLogDirectory() + File.separator
-                + MegaMek.DEFAULT_LOG_FILE_NAME;
-        getLogger().resetLogFile(logFileNameMHQ);
-        getLogger().resetLogFile(logFileNameMM);
         // redirect output to log file
         redirectOutput(logFileNameMHQ); // Deprecated call required for MegaMek usage
 
@@ -337,26 +256,21 @@ public class MekHQ implements GameListener {
     }
 
     private void showInfo() {
-        final long TIMESTAMP = new File(
-                PreferenceManager.getClientPreferences().getLogDirectory() + File.separator + "timestamp")
-                        .lastModified();
+        final long TIMESTAMP = new File(PreferenceManager.getClientPreferences().getLogDirectory()
+                + File.separator + "timestamp").lastModified();
         // echo some useful stuff
-        ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MekHQ", new EncodeControl());
-
-        StringBuilder msg = new StringBuilder();
-        msg.append("\t").append(resourceMap.getString("Application.name")).append(" ")
-                .append(MekHqConstants.VERSION);
+        String msg = "Starting MekHQ v" + MekHqConstants.VERSION;
         if (TIMESTAMP > 0) {
-            msg.append("\n\tCompiled on ").append(Instant.ofEpochMilli(TIMESTAMP));
+            msg += "\n\tCompiled on " + new Date(TIMESTAMP);
         }
-        msg.append("\n\tToday is ").append(LocalDate.now()).append("\n\tJava vendor ")
-                .append(System.getProperty("java.vendor")).append("\n\tJava version ")
-                .append(System.getProperty("java.version")).append("\n\tPlatform ")
-                .append(System.getProperty("os.name")).append(" ").append(System.getProperty("os.version")).append(" (")
-                .append(System.getProperty("os.arch")).append(")");
-        msg.append("\n\tTotal memory available to MegaMek: ")
-                .append(NumberFormat.getInstance().format(Runtime.getRuntime().maxMemory() / 1024)).append(" kB");
-        getLogger().info(msg.toString());
+        msg += "\n\tToday is " + LocalDate.now()
+                + "\n\tJava Vendor: " + System.getProperty("java.vendor")
+                + "\n\tJava Version: " + System.getProperty("java.version")
+                + "\n\tPlatform: " + System.getProperty("os.name") + " " + System.getProperty("os.version")
+                + " (" + System.getProperty("os.arch") + ")"
+                + "\n\tTotal memory available to MegaMek: "
+                + NumberFormat.getInstance().format(Runtime.getRuntime().maxMemory()) + " GB";
+        LogManager.getLogger().info(msg);
     }
 
     /**
@@ -371,7 +285,7 @@ public class MekHQ implements GameListener {
             File logDir = new File("logs");
             if (!logDir.exists()) {
                 if (!logDir.mkdir()) {
-                    MekHQ.getLogger().error("Failed to create directory " + logDir + ", and therefore redirect the logs.");
+                    LogManager.getLogger().error("Failed to create directory " + logDir + ", and therefore redirect the logs.");
                     return;
                 }
             }
@@ -383,7 +297,7 @@ public class MekHQ implements GameListener {
             System.setOut(ps);
             System.setErr(ps);
         } catch (Exception e) {
-            MekHQ.getLogger().error("Unable to redirect output to mekhqlog.txt", e);
+            LogManager.getLogger().error("Unable to redirect output to mekhqlog.txt", e);
         }
     }
 
@@ -433,7 +347,7 @@ public class MekHQ implements GameListener {
         try {
             client = new Client(playerName, serverAddress, port);
         } catch (Exception e) {
-            getLogger().error("Failed to connect to server properly", e);
+            LogManager.getLogger().error("Failed to connect to server properly", e);
             return;
         }
 
@@ -486,7 +400,7 @@ public class MekHQ implements GameListener {
             stopHost();
             return;
         } catch (Exception ex) {
-            MekHQ.getLogger().error("Failed to start up server", ex);
+            LogManager.getLogger().error("Failed to start up server", ex);
             stopHost();
             return;
         }
@@ -601,7 +515,7 @@ public class MekHQ implements GameListener {
             MekHQ.triggerEvent(new ScenarioResolvedEvent(currentScenario));
 
         } catch (Exception e) {
-            getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -711,7 +625,7 @@ public class MekHQ implements GameListener {
                 }
             } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
                     | UnsupportedLookAndFeelException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         };
         SwingUtilities.invokeLater(runnable);

--- a/MekHQ/src/mekhq/MekHqXmlUtil.java
+++ b/MekHQ/src/mekhq/MekHqXmlUtil.java
@@ -20,6 +20,7 @@ package mekhq;
 
 import megamek.common.*;
 import megamek.utils.MegaMekXmlUtil;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -475,7 +476,7 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
      * @throws IllegalArgumentException if the given element parses to multiple entities
      */
     public static Entity parseSingleEntityMul(Element element) {
-        MekHQ.getLogger().trace("Executing getEntityFromXmlString(Node)...");
+        LogManager.getLogger().trace("Executing getEntityFromXmlString(Node)...");
 
         MULParser prs = new MULParser();
         prs.parse(element);
@@ -486,7 +487,7 @@ public class MekHqXmlUtil extends MegaMekXmlUtil {
                 return null;
             case 1:
                 final Entity entity = entities.get(0);
-                MekHQ.getLogger().trace("Returning " + entity + " from getEntityFromXmlString(String)...");
+                LogManager.getLogger().trace("Returning " + entity + " from getEntityFromXmlString(String)...");
                 return entity;
             default:
                 throw new IllegalArgumentException(

--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -42,6 +42,7 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitTechProgression;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 
 import javax.swing.*;
@@ -348,7 +349,7 @@ public class Utilities {
             if (null == techProg) {
                 // This should never happen unless there was an exception thrown when calculating the progression.
                 // In such a case we will log it and take the least restrictive action, which is to let it through.
-                MekHQ.getLogger().warning("Could not determine tech progression for " + summary.getName()
+                LogManager.getLogger().warn("Could not determine tech progression for " + summary.getName()
                                 + ", including among available refits.");
             } else if (!campaign.isLegal(techProg)) {
                 continue;
@@ -1071,11 +1072,11 @@ public class Utilities {
             }
             in.close();
             out.close();
-            MekHQ.getLogger().info("File copied.");
+            LogManager.getLogger().info("File copied.");
         } catch (FileNotFoundException e) {
-            MekHQ.getLogger().error(e.getMessage() + " in the specified directory.");
+            LogManager.getLogger().error(e.getMessage() + " in the specified directory.");
         } catch (IOException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -1109,7 +1110,7 @@ public class Utilities {
 
             report = model.getRowCount() + " " + resourceMap.getString("RowsWritten.text");
         } catch (Exception ioe) {
-            MekHQ.getLogger().error("Error exporting JTable", ioe);
+            LogManager.getLogger().error("Error exporting JTable", ioe);
             report = "Error exporting JTable. See log for details.";
         }
         return report;
@@ -1242,7 +1243,7 @@ public class Utilities {
                             parser.accept(fis);
                         } catch (Exception ex) {
                             // Ignore this file then
-                            MekHQ.getLogger().error("Exception trying to parse " + file.getPath() + " - ignoring.", ex);
+                            LogManager.getLogger().error("Exception trying to parse " + file.getPath() + " - ignoring.", ex);
                         }
                     }
                 }
@@ -1328,7 +1329,7 @@ public class Utilities {
                 try {
                     Thread.sleep(500);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             } else if (loadGround && transport.canLoad(cargo, false) && cargo.getTargetBay() != -1) {
                 client.sendLoadEntity(id, trnId, cargo.getTargetBay());
@@ -1336,7 +1337,7 @@ public class Utilities {
                 try {
                     Thread.sleep(500);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -147,6 +147,7 @@ import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
 import mekhq.module.atb.AtBEventProcessor;
 import mekhq.service.MassRepairService;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * The main campaign class, keeps track of teams and units
@@ -496,7 +497,7 @@ public class Campaign implements Serializable, ITechManager {
                 try {
                     Thread.sleep(50);
                 } catch (InterruptedException e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             }
             rm.setSelectedRATs(campaignOptions.getRATs());
@@ -633,7 +634,7 @@ public class Campaign implements Serializable, ITechManager {
     public void purchaseShipSearchResult() {
         MechSummary ms = MechSummaryCache.getInstance().getMech(getShipSearchResult());
         if (ms == null) {
-            MekHQ.getLogger().error("Cannot find entry for " + getShipSearchResult());
+            LogManager.getLogger().error("Cannot find entry for " + getShipSearchResult());
             return;
         }
 
@@ -648,7 +649,7 @@ public class Campaign implements Serializable, ITechManager {
         try {
             mechFileParser = new MechFileParser(ms.getSourceFile(), ms.getEntryName());
         } catch (Exception ex) {
-            MekHQ.getLogger().error("Unable to load unit: " + ms.getEntryName(), ex);
+            LogManager.getLogger().error("Unable to load unit: " + ms.getEntryName(), ex);
             return;
         }
         Entity en = mechFileParser.getEntity();
@@ -1036,7 +1037,7 @@ public class Campaign implements Serializable, ITechManager {
     public void importUnit(Unit u) {
         Objects.requireNonNull(u);
 
-        MekHQ.getLogger().debug("Importing unit: (" + u.getId() + "): " + u.getName());
+        LogManager.getLogger().debug("Importing unit: (" + u.getId() + "): " + u.getName());
 
         getHangar().addUnit(u);
 
@@ -1063,7 +1064,7 @@ public class Campaign implements Serializable, ITechManager {
      * @param unit - The ship we want to add to this Set
      */
     public void addTransportShip(Unit unit) {
-        MekHQ.getLogger().debug("Adding DropShip/WarShip: " + unit.getId());
+        LogManager.getLogger().debug("Adding DropShip/WarShip: " + unit.getId());
 
         transportShips.add(Objects.requireNonNull(unit));
     }
@@ -2541,7 +2542,7 @@ public class Campaign implements Serializable, ITechManager {
      */
     public void mothball(Unit u) {
         if (u.isMothballed()) {
-            MekHQ.getLogger().warning("Unit is already mothballed, cannot mothball.");
+            LogManager.getLogger().warn("Unit is already mothballed, cannot mothball.");
             return;
         }
 
@@ -2588,7 +2589,7 @@ public class Campaign implements Serializable, ITechManager {
      */
     public void activate(Unit u) {
         if (!u.isMothballed()) {
-            MekHQ.getLogger().warning("Unit is already activated, cannot activate.");
+            LogManager.getLogger().warn("Unit is already activated, cannot activate.");
             return;
         }
 
@@ -3264,7 +3265,7 @@ public class Campaign implements Serializable, ITechManager {
 
                 doMaintenance(u);
             } catch (Exception e) {
-                MekHQ.getLogger().error(String.format(
+                LogManager.getLogger().error(String.format(
                         "Unable to perform maintenance on %s (%s) due to an error",
                         u.getName(), u.getId().toString()), e);
                 addReport(String.format("ERROR: An error occurred performing maintenance on %s, check the log",
@@ -3316,7 +3317,7 @@ public class Campaign implements Serializable, ITechManager {
                     try {
                         fixPart(part, tech);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error(String.format(
+                        LogManager.getLogger().error(String.format(
                                 "Could not perform overnight maintenance on %s (%d) due to an error",
                                 part.getName(), part.getId()), e);
                         addReport(String.format("ERROR: an error occurred performing overnight maintenance on %s, check the log",
@@ -3365,7 +3366,7 @@ public class Campaign implements Serializable, ITechManager {
             try {
                 MassRepairService.massRepairSalvageAllUnits(this);
             } catch (Exception e) {
-                MekHQ.getLogger().error("Could not perform mass repair/salvage on units due to an error", e);
+                LogManager.getLogger().error("Could not perform mass repair/salvage on units due to an error", e);
                 addReport("ERROR: an error occurred performing mass repair/salvage on units, check the log");
             }
         }
@@ -4236,7 +4237,7 @@ public class Campaign implements Serializable, ITechManager {
             try {
                 mechFileParser = new MechFileParser(ms.getSourceFile());
             } catch (EntityLoadingException ex) {
-                MekHQ.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
             if (mechFileParser == null) {
                 continue;
@@ -4838,7 +4839,7 @@ public class Campaign implements Serializable, ITechManager {
 
         final int minutes = Math.min(partWork.getTimeLeft(), techTime);
         if (minutes <= 0) {
-            MekHQ.getLogger().error("Attempting to get the target number for a part with zero time left.");
+            LogManager.getLogger().error("Attempting to get the target number for a part with zero time left.");
             return new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "No part repair time remaining.");
         }
 
@@ -5114,7 +5115,7 @@ public class Campaign implements Serializable, ITechManager {
             }
 
             if (contract == null) {
-                MekHQ.getLogger().error("AtB: used bonus part but no contract has bonus parts available.");
+                LogManager.getLogger().error("AtB: used bonus part but no contract has bonus parts available.");
             } else {
                 addReport(resources.getString("bonusPartLog.text") + " " + targetWork.getAcquisitionPart().getPartName());
                 contract.useBonusPart();
@@ -5275,7 +5276,7 @@ public class Campaign implements Serializable, ITechManager {
 
     public int getAvailableAstechs(final int minutes, final boolean alreadyOvertime) {
         if (minutes == 0) {
-            MekHQ.getLogger().error("Tried to getAvailableAstechs with 0 minutes. Returning 0 Astechs.");
+            LogManager.getLogger().error("Tried to getAvailableAstechs with 0 minutes. Returning 0 Astechs.");
             return 0;
         }
 
@@ -6320,7 +6321,7 @@ public class Campaign implements Serializable, ITechManager {
                         maintenanceReport.append(partReport).append("<br>");
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(String.format(
+                    LogManager.getLogger().error(String.format(
                             "Could not perform maintenance on part %s (%d) for %s (%s) due to an error",
                             p.getName(), p.getId(), u.getName(), u.getId().toString()), e);
                     addReport(String.format("ERROR: An error occurred performing maintenance on %s for unit %s, check the log",
@@ -6344,7 +6345,7 @@ public class Campaign implements Serializable, ITechManager {
             u.setLastMaintenanceReport(maintenanceReport.toString());
 
             if (getCampaignOptions().logMaintenance()) {
-                MekHQ.getLogger().info(maintenanceReport.toString());
+                LogManager.getLogger().info(maintenanceReport.toString());
             }
 
             int quality = u.getQuality();

--- a/MekHQ/src/mekhq/campaign/CampaignFactory.java
+++ b/MekHQ/src/mekhq/campaign/CampaignFactory.java
@@ -18,15 +18,15 @@
  */
 package mekhq.campaign;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.zip.GZIPInputStream;
-
 import mekhq.MekHQ;
 import mekhq.NullEntityException;
 import mekhq.campaign.io.CampaignXmlParseException;
 import mekhq.campaign.io.CampaignXmlParser;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
 
 /**
  * Defines a factory API that enables {@link Campaign} instances to be created

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -38,6 +38,7 @@ import mekhq.campaign.personnel.enums.*;
 import mekhq.campaign.rating.UnitRatingMethod;
 import mekhq.service.MassRepairOption;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -3635,7 +3636,7 @@ public class CampaignOptions implements Serializable {
     }
 
     public static CampaignOptions generateCampaignOptionsFromXml(Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Campaign Options from Version " + version + " XML...");
+        LogManager.getLogger().info("Loading Campaign Options from Version " + version + " XML...");
 
         wn.normalize();
         CampaignOptions retVal = new CampaignOptions();
@@ -3650,7 +3651,7 @@ public class CampaignOptions implements Serializable {
                 continue;
             }
 
-            MekHQ.getLogger().debug(String.format("%s\n\t%s", wn2.getNodeName(), wn2.getTextContent()));
+            LogManager.getLogger().debug(String.format("%s\n\t%s", wn2.getNodeName(), wn2.getTextContent()));
             try {
                 //region Repair and Maintenance Tab
                 if (wn2.getNodeName().equalsIgnoreCase("checkMaintenance")) {
@@ -3981,7 +3982,7 @@ public class CampaignOptions implements Serializable {
                     } else if (values.length == 9) {
                         migrateMarriageSurnameWeights(retVal, values);
                     } else {
-                        MekHQ.getLogger().error("Unknown length of randomMarriageSurnameWeights");
+                        LogManager.getLogger().error("Unknown length of randomMarriageSurnameWeights");
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("useRandomMarriages")) {
                     retVal.setUseRandomMarriages(Boolean.parseBoolean(wn2.getTextContent().trim()));
@@ -4366,7 +4367,7 @@ public class CampaignOptions implements Serializable {
                 }
                 //endregion Legacy
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
@@ -4376,7 +4377,7 @@ public class CampaignOptions implements Serializable {
             retVal.setContractMarketMethod(ContractMarketMethod.ATB_MONTHLY);
         }
 
-        MekHQ.getLogger().debug("Load Campaign Options Complete!");
+        LogManager.getLogger().debug("Load Campaign Options Complete!");
 
         return retVal;
     }
@@ -4395,7 +4396,7 @@ public class CampaignOptions implements Serializable {
             try {
                 weights[i] = Integer.parseInt(values[i]);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
                 weights[i] = 0;
             }
         }

--- a/MekHQ/src/mekhq/campaign/CampaignPreset.java
+++ b/MekHQ/src/mekhq/campaign/CampaignPreset.java
@@ -37,6 +37,7 @@ import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.Systems;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -289,7 +290,7 @@ public class CampaignPreset implements Serializable {
              PrintWriter pw = new PrintWriter(osw)) {
             writeToXML(pw, 0);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign", new EncodeControl());
             JOptionPane.showMessageDialog(frame, resources.getString("CampaignPresetSaveFailure.text"),
                     resources.getString("CampaignPresetSaveFailure.title"), JOptionPane.ERROR_MESSAGE);
@@ -380,7 +381,7 @@ public class CampaignPreset implements Serializable {
         try (InputStream is = new FileInputStream(file)) {
             xmlDoc = MekHqXmlUtil.newSafeDocumentBuilder().parse(is);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return null;
         }
 
@@ -453,7 +454,7 @@ public class CampaignPreset implements Serializable {
                             if (wn2.getNodeType() != Node.ELEMENT_NODE) {
                                 continue;
                             } else if (!wn2.getNodeName().equalsIgnoreCase("skillType")) {
-                                MekHQ.getLogger().error("Unknown node type not loaded in Skill Type nodes: " + wn2.getNodeName());
+                                LogManager.getLogger().error("Unknown node type not loaded in Skill Type nodes: " + wn2.getNodeName());
                                 continue;
                             }
                             SkillType.generateSeparateInstanceFromXML(wn2, preset.getSkills());
@@ -468,7 +469,7 @@ public class CampaignPreset implements Serializable {
                             if (wn2.getNodeType() != Node.ELEMENT_NODE) {
                                 continue;
                             } else if (!wn2.getNodeName().equalsIgnoreCase("ability")) {
-                                MekHQ.getLogger().error("Unknown node type not loaded in Special Ability nodes: " + wn2.getNodeName());
+                                LogManager.getLogger().error("Unknown node type not loaded in Special Ability nodes: " + wn2.getNodeName());
                                 continue;
                             }
                             SpecialAbility.generateSeparateInstanceFromXML(wn2, preset.getSpecialAbilities(), options);
@@ -482,7 +483,7 @@ public class CampaignPreset implements Serializable {
                 }
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return null;
         }
         return preset;

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -27,6 +27,7 @@ import mekhq.campaign.event.LocationChangedEvent;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.universe.Systems;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -48,12 +49,12 @@ public class CurrentLocation implements Serializable {
     private static final long serialVersionUID = -4337642922571022697L;
 
     private PlanetarySystem currentSystem;
-    //keep track of jump path
+    // keep track of jump path
     private JumpPath jumpPath;
     private double rechargeTime;
-    //I would like to keep track of distance, but I ain't too good with fyziks
+    // I would like to keep track of distance, but I ain't too good with fyziks
     private double transitTime;
-    //jumpship at nadir or zenith
+    // JumpShip at nadir or zenith
     private boolean jumpZenith;
 
     public CurrentLocation() {
@@ -290,7 +291,7 @@ public class CurrentLocation implements Serializable {
                     PlanetarySystem p = Systems.getInstance().getSystemById(wn2.getTextContent());
                     if (null == p) {
                         //whoops we cant find your planet man, back to Earth
-                        MekHQ.getLogger().error("Couldn't find planet named " + wn2.getTextContent());
+                        LogManager.getLogger().error("Couldn't find planet named " + wn2.getTextContent());
                         p = c.getSystemByName("Terra");
                         if (null == p) {
                             //if that doesn't work then give the first planet we have
@@ -309,7 +310,7 @@ public class CurrentLocation implements Serializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/ExtraData.java
+++ b/MekHQ/src/mekhq/campaign/ExtraData.java
@@ -18,30 +18,20 @@
  */
 package mekhq.campaign;
 
-import java.io.OutputStream;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import org.w3c.dom.Node;
-
-import mekhq.MekHQ;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Class for holding extra data/properties with free-form strings as keys.
@@ -88,7 +78,7 @@ public class ExtraData {
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             u = context.createUnmarshaller();
         } catch(Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         marshaller = m;
         unmarshaller = u;
@@ -106,7 +96,7 @@ public class ExtraData {
                 try {
                     return Integer.valueOf(str);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     return 0;
                 }
             }
@@ -117,7 +107,7 @@ public class ExtraData {
                 try {
                     return Double.valueOf(str);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     return 0.0;
                 }
             }
@@ -128,7 +118,7 @@ public class ExtraData {
                 try {
                     return Boolean.valueOf(str);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     return false;
                 }
             }
@@ -209,7 +199,7 @@ public class ExtraData {
         try {
             marshaller.marshal(this, writer);
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -217,7 +207,7 @@ public class ExtraData {
         try {
             marshaller.marshal(this, os);
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -225,7 +215,7 @@ public class ExtraData {
         try {
             return (ExtraData) unmarshaller.unmarshal(wn);
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/campaign/JumpPath.java
+++ b/MekHQ/src/mekhq/campaign/JumpPath.java
@@ -20,18 +20,17 @@
  */
 package mekhq.campaign;
 
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.universe.PlanetarySystem;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.universe.PlanetarySystem;
 
 /**
  * This is an array list of planets for a jump path, from which we can derive
@@ -171,12 +170,12 @@ public class JumpPath implements Serializable {
                     if (null != p) {
                         retVal.addSystem(p);
                     } else {
-                        MekHQ.getLogger().error("Couldn't find planet named " + wn2.getTextContent());
+                        LogManager.getLogger().error("Couldn't find planet named " + wn2.getTextContent());
                     }
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/Kill.java
+++ b/MekHQ/src/mekhq/campaign/Kill.java
@@ -21,17 +21,16 @@
  */
 package mekhq.campaign;
 
+import megamek.Version;
+import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.UUID;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import megamek.Version;
 
 /**
  * A kill record
@@ -109,7 +108,7 @@ public class Kill implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/MercRosterAccess.java
+++ b/MekHQ/src/mekhq/campaign/MercRosterAccess.java
@@ -18,31 +18,23 @@
  */
 package mekhq.campaign;
 
-import java.sql.Connection;
-import java.sql.Date;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
+import megamek.common.UnitType;
+import mekhq.campaign.force.Force;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.Skill;
+import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.enums.Profession;
+import mekhq.campaign.personnel.ranks.Rank;
+import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.sql.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-
-import javax.swing.SwingWorker;
-
-import megamek.common.UnitType;
-import mekhq.MekHQ;
-import mekhq.campaign.force.Force;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.enums.Profession;
-import mekhq.campaign.personnel.ranks.Rank;
-import mekhq.campaign.personnel.Skill;
-import mekhq.campaign.personnel.SkillType;
-import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.unit.Unit;
 
 public class MercRosterAccess extends SwingWorker<Void, Void> {
     //region Variable Declarations
@@ -93,7 +85,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
         } catch (SQLException e) {
             throw e;
         } catch (ClassNotFoundException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -102,7 +94,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
         try {
             statement = connect.createStatement();
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         writeBasicData();
@@ -122,7 +114,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             preparedStatement.setString(1, truncateString(campaign.getName(), 100));
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         progressNote = "Uploading dates";
@@ -133,7 +125,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             preparedStatement.setDate(1, Date.valueOf(campaign.getLocalDate().toString()));
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         progressTicker++;
         progressNote = "Uploading ranks";
@@ -153,7 +145,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             }
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         //write skill types
         progressNote = "Uploading skill types";
@@ -170,7 +162,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             }
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         //write crewtypes
         progressNote = "Uploading personnel types";
@@ -386,7 +378,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             }
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         //write equipment types
@@ -416,7 +408,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 determineProgress();
             }
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -433,7 +425,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             preparedStatement.setString(5, campaign.getForces().getDescription());
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         progressNote = "Uploading force data";
@@ -461,7 +453,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             preparedStatement.setString(5, force.getDescription());
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         //retrieve the MercRoster id of this force
         int id = parent;
@@ -469,7 +461,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             rs.next();
             id = rs.getInt("id");
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         progressTicker += 2;
@@ -500,7 +492,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             statement.execute("TRUNCATE TABLE " + table + ".skills");
             statement.execute("TRUNCATE TABLE " + table + ".kills");
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         progressNote = "Uploading personnel data";
@@ -582,7 +574,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 progressTicker += 4;
                 determineProgress();
             } catch (SQLException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }
@@ -599,7 +591,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
             }
             rs.close();
         } catch (SQLException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         progressNote = "Uploading equipment data";
@@ -640,7 +632,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 progressTicker += 1;
                 determineProgress();
             } catch (SQLException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/Quartermaster.java
+++ b/MekHQ/src/mekhq/campaign/Quartermaster.java
@@ -16,7 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign;
 
 import megamek.common.AmmoType;

--- a/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
+++ b/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
@@ -20,17 +20,16 @@
  */
 package mekhq.campaign;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-
 import megamek.Version;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
 
 /**
  * @author Jay Lawson
@@ -201,7 +200,7 @@ public class RandomSkillPreferences implements Serializable {
     }
 
     public static RandomSkillPreferences generateRandomSkillPreferencesFromXml(Node wn, Version version) {
-        MekHQ.getLogger().debug("Loading Random Skill Preferences from XML...");
+        LogManager.getLogger().debug("Loading Random Skill Preferences from XML...");
 
         wn.normalize();
         RandomSkillPreferences retVal = new RandomSkillPreferences();
@@ -216,7 +215,7 @@ public class RandomSkillPreferences implements Serializable {
                 continue;
             }
 
-            MekHQ.getLogger().debug(wn2.getNodeName() + ": " + wn2.getTextContent());
+            LogManager.getLogger().debug(wn2.getNodeName() + ": " + wn2.getTextContent());
             try {
                 if (wn2.getNodeName().equalsIgnoreCase("overallRecruitBonus")) {
                     retVal.overallRecruitBonus = Integer.parseInt(wn2.getTextContent().trim());
@@ -261,11 +260,11 @@ public class RandomSkillPreferences implements Serializable {
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
-        MekHQ.getLogger().debug("Load Random Skill Preferences Complete!");
+        LogManager.getLogger().debug("Load Random Skill Preferences Complete!");
 
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -42,6 +42,7 @@ import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.actions.AdjustLargeCraftAmmoAction;
 import mekhq.gui.FileDialogs;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -142,7 +143,7 @@ public class ResolveScenarioTracker {
             try {
                 loadUnitsAndPilots(unitList.get());
             } catch (IOException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         } else {
             initUnitsAndPilotsWithoutBattle();
@@ -474,7 +475,7 @@ public class ResolveScenarioTracker {
                         PersonStatus status = peopleStatus.get(p.getId());
                         if (null == status) {
                             //this shouldn't happen so report
-                            MekHQ.getLogger().error(
+                            LogManager.getLogger().error(
                                     "A null person status was found for person id " + p.getId().toString()
                                     + " when trying to assign kills");
                             continue;
@@ -684,7 +685,7 @@ public class ResolveScenarioTracker {
                 Entity e = entities.get(UUID.fromString(id));
                 // Invalid entity?
                 if (e == null) {
-                    MekHQ.getLogger().error("Null entity reference in:" + aero.getDisplayName() + "getEscapeCraft()");
+                    LogManager.getLogger().error("Null entity reference in:" + aero.getDisplayName() + "getEscapeCraft()");
                     continue;
                 }
                 //If the escape craft was destroyed in combat, skip it
@@ -1049,12 +1050,12 @@ public class ResolveScenarioTracker {
                 // Read a Vector from the file.
                 parser.parse(listStream);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
 
             // Was there any error in parsing?
             if (parser.hasWarningMessage()) {
-                MekHQ.getLogger().warning(parser.getWarningMessage());
+                LogManager.getLogger().warn(parser.getWarningMessage());
             }
 
             killCredits = parser.getKills();
@@ -1910,7 +1911,7 @@ public class ResolveScenarioTracker {
                             : unit.getEntity();
                     baseEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
                 } catch (EntityLoadingException e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/Warehouse.java
+++ b/MekHQ/src/mekhq/campaign/Warehouse.java
@@ -16,18 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign;
-
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.TreeMap;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
@@ -38,6 +27,12 @@ import mekhq.campaign.event.PartRemovedEvent;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Part;
+
+import java.io.PrintWriter;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 /**
  * Stores parts for a Campaign.

--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
@@ -21,41 +21,30 @@
  */
 package mekhq.campaign.againstTheBot;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.io.Serializable;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ResourceBundle;
-import java.util.function.Function;
-
-import javax.xml.parsers.DocumentBuilder;
-
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.rating.IUnitRating;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.Factions;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Compute;
-import megamek.common.EntityWeightClass;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.TargetRoll;
-import megamek.common.UnitType;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.SkillType;
-import mekhq.campaign.rating.IUnitRating;
-import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
+import javax.xml.parsers.DocumentBuilder;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.function.Function;
 
 /**
  * @author Neoancient
@@ -112,14 +101,14 @@ public class AtBConfiguration implements Serializable {
 
     private WeightedTable<String> getDefaultForceTable(String key, int index) {
         if (index < 0) {
-            MekHQ.getLogger().error("Default force tables don't support negative weights, limiting to 0");
+            LogManager.getLogger().error("Default force tables don't support negative weights, limiting to 0");
             index = 0;
         }
         String property = defaultProperties.getString(key);
         String[] fields = property.split("\\|");
         if (index >= fields.length) {
             // Deal with too short field lengths
-            MekHQ.getLogger().error(String.format("Default force tables have %d weight entries; limiting the original value of %d.", fields.length, index));
+            LogManager.getLogger().error(String.format("Default force tables have %d weight entries; limiting the original value of %d.", fields.length, index));
             index = fields.length - 1;
         }
         return parseDefaultWeightedTable(fields[index]);
@@ -137,7 +126,7 @@ public class AtBConfiguration implements Serializable {
                 String[] fields = e.split(":");
                 retVal.add(Integer.parseInt(fields[0]), fromString.apply(fields[1]));
             } catch (Exception ex) {
-                MekHQ.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
         return retVal;
@@ -235,20 +224,20 @@ public class AtBConfiguration implements Serializable {
             int weightClassIndex = weightClassIndex(weightClass);
             WeightedTable<String> table;
             if ((weightClassIndex < 0) || (weightClassIndex >= botForceTable.size())) {
-                MekHQ.getLogger().error(String.format("Bot force tables for organization \"%s\" don't have an entry for weight class %d, limiting to valid values", org, weightClass));
+                LogManager.getLogger().error(String.format("Bot force tables for organization \"%s\" don't have an entry for weight class %d, limiting to valid values", org, weightClass));
                 weightClassIndex = Math.max(0, Math.min(weightClassIndex, botForceTable.size() - 1));
             }
             table = botForceTable.get(weightClassIndex);
             if (null == table) {
                 table = getDefaultForceTable("botForce." + org, weightClassIndex);
                 if (null == table) {
-                    MekHQ.getLogger().error(String.format("Default (fallback) bot force table for organization \"%s\" and weight class %d doesn't exist, ignoring", org, weightClass));
+                    LogManager.getLogger().error(String.format("Default (fallback) bot force table for organization \"%s\" and weight class %d doesn't exist, ignoring", org, weightClass));
                     return null;
                 }
             }
             return table.select(rollMod);
         } else {
-            MekHQ.getLogger().error(String.format("Bot force tables for organization \"%s\" not found, ignoring", org));
+            LogManager.getLogger().error(String.format("Bot force tables for organization \"%s\" not found, ignoring", org));
             return null;
         }
     }
@@ -395,7 +384,7 @@ public class AtBConfiguration implements Serializable {
     public static AtBConfiguration loadFromXml() {
         AtBConfiguration retVal = new AtBConfiguration();
 
-        MekHQ.getLogger().info("Starting load of AtB configuration data from XML...");
+        LogManager.getLogger().info("Starting load of AtB configuration data from XML...");
 
         Document xmlDoc;
         try (InputStream is = new FileInputStream("data/universe/atbconfig.xml")) { // TODO : Remove inline file path
@@ -403,11 +392,11 @@ public class AtBConfiguration implements Serializable {
 
             xmlDoc = db.parse(is);
         } catch (FileNotFoundException ex) {
-            MekHQ.getLogger().info("File data/universe/atbconfig.xml not found. Loading defaults.");
+            LogManager.getLogger().info("File data/universe/atbconfig.xml not found. Loading defaults.");
             retVal.setAllValuesToDefaults();
             return retVal;
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return retVal;
         }
 
@@ -482,7 +471,7 @@ public class AtBConfiguration implements Serializable {
                     }
                     retVal.set(weightClass, loadWeightedTableFromXml(wn));
                 } catch (Exception ex) {
-                    MekHQ.getLogger().error("Could not parse weight class attribute for enemy forces table", ex);
+                    LogManager.getLogger().error("Could not parse weight class attribute for enemy forces table", ex);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/enums/PlanetaryAcquisitionFactionLimit.java
+++ b/MekHQ/src/mekhq/campaign/enums/PlanetaryAcquisitionFactionLimit.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -97,7 +97,7 @@ public enum PlanetaryAcquisitionFactionLimit {
 
         }
 
-        MekHQ.getLogger().error("Unable to parse a PlanetaryAcquisitionFactionLimit from " + text
+        LogManager.getLogger().error("Unable to parse a PlanetaryAcquisitionFactionLimit from " + text
                 + ". Returning NEUTRAL");
 
         return NEUTRAL;

--- a/MekHQ/src/mekhq/campaign/finances/Asset.java
+++ b/MekHQ/src/mekhq/campaign/finances/Asset.java
@@ -21,9 +21,9 @@
  */
 package mekhq.campaign.finances;
 
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.finances.enums.FinancialTerm;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -118,7 +118,7 @@ public class Asset implements Serializable {
                     asset.setFinancialTerm(FinancialTerm.parseFromString(wn2.getTextContent().trim()));
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         return asset;

--- a/MekHQ/src/mekhq/campaign/finances/CurrencyManager.java
+++ b/MekHQ/src/mekhq/campaign/finances/CurrencyManager.java
@@ -20,7 +20,6 @@
  */
 package mekhq.campaign.finances;
 
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
@@ -28,7 +27,7 @@ import mekhq.campaign.mission.Contract;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.PlanetarySystem;
-
+import org.apache.logging.log4j.LogManager;
 import org.joda.money.CurrencyUnitDataProvider;
 import org.joda.money.format.MoneyFormatter;
 import org.joda.money.format.MoneyFormatterBuilder;
@@ -40,12 +39,7 @@ import org.w3c.dom.NodeList;
 import javax.xml.parsers.DocumentBuilder;
 import java.io.FileInputStream;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Main class used to handle all money and currency information.
@@ -196,7 +190,7 @@ public class CurrencyManager extends CurrencyUnitDataProvider {
 
     @Override
     protected void registerCurrencies() {
-        MekHQ.getLogger().info("Starting load currency information from XML...");
+        LogManager.getLogger().info("Starting load currency information from XML...");
 
         try {
             // Using factory get an instance of document builder
@@ -291,9 +285,9 @@ public class CurrencyManager extends CurrencyUnitDataProvider {
                 }
             }
 
-            MekHQ.getLogger().info("Load of currency information complete!");
+            LogManager.getLogger().info("Load of currency information complete!");
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -19,6 +19,25 @@
  */
 package mekhq.campaign.finances;
 
+import megamek.common.util.EncodeControl;
+import mekhq.MekHQ;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.event.LoanDefaultedEvent;
+import mekhq.campaign.event.TransactionCreditEvent;
+import mekhq.campaign.event.TransactionDebitEvent;
+import mekhq.campaign.finances.enums.TransactionType;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.Contract;
+import mekhq.campaign.personnel.Person;
+import mekhq.io.FileType;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -29,26 +48,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
-
-import mekhq.campaign.finances.enums.TransactionType;
-import mekhq.io.FileType;
-import mekhq.campaign.personnel.Person;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.CampaignOptions;
-import mekhq.campaign.event.LoanDefaultedEvent;
-import mekhq.campaign.event.TransactionCreditEvent;
-import mekhq.campaign.event.TransactionDebitEvent;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.Contract;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -199,7 +198,7 @@ public class Finances implements Serializable {
                     retVal.wentIntoDebt = MekHqXmlUtil.parseDate(wn2.getTextContent().trim());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
@@ -399,7 +398,7 @@ public class Finances implements Serializable {
                  * payment that has just been made.
                  */
                 campaign.addReport(String.format(resourceMap.getString("NotImplemented.text"), "shares"));
-                MekHQ.getLogger().error("Attempted to payout share amount larger than the payment of the contract");
+                LogManager.getLogger().error("Attempted to payout share amount larger than the payment of the contract");
             }
         }
     }
@@ -498,7 +497,7 @@ public class Finances implements Serializable {
 
             report = transactions.size() + resourceMap.getString("FinanceExport.text");
         } catch (IOException ioe) {
-            MekHQ.getLogger().info("Error exporting finances to " + format);
+            LogManager.getLogger().info("Error exporting finances to " + format);
             report = "Error exporting finances. See log for details.";
         }
 

--- a/MekHQ/src/mekhq/campaign/finances/Loan.java
+++ b/MekHQ/src/mekhq/campaign/finances/Loan.java
@@ -22,10 +22,10 @@
 package mekhq.campaign.finances;
 
 import megamek.common.Compute;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.campaign.finances.enums.FinancialTerm;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -387,7 +387,7 @@ public class Loan implements Serializable {
                     loan.setRemainingPayments(Integer.parseInt(wn2.getTextContent().trim()));
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         return loan;

--- a/MekHQ/src/mekhq/campaign/finances/Transaction.java
+++ b/MekHQ/src/mekhq/campaign/finances/Transaction.java
@@ -24,6 +24,7 @@ package mekhq.campaign.finances;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.finances.enums.TransactionType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -138,7 +139,7 @@ public class Transaction implements Serializable {
                     transaction.setType(TransactionType.parseFromString(wn2.getTextContent().trim()));
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         return transaction;

--- a/MekHQ/src/mekhq/campaign/finances/enums/FinancialTerm.java
+++ b/MekHQ/src/mekhq/campaign/finances/enums/FinancialTerm.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.finances.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -136,7 +136,7 @@ public enum FinancialTerm {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse the FinancialTerm from text " + text + ", returning ANNUALLY.");
+        LogManager.getLogger().error("Failed to parse the FinancialTerm from text " + text + ", returning ANNUALLY.");
 
         return ANNUALLY;
     }

--- a/MekHQ/src/mekhq/campaign/finances/enums/FinancialYearDuration.java
+++ b/MekHQ/src/mekhq/campaign/finances/enums/FinancialYearDuration.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.finances.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -123,7 +123,7 @@ public enum FinancialYearDuration {
             return BIENNIAL;
         }
 
-        MekHQ.getLogger().error("Failed to parse the FinancialYearDuration from text " + text + ", returning ANNUAL.");
+        LogManager.getLogger().error("Failed to parse the FinancialYearDuration from text " + text + ", returning ANNUAL.");
 
         return ANNUAL;
     }

--- a/MekHQ/src/mekhq/campaign/finances/enums/TransactionType.java
+++ b/MekHQ/src/mekhq/campaign/finances/enums/TransactionType.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.finances.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -225,7 +225,7 @@ public enum TransactionType {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse the TransactionType from text " + text + ", returning MISCELLANEOUS.");
+        LogManager.getLogger().error("Failed to parse the TransactionType from text " + text + ", returning MISCELLANEOUS.");
 
         return MISCELLANEOUS;
     }

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -21,35 +21,26 @@
  */
 package mekhq.campaign.force;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
-import java.util.UUID;
-import java.util.Vector;
-
+import megamek.Version;
 import megamek.common.annotations.Nullable;
 import megamek.common.icons.AbstractIcon;
 import megamek.common.icons.Camouflage;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.io.Migration.CamouflageMigrator;
 import mekhq.campaign.log.ServiceLogger;
+import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
 import mekhq.gui.enums.LayeredForceIcon;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import megamek.Version;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.Scenario;
-import mekhq.campaign.unit.Unit;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.util.*;
 
 /**
  * This is a hierarchical object to define forces for TO&E. Each Force
@@ -534,7 +525,7 @@ public class Force implements Serializable {
                         if (!wn3.getNodeName().equalsIgnoreCase("force")) {
                             // Error condition of sorts!
                             // Errr, what should we do here?
-                            MekHQ.getLogger().error("Unknown node type not loaded in Forces nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in Forces nodes: " + wn3.getNodeName());
                             continue;
                         }
 
@@ -544,7 +535,7 @@ public class Force implements Serializable {
             }
             c.importForce(retVal);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return null;
         }
 

--- a/MekHQ/src/mekhq/campaign/force/ForceStub.java
+++ b/MekHQ/src/mekhq/campaign/force/ForceStub.java
@@ -20,21 +20,20 @@
  */
 package mekhq.campaign.force;
 
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Vector;
-
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.unit.Unit;
 
 /**
  * this is a hierarchical object that represents forces from the TO&E using
@@ -195,7 +194,7 @@ public class ForceStub implements Serializable {
                             continue;
 
                         if (!wn3.getNodeName().equalsIgnoreCase("unitStub")) {
-                            MekHQ.getLogger().error("Unknown node type not loaded in ForceStub nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in ForceStub nodes: " + wn3.getNodeName());
                             continue;
                         }
 
@@ -210,7 +209,7 @@ public class ForceStub implements Serializable {
                             continue;
 
                         if (!wn3.getNodeName().equalsIgnoreCase("forceStub")) {
-                            MekHQ.getLogger().error("Unknown node type not loaded in ForceStub nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in ForceStub nodes: " + wn3.getNodeName());
                             continue;
                         }
 
@@ -219,7 +218,7 @@ public class ForceStub implements Serializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/force/Lance.java
+++ b/MekHQ/src/mekhq/campaign/force/Lance.java
@@ -21,33 +21,28 @@
  */
 package mekhq.campaign.force;
 
+import megamek.common.*;
+import mekhq.MekHqXmlSerializable;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.AtBScenario;
+import mekhq.campaign.mission.atb.AtBScenarioFactory;
+import mekhq.campaign.mission.enums.AtBLanceRole;
+import mekhq.campaign.mission.enums.AtBMoraleLevel;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Faction;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.UUID;
-
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.EntityWeightClass;
-import megamek.common.Infantry;
-import megamek.common.UnitType;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlSerializable;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.enums.AtBLanceRole;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.atb.AtBScenarioFactory;
-import mekhq.campaign.mission.enums.AtBMoraleLevel;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.unit.Unit;
-import mekhq.campaign.universe.Faction;
-
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * Used by Against the Bot to track additional information about each force
@@ -496,7 +491,7 @@ public class Lance implements Serializable, MekHqXmlSerializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/force/UnitStub.java
+++ b/MekHQ/src/mekhq/campaign/force/UnitStub.java
@@ -20,19 +20,18 @@
  */
 package mekhq.campaign.force;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-
 import megamek.common.icons.AbstractIcon;
 import megamek.common.icons.Portrait;
 import megamek.common.util.StringUtil;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
-
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
 
 public class UnitStub implements Serializable {
     //region Variable Declarations
@@ -120,7 +119,7 @@ public class UnitStub implements Serializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -57,6 +57,7 @@ import mekhq.campaign.universe.Systems;
 import mekhq.io.idReferenceClasses.PersonIdReference;
 import mekhq.module.atb.AtBEventProcessor;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -84,7 +85,7 @@ public class CampaignXmlParser {
      * @throws NullEntityException Thrown when an entity is referenced but cannot be loaded or found
      */
     public Campaign parse() throws CampaignXmlParseException, NullEntityException {
-        MekHQ.getLogger().info("Starting load of campaign file from XML...");
+        LogManager.getLogger().info("Starting load of campaign file from XML...");
         // Initialize variables.
         Campaign retVal = new Campaign();
         retVal.setApp(app);
@@ -98,7 +99,7 @@ public class CampaignXmlParser {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(is);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
 
             throw new CampaignXmlParseException(ex);
         }
@@ -326,19 +327,19 @@ public class CampaignXmlParser {
             for (Force f : retVal.getAllForces()) {
                 if ((f.getUnits().size() > 0) && (null == lances.get(f.getId()))) {
                     lances.put(f.getId(), new Lance(f.getId(), retVal));
-                    MekHQ.getLogger().warning(String.format("Added missing Lance %s to AtB list", f.getName()));
+                    LogManager.getLogger().warn(String.format("Added missing Lance %s to AtB list", f.getName()));
                 }
             }
         }
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Force IDs set in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Force IDs set in %dms",
             System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
         // Process parts...
         postProcessParts(retVal, version);
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Parts processed in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Parts processed in %dms",
             System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
@@ -347,7 +348,7 @@ public class CampaignXmlParser {
             psn.resetSkillTypes();
         }
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Rank references fixed in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Rank references fixed in %dms",
             System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
@@ -386,7 +387,7 @@ public class CampaignXmlParser {
             final EquipmentUnscrambler unscrambler = EquipmentUnscrambler.create(unit);
             final EquipmentUnscramblerResult result = unscrambler.unscramble();
             if (!result.succeeded()) {
-                MekHQ.getLogger().warning(result.getMessage());
+                LogManager.getLogger().warn(result.getMessage());
             }
 
             // some units might need to be assigned to scenarios
@@ -400,7 +401,7 @@ public class CampaignXmlParser {
             }
         });
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Pilot references fixed in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Pilot references fixed in %dms",
             System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
@@ -414,7 +415,7 @@ public class CampaignXmlParser {
         });
         retVal.refreshNetworks();
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] C3 networks refreshed in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] C3 networks refreshed in %dms",
             System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
@@ -440,7 +441,7 @@ public class CampaignXmlParser {
             retVal.removeUnit(unit.getId());
         }
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Units initialized in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Units initialized in %dms",
                 System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
@@ -448,13 +449,13 @@ public class CampaignXmlParser {
             person.fixReferences(retVal);
         }
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Personnel initialized in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Personnel initialized in %dms",
                 System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
         retVal.reloadNews();
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] News loaded in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] News loaded in %dms",
                 System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
@@ -495,7 +496,7 @@ public class CampaignXmlParser {
             bin.unload();
         }
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Ammo bins cleared in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Ammo bins cleared in %dms",
                 System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
@@ -511,7 +512,7 @@ public class CampaignXmlParser {
             }
         }
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Reserved refit parts fixed in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Reserved refit parts fixed in %dms",
                 System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
@@ -524,12 +525,12 @@ public class CampaignXmlParser {
         // This will have aggregated all of the possible spare parts together
         retVal.setWarehouse(warehouse);
 
-        MekHQ.getLogger().info(String.format("[Campaign Load] Warehouse cleaned up in %dms",
+        LogManager.getLogger().info(String.format("[Campaign Load] Warehouse cleaned up in %dms",
                 System.currentTimeMillis() - timestamp));
 
         retVal.setUnitRating(null);
 
-        MekHQ.getLogger().info("Load of campaign file complete!");
+        LogManager.getLogger().info("Load of campaign file complete!");
 
         return retVal;
     }
@@ -557,7 +558,7 @@ public class CampaignXmlParser {
                     tech.removeTechUnit(u);
                 }
                 if (null != reason) {
-                    MekHQ.getLogger().warning(String.format("Tech %s %s %s (fixed)", tech.getFullName(), reason, unitDesc));
+                    LogManager.getLogger().warn(String.format("Tech %s %s %s (fixed)", tech.getFullName(), reason, unitDesc));
                 }
             }
         }
@@ -704,7 +705,7 @@ public class CampaignXmlParser {
                     retVal.setId(UUID.fromString(wn.getTextContent().trim()));
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
@@ -740,7 +741,7 @@ public class CampaignXmlParser {
             if (!wn2.getNodeName().equalsIgnoreCase("lance")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Lance nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Lance nodes: " + wn2.getNodeName());
                 continue;
             }
 
@@ -769,13 +770,13 @@ public class CampaignXmlParser {
     }
 
     private static void processFinances(Campaign retVal, Node wn) {
-        MekHQ.getLogger().info("Loading Finances from XML...");
+        LogManager.getLogger().info("Loading Finances from XML...");
         retVal.setFinances(Finances.generateInstanceFromXML(wn));
-        MekHQ.getLogger().info("Load of Finances complete!");
+        LogManager.getLogger().info("Load of Finances complete!");
     }
 
     private static void processForces(Campaign retVal, Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Force Organization from XML...");
+        LogManager.getLogger().info("Loading Force Organization from XML...");
 
         NodeList wList = wn.getChildNodes();
 
@@ -792,7 +793,7 @@ public class CampaignXmlParser {
             if (!wn2.getNodeName().equalsIgnoreCase("force")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Forces nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Forces nodes: " + wn2.getNodeName());
 
                 continue;
             }
@@ -804,15 +805,15 @@ public class CampaignXmlParser {
                     foundForceAlready = true;
                 }
             } else {
-                MekHQ.getLogger().error("More than one type-level force found");
+                LogManager.getLogger().error("More than one type-level force found");
             }
         }
 
-        MekHQ.getLogger().info("Load of Force Organization complete!");
+        LogManager.getLogger().info("Load of Force Organization complete!");
     }
 
     private static void processPersonnelNodes(Campaign retVal, Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Personnel Nodes from XML...");
+        LogManager.getLogger().info("Loading Personnel Nodes from XML...");
 
         NodeList wList = wn.getChildNodes();
 
@@ -828,7 +829,7 @@ public class CampaignXmlParser {
             if (!wn2.getNodeName().equalsIgnoreCase("person")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Personnel nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Personnel nodes: " + wn2.getNodeName());
 
                 continue;
             }
@@ -840,11 +841,11 @@ public class CampaignXmlParser {
             }
         }
 
-        MekHQ.getLogger().info("Load Personnel Nodes Complete!");
+        LogManager.getLogger().info("Load Personnel Nodes Complete!");
     }
 
     private static void processSkillTypeNodes(Campaign retVal, Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Skill Type Nodes from XML...");
+        LogManager.getLogger().info("Loading Skill Type Nodes from XML...");
 
         NodeList wList = wn.getChildNodes();
 
@@ -862,7 +863,7 @@ public class CampaignXmlParser {
             } else if (!wn2.getNodeName().equalsIgnoreCase("skillType")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Skill Type nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Skill Type nodes: " + wn2.getNodeName());
                 continue;
             }
 
@@ -870,11 +871,11 @@ public class CampaignXmlParser {
             SkillType.generateInstanceFromXML(wn2, version);
         }
 
-        MekHQ.getLogger().info("Load Skill Type Nodes Complete!");
+        LogManager.getLogger().info("Load Skill Type Nodes Complete!");
     }
 
     private static void processSpecialAbilityNodes(Campaign retVal, Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Special Ability Nodes from XML...");
+        LogManager.getLogger().info("Loading Special Ability Nodes from XML...");
 
         PersonnelOptions options = new PersonnelOptions();
 
@@ -895,17 +896,17 @@ public class CampaignXmlParser {
             if (!wn2.getNodeName().equalsIgnoreCase("ability")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Special Ability nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Special Ability nodes: " + wn2.getNodeName());
                 continue;
             }
             SpecialAbility.generateInstanceFromXML(wn2, options, version);
         }
 
-        MekHQ.getLogger().info("Load Special Ability Nodes Complete!");
+        LogManager.getLogger().info("Load Special Ability Nodes Complete!");
     }
 
     private static void processKillNodes(Campaign retVal, Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Kill Nodes from XML...");
+        LogManager.getLogger().info("Loading Kill Nodes from XML...");
 
         NodeList wList = wn.getChildNodes();
 
@@ -919,7 +920,7 @@ public class CampaignXmlParser {
             } else if (!wn2.getNodeName().equalsIgnoreCase("kill")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Kill nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Kill nodes: " + wn2.getNodeName());
                 continue;
             }
 
@@ -929,7 +930,7 @@ public class CampaignXmlParser {
             }
         }
 
-        MekHQ.getLogger().info("Load Kill Nodes Complete!");
+        LogManager.getLogger().info("Load Kill Nodes Complete!");
     }
 
     /**
@@ -946,14 +947,14 @@ public class CampaignXmlParser {
         File customsDir = new File(sCustomsDir);
         if (!customsDir.exists()) {
             if (!customsDir.mkdir()) {
-                MekHQ.getLogger().error("Failed to create directory " + sCustomsDir + ", and therefore cannot save the unit.");
+                LogManager.getLogger().error("Failed to create directory " + sCustomsDir + ", and therefore cannot save the unit.");
                 return false;
             }
         }
         File customsDirCampaign = new File(sCustomsDirCampaign);
         if (!customsDirCampaign.exists()) {
             if (!customsDirCampaign.mkdir()) {
-                MekHQ.getLogger().error("Failed to create directory " + sCustomsDirCampaign + ", and therefore cannot save the unit.");
+                LogManager.getLogger().error("Failed to create directory " + sCustomsDirCampaign + ", and therefore cannot save the unit.");
                 return false;
             }
         }
@@ -1017,24 +1018,24 @@ public class CampaignXmlParser {
     }
 
     private static boolean tryWriteCustomToFile(String fileName, String contents) {
-        MekHQ.getLogger().info("Writing custom unit from inline data to " + fileName);
+        LogManager.getLogger().info("Writing custom unit from inline data to " + fileName);
 
         try (OutputStream out = new FileOutputStream(fileName);
             PrintStream p = new PrintStream(out)) {
 
             p.println(contents);
 
-            MekHQ.getLogger().info("Wrote custom unit from inline data to: " + fileName);
+            LogManager.getLogger().info("Wrote custom unit from inline data to: " + fileName);
 
             return true;
         } catch (Exception ex) {
-            MekHQ.getLogger().error("Error writing custom unit from inline data to: " + fileName, ex);
+            LogManager.getLogger().error("Error writing custom unit from inline data to: " + fileName, ex);
             return false;
         }
     }
 
     private static void processMissionNodes(Campaign retVal, Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Mission Nodes from XML...");
+        LogManager.getLogger().info("Loading Mission Nodes from XML...");
 
         NodeList wList = wn.getChildNodes();
 
@@ -1050,7 +1051,7 @@ public class CampaignXmlParser {
             if (!wn2.getNodeName().equalsIgnoreCase("mission")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().warning("Unknown node type not loaded in Mission nodes: " + wn2.getNodeName());
+                LogManager.getLogger().warn("Unknown node type not loaded in Mission nodes: " + wn2.getNodeName());
                 continue;
             }
 
@@ -1066,11 +1067,11 @@ public class CampaignXmlParser {
             contract.restore(retVal);
         }
 
-        MekHQ.getLogger().info("Load Mission Nodes Complete!");
+        LogManager.getLogger().info("Load Mission Nodes Complete!");
     }
 
     private static String checkUnits(Node wn) {
-        MekHQ.getLogger().info("Checking for missing entities...");
+        LogManager.getLogger().info("Checking for missing entities...");
 
         List<String> unitList = new ArrayList<>();
         NodeList wList = wn.getChildNodes();
@@ -1101,12 +1102,12 @@ public class CampaignXmlParser {
                             }
                         }
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Could not read entity from XML", e);
+                        LogManager.getLogger().error("Could not read entity from XML", e);
                     }
                 }
             }
         }
-        MekHQ.getLogger().info("Finished checking for missing entities!");
+        LogManager.getLogger().info("Finished checking for missing entities!");
 
         if (unitList.isEmpty()) {
             return null;
@@ -1115,13 +1116,13 @@ public class CampaignXmlParser {
             for (String s : unitList) {
                 unitListString.append("\n").append(s);
             }
-            MekHQ.getLogger().error(String.format("Could not load the following units: %s", unitListString.toString()));
+            LogManager.getLogger().error(String.format("Could not load the following units: %s", unitListString.toString()));
             return unitListString.toString();
         }
     }
 
     private static void processUnitNodes(Campaign retVal, Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Unit Nodes from XML...");
+        LogManager.getLogger().info("Loading Unit Nodes from XML...");
 
         NodeList wList = wn.getChildNodes();
 
@@ -1135,7 +1136,7 @@ public class CampaignXmlParser {
             }
 
             if (!wn2.getNodeName().equalsIgnoreCase("unit")) {
-                MekHQ.getLogger().error("Unknown node type not loaded in Unit nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Unit nodes: " + wn2.getNodeName());
                 continue;
             }
 
@@ -1146,11 +1147,11 @@ public class CampaignXmlParser {
             }
         }
 
-        MekHQ.getLogger().info("Load Unit Nodes Complete!");
+        LogManager.getLogger().info("Load Unit Nodes Complete!");
     }
 
     private static void processPartNodes(Campaign retVal, Node wn, Version version) {
-        MekHQ.getLogger().info("Loading Part Nodes from XML...");
+        LogManager.getLogger().info("Loading Part Nodes from XML...");
 
         NodeList wList = wn.getChildNodes();
 
@@ -1165,7 +1166,7 @@ public class CampaignXmlParser {
             }
 
             if (!wn2.getNodeName().equalsIgnoreCase("part")) {
-                MekHQ.getLogger().error("Unknown node type not loaded in Part nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Part nodes: " + wn2.getNodeName());
                 continue;
             }
 
@@ -1178,7 +1179,7 @@ public class CampaignXmlParser {
 
         retVal.importParts(parts);
 
-        MekHQ.getLogger().info("Load Part Nodes Complete!");
+        LogManager.getLogger().info("Load Part Nodes Complete!");
     }
 
     private static void postProcessParts(Campaign retVal, Version version) {
@@ -1190,7 +1191,7 @@ public class CampaignXmlParser {
             // Remove fundamentally broken equipment parts
             if (((prt instanceof EquipmentPart) && ((EquipmentPart) prt).getType() == null)
                     || ((prt instanceof MissingEquipmentPart) && ((MissingEquipmentPart) prt).getType() == null)) {
-                MekHQ.getLogger().warning("Could not find matching EquipmentType for part " + prt.getName());
+                LogManager.getLogger().warn("Could not find matching EquipmentType for part " + prt.getName());
                 removeParts.add(prt);
                 continue;
             }
@@ -1414,7 +1415,7 @@ public class CampaignXmlParser {
             }
         }
         for (Part prt : removeParts) {
-            MekHQ.getLogger().debug("Removing part #" + prt.getId() + " " + prt.getName());
+            LogManager.getLogger().debug("Removing part #" + prt.getId() + " " + prt.getName());
             retVal.getWarehouse().removePart(prt);
         }
     }
@@ -1603,21 +1604,21 @@ public class CampaignXmlParser {
                 people.remove();
 
                 if (father == null) {
-                    MekHQ.getLogger().warning("Unknown father does not exist, skipping adding Genealogy for them.");
+                    LogManager.getLogger().warn("Unknown father does not exist, skipping adding Genealogy for them.");
                 } else if (father.getId() != null) {
                     person.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, father);
                     father.getGenealogy().addFamilyMember(FamilialRelationshipType.CHILD, person);
                 } else {
-                    MekHQ.getLogger().warning("Person with id " + father.getId() + "does not exist, skipping adding Genealogy for them.");
+                    LogManager.getLogger().warn("Person with id " + father.getId() + "does not exist, skipping adding Genealogy for them.");
                 }
 
                 if (mother == null) {
-                    MekHQ.getLogger().warning("Unknown mother does not exist, skipping adding Genealogy for them.");
+                    LogManager.getLogger().warn("Unknown mother does not exist, skipping adding Genealogy for them.");
                 } else if (mother.getId() != null) {
                     person.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, mother);
                     mother.getGenealogy().addFamilyMember(FamilialRelationshipType.CHILD, person);
                 } else {
-                    MekHQ.getLogger().warning("Person with id " + mother.getId() + " does not exist, skipping adding Genealogy for them.");
+                    LogManager.getLogger().warn("Person with id " + mother.getId() + " does not exist, skipping adding Genealogy for them.");
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/io/Migration/CamouflageMigrator.java
+++ b/MekHQ/src/mekhq/campaign/io/Migration/CamouflageMigrator.java
@@ -18,9 +18,9 @@
  */
 package mekhq.campaign.io.Migration;
 
-import megamek.common.icons.Camouflage;
-import mekhq.MekHQ;
 import megamek.Version;
+import megamek.common.icons.Camouflage;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * This migrates Camouflage from SeaBee's Pack to Deadborder's Pack.
@@ -48,7 +48,7 @@ public class CamouflageMigrator {
                 default:
                     break;
             }
-            MekHQ.getLogger().warning("Migrated to " + camouflage.toString());
+            LogManager.getLogger().warn("Migrated to " + camouflage.toString());
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/log/LogEntryFactory.java
+++ b/MekHQ/src/mekhq/campaign/log/LogEntryFactory.java
@@ -18,8 +18,8 @@
  */
 package mekhq.campaign.log;
 
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -97,7 +97,7 @@ public class LogEntryFactory {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return null;
         }
 

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -20,12 +20,11 @@
  */
 package mekhq.campaign.market;
 
+import megamek.Version;
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.market.enums.ContractMarketMethod;
@@ -39,6 +38,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.universe.*;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -196,7 +196,7 @@ public class ContractMarket implements Serializable {
                     }
                 }
             } else {
-                MekHQ.getLogger().warning(
+                LogManager.getLogger().warn(
                         "Unable to find any factions around "
                             + campaign.getCurrentSystem().getName(campaign.getLocalDate())
                             + " on "
@@ -307,10 +307,10 @@ public class ContractMarket implements Serializable {
 
     private @Nullable AtBContract generateAtBContract(Campaign campaign, @Nullable String employer, int unitRatingMod, int retries) {
         if (employer == null) {
-            MekHQ.getLogger().warning("Could not generate an AtB Contract because there was no employer!");
+            LogManager.getLogger().warn("Could not generate an AtB Contract because there was no employer!");
             return null;
         } else if (retries <= 0) {
-            MekHQ.getLogger().warning("Could not generate an AtB Contract because we ran out of retries!");
+            LogManager.getLogger().warn("Could not generate an AtB Contract because we ran out of retries!");
             return null;
         }
 
@@ -329,7 +329,7 @@ public class ContractMarket implements Serializable {
             }
 
             if ((employer == null) || employer.equals("MERC")) {
-                MekHQ.getLogger().warning("Could not generate an AtB Contract because we could not find a non-MERC employer!");
+                LogManager.getLogger().warn("Could not generate an AtB Contract because we could not find a non-MERC employer!");
                 return null;
             }
         }
@@ -374,7 +374,7 @@ public class ContractMarket implements Serializable {
             contract.setSystemId(RandomFactionGenerator.getInstance().getMissionTarget(contract.getEnemyCode(), contract.getEmployerCode()));
         }
         if (contract.getSystem() == null) {
-            MekHQ.getLogger().warning("Could not find contract location for "
+            LogManager.getLogger().warn("Could not find contract location for "
                             + contract.getEmployerCode() + " vs. " + contract.getEnemyCode());
             return generateAtBContract(campaign, employer, unitRatingMod, retries - 1);
         }
@@ -383,7 +383,7 @@ public class ContractMarket implements Serializable {
             jp = contract.getJumpPath(campaign);
         } catch (NullPointerException ex) {
             // could not calculate jump path; leave jp null
-            MekHQ.getLogger().warning("Could not calculate jump path to contract location: "
+            LogManager.getLogger().warn("Could not calculate jump path to contract location: "
                             + contract.getSystem().getName(campaign.getLocalDate()), ex);
         }
 
@@ -897,7 +897,7 @@ public class ContractMarket implements Serializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -12,13 +12,28 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.market;
+
+import megamek.common.*;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.verifier.TestEntity;
+import megamek.common.weapons.InfantryAttack;
+import megamek.common.weapons.Weapon;
+import megamek.common.weapons.bayweapons.BayWeapon;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.*;
+import mekhq.campaign.parts.equipment.EquipmentPart;
+import mekhq.campaign.parts.equipment.HeatSink;
+import mekhq.campaign.parts.equipment.JumpJet;
+import mekhq.campaign.parts.equipment.MASC;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -26,70 +41,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.BayType;
-import megamek.common.Dropship;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.Jumpship;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.MiscType;
-import megamek.common.Protomech;
-import megamek.common.TechConstants;
-import megamek.common.WeaponType;
-import megamek.common.loaders.EntityLoadingException;
-import megamek.common.verifier.TestEntity;
-import megamek.common.weapons.InfantryAttack;
-import megamek.common.weapons.Weapon;
-import megamek.common.weapons.bayweapons.BayWeapon;
-import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.AeroHeatSink;
-import mekhq.campaign.parts.AeroSensor;
-import mekhq.campaign.parts.AmmoStorage;
-import mekhq.campaign.parts.Armor;
-import mekhq.campaign.parts.Avionics;
-import mekhq.campaign.parts.BaArmor;
-import mekhq.campaign.parts.BattleArmorSuit;
-import mekhq.campaign.parts.BayDoor;
-import mekhq.campaign.parts.Cubicle;
-import mekhq.campaign.parts.DropshipDockingCollar;
-import mekhq.campaign.parts.EnginePart;
-import mekhq.campaign.parts.FireControlSystem;
-import mekhq.campaign.parts.GravDeck;
-import mekhq.campaign.parts.JumpshipDockingCollar;
-import mekhq.campaign.parts.KfBoom;
-import mekhq.campaign.parts.LandingGear;
-import mekhq.campaign.parts.MekActuator;
-import mekhq.campaign.parts.MekCockpit;
-import mekhq.campaign.parts.MekGyro;
-import mekhq.campaign.parts.MekLifeSupport;
-import mekhq.campaign.parts.MekLocation;
-import mekhq.campaign.parts.MekSensor;
-import mekhq.campaign.parts.OmniPod;
-import mekhq.campaign.parts.Part;
-import mekhq.campaign.parts.ProtomekArmActuator;
-import mekhq.campaign.parts.ProtomekArmor;
-import mekhq.campaign.parts.ProtomekJumpJet;
-import mekhq.campaign.parts.ProtomekLegActuator;
-import mekhq.campaign.parts.ProtomekLocation;
-import mekhq.campaign.parts.ProtomekSensor;
-import mekhq.campaign.parts.QuadVeeGear;
-import mekhq.campaign.parts.Rotor;
-import mekhq.campaign.parts.Turret;
-import mekhq.campaign.parts.VeeSensor;
-import mekhq.campaign.parts.VeeStabiliser;
-import mekhq.campaign.parts.equipment.EquipmentPart;
-import mekhq.campaign.parts.equipment.HeatSink;
-import mekhq.campaign.parts.equipment.JumpJet;
-import mekhq.campaign.parts.equipment.MASC;
 
 /**
  * This is a parts store which will contain one copy of every possible
@@ -102,10 +53,6 @@ import mekhq.campaign.parts.equipment.MASC;
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class PartsStore implements Serializable {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 1686222527383868364L;
 
     private static int EXPECTED_SIZE = 50000;
@@ -171,7 +118,7 @@ public class PartsStore implements Serializable {
             try {
                 newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
             } catch (EntityLoadingException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
             if(null != newEntity) {
                 BattleArmorSuit ba = new BattleArmorSuit(summary.getChassis(), summary.getModel(), (int)summary.getTons(), 1, summary.getWeightClass(), summary.getWalkMp(), summary.getJumpMp(), newEntity.entityIsQuad(), summary.isClan(), newEntity.getMovementMode(), c);

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -18,37 +18,28 @@
  */
 package mekhq.campaign.market;
 
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import mekhq.campaign.personnel.enums.PersonnelRole;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Entity;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.TargetRoll;
+import megamek.Version;
+import megamek.common.*;
 import megamek.common.event.Subscribe;
 import megamek.common.loaders.EntityLoadingException;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.MarketNewPersonnelEvent;
 import mekhq.campaign.event.OptionsChangedEvent;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.unit.HangarStatistics;
 import mekhq.module.PersonnelMarketServiceManager;
 import mekhq.module.api.PersonnelMarketMethod;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.*;
 
 public class PersonnelMarket {
     private List<Person> personnel = new ArrayList<>();
@@ -264,7 +255,7 @@ public class PersonnelMarket {
                     try {
                         en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
                     } catch (EntityLoadingException ex) {
-                        MekHQ.getLogger().error("Unable to load entity: " + ms.getSourceFile() + ": " + ms.getEntryName() + ": " + ex.getMessage(), ex);
+                        LogManager.getLogger().error("Unable to load entity: " + ms.getSourceFile() + ": " + ms.getEntryName() + ": " + ex.getMessage(), ex);
                     }
                     if (null != en) {
                         retVal.attachedEntities.put(id, en);
@@ -278,7 +269,7 @@ public class PersonnelMarket {
                 } else  {
                     // Error condition of sorts!
                     // Errr, what should we do here?
-                    MekHQ.getLogger().error("Unknown node type not loaded in Personnel nodes: " + wn2.getNodeName());
+                    LogManager.getLogger().error("Unknown node type not loaded in Personnel nodes: " + wn2.getNodeName());
                 }
             }
 
@@ -293,7 +284,7 @@ public class PersonnelMarket {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -20,18 +20,11 @@
  */
 package mekhq.campaign.market;
 
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
+import megamek.Version;
 import megamek.common.Entity;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.ProcurementEvent;
 import mekhq.campaign.parts.Part;
@@ -39,6 +32,13 @@ import mekhq.campaign.parts.Refit;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.unit.UnitOrder;
 import mekhq.campaign.work.IAcquisitionWork;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A list of IAcquisitionWork
@@ -198,7 +198,7 @@ public class ShoppingList implements MekHqXmlSerializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/market/enums/UnitMarketType.java
+++ b/MekHQ/src/mekhq/campaign/market/enums/UnitMarketType.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.market.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -75,7 +75,7 @@ public enum UnitMarketType {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse " + text + " into a UnitMarketType");
+        LogManager.getLogger().error("Failed to parse " + text + " into a UnitMarketType");
 
         return OPEN;
     }

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AbstractUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AbstractUnitMarket.java
@@ -18,19 +18,19 @@
  */
 package mekhq.campaign.market.unitMarket;
 
+import megamek.Version;
 import megamek.client.ratgenerator.MissionRole;
 import megamek.common.Compute;
 import megamek.common.EntityMovementMode;
 import megamek.common.MechSummary;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.market.enums.UnitMarketMethod;
 import mekhq.campaign.market.enums.UnitMarketType;
 import mekhq.campaign.universe.Faction;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -264,7 +264,7 @@ public abstract class AbstractUnitMarket implements Serializable {
                 parseXMLNode(wn2, campaign, version);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("Failed to parse Unit Market, keeping currently parsed market", e);
+            LogManager.getLogger().error("Failed to parse Unit Market, keeping currently parsed market", e);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/UnitMarketOffer.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/UnitMarketOffer.java
@@ -18,18 +18,14 @@
  */
 package mekhq.campaign.market.unitMarket;
 
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
 import megamek.Version;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.market.enums.UnitMarketType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -108,7 +104,7 @@ public class UnitMarketOffer {
         try {
             return new MechFileParser(getUnit().getSourceFile(), getUnit().getEntryName()).getEntity();
         } catch (Exception e) {
-            MekHQ.getLogger().error("Unable to load entity: " + getUnit().getSourceFile()
+            LogManager.getLogger().error("Unable to load entity: " + getUnit().getSourceFile()
                     + ": " + getUnit().getEntryName() + ". Returning null.", e);
             return null;
         }
@@ -158,7 +154,7 @@ public class UnitMarketOffer {
                 }
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         if (version.isLowerThan("0.49.3")) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -46,6 +46,7 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.RandomFactionGenerator;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -522,7 +523,7 @@ public class AtBContract extends Contract implements Serializable {
                 try {
                     en = new MechFileParser(msl.get(0).getSourceFile(), msl.get(0).getEntryName()).getEntity();
                 } catch (EntityLoadingException ex) {
-                    MekHQ.getLogger().error("Unable to load entity: " + msl.get(0).getSourceFile()
+                    LogManager.getLogger().error("Unable to load entity: " + msl.get(0).getSourceFile()
                             + ": " + msl.get(0).getEntryName() + ": " + ex.getMessage(), ex);
                 }
             }
@@ -913,7 +914,7 @@ public class AtBContract extends Contract implements Serializable {
                     parentContract = new AtBContractRef(Integer.parseInt(wn2.getTextContent()));
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }
@@ -929,12 +930,12 @@ public class AtBContract extends Contract implements Serializable {
                 if (m instanceof AtBContract) {
                     setParentContract((AtBContract) m);
                 } else {
-                    MekHQ.getLogger().warning(String.format("Parent Contract reference #%d is not an AtBContract for contract %s",
+                    LogManager.getLogger().warn(String.format("Parent Contract reference #%d is not an AtBContract for contract %s",
                             parentContract.getId(), getName()));
                     setParentContract(null);
                 }
             } else {
-                MekHQ.getLogger().warning(String.format("Parent Contract #%d reference was not found for contract %s",
+                LogManager.getLogger().warn(String.format("Parent Contract #%d reference was not found for contract %s",
                         parentContract.getId(), getName()));
                 setParentContract(null);
             }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -18,21 +18,15 @@
  */
 package mekhq.campaign.mission;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
+import megamek.client.bot.princess.CardinalEdge;
 import megamek.client.generator.RandomGenderGenerator;
+import megamek.client.generator.RandomNameGenerator;
+import megamek.client.generator.RandomUnitGenerator;
 import megamek.client.generator.enums.SkillGeneratorType;
 import megamek.client.generator.skillGenerators.AbstractSkillGenerator;
 import megamek.client.generator.skillGenerators.TaharqaSkillGenerator;
-import megamek.common.MechSummaryCache;
+import megamek.client.ratgenerator.MissionRole;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.enums.SkillLevel;
@@ -40,34 +34,9 @@ import megamek.common.icons.Camouflage;
 import megamek.common.util.StringUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.utils.BoardClassifier;
-import megamek.client.generator.RandomNameGenerator;
-import megamek.client.generator.RandomUnitGenerator;
-import megamek.client.bot.princess.CardinalEdge;
-import megamek.client.ratgenerator.MissionRole;
-import megamek.common.Board;
-import megamek.common.BoardDimensions;
-import megamek.common.BombType;
-import megamek.common.Compute;
-import megamek.common.Crew;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityWeightClass;
-import megamek.common.IAero;
-import megamek.common.IBomber;
-import megamek.common.Infantry;
-import megamek.common.LandAirMech;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.OffBoardDirection;
-import megamek.common.PlanetaryConditions;
-import megamek.common.Transporter;
-import megamek.common.TroopSpace;
-import megamek.common.UnitType;
-import mekhq.MekHQ;
 import mekhq.Utilities;
-import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.Lance;
 import mekhq.campaign.mission.AtBDynamicScenario.BenchedEntityData;
@@ -83,15 +52,14 @@ import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.Phenotype;
 import mekhq.campaign.unit.Unit;
-import mekhq.campaign.universe.enums.EraFlag;
-import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.*;
 import mekhq.campaign.universe.Faction.Tag;
-import mekhq.campaign.universe.IUnitGenerator;
-import mekhq.campaign.universe.Planet;
-import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.campaign.universe.Systems;
-import mekhq.campaign.universe.UnitGeneratorParameters;
+import mekhq.campaign.universe.enums.EraFlag;
+import org.apache.logging.log4j.LogManager;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * This class handles the creation and substantive manipulation of AtBDynamicScenarios
@@ -333,7 +301,7 @@ public class AtBDynamicScenarioFactory {
                 quality = scenario.getEffectiveOpforQuality();
                 break;
             default:
-                MekHQ.getLogger().warning(
+                LogManager.getLogger().warn(
                         String.format("Invalid force alignment %d", forceTemplate.getForceAlignment()));
         }
 
@@ -423,7 +391,7 @@ public class AtBDynamicScenarioFactory {
             // no reason to go into an endless loop if we can't generate a lance
             if (generatedLance.isEmpty()) {
                 stopGenerating = true;
-                MekHQ.getLogger().warning(
+                LogManager.getLogger().warn(
                         String.format("Unable to generate units from RAT: %s, type %d, max weight %d",
                                 factionCode, forceTemplate.getAllowedUnitType(), weightClass));
                 continue;
@@ -660,7 +628,7 @@ public class AtBDynamicScenarioFactory {
 
         for (int forceID : scenario.getPlayerForceTemplates().keySet()) {
             ScenarioForceTemplate forceTemplate = scenario.getPlayerForceTemplates().get(forceID);
-            
+
             if ((forceTemplate != null) && forceTemplate.getContributesToUnitCount()) {
                 primaryUnitCount += campaign.getForce(forceID).getAllUnits(true).size();
             }
@@ -1338,7 +1306,7 @@ public class AtBDynamicScenarioFactory {
         try {
             en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
         } catch (Exception ex) {
-            MekHQ.getLogger().error("Unable to load entity: " + ms.getSourceFile() + ": " + ms.getEntryName(), ex);
+            LogManager.getLogger().error("Unable to load entity: " + ms.getSourceFile() + ": " + ms.getEntryName(), ex);
             return null;
         }
 
@@ -1774,7 +1742,7 @@ public class AtBDynamicScenarioFactory {
         // if so, we log a warning, then generate what we can.
         // having a longer weight string is not an issue, as we simply generate the first N units where N is the size of unitTypes.
         if (unitTypeSize > weights.length()) {
-            MekHQ.getLogger().error(
+            LogManager.getLogger().error(
                     String.format("More unit types (%d) provided than weights (%d). Truncating generated lance.", unitTypes.size(), weights.length()));
             unitTypeSize = weights.length();
         }
@@ -2193,7 +2161,7 @@ public class AtBDynamicScenarioFactory {
      * @param entityList The list of entities to process.
      */
     private static void setDeploymentTurnsStaggeredByLance(List<Entity> entityList) {
-        MekHQ.getLogger().warning("Deployment Turn - Staggered by Lance not implemented");
+        LogManager.getLogger().warn("Deployment Turn - Staggered by Lance not implemented");
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -29,7 +29,9 @@ import megamek.common.icons.Camouflage;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.EncodeControl;
 import megamek.common.util.StringUtil;
-import mekhq.*;
+import mekhq.MekHqConstants;
+import mekhq.MekHqXmlUtil;
+import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.force.Force;
@@ -43,6 +45,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.*;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -715,7 +718,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                     en.setCamouflage(camouflage.clone());
                 }
             } else {
-                MekHQ.getLogger().error("Entity for player-controlled allies is null");
+                LogManager.getLogger().error("Entity for player-controlled allies is null");
             }
         }
 
@@ -729,7 +732,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 allyEntities.add(en);
                 attachedUnitIds.add(UUID.fromString(en.getExternalIdAsString()));
             } else {
-                MekHQ.getLogger().error("Entity for ally bot is null");
+                LogManager.getLogger().error("Entity for ally bot is null");
             }
         }
 
@@ -1771,7 +1774,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                             try {
                                 en = MekHqXmlUtil.getEntityFromXmlString(wn3);
                             } catch (Exception e) {
-                                MekHQ.getLogger().error("Error loading allied unit in scenario", e);
+                                LogManager.getLogger().error("Error loading allied unit in scenario", e);
                             }
                             if (en != null) {
                                 alliesPlayer.add(en);
@@ -1790,7 +1793,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                             try {
                                 en = MekHqXmlUtil.getEntityFromXmlString(wn3);
                             } catch (Exception e) {
-                                MekHQ.getLogger().error("Error loading allied unit in scenario", e);
+                                LogManager.getLogger().error("Error loading allied unit in scenario", e);
                             }
                             if (en != null) {
                                 bigBattleAllies.add(en);
@@ -1817,7 +1820,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                                     try {
                                         en = MekHqXmlUtil.getEntityFromXmlString(wn4);
                                     } catch (Exception e) {
-                                        MekHQ.getLogger().error("Error loading enemy unit in scenario", e);
+                                        LogManager.getLogger().error("Error loading enemy unit in scenario", e);
                                     }
                                     if (null != en) {
                                         specMissionEnemies.get(weightClass).add(en);
@@ -1833,7 +1836,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                     try {
                         bf.setFieldsFromXmlNode(wn2, version);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Error loading bot force in scenario", e);
+                        LogManager.getLogger().error("Error loading bot force in scenario", e);
                         bf = null;
                     }
 
@@ -1860,17 +1863,17 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                     try {
                         transportLinkages = loadTransportLinkages(wn2);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Error loading transport linkages in scenario", e);
+                        LogManager.getLogger().error("Error loading transport linkages in scenario", e);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("numPlayerMinefields")) {
                     try {
                         loadMinefieldCounts(wn2);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Error loading minefield counts in scenario", e);
+                        LogManager.getLogger().error("Error loading minefield counts in scenario", e);
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         /* In the event a discrepancy occurs between a RAT entry and the unit lookup name,

--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -18,33 +18,31 @@
  */
 package mekhq.campaign.mission;
 
+import megamek.Version;
+import megamek.client.bot.princess.BehaviorSettings;
+import megamek.client.bot.princess.BehaviorSettingsFactory;
+import megamek.client.bot.princess.CardinalEdge;
+import megamek.client.bot.princess.PrincessException;
+import megamek.client.ui.swing.util.PlayerColour;
+import megamek.common.Board;
+import megamek.common.Compute;
+import megamek.common.Entity;
+import megamek.common.UnitNameTracker;
+import megamek.common.icons.Camouflage;
+import mekhq.MekHqXmlSerializable;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.io.Migration.CamouflageMigrator;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
-import megamek.client.ui.swing.util.PlayerColour;
-import megamek.common.icons.Camouflage;
-import megamek.common.logging.LogLevel;
-import megamek.Version;
-import mekhq.campaign.io.Migration.CamouflageMigrator;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.client.bot.princess.BehaviorSettings;
-import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.CardinalEdge;
-import megamek.client.bot.princess.PrincessException;
-import megamek.common.Board;
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.UnitNameTracker;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlSerializable;
-import mekhq.MekHqXmlUtil;
 
 public class BotForce implements Serializable, MekHqXmlSerializable {
     private static final long serialVersionUID = 8259058549964342518L;
@@ -64,7 +62,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
         try {
             behaviorSettings = BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR.getCopy();
         } catch (PrincessException ex) {
-            MekHQ.getLogger().error("Error getting Princess default behaviors", ex);
+            LogManager.getLogger().error("Error getting Princess default behaviors", ex);
         }
     }
 
@@ -91,7 +89,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
         try {
             behaviorSettings = BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR.getCopy();
         } catch (PrincessException ex) {
-            MekHQ.getLogger().error("Error getting Princess default behaviors", ex);
+            LogManager.getLogger().error("Error getting Princess default behaviors", ex);
         }
         behaviorSettings.setRetreatEdge(CardinalEdge.NEAREST);
         behaviorSettings.setDestinationEdge(CardinalEdge.NONE);
@@ -210,7 +208,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
 
         for (Entity entity : getEntityList()) {
             if (entity == null) {
-                MekHQ.getLogger().error("Null entity when calculating the BV a bot force, we should never find a null here. Please investigate");
+                LogManager.getLogger().error("Null entity when calculating the BV a bot force, we should never find a null here. Please investigate");
             } else {
                 bv += entity.calculateBattleValue(true, false);
             }
@@ -246,14 +244,13 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
         MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent++, "entities");
         for (Entity en : entityList) {
             if (en == null) {
-                MekHQ.getLogger().error("Null entity when saving a bot force, we should never find a null here. Please investigate");
+                LogManager.getLogger().error("Null entity when saving a bot force, we should never find a null here. Please investigate");
             } else {
                 pw1.println(AtBScenario.writeEntityWithCrewToXmlString(en, indent, entityList));
             }
         }
         MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw1, --indent, "entities");
         MekHqXmlUtil.writeSimpleXMLOpenIndentedLine(pw1, indent++, "behaviorSettings");
-        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "verbosity", behaviorSettings.getVerbosity().toString());
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "forcedWithdrawal", behaviorSettings.isForcedWithdrawal());
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "autoFlee", behaviorSettings.shouldAutoFlee());
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent, "selfPreservationIndex", behaviorSettings.getSelfPreservationIndex());
@@ -302,7 +299,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
                             try {
                                 en = MekHqXmlUtil.parseSingleEntityMul((Element) wn3);
                             } catch (Exception e) {
-                                MekHQ.getLogger().error("Error loading allied unit in scenario", e);
+                                LogManager.getLogger().error("Error loading allied unit in scenario", e);
                             }
 
                             if (en != null) {
@@ -314,9 +311,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
                     NodeList nl2 = wn2.getChildNodes();
                     for (int i = 0; i < nl2.getLength(); i++) {
                         Node wn3 = nl2.item(i);
-                        if (wn3.getNodeName().equalsIgnoreCase("verbosity")) {
-                            behaviorSettings.setVerbosity(LogLevel.getLogLevel(wn3.getTextContent()));
-                        } else if (wn3.getNodeName().equalsIgnoreCase("forcedWithdrawal")) {
+                        if (wn3.getNodeName().equalsIgnoreCase("forcedWithdrawal")) {
                             behaviorSettings.setForcedWithdrawal(Boolean.parseBoolean(wn3.getTextContent()));
                         } else if (wn3.getNodeName().equalsIgnoreCase("autoFlee")) {
                             behaviorSettings.setAutoFlee(Boolean.parseBoolean(wn3.getTextContent()));
@@ -338,7 +333,7 @@ public class BotForce implements Serializable, MekHqXmlSerializable {
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -20,24 +20,23 @@
  */
 package mekhq.campaign.mission;
 
+import mekhq.MekHqXmlSerializable;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.finances.Accountant;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.enums.ContractCommandRights;
+import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Accountant;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.mission.enums.ContractCommandRights;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import mekhq.MekHqXmlSerializable;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.JumpPath;
-import mekhq.campaign.unit.Unit;
 
 /**
  * Contracts - we need to track static amounts here because changes in the
@@ -751,7 +750,7 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
                     salvagedByEmployer = Money.fromXmlString(wn2.getTextContent().trim());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -20,6 +20,19 @@
  */
 package mekhq.campaign.mission;
 
+import megamek.Version;
+import megamek.common.annotations.Nullable;
+import mekhq.MekHqXmlSerializable;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.enums.MissionStatus;
+import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.campaign.universe.Systems;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.text.ParseException;
@@ -27,20 +40,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import megamek.common.annotations.Nullable;
-import mekhq.campaign.mission.enums.MissionStatus;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlSerializable;
-import mekhq.MekHqXmlUtil;
-import megamek.Version;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.campaign.universe.Systems;
 
 /**
  * Missions are primarily holder objects for a set of scenarios.
@@ -286,7 +285,7 @@ public class Mission implements Serializable, MekHqXmlSerializable {
                         if (!wn3.getNodeName().equalsIgnoreCase("scenario")) {
                             // Error condition of sorts!
                             // Errr, what should we do here?
-                            MekHQ.getLogger().error("Unknown node type not loaded in Scenario nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in Scenario nodes: " + wn3.getNodeName());
 
                             continue;
                         }
@@ -299,7 +298,7 @@ public class Mission implements Serializable, MekHqXmlSerializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -21,33 +21,29 @@
  */
 package mekhq.campaign.mission;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.text.ParseException;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import megamek.common.annotations.Nullable;
-import mekhq.campaign.mission.enums.ScenarioStatus;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
+import megamek.Version;
 import megamek.common.Entity;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.DeploymentChangedEvent;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.ForceStub;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
 import mekhq.campaign.mission.atb.IAtBScenario;
+import mekhq.campaign.mission.enums.ScenarioStatus;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.util.*;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -379,14 +375,14 @@ public class Scenario implements Serializable {
                 }
 
                 if (battleType == -1) {
-                    MekHQ.getLogger().error("Unable to load an old AtBScenario because we could not determine the battle type");
+                    LogManager.getLogger().error("Unable to load an old AtBScenario because we could not determine the battle type");
                     return null;
                 }
 
                 List<Class<IAtBScenario>> scenarioClassList = AtBScenarioFactory.getScenarios(battleType);
 
                 if ((null == scenarioClassList) || scenarioClassList.isEmpty()) {
-                    MekHQ.getLogger().error("Unable to load an old AtBScenario of battle type " + battleType);
+                    LogManager.getLogger().error("Unable to load an old AtBScenario of battle type " + battleType);
                     return null;
                 }
 
@@ -431,7 +427,7 @@ public class Scenario implements Serializable {
                         if (!wn3.getNodeName().equalsIgnoreCase("loot")) {
                             // Error condition of sorts!
                             // Errr, what should we do here?
-                            MekHQ.getLogger().error("Unknown node type not loaded in techUnitIds nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in techUnitIds nodes: " + wn3.getNodeName());
                             continue;
                         }
                         Loot loot = Loot.generateInstanceFromXML(wn3, c, version);
@@ -442,7 +438,7 @@ public class Scenario implements Serializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
@@ -10,33 +10,26 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.mission;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import megamek.common.Board;
+import megamek.common.UnitType;
+import megamek.common.annotations.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
-
-import org.w3c.dom.Node;
-
-import megamek.common.Board;
-import megamek.common.UnitType;
-import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
+import java.util.*;
 
 public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> {
     // A scenario force template is a way to describe a particular force that gets generated when creating a DymanicScenario
@@ -687,7 +680,7 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
             JAXBElement<ScenarioForceTemplate> templateElement = um.unmarshal(xmlNode, ScenarioForceTemplate.class);
             resultingTemplate = templateElement.getValue();
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Scenario Force Template", e);
+            LogManager.getLogger().error("Error Deserializing Scenario Force Template", e);
         }
 
         return resultingTemplate;

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjective.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjective.java
@@ -10,23 +10,18 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.mission;
 
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Collections;
+import megamek.common.OffBoardDirection;
+import mekhq.campaign.mission.ObjectiveEffect.EffectScalingType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -35,12 +30,8 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.namespace.QName;
-
-import org.w3c.dom.Node;
-
-import megamek.common.OffBoardDirection;
-import mekhq.MekHQ;
-import mekhq.campaign.mission.ObjectiveEffect.EffectScalingType;
+import java.io.PrintWriter;
+import java.util.*;
 
 /**
  * Contains metadata used to describe a scenario objective
@@ -507,7 +498,7 @@ public class ScenarioObjective {
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             m.marshal(objectiveElement, pw);
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error Serializing Scenario Objective", e);
+            LogManager.getLogger().error("Error Serializing Scenario Objective", e);
         }
     }
 
@@ -525,7 +516,7 @@ public class ScenarioObjective {
             JAXBElement<ScenarioObjective> templateElement = um.unmarshal(xmlNode, ScenarioObjective.class);
             resultingObjective = templateElement.getValue();
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Scenario Objective", e);
+            LogManager.getLogger().error("Error Deserializing Scenario Objective", e);
         }
 
         return resultingObjective;

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
@@ -1,13 +1,10 @@
 package mekhq.campaign.mission;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
+import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -18,40 +15,40 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
-
-import org.w3c.dom.Node;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
-import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This is the root data structure for organizing information related to a scenario template.
  * @author NickAragua
- *
  */
 @XmlRootElement(name="ScenarioTemplate")
 public class ScenarioTemplate implements Cloneable {
     public static final String ROOT_XML_ELEMENT_NAME = "ScenarioTemplate";
     public static final String PRIMARY_PLAYER_FORCE_ID = "Player";
-    
+
     public String name;
     public String shortBriefing;
     public String detailedBriefing;
-    
+
     public boolean isHostileFacility;
     public boolean isAlliedFacility;
-    
+
     public ScenarioMapParameters mapParameters = new ScenarioMapParameters();
-    public List<String> scenarioModifiers = new ArrayList<>(); 
-    
+    public List<String> scenarioModifiers = new ArrayList<>();
+
     private Map<String, ScenarioForceTemplate> scenarioForces = new HashMap<>();
-    
+
     @XmlElementWrapper(name="scenarioObjectives")
     @XmlElement(name="scenarioObjective")
     public List<ScenarioObjective> scenarioObjectives = new ArrayList<>();
-    
+
     @Override
     public ScenarioTemplate clone() {
         ScenarioTemplate st = new ScenarioTemplate();
@@ -63,21 +60,21 @@ public class ScenarioTemplate implements Cloneable {
         for (ScenarioForceTemplate sft : scenarioForces.values()) {
             st.scenarioForces.put(sft.getForceName(), sft.clone());
         }
-        
+
         for (String mod : scenarioModifiers) {
             st.scenarioModifiers.add(mod);
         }
-        
+
         for (ScenarioObjective obj : scenarioObjectives) {
             st.scenarioObjectives.add(new ScenarioObjective(obj));
         }
-        
+
         st.mapParameters = (ScenarioMapParameters) mapParameters.clone();
-        
-        
+
+
         return st;
     }
-    
+
     /**
      * Returns the "primary" player force. This is always the force with the name "Player".
      * @return Primary player force.
@@ -85,67 +82,67 @@ public class ScenarioTemplate implements Cloneable {
     public ScenarioForceTemplate getPrimaryPlayerForce() {
         return scenarioForces.get(PRIMARY_PLAYER_FORCE_ID);
     }
-    
+
     public List<ScenarioForceTemplate> getAllScenarioForces() {
         return scenarioForces.values().stream().collect(Collectors.toList());
     }
-    
+
     @XmlElementWrapper(name="scenarioForces")
     @XmlElement(name="scenarioForce")
     public Map<String, ScenarioForceTemplate> getScenarioForces() {
         return scenarioForces;
     }
-    
+
     public void setScenarioForces(Map<String, ScenarioForceTemplate> forces) {
         scenarioForces = forces;
     }
-    
+
     public boolean isHostileFacility() {
         return isHostileFacility;
     }
-    
+
     public boolean isAlliedFacility() {
         return isAlliedFacility;
     }
-    
+
     public boolean isFacilityScenario() {
         return isHostileFacility || isAlliedFacility;
     }
-    
+
     public List<ScenarioForceTemplate> getAllBotControlledAllies() {
-        return scenarioForces.values().stream().filter(forceTemplate -> 
+        return scenarioForces.values().stream().filter(forceTemplate ->
             (forceTemplate.getForceAlignment() == ForceAlignment.Allied.ordinal()) &&
             (forceTemplate.getGenerationMethod() != ForceGenerationMethod.PlayerSupplied.ordinal()))
                 .collect(Collectors.toList());
     }
-    
+
     public List<ScenarioForceTemplate> getAllBotControlledHostiles() {
-        return scenarioForces.values().stream().filter(forceTemplate -> 
+        return scenarioForces.values().stream().filter(forceTemplate ->
             (forceTemplate.getForceAlignment() == ForceAlignment.Opposing.ordinal()) ||
             (forceTemplate.getForceAlignment() == ForceAlignment.Third.ordinal()))
                 .collect(Collectors.toList());
     }
-    
+
     /**
      * All force templates that are controlled and supplied, or potentially supplied, by the player, that are not reinforcements
      * @return List of scenario force templates
      */
     public List<ScenarioForceTemplate> getAllPrimaryPlayerForces() {
-        return scenarioForces.values().stream().filter(forceTemplate -> 
+        return scenarioForces.values().stream().filter(forceTemplate ->
             (forceTemplate.getForceAlignment() == ForceAlignment.Player.ordinal()) &&
             (forceTemplate.getArrivalTurn() != ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS) &&
                 ((forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerSupplied.ordinal()) ||
-                 (forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerOrFixedUnitCount.ordinal())))  
+                 (forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerOrFixedUnitCount.ordinal())))
                 .collect(Collectors.toList());
     }
-    
+
     /**
      * All force templates that are controlled and supplied, or potentially supplied, by the player, that are not reinforcements
      * @return List of scenario force templates
      */
     public List<ScenarioForceTemplate> getAllPlayerReinforcementForces() {
         List<ScenarioForceTemplate> retVal = new ArrayList<>();
-        
+
         for (ScenarioForceTemplate forceTemplate : scenarioForces.values()) {
             if ((forceTemplate.getForceAlignment() == ForceAlignment.Player.ordinal()) &&
                     (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS) &&
@@ -154,10 +151,10 @@ public class ScenarioTemplate implements Cloneable {
                 retVal.add(forceTemplate);
             }
         }
-        
+
         return retVal;
     }
-    
+
     /**
      * Serialize this instance of a scenario template to a File
      * Please pass in a non-null file.
@@ -171,10 +168,10 @@ public class ScenarioTemplate implements Cloneable {
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             m.marshal(templateElement, outputFile);
         } catch(Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
-    
+
     /**
      * Serialize this instance of a scenario template to a PrintWriter
      * Omits initial xml declaration
@@ -189,10 +186,10 @@ public class ScenarioTemplate implements Cloneable {
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             m.marshal(templateElement, pw);
         } catch(Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
-    
+
     /**
      * Attempt to deserialize a file at the given path.
      * @param filePath The location of the file
@@ -201,15 +198,15 @@ public class ScenarioTemplate implements Cloneable {
     public static ScenarioTemplate Deserialize(String filePath) {
         File inputFile = new File(filePath);
         if (!inputFile.exists()) {
-            MekHQ.getLogger().error(String.format("Cannot deserialize file %s, does not exist", filePath));
+            LogManager.getLogger().error(String.format("Cannot deserialize file %s, does not exist", filePath));
             return null;
         }
-        
+
         return Deserialize(inputFile);
     }
-    
+
     /**
-     * Attempt to deserialize an instance of a ScenarioTemplate from the passed-in file 
+     * Attempt to deserialize an instance of a ScenarioTemplate from the passed-in file
      * @param inputFile The source file
      * @return Possibly an instance of a ScenarioTemplate
      */
@@ -225,12 +222,12 @@ public class ScenarioTemplate implements Cloneable {
                 resultingTemplate = templateElement.getValue();
             }
         } catch(Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Scenario Template", e);
+            LogManager.getLogger().error("Error Deserializing Scenario Template", e);
         }
 
         return resultingTemplate;
     }
-    
+
     /**
      * Attempt to deserialize an instance of a ScenarioTemplate from the passed-in XML Node
      * @param xmlNode The node with the scenario template
@@ -238,16 +235,16 @@ public class ScenarioTemplate implements Cloneable {
      */
     public static ScenarioTemplate Deserialize(Node xmlNode) {
         ScenarioTemplate resultingTemplate = null;
-        
+
         try {
             JAXBContext context = JAXBContext.newInstance(ScenarioTemplate.class);
             Unmarshaller um = context.createUnmarshaller();
             JAXBElement<ScenarioTemplate> templateElement = um.unmarshal(xmlNode, ScenarioTemplate.class);
             resultingTemplate = templateElement.getValue();
         } catch(Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Scenario Template", e);
+            LogManager.getLogger().error("Error Deserializing Scenario Template", e);
         }
-        
+
         return resultingTemplate;
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -10,50 +10,24 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
 package mekhq.campaign.mission.atb;
 
-import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Lance;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.atb.scenario.AceDuelBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.AlliedTraitorsBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.AllyRescueBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.AmbushBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.BaseAttackBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.BreakthroughBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.ChaseBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.CivilianHelpBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.CivilianRiotBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.ConvoyAttackBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.ConvoyRescueBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.ExtractionBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.HideAndSeekBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.HoldTheLineBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.OfficerDualBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.PirateFreeForAllBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.PrisonBreakBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.ProbeBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.ReconRaidBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.StandUpBuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.StarLeagueCache1BuiltInScenario;
-import mekhq.campaign.mission.atb.scenario.StarLeagueCache2BuiltInScenario;
+import mekhq.campaign.mission.atb.scenario.*;
+import org.apache.logging.log4j.LogManager;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 public class AtBScenarioFactory {
     private static Map<Integer, List<Class<IAtBScenario>>> scenarioMap = new HashMap<>();
@@ -112,7 +86,7 @@ public class AtBScenarioFactory {
 
             return s;
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         return null;
@@ -121,7 +95,7 @@ public class AtBScenarioFactory {
     @SuppressWarnings("unchecked")
     public static void registerScenario(IAtBScenario scenario) {
         if (!scenario.getClass().isAnnotationPresent(AtBScenarioEnabled.class)) {
-            MekHQ.getLogger().error(String.format(
+            LogManager.getLogger().error(String.format(
                     "Unable to register an AtBScenario of class '%s' because is does not have the '%s' annotation.",
                     scenario.getClass().getName(), AtBScenarioEnabled.class.getName()));
         } else {
@@ -294,10 +268,10 @@ public class AtBScenarioFactory {
                             assignedLances.add(lance.getForceId());
                         }
                     } else {
-                        MekHQ.getLogger().error("Unable to generate Base Attack scenario.");
+                        LogManager.getLogger().error("Unable to generate Base Attack scenario.");
                     }
                 } else {
-                    MekHQ.getLogger().warning("No lances assigned to mission " + contract.getName()
+                    LogManager.getLogger().warn("No lances assigned to mission " + contract.getName()
                             + ". Can't generate an Invincible Morale base defence mission for this force.");
                 }
             }

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioManifest.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioManifest.java
@@ -11,12 +11,10 @@
 * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
 * details.
 */
-
 package mekhq.campaign.mission.atb;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.Map;
+import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -25,9 +23,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.transform.Source;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Map;
 
 /**
  * A manifest containing IDs and file names of scenario template definitions
@@ -38,7 +36,7 @@ public class AtBScenarioManifest {
     @XmlElementWrapper(name = "scenarioFileNames")
     @XmlElement(name = "scenarioFileName")
     public Map<Integer, String> scenarioFileNames;
-    
+
     /**
      * Attempt to deserialize an instance of an AtBScenarioManifest from the passed-in file path
      * @return Possibly an instance of a ScenarioManifest
@@ -47,7 +45,7 @@ public class AtBScenarioManifest {
         AtBScenarioManifest resultingManifest = null;
         File inputFile = new File(fileName);
         if (!inputFile.exists()) {
-            MekHQ.getLogger().warning(String.format("Specified file %s does not exist", fileName));
+            LogManager.getLogger().warn(String.format("Specified file %s does not exist", fileName));
             return null;
         }
 
@@ -60,7 +58,7 @@ public class AtBScenarioManifest {
                 resultingManifest = manifestElement.getValue();
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Scenario Manifest", e);
+            LogManager.getLogger().error("Error Deserializing Scenario Manifest", e);
         }
 
         return resultingManifest;

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
@@ -10,22 +10,24 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.mission.atb;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import mekhq.MekHqConstants;
+import mekhq.MekHqXmlUtil;
+import mekhq.Utilities;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.mission.ScenarioForceTemplate;
+import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
+import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
+import mekhq.campaign.mission.ScenarioObjective;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -36,24 +38,16 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
-
-import mekhq.MekHQ;
-import mekhq.MekHqConstants;
-import mekhq.MekHqXmlUtil;
-import mekhq.Utilities;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.ScenarioForceTemplate;
-import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
-import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
-import mekhq.campaign.mission.ScenarioObjective;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.*;
 
 /**
  * Data structure representing a scenario modifier for dynamic AtB scenarios
  * @author NickAragua
  */
 @XmlRootElement(name = "AtBScenarioModifier")
-public class AtBScenarioModifier implements Cloneable {    
+public class AtBScenarioModifier implements Cloneable {
     /**
      * Possible values for when a scenario modifier may occur: before or after primary force generation.
      */
@@ -75,24 +69,24 @@ public class AtBScenarioModifier implements Cloneable {
     private Integer ammoExpenditureIntensity = null;
     private Integer unitRemovalCount = null;
     private List<MapLocation> allowedMapLocations = null;
-    private Boolean useAmbushLogic = null; 
+    private Boolean useAmbushLogic = null;
     private Boolean switchSides = null;
     private Integer numExtraEvents = null;
     private Double bvBudgetAdditiveMultiplier = null;
     private Integer reinforcementDelayReduction = null;
     private List<ScenarioObjective> objectives = new ArrayList<>();
-    
-    private Map<String, String> linkedModifiers = new HashMap<>(); 
-    
+
+    private Map<String, String> linkedModifiers = new HashMap<>();
+
     // ----------------------------------------------------------------
     // This section contains static variables and methods
-    // 
+    //
     private static ScenarioModifierManifest scenarioModifierManifest;
-    
+
     public static List<String> getScenarioFileNames() {
         return scenarioModifierManifest.fileNameList;
     }
-    
+
     private static Map<String, AtBScenarioModifier> scenarioModifiers;
     private static List<String> scenarioModifierKeys = new ArrayList<>();
     private static List<String> requiredHostileFacilityModifierKeys = new ArrayList<>();
@@ -105,15 +99,15 @@ public class AtBScenarioModifier implements Cloneable {
     private static List<String> negativeGroundBattleModifierKeys = new ArrayList<>();
     private static List<String> negativeAirBattleModifierKeys = new ArrayList<>();
     private static List<String> primaryPlayerForceModifierKeys = new ArrayList<>();
-    
+
     public static Map<String, AtBScenarioModifier> getScenarioModifiers() {
         return scenarioModifiers;
     }
-    
+
     public static List<String> getOrderedModifierKeys() {
         return scenarioModifierKeys;
     }
-    
+
     /**
      * Convenience method to get a scenario modifier with the specified key.
      * @param key The key
@@ -121,14 +115,14 @@ public class AtBScenarioModifier implements Cloneable {
      */
     public static AtBScenarioModifier getScenarioModifier(String key) {
         if (!scenarioModifiers.containsKey(key)) {
-            MekHQ.getLogger().error("Scenario modifier " + key + " does not exist.");
+            LogManager.getLogger().error("Scenario modifier " + key + " does not exist.");
             return null;
         }
-        
+
         // clone it to avoid calling code changing the modifier
         return scenarioModifiers.get(key).clone();
     }
-    
+
     /**
      * Convenience method to get all the 'required' hostile facility modifiers()
      */
@@ -137,10 +131,10 @@ public class AtBScenarioModifier implements Cloneable {
         for (String key : requiredHostileFacilityModifierKeys) {
             retval.add(scenarioModifiers.get(key).clone());
         }
-        
+
         return retval;
     }
-    
+
     /**
      * Convenience method to get a random hostile facility modifier
      * @return The scenario modifier, if any.
@@ -148,7 +142,7 @@ public class AtBScenarioModifier implements Cloneable {
     public static AtBScenarioModifier getRandomHostileFacilityModifier() {
         return getScenarioModifier(Utilities.getRandomItem(hostileFacilityModifierKeys));
     }
-    
+
     /**
      * Convenience method to get a random allied facility modifier
      * @return The scenario modifier, if any.
@@ -156,21 +150,21 @@ public class AtBScenarioModifier implements Cloneable {
     public static AtBScenarioModifier getRandomAlliedFacilityModifier() {
         return getScenarioModifier(Utilities.getRandomItem(alliedFacilityModifierKeys));
     }
-    
+
     /**
      * Get a random modifier, appropriate for the map location (space, atmo, ground)
      */
     public static AtBScenarioModifier getRandomBattleModifier(MapLocation mapLocation) {
         return getRandomBattleModifier(mapLocation, null);
     }
-    
+
     /**
      * Convenience method to get a random battle modifier
      * @return The scenario modifier, if any.
      */
     public static AtBScenarioModifier getRandomBattleModifier(MapLocation mapLocation, Boolean beneficial) {
         List<String> keyList = null;
-        
+
         switch (mapLocation) {
             case Space:
             case LowAtmosphere:
@@ -194,14 +188,14 @@ public class AtBScenarioModifier implements Cloneable {
                 }
                 break;
         }
-        
+
         if (keyList == null) {
             return null;
         }
-        
+
         return getScenarioModifier(Utilities.getRandomItem(keyList));
     }
-    
+
     static {
         loadManifest();
         loadScenarioModifiers();
@@ -212,23 +206,23 @@ public class AtBScenarioModifier implements Cloneable {
         initializeSpecificManifest(MekHqConstants.STRATCON_GROUND_MODS, groundBattleModifierKeys);
         initializeSpecificManifest(MekHqConstants.STRATCON_AIR_MODS, airBattleModifierKeys);
         initializeSpecificManifest(MekHqConstants.STRATCON_PRIMARY_PLAYER_FORCE_MODS, primaryPlayerForceModifierKeys);
-        
+
         initializePositiveNegativeManifests(groundBattleModifierKeys, positiveGroundBattleModifierKeys, negativeGroundBattleModifierKeys);
         initializePositiveNegativeManifests(airBattleModifierKeys, positiveAirBattleModifierKeys, negativeAirBattleModifierKeys);
     }
-    
+
     /**
      * Initializes a specific manifest file name list from a file with the given name
      */
     private static void initializeSpecificManifest(String manifestFileName, List<String> keyCollection) {
         ScenarioModifierManifest manifest = ScenarioModifierManifest.Deserialize(manifestFileName);
-        
+
         // add trimmed versions of each file name to the given collection
         for (String modifierName : manifest.fileNameList) {
             keyCollection.add(modifierName.trim());
         }
     }
-    
+
     /**
      * Divides the given modifiers into a positive and negative bucket.
      */
@@ -237,7 +231,7 @@ public class AtBScenarioModifier implements Cloneable {
             if (!scenarioModifiers.containsKey(modifier)) {
                 continue;
             }
-            
+
             if (scenarioModifiers.get(modifier).benefitsPlayer) {
                 positiveKeyCollection.add(modifier);
             } else {
@@ -245,48 +239,48 @@ public class AtBScenarioModifier implements Cloneable {
             }
         }
     }
-    
+
     /**
      * Loads the scenario modifier manifest.
      */
     private static void loadManifest() {
         scenarioModifierManifest = ScenarioModifierManifest.Deserialize("./data/scenariomodifiers/modifiermanifest.xml");
-        
+
         // load user-specified modifier list
         ScenarioModifierManifest userModList = ScenarioModifierManifest.Deserialize("./data/scenariomodifiers/usermodifiermanifest.xml");
         if (userModList != null) {
             scenarioModifierManifest.fileNameList.addAll(userModList.fileNameList);
         }
-        
+
         // go through each entry and clean it up for preceding/trailing white space
         for (int x = 0; x < scenarioModifierManifest.fileNameList.size(); x++) {
             scenarioModifierManifest.fileNameList.set(x, scenarioModifierManifest.fileNameList.get(x).trim());
         }
     }
-    
-    /** 
+
+    /**
      * Loads the defined scenario modifiers from the manifest.
      */
     private static void loadScenarioModifiers() {
         scenarioModifiers = new HashMap<>();
         scenarioModifierKeys = new ArrayList<String>();
-        
+
         for (String fileName : scenarioModifierManifest.fileNameList) {
             String filePath = String.format("./data/scenariomodifiers/%s", fileName);
-            
+
             try {
                 AtBScenarioModifier modifier = Deserialize(filePath);
-                
+
                 if (modifier != null) {
                     scenarioModifiers.put(fileName, modifier);
                     scenarioModifierKeys.add(fileName);
-                    
+
                     if (modifier.getModifierName() == null) {
                         modifier.setModifierName(fileName);
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(String.format("Error Loading Scenario %s", filePath), e);
+                LogManager.getLogger().error(String.format("Error Loading Scenario %s", filePath), e);
             }
         }
 
@@ -297,7 +291,7 @@ public class AtBScenarioModifier implements Cloneable {
             }
         });
     }
-    
+
     /**
      * Attempt to deserialize an instance of a scenario modifier from the passed-in file
      * @param fileName Name of the file that contains the scenario modifier
@@ -311,7 +305,7 @@ public class AtBScenarioModifier implements Cloneable {
             Unmarshaller um = context.createUnmarshaller();
             File xmlFile = new File(fileName);
             if (!xmlFile.exists()) {
-                MekHQ.getLogger().warning(String.format("Specified file %s does not exist", fileName));
+                LogManager.getLogger().warn(String.format("Specified file %s does not exist", fileName));
                 return null;
             }
 
@@ -321,12 +315,12 @@ public class AtBScenarioModifier implements Cloneable {
                 resultingModifier = modifierElement.getValue();
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Scenario Modifier: " + fileName, e);
+            LogManager.getLogger().error("Error Deserializing Scenario Modifier: " + fileName, e);
         }
 
         return resultingModifier;
     }
-    
+
     /**
      * Serialize this instance of a scenario template to a File
      * Please pass in a non-null file.
@@ -340,10 +334,10 @@ public class AtBScenarioModifier implements Cloneable {
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             m.marshal(templateElement, outputFile);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
-    
+
     /**
      * Process this scenario modifier for a particular scenario, given a particular timing indicator.
      * @param eventTiming Whether this is occurring before or after primary forces have been generated.
@@ -351,69 +345,69 @@ public class AtBScenarioModifier implements Cloneable {
     public void processModifier(AtBDynamicScenario scenario, Campaign campaign, EventTiming eventTiming) {
         if (eventTiming == getEventTiming()) {
             if ((getAdditionalBriefingText() != null) && !getAdditionalBriefingText().isBlank()) {
-                AtBScenarioModifierApplicator.appendScenarioBriefingText(scenario, 
+                AtBScenarioModifierApplicator.appendScenarioBriefingText(scenario,
                         String.format("%s: %s", getModifierName(), getAdditionalBriefingText()));
             }
-            
+
             if (getForceDefinition() != null) {
                 AtBScenarioModifierApplicator.addForce(campaign, scenario, getForceDefinition(), eventTiming);
             }
-            
+
             if ((getSkillAdjustment() != null) && (getEventRecipient() != null)) {
                 AtBScenarioModifierApplicator.adjustSkill(scenario, campaign, getEventRecipient(), getSkillAdjustment());
             }
-            
+
             if ((getQualityAdjustment() != null) && (getEventRecipient() != null)) {
                 AtBScenarioModifierApplicator.adjustQuality(scenario, campaign, getEventRecipient(), getQualityAdjustment());
             }
-            
+
             if ((getBattleDamageIntensity() != null) && (getEventRecipient() != null)) {
                 AtBScenarioModifierApplicator.inflictBattleDamage(scenario, campaign, getEventRecipient(), getBattleDamageIntensity());
             }
-            
+
             if ((getAmmoExpenditureIntensity() != null) && (getEventRecipient() != null)) {
                 AtBScenarioModifierApplicator.expendAmmo(scenario, campaign, getEventRecipient(), getAmmoExpenditureIntensity());
             }
-            
+
             if ((getUnitRemovalCount() != null) && (getEventRecipient() != null)) {
                 AtBScenarioModifierApplicator.removeUnits(scenario, campaign, getEventRecipient(), getUnitRemovalCount());
             }
-            
+
             if ((getUseAmbushLogic() != null) && (getEventRecipient() != null)) {
                 AtBScenarioModifierApplicator.setupAmbush(scenario, campaign, getEventRecipient());
             }
-            
+
             if ((getSwitchSides() != null) && (getEventRecipient() != null)) {
                 AtBScenarioModifierApplicator.switchSides(scenario, getEventRecipient());
             }
-            
+
             if ((getObjectives() != null) && !getObjectives().isEmpty()) {
                 for (ScenarioObjective objective : getObjectives()) {
                     AtBScenarioModifierApplicator.applyObjective(scenario, campaign, objective, eventTiming);
                 }
             }
-            
+
             if ((getNumExtraEvents() != null) && (getNumExtraEvents() > 0)) {
                 for (int x = 0; x < getNumExtraEvents(); x++) {
                     AtBScenarioModifierApplicator.applyExtraEvent(scenario, getEventRecipient() == ForceAlignment.Allied);
                 }
             }
-            
+
             if (getBVBudgetAdditiveMultiplier() != null) {
                 scenario.setEffectivePlayerBVMultiplier(getBVBudgetAdditiveMultiplier());
             }
-            
+
             if ((getReinforcementDelayReduction() != null) && (getEventRecipient() != null)) {
                 AtBScenarioModifierApplicator.applyReinforcementDelayReduction(scenario, eventRecipient, getReinforcementDelayReduction());
             }
         }
     }
-    
+
     @Override
     public String toString() {
         return getModifierName();
     }
-    
+
     @Override
     public AtBScenarioModifier clone() {
         final AtBScenarioModifier copy = new AtBScenarioModifier();
@@ -438,7 +432,7 @@ public class AtBScenarioModifier implements Cloneable {
         copy .reinforcementDelayReduction = reinforcementDelayReduction;
         return copy;
     }
-    
+
     public String getModifierName() {
         return modifierName;
     }
@@ -552,21 +546,21 @@ public class AtBScenarioModifier implements Cloneable {
     public void setUseAmbushLogic(Boolean useAmbushLogic) {
         this.useAmbushLogic = useAmbushLogic;
     }
-    
+
     public Boolean getSwitchSides() {
         return switchSides;
     }
-    
+
     public void setSwitchSides(Boolean switchSides) {
         this.switchSides = switchSides;
     }
-    
+
     @XmlElementWrapper(name = "objectives")
     @XmlElement(name = "objective")
     public List<ScenarioObjective> getObjectives() {
         return objectives;
     }
-    
+
     public Integer getNumExtraEvents() {
         return numExtraEvents;
     }
@@ -574,7 +568,7 @@ public class AtBScenarioModifier implements Cloneable {
     public void setNumExtraEvents(Integer numExtraEvents) {
         this.numExtraEvents = numExtraEvents;
     }
-    
+
     public Double getBVBudgetAdditiveMultiplier() {
         return bvBudgetAdditiveMultiplier;
     }
@@ -598,7 +592,7 @@ public class AtBScenarioModifier implements Cloneable {
     public Map<String, String> getLinkedModifiers() {
         return linkedModifiers;
     }
-    
+
     public void setLinkedModifiers(Map<String, String> linkedModifiers) {
         this.linkedModifiers = linkedModifiers;
     }
@@ -614,7 +608,7 @@ class ScenarioModifierManifest {
     @XmlElementWrapper(name = "modifiers")
     @XmlElement(name = "modifier")
     public List<String> fileNameList = new ArrayList<>();
-    
+
     /**
      * Attempt to deserialize an instance of a scenario modifier list from the passed-in file
      * @param fileName Name of the file that contains the scenario modifier list
@@ -628,7 +622,7 @@ class ScenarioModifierManifest {
             Unmarshaller um = context.createUnmarshaller();
             File xmlFile = new File(fileName);
             if (!xmlFile.exists()) {
-                MekHQ.getLogger().warning(String.format("Specified file %s does not exist", fileName));
+                LogManager.getLogger().warn(String.format("Specified file %s does not exist", fileName));
                 return null;
             }
 
@@ -638,7 +632,7 @@ class ScenarioModifierManifest {
                 resultingList = templateElement.getValue();
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Scenario Modifier List", e);
+            LogManager.getLogger().error("Error Deserializing Scenario Modifier List", e);
         }
 
         return resultingList;

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -10,43 +10,32 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.mission.atb;
-
-import java.util.UUID;
 
 import megamek.client.generator.enums.SkillGeneratorType;
 import megamek.client.generator.skillGenerators.AbstractSkillGenerator;
 import megamek.client.generator.skillGenerators.TaharqaSkillGenerator;
-import megamek.common.Board;
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.EntityWeightClass;
-import megamek.common.HitData;
-import megamek.common.Mounted;
-import megamek.common.ToHitData;
+import megamek.common.*;
 import megamek.common.enums.SkillLevel;
 import megamek.common.options.OptionsConstants;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.ScenarioForceTemplate;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
-import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.atb.AtBScenarioModifier.EventTiming;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Factions;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.UUID;
 
 /**
  * Class that handles the application of scenario modifier actions to AtBDynamicScenarios
@@ -215,7 +204,7 @@ public class AtBScenarioModifierApplicator {
      */
     public static void adjustQuality(AtBDynamicScenario scenario, Campaign c, ForceAlignment eventRecipient, int qualityAdjustment) {
         if (eventRecipient != ForceAlignment.Opposing) {
-            MekHQ.getLogger().warning( "Can only adjust opfor unit quality");
+            LogManager.getLogger().warn( "Can only adjust opfor unit quality");
             return;
         }
 
@@ -354,7 +343,7 @@ public class AtBScenarioModifierApplicator {
         scenario.addScenarioModifier(AtBScenarioModifier.getRandomBattleModifier(scenario.getTemplate().mapParameters.getMapLocation(),
                 (Boolean) goodEvent));
     }
-    
+
     /**
      * Applies a flat reduction to the reinforcement arrival times, either of player/allied forces or hostile forces.
      */

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
@@ -19,23 +19,18 @@
 
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.PrincessException;
 import megamek.common.Board;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.OffBoardDirection;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.ArrayList;
 
 @AtBScenarioEnabled
 public class BreakthroughBuiltInScenario extends AtBScenario {
@@ -114,7 +109,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
                 botForce.setDestinationEdge(getEnemyHome());
             }
         } catch (PrincessException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         addBotForce(botForce);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -19,24 +19,15 @@
 
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.PrincessException;
-import megamek.common.Board;
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.EntityWeightClass;
-import megamek.common.OffBoardDirection;
-import mekhq.MekHQ;
+import megamek.common.*;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.ArrayList;
 
 @AtBScenarioEnabled
 public class ChaseBuiltInScenario extends AtBScenario {
@@ -110,7 +101,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
                 botForce.setDestinationEdge(destinationEdge);
             }
         } catch (PrincessException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         addBotForce(botForce);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
@@ -19,26 +19,21 @@
 
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-import java.util.UUID;
-
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.PrincessException;
 import megamek.common.Board;
 import megamek.common.Compute;
 import megamek.common.Entity;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ObjectiveEffect;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ObjectiveEffect.EffectScalingType;
 import mekhq.campaign.mission.ObjectiveEffect.ObjectiveEffectType;
 import mekhq.campaign.mission.ScenarioObjective.TimeLimitType;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.ArrayList;
+import java.util.UUID;
 
 @AtBScenarioEnabled
 public class ExtractionBuiltInScenario extends AtBScenario {
@@ -129,7 +124,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
                 addBotForce(bf);
             }
         } catch (PrincessException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
@@ -20,11 +20,11 @@ package mekhq.campaign.mission.enums;
 
 import megamek.common.Compute;
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.universe.enums.EraFlag;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -549,7 +549,7 @@ public enum AtBContractType {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse text " + text + " into an AtBContractType, returning GARRISON_DUTY.");
+        LogManager.getLogger().error("Failed to parse text " + text + " into an AtBContractType, returning GARRISON_DUTY.");
 
         return GARRISON_DUTY;
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBLanceRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBLanceRole.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.mission.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -101,7 +101,7 @@ public enum AtBLanceRole {
 
         }
 
-        MekHQ.getLogger().error("Unable to parse " + text + " into an AtBLanceRole. Returning FIGHTING.");
+        LogManager.getLogger().error("Unable to parse " + text + " into an AtBLanceRole. Returning FIGHTING.");
 
         return FIGHTING;
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBMoraleLevel.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBMoraleLevel.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.mission.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -112,7 +112,7 @@ public enum AtBMoraleLevel {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse text " + text + " into an AtBMoraleLevel, returning NORMAL.");
+        LogManager.getLogger().error("Failed to parse text " + text + " into an AtBMoraleLevel, returning NORMAL.");
 
         return NORMAL;
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/ContractCommandRights.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ContractCommandRights.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.mission.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -104,7 +104,7 @@ public enum ContractCommandRights {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse text " + text + " into a ContractCommandRights, returning HOUSE.");
+        LogManager.getLogger().error("Failed to parse text " + text + " into a ContractCommandRights, returning HOUSE.");
 
         return HOUSE;
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/MissionStatus.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/MissionStatus.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.mission.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -107,7 +107,7 @@ public enum MissionStatus {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse text " + text + " into a MissionStatus, returning ACTIVE.");
+        LogManager.getLogger().error("Failed to parse text " + text + " into a MissionStatus, returning ACTIVE.");
 
         return ACTIVE;
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.mission.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -131,7 +131,7 @@ public enum ScenarioStatus {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse text " + text + " into a ScenarioStatus, returning CURRENT.");
+        LogManager.getLogger().error("Failed to parse text " + text + " into a ScenarioStatus, returning CURRENT.");
 
         return CURRENT;
     }

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
@@ -18,20 +18,21 @@
  */
 package mekhq.campaign.mod.am;
 
-import java.util.*;
-
 import megamek.common.Compute;
 import megamek.common.enums.Gender;
-import mekhq.MekHQ;
 import mekhq.Utilities;
-import mekhq.campaign.*;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.GameEffect;
 import mekhq.campaign.log.MedicalLogEntry;
 import mekhq.campaign.log.MedicalLogger;
-import mekhq.campaign.personnel.enums.*;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.InjuryType;
 import mekhq.campaign.personnel.Modifier;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.*;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.*;
 
 /** Advanced Medical sub-system injury types */
 public final class InjuryTypes {
@@ -141,7 +142,7 @@ public final class InjuryTypes {
                             p.addInjury(severedSpine);
 
                             MedicalLogEntry entry = MedicalLogger.severedSpine(p, c.getLocalDate());
-                            MekHQ.getLogger().info(entry.toString());
+                            LogManager.getLogger().info(entry.toString());
                         }
                     }));
         }
@@ -174,7 +175,7 @@ public final class InjuryTypes {
                                 rnd -> {
                                     p.changeStatus(c, c.getLocalDate(), PersonnelStatus.WOUNDS);
                                     MedicalLogEntry entry = MedicalLogger.diedDueToBrainTrauma(p, c.getLocalDate());
-                                    MekHQ.getLogger().info(entry.toString());
+                                    LogManager.getLogger().info(entry.toString());
                                 }));
             } else {
                 // We have a chance!
@@ -185,7 +186,7 @@ public final class InjuryTypes {
                             if (rnd.applyAsInt(6) + hits >= 5) {
                                 p.changeStatus(c, c.getLocalDate(), PersonnelStatus.WOUNDS);
                                 MedicalLogEntry entry = MedicalLogger.diedDueToBrainTrauma(p, c.getLocalDate());
-                                MekHQ.getLogger().info(entry.toString());
+                                LogManager.getLogger().info(entry.toString());
                         }
                     }));
             }
@@ -238,7 +239,7 @@ public final class InjuryTypes {
                             p.addInjury(cte);
                             p.removeInjury(i);
                             MedicalLogEntry entry = MedicalLogger.developedEncephalopathy(p, c.getLocalDate());
-                            MekHQ.getLogger().info(entry.toString());
+                            LogManager.getLogger().info(entry.toString());
                         }
                     })
                 );
@@ -355,7 +356,7 @@ public final class InjuryTypes {
                                 rnd -> {
                                     p.changeStatus(c, c.getLocalDate(), PersonnelStatus.WOUNDS);
                                     MedicalLogEntry entry = MedicalLogger.diedOfInternalBleeding(p, c.getLocalDate());
-                                    MekHQ.getLogger().info(entry.toString());
+                                    LogManager.getLogger().info(entry.toString());
                                 })
                 );
             } else {
@@ -369,11 +370,11 @@ public final class InjuryTypes {
                                 if (i.getHits() < 3) {
                                     i.setHits(i.getHits() + 1);
                                     MedicalLogEntry entry = MedicalLogger.internalBleedingWorsened(p, c.getLocalDate());
-                                    MekHQ.getLogger().info(entry.toString());
+                                    LogManager.getLogger().info(entry.toString());
                                 } else {
                                     p.changeStatus(c, c.getLocalDate(), PersonnelStatus.WOUNDS);
                                     MedicalLogEntry entry = MedicalLogger.diedOfInternalBleeding(p, c.getLocalDate());
-                                    MekHQ.getLogger().info(entry.toString());
+                                    LogManager.getLogger().info(entry.toString());
                                 }
                             }
                         })
@@ -458,7 +459,7 @@ public final class InjuryTypes {
                             Injury bleeding = INTERNAL_BLEEDING.newInjury(c, p, BodyLocation.ABDOMEN, 1);
                             p.addInjury(bleeding);
                             MedicalLogEntry entry = MedicalLogger.brokenRibPuncture(p, c.getLocalDate());
-                            MekHQ.getLogger().info(entry.toString());
+                            LogManager.getLogger().info(entry.toString());
                         }
                     }));
         }
@@ -482,12 +483,12 @@ public final class InjuryTypes {
                         if (rib < 1) {
                             p.changeStatus(c, c.getLocalDate(), PersonnelStatus.WOUNDS);
                             MedicalLogEntry entry = MedicalLogger.brokenRibPunctureDead(p, c.getLocalDate());
-                            MekHQ.getLogger().info(entry.toString());
+                            LogManager.getLogger().info(entry.toString());
                         } else if (rib < 10) {
                             Injury puncturedLung = PUNCTURED_LUNG.newInjury(c, p, BodyLocation.CHEST, 1);
                             p.addInjury(puncturedLung);
                             MedicalLogEntry entry = MedicalLogger.brokenRibPuncture(p, c.getLocalDate());
-                            MekHQ.getLogger().info(entry.toString());
+                            LogManager.getLogger().info(entry.toString());
                         }
                     }));
         }
@@ -532,13 +533,13 @@ public final class InjuryTypes {
                             if (i.getHits() == 1) {
                                 i.setHits(2);
                                 MedicalLogEntry entry = MedicalLogger.concussionWorsened(p, c.getLocalDate());
-                                MekHQ.getLogger().info(entry.toString());
+                                LogManager.getLogger().info(entry.toString());
                             } else {
                                 Injury cerebralContusion = CEREBRAL_CONTUSION.newInjury(c, p, BodyLocation.HEAD, 1);
                                 p.addInjury(cerebralContusion);
                                 p.removeInjury(i);
                                 MedicalLogEntry entry = MedicalLogger.developedCerebralContusion(p, c.getLocalDate());
-                                MekHQ.getLogger().info(entry.toString());
+                                LogManager.getLogger().info(entry.toString());
                             }
                         }
                     })

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -12,22 +12,13 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.parts;
-
-import java.io.PrintWriter;
-import java.util.Objects;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import megamek.common.AmmoType;
 import megamek.common.ITechnology;
@@ -36,10 +27,17 @@ import megamek.common.TechAdvancement;
 import megamek.common.annotations.Nullable;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.work.IAcquisitionWork;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.Objects;
 
 /**
  * This will be a special type of part that will only exist as spares
@@ -171,7 +169,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
                     shots = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -20,28 +20,21 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.text.DecimalFormat;
-import java.util.Objects;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.IArmorState;
-import megamek.common.ITechnology;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.WorkTime;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.text.DecimalFormat;
+import java.util.Objects;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -333,7 +326,7 @@ public class Armor extends Part implements IAcquisitionWork {
                     clan = wn2.getTextContent().equalsIgnoreCase("true");
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -20,35 +20,23 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.ArrayList;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.BattleArmor;
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityWeightClass;
-import megamek.common.EquipmentType;
-import megamek.common.IArmorState;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.equipment.BattleArmorEquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
 
 /**
  * Battle Armor suits are crazy - you cant crit the equipment in them, so
@@ -402,7 +390,7 @@ public class BattleArmorSuit extends Part {
                     alternateTon = Double.parseDouble(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }
@@ -484,7 +472,7 @@ public class BattleArmorSuit extends Part {
     public void updateConditionFromEntity(boolean checkForDestruction) {
         if (null != unit) {
             if (trooper < 0) {
-                MekHQ.getLogger().error("Trooper location -1 found on BattleArmorSuit attached to unit");
+                LogManager.getLogger().error("Trooper location -1 found on BattleArmorSuit attached to unit");
                 return;
             }
 
@@ -611,7 +599,7 @@ public class BattleArmorSuit extends Part {
         try {
             newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
         } catch (EntityLoadingException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         Unit newUnit = null;
         if (null != newEntity) {

--- a/MekHQ/src/mekhq/campaign/parts/Cubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/Cubicle.java
@@ -18,18 +18,17 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.BayType;
 import megamek.common.Entity;
 import megamek.common.ITechnology;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * A transport bay cubicle for a Mech, ProtoMech, vehicle, fighter, or small craft.
@@ -163,7 +162,7 @@ public class Cubicle extends Part {
             if (wn2.getNodeName().equalsIgnoreCase("bayType")) {
                 bayType = BayType.parse(wn2.getTextContent());
                 if (null == bayType) {
-                    MekHQ.getLogger().error("Could not parse bay type " + wn2.getTextContent());
+                    LogManager.getLogger().error("Could not parse bay type " + wn2.getTextContent());
                     bayType = BayType.MECH;
                 }
                 name = bayType.getDisplayName() + " Cubicle";

--- a/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
+++ b/MekHQ/src/mekhq/campaign/parts/DropshipDockingCollar.java
@@ -20,21 +20,16 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Compute;
-import megamek.common.Dropship;
-import megamek.common.Entity;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechAdvancement;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.SkillType;
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -203,7 +198,7 @@ public class DropshipDockingCollar extends Part {
                     collarType = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -20,29 +20,19 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Aero;
-import megamek.common.CriticalSlot;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.IArmorState;
-import megamek.common.Mech;
-import megamek.common.Protomech;
-import megamek.common.Tank;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
 import megamek.common.verifier.TestEntity;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -198,7 +188,7 @@ public class EnginePart extends Part {
                     forHover = wn2.getTextContent().equalsIgnoreCase("true");
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/GravDeck.java
+++ b/MekHQ/src/mekhq/campaign/parts/GravDeck.java
@@ -20,21 +20,16 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.Jumpship;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechAdvancement;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.SkillType;
+import java.io.PrintWriter;
 
 /**
  * @author MKerensky
@@ -220,7 +215,7 @@ public class GravDeck extends Part {
                     deckNumber = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/InfantryAmmoStorage.java
@@ -18,13 +18,15 @@
  */
 package mekhq.campaign.parts;
 
-import megamek.common.*;
+import megamek.common.AmmoType;
+import megamek.common.EquipmentType;
+import megamek.common.TechAdvancement;
 import megamek.common.annotations.Nullable;
 import megamek.common.weapons.infantry.InfantryWeapon;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -62,7 +64,7 @@ public class InfantryAmmoStorage extends AmmoStorage {
                 this.name = weaponType.getShortName() + " Ammo";
             }
         } else {
-            MekHQ.getLogger().error("InfantryAmmoStorage does not have a weapon type!");
+            LogManager.getLogger().error("InfantryAmmoStorage does not have a weapon type!");
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/JumpshipDockingCollar.java
+++ b/MekHQ/src/mekhq/campaign/parts/JumpshipDockingCollar.java
@@ -20,22 +20,16 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Compute;
-import megamek.common.DockingCollar;
-import megamek.common.Entity;
-import megamek.common.Jumpship;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechAdvancement;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.SkillType;
+import java.io.PrintWriter;
 
 /**
  * @author MKerensky
@@ -221,7 +215,7 @@ public class JumpshipDockingCollar extends Part {
                     collarNumber = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/KFChargingSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFChargingSystem.java
@@ -20,21 +20,20 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.StringJoiner;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.Jumpship;
 import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 /**
  * @author MKerensky
@@ -240,7 +239,7 @@ public class KFChargingSystem extends Part {
                     docks = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/KFDriveCoil.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFDriveCoil.java
@@ -20,21 +20,20 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.StringJoiner;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.Jumpship;
 import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 /**
  * @author MKerensky
@@ -239,7 +238,7 @@ public class KFDriveCoil extends Part {
                     docks = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/KFDriveController.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFDriveController.java
@@ -20,21 +20,20 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.StringJoiner;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.Jumpship;
 import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 /**
  * @author MKerensky
@@ -242,7 +241,7 @@ public class KFDriveController extends Part {
                     docks = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/KFFieldInitiator.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFFieldInitiator.java
@@ -20,21 +20,20 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.StringJoiner;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.Jumpship;
 import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 /**
  * @author MKerensky
@@ -244,7 +243,7 @@ public class KFFieldInitiator extends Part {
                     docks = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/KFHeliumTank.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFHeliumTank.java
@@ -20,21 +20,20 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.StringJoiner;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.Jumpship;
 import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 /**
  * @author MKerensky
@@ -245,7 +244,7 @@ public class KFHeliumTank extends Part {
                     docks = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/KfBoom.java
+++ b/MekHQ/src/mekhq/campaign/parts/KfBoom.java
@@ -20,21 +20,16 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Compute;
-import megamek.common.Dropship;
-import megamek.common.Entity;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechAdvancement;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.SkillType;
+import java.io.PrintWriter;
 
 /**
  * @author MKerensky
@@ -203,7 +198,7 @@ public class KfBoom extends Part {
                     boomType = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/LFBattery.java
+++ b/MekHQ/src/mekhq/campaign/parts/LFBattery.java
@@ -20,21 +20,20 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.StringJoiner;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.Jumpship;
 import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.StringJoiner;
 
 /**
  * @author MKerensky
@@ -229,7 +228,7 @@ public class LFBattery extends Part {
                     docks = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekCockpit.java
@@ -20,22 +20,17 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.enums.PartRepairType;
+import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Compute;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.Mech;
-import megamek.common.TechAdvancement;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.SkillType;
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -140,7 +135,7 @@ public class MekCockpit extends Part {
                     type = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekGyro.java
@@ -20,21 +20,20 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.CriticalSlot;
 import megamek.common.Mech;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -141,7 +140,7 @@ public class MekGyro extends Part {
                     uTonnage = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         if (gyroTonnage == 0) {

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -20,37 +20,25 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.StringJoiner;
-
-import megamek.common.MiscType;
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.enums.PartRepairType;
-import mekhq.campaign.parts.equipment.EquipmentPart;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.IArmorState;
-import megamek.common.ILocationExposureStatus;
-import megamek.common.LandAirMech;
-import megamek.common.Mech;
-import megamek.common.Mounted;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.enums.PartRepairType;
+import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.WorkTime;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringJoiner;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -308,7 +296,7 @@ public class MekLocation extends Part {
                     breached = Boolean.parseBoolean(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
@@ -18,21 +18,19 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.BayType;
 import megamek.common.Entity;
 import megamek.common.ITechnology;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Neoancient
- *
  */
 public class MissingCubicle extends MissingPart {
     private static final long serialVersionUID = -5418633125937755683L;
@@ -125,7 +123,7 @@ public class MissingCubicle extends MissingPart {
             if (wn2.getNodeName().equalsIgnoreCase("bayType")) {
                 bayType = BayType.parse(wn2.getTextContent());
                 if (null == bayType) {
-                    MekHQ.getLogger().error("Could not parse bay type " + wn2.getTextContent());
+                    LogManager.getLogger().error("Could not parse bay type " + wn2.getTextContent());
                     bayType = BayType.MECH;
                 }
                 name = bayType.getDisplayName() + " Cubicle";

--- a/MekHQ/src/mekhq/campaign/parts/MissingEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingEnginePart.java
@@ -20,25 +20,16 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Aero;
-import megamek.common.CriticalSlot;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.Mech;
-import megamek.common.Protomech;
-import megamek.common.Tank;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
 import megamek.common.verifier.TestEntity;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.enums.PartRepairType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -158,7 +149,7 @@ public class MissingEnginePart extends MissingPart {
                     engineFlags = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/MissingInfantryArmorPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingInfantryArmorPart.java
@@ -20,17 +20,16 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Entity;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.enums.PartRepairType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -178,7 +177,7 @@ public class MissingInfantryArmorPart extends MissingPart {
                     spaceSuit = Boolean.parseBoolean(wn2.getTextContent().trim());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
@@ -20,19 +20,18 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.BipedMech;
 import megamek.common.CriticalSlot;
 import megamek.common.Mech;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.enums.PartRepairType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -112,7 +111,7 @@ public class MissingMekActuator extends MissingPart {
                     location = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekCockpit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekCockpit.java
@@ -20,18 +20,17 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.CriticalSlot;
 import megamek.common.Mech;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.enums.PartRepairType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -97,7 +96,7 @@ public class MissingMekCockpit extends MissingPart {
                     type = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekGyro.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekGyro.java
@@ -20,19 +20,18 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
 import megamek.common.CriticalSlot;
 import megamek.common.EquipmentType;
 import megamek.common.Mech;
 import megamek.common.TechAdvancement;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
-
 import mekhq.campaign.parts.enums.PartRepairType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -105,7 +104,7 @@ public class MissingMekGyro extends MissingPart {
                     walkMP = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
 
             if (walkMP > -1) {

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -20,27 +20,19 @@
  */
 package mekhq.campaign.parts;
 
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.enums.PartRepairType;
+import mekhq.campaign.parts.equipment.EquipmentPart;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.StringJoiner;
-
-import megamek.common.CriticalSlot;
-import megamek.common.EquipmentType;
-import megamek.common.IArmorState;
-import megamek.common.LandAirMech;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.TechAdvancement;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-
-import mekhq.campaign.parts.enums.PartRepairType;
-import mekhq.campaign.parts.equipment.EquipmentPart;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -199,7 +191,7 @@ public class MissingMekLocation extends MissingPart {
                     forQuad = Boolean.parseBoolean(wn2.getTextContent().trim());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingOmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingOmniPod.java
@@ -18,23 +18,18 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.TechAdvancement;
-import mekhq.MekHQ;
+import megamek.common.*;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.HeatSink;
 import mekhq.campaign.parts.equipment.JumpJet;
 import mekhq.campaign.parts.equipment.MASC;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * Like {@link OmniPod} this is never added to a <code>Unit</code>. <code>OmniPod</code> is used for empty
@@ -90,7 +85,7 @@ public class MissingOmniPod extends MissingPart {
                 pw1.print("' rating='" + ((MASC) partType).getEngineRating());
             }
         } else {
-            MekHQ.getLogger().info("MissingOmniPod partType is not EquipmentType");
+            LogManager.getLogger().info("MissingOmniPod partType is not EquipmentType");
         }
         pw1.println("'/>");
         writeToXmlEnd(pw1, indent);
@@ -108,9 +103,9 @@ public class MissingOmniPod extends MissingPart {
             Node wn2 = nl.item(x);
             if (wn2.getNodeName().equalsIgnoreCase("partType")) {
                 if (null == wn2.getAttributes().getNamedItem("type")) {
-                    MekHQ.getLogger().error("OmniPod lacks part type attribute.");
+                    LogManager.getLogger().error("OmniPod lacks part type attribute.");
                 } else if (null == wn2.getAttributes().getNamedItem("tonnage")) {
-                    MekHQ.getLogger().error("OmniPod lacks partType tonnage attribute.");
+                    LogManager.getLogger().error("OmniPod lacks partType tonnage attribute.");
                 } else {
                     String type = wn2.getAttributes().getNamedItem("type").getTextContent();
                     int tonnage = Integer.parseInt(wn2.getAttributes().getNamedItem("tonnage").getTextContent());
@@ -120,14 +115,14 @@ public class MissingOmniPod extends MissingPart {
                             hsType = Integer.parseInt(wn2.getAttributes().getNamedItem("hsType").getTextContent());
                         }
                         if (hsType != Aero.HEAT_SINGLE && hsType != Aero.HEAT_DOUBLE && hsType != AeroHeatSink.CLAN_HEAT_DOUBLE) {
-                            MekHQ.getLogger().error("Aero heatsink OmniPod does not have a legal value for heat sink type; using SINGLE");
+                            LogManager.getLogger().error("Aero heatsink OmniPod does not have a legal value for heat sink type; using SINGLE");
                             hsType = Aero.HEAT_SINGLE;
                         }
                         partType = new AeroHeatSink(0, hsType, false, campaign);
                     } else {
                         EquipmentType et = EquipmentType.get(type);
                         if (null == et) {
-                            MekHQ.getLogger().error("Unknown part type " + type + " for OmniPod");
+                            LogManager.getLogger().error("Unknown part type " + type + " for OmniPod");
                             //Throw a generic value in there to prevent NPE but still indicate a problem
                             et = EquipmentType.get(EquipmentType
                                     .getStructureTypeName(EquipmentType.T_STRUCTURE_STANDARD));
@@ -146,7 +141,7 @@ public class MissingOmniPod extends MissingPart {
                                 int rating = Integer.parseInt(wn2.getAttributes().getNamedItem("rating").getTextContent());
                                 partType = new MASC(tonnage, et, -1, campaign, rating, false);
                             } else {
-                                MekHQ.getLogger().error("OmniPod for MASC lacks engine rating");
+                                LogManager.getLogger().error("OmniPod for MASC lacks engine rating");
                             }
                         } else {
                             partType = new EquipmentPart(tonnage, et, -1, 1.0, false, campaign);

--- a/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingProtomekArmActuator.java
@@ -20,18 +20,17 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.CriticalSlot;
 import megamek.common.Protomech;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.enums.PartRepairType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -103,7 +102,7 @@ public class MissingProtomekArmActuator extends MissingPart {
                     location = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingTurret.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingTurret.java
@@ -20,19 +20,18 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Entity;
 import megamek.common.IArmorState;
 import megamek.common.Tank;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.enums.PartRepairType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -84,7 +83,7 @@ public class MissingTurret extends MissingPart {
                     weight = Double.parseDouble(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingVeeStabiliser.java
@@ -20,16 +20,15 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Tank;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -100,7 +99,7 @@ public class MissingVeeStabiliser extends MissingPart {
                     loc = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/MotiveSystem.java
@@ -20,18 +20,17 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Entity;
 import megamek.common.Tank;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -106,7 +105,7 @@ public class MotiveSystem extends Part {
                     penalty = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -18,26 +18,20 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.TechAdvancement;
-import megamek.common.TechConstants;
-import mekhq.MekHQ;
+import megamek.common.*;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.HeatSink;
 import mekhq.campaign.parts.equipment.JumpJet;
 import mekhq.campaign.parts.equipment.MASC;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * An empty omnipod, which can be purchased or created when equipment is removed from a pod.
@@ -149,9 +143,9 @@ public class OmniPod extends Part {
             Node wn2 = nl.item(x);
             if (wn2.getNodeName().equalsIgnoreCase("partType")) {
                 if (null == wn2.getAttributes().getNamedItem("type")) {
-                    MekHQ.getLogger().error("OmniPod lacks part type attribute.");
+                    LogManager.getLogger().error("OmniPod lacks part type attribute.");
                 } else if (null == wn2.getAttributes().getNamedItem("tonnage")) {
-                    MekHQ.getLogger().error("OmniPod lacks partType tonnage attribute.");
+                    LogManager.getLogger().error("OmniPod lacks partType tonnage attribute.");
                 } else {
                     String type = wn2.getAttributes().getNamedItem("type").getTextContent();
                     int tonnage = Integer.parseInt(wn2.getAttributes().getNamedItem("tonnage").getTextContent());
@@ -161,14 +155,14 @@ public class OmniPod extends Part {
                             hsType = Integer.parseInt(wn2.getAttributes().getNamedItem("hsType").getTextContent());
                         }
                         if ((hsType != Aero.HEAT_SINGLE) && (hsType != Aero.HEAT_DOUBLE)) {
-                            MekHQ.getLogger().error("Aero heatsink OmniPod does not have a legal value for heat sink type; using SINGLE");
+                            LogManager.getLogger().error("Aero heatsink OmniPod does not have a legal value for heat sink type; using SINGLE");
                             hsType = Aero.HEAT_SINGLE;
                         }
                         partType = new AeroHeatSink(0, hsType, false, campaign);
                     } else {
                         EquipmentType et = EquipmentType.get(type);
                         if (null == et) {
-                            MekHQ.getLogger().error("Unknown part type " + type + " for OmniPod");
+                            LogManager.getLogger().error("Unknown part type " + type + " for OmniPod");
                             //Throw a generic value in there to prevent NPE but still indicate a problem
                             et = EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_STANDARD));
                         }
@@ -186,7 +180,7 @@ public class OmniPod extends Part {
                                 int rating = Integer.parseInt(wn2.getAttributes().getNamedItem("rating").getTextContent());
                                 partType = new MASC(tonnage, et, -1, campaign, rating, false);
                             } else {
-                                MekHQ.getLogger().error("OmniPod for MASC lacks engine rating");
+                                LogManager.getLogger().error("OmniPod for MASC lacks engine rating");
                             }
                         } else {
                             partType = new EquipmentPart(tonnage, et, -1, 1.0, false, campaign);
@@ -304,7 +298,7 @@ public class OmniPod extends Part {
                 pw1.print("' rating='" + ((MASC) partType).getEngineRating());
             }
         } else {
-            MekHQ.getLogger().info("OmniPod partType is not EquipmentType");
+            LogManager.getLogger().info("OmniPod partType is not EquipmentType");
         }
         pw1.println("'/>");
         writeToXmlEnd(pw1, indent);

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -20,40 +20,16 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.ResourceBundle;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.StringJoiner;
-import java.util.UUID;
-
+import megamek.Version;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.EncodeControl;
-import mekhq.campaign.finances.Money;
-
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechnology;
-import megamek.common.SimpleTechLevel;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
-import megamek.common.WeaponType;
-import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
@@ -63,6 +39,15 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
 import mekhq.campaign.work.WorkTime;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.util.*;
 
 /**
  * Parts do the lions share of the work of repairing, salvaging, reloading, refueling, etc.
@@ -857,7 +842,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;
@@ -1873,7 +1858,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             int id = replacementPart.getId();
             replacementPart = campaign.getWarehouse().getPart(id);
             if ((replacementPart == null) && (id > 0)) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Part %d ('%s') references missing replacement part %d",
                         getId(), getName(), id));
             }
@@ -1883,7 +1868,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             int id = parentPart.getId();
             parentPart = campaign.getWarehouse().getPart(id);
             if ((parentPart == null) && (id > 0)) {
-                MekHQ.getLogger().error(String.format("Part %d ('%s') references missing parent part %d",
+                LogManager.getLogger().error(String.format("Part %d ('%s') references missing parent part %d",
                         getId(), getName(), id));
             }
         }
@@ -1895,7 +1880,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
                 if (realPart != null) {
                     childParts.set(ii, realPart);
                 } else if (childPart.getId() > 0) {
-                    MekHQ.getLogger().error(String.format("Part %d ('%s') references missing child part %d",
+                    LogManager.getLogger().error(String.format("Part %d ('%s') references missing child part %d",
                             getId(), getName(), childPart.getId()));
                     childParts.remove(ii);
                 }
@@ -1906,7 +1891,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             UUID id = tech.getId();
             tech = campaign.getPerson(id);
             if (tech == null) {
-                MekHQ.getLogger().error(String.format("Part %d ('%s') references missing tech %s",
+                LogManager.getLogger().error(String.format("Part %d ('%s') references missing tech %s",
                         getId(), getName(), id));
             }
         }
@@ -1914,7 +1899,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             UUID id = reservedBy.getId();
             reservedBy = campaign.getPerson(id);
             if (reservedBy == null) {
-                MekHQ.getLogger().error(String.format("Part %d ('%s') references missing tech (reservation) %s",
+                LogManager.getLogger().error(String.format("Part %d ('%s') references missing tech (reservation) %s",
                         getId(), getName(), id));
             }
         }
@@ -1923,7 +1908,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             UUID id = unit.getId();
             unit = campaign.getUnit(id);
             if (unit == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Part %d ('%s') references missing unit %s",
                         getId(), getName(), id));
             }
@@ -1933,7 +1918,7 @@ public abstract class Part implements Serializable, MekHqXmlSerializable, IPartW
             UUID id = refitUnit.getId();
             refitUnit = campaign.getUnit(id);
             if (refitUnit == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Part %d ('%s') references missing refit unit %s",
                         getId(), getName(), id));
             }

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -18,17 +18,7 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.Mech;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
+import megamek.common.*;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PartChangedEvent;
@@ -38,6 +28,12 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IPartWork;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * An abstraction of all the pod-mounted equipment within a single location of an omni unit. Used

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekArmActuator.java
@@ -20,22 +20,17 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.enums.PartRepairType;
+import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Compute;
-import megamek.common.CriticalSlot;
-import megamek.common.Protomech;
-import megamek.common.TechAdvancement;
-import megamek.common.TechConstants;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.SkillType;
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -116,7 +111,7 @@ public class ProtomekArmActuator extends Part {
                     location = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
@@ -20,27 +20,19 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.enums.PartRepairType;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.CriticalSlot;
-import megamek.common.IArmorState;
-import megamek.common.ILocationExposureStatus;
-import megamek.common.Mounted;
-import megamek.common.Protomech;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.work.WorkTime;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -236,7 +228,7 @@ public class ProtomekLocation extends Part {
                     breached = Boolean.parseBoolean(wn2.getTextContent().trim());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -20,51 +20,8 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.Bay;
-import megamek.common.BayType;
-import megamek.common.BipedMech;
-import megamek.common.ConvFighter;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechnology;
-import megamek.common.Infantry;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.SmallCraft;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
-import megamek.common.WeaponType;
+import megamek.Version;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.loaders.BLKFile;
 import megamek.common.loaders.EntityLoadingException;
@@ -78,21 +35,24 @@ import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.MhqFileUtil;
 import mekhq.Utilities;
-import megamek.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PartChangedEvent;
 import mekhq.campaign.event.UnitRefitEvent;
-import mekhq.campaign.parts.equipment.AmmoBin;
-import mekhq.campaign.parts.equipment.EquipmentPart;
-import mekhq.campaign.parts.equipment.HeatSink;
-import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
-import mekhq.campaign.parts.equipment.MissingEquipmentPart;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.equipment.*;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.cleanup.EquipmentUnscrambler;
 import mekhq.campaign.unit.cleanup.EquipmentUnscramblerResult;
-import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * This object tracks the refit of a given unit into a new unit.
@@ -491,7 +451,7 @@ public class Refit extends Part implements IAcquisitionWork {
                     if (null != mPart) {
                         newPartList.add(mPart);
                     } else {
-                        MekHQ.getLogger().error("null missing part for "
+                        LogManager.getLogger().error("null missing part for "
                                 + part.getName() + " during refit calculations");
                     }
                 }
@@ -1013,7 +973,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 time = oneWeekInMinutes; // 1 Week
             } else {
                 time = 1111;
-                MekHQ.getLogger().error("Unit " + newEntity.getModel() + " did not set its time correctly.");
+                LogManager.getLogger().error("Unit " + newEntity.getModel() + " did not set its time correctly.");
             }
 
             // The cost is equal to 10 percent of the units base value (not modified for quality). (SO p189)
@@ -1473,7 +1433,7 @@ public class Refit extends Part implements IAcquisitionWork {
         final EquipmentUnscrambler unscrambler = EquipmentUnscrambler.create(oldUnit);
         final EquipmentUnscramblerResult result = unscrambler.unscramble();
         if (!result.succeeded()) {
-            MekHQ.getLogger().warning(result.getMessage());
+            LogManager.getLogger().warn(result.getMessage());
         }
 
         changeAmmoBinMunitions(oldUnit);
@@ -1583,14 +1543,14 @@ public class Refit extends Part implements IAcquisitionWork {
         File customsDir = new File(sCustomsDir);
         if (!customsDir.exists()) {
             if (!customsDir.mkdir()) {
-                MekHQ.getLogger().error("Failed to create directory " + sCustomsDir + ", and therefore cannot save the unit.");
+                LogManager.getLogger().error("Failed to create directory " + sCustomsDir + ", and therefore cannot save the unit.");
                 return;
             }
         }
         File customsDirCampaign = new File(sCustomsDirCampaign);
         if (!customsDirCampaign.exists()) {
             if (!customsDirCampaign.mkdir()) {
-                MekHQ.getLogger().error("Failed to create directory " + sCustomsDirCampaign + ", and therefore cannot save the unit.");
+                LogManager.getLogger().error("Failed to create directory " + sCustomsDirCampaign + ", and therefore cannot save the unit.");
                 return;
             }
         }
@@ -1618,7 +1578,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 BLKFile.encode(fileNameCampaign, newEntity);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             fileNameCampaign = null;
         }
 
@@ -1636,18 +1596,18 @@ public class Refit extends Part implements IAcquisitionWork {
             }
 
             newEntity = new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
-            MekHQ.getLogger().info(String.format("Saved %s %s to %s",
+            LogManager.getLogger().info(String.format("Saved %s %s to %s",
                     newEntity.getChassis(), newEntity.getModel(), summary.getSourceFile()));
         } catch (EntityLoadingException e) {
-            MekHQ.getLogger().error(String.format("Could not read back refit entity %s %s",
+            LogManager.getLogger().error(String.format("Could not read back refit entity %s %s",
                     newEntity.getChassis(), newEntity.getModel()), e);
 
             if (fileNameCampaign != null) {
-                MekHQ.getLogger().warning("Deleting invalid refit file " + fileNameCampaign);
+                LogManager.getLogger().warn("Deleting invalid refit file " + fileNameCampaign);
                 try {
                     new File(fileNameCampaign).delete();
                 } catch (SecurityException se) {
-                    MekHQ.getLogger().warning("Could not clean up bad refit file " + fileNameCampaign, se);
+                    LogManager.getLogger().warn("Could not clean up bad refit file " + fileNameCampaign, se);
                 }
             }
 
@@ -2078,7 +2038,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;
@@ -2099,7 +2059,7 @@ public class Refit extends Part implements IAcquisitionWork {
             if (!wn2.getNodeName().equalsIgnoreCase("part")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Part nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Part nodes: " + wn2.getNodeName());
                 continue;
             }
 
@@ -2108,7 +2068,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 p.setUnit(u);
                 retVal.shoppingList.add(p);
             } else {
-                MekHQ.getLogger().error((u != null)
+                LogManager.getLogger().error((u != null)
                         ? String.format("Unit %s has invalid parts in its refit shopping list", u.getId())
                         : "Invalid parts in shopping list");
             }
@@ -2130,7 +2090,7 @@ public class Refit extends Part implements IAcquisitionWork {
             if (!wn2.getNodeName().equalsIgnoreCase("part")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Part nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Part nodes: " + wn2.getNodeName());
 
                 continue;
             }
@@ -2642,7 +2602,7 @@ public class Refit extends Part implements IAcquisitionWork {
             if (realPart instanceof Armor) {
                 newArmorSupplies = (Armor) realPart;
             } else {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Refit on Unit %s references missing armor supplies %d",
                         getUnit().getId(), newArmorSupplies.getId()));
                 newArmorSupplies = null;
@@ -2656,7 +2616,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (realPart != null) {
                     oldUnitParts.set(ii, realPart);
                 } else if (part.getId() > 0) {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Refit on Unit %s references missing old unit part %d",
                             getUnit().getId(), part.getId()));
                     oldUnitParts.remove(ii);
@@ -2671,7 +2631,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (realPart != null) {
                     newUnitParts.set(ii, realPart);
                 } else if (part.getId() > 0) {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Refit on Unit %s references missing new unit part %d",
                             getUnit().getId(), part.getId()));
                     newUnitParts.remove(ii);
@@ -2689,7 +2649,7 @@ public class Refit extends Part implements IAcquisitionWork {
                 if (realPart != null) {
                     realParts.add(realPart);
                 } else {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Refit on Unit %s references missing large craft ammo bin %d",
                             getUnit().getId(), part.getId()));
                 }
@@ -2702,7 +2662,7 @@ public class Refit extends Part implements IAcquisitionWork {
             UUID id = assignedTech.getId();
             assignedTech = campaign.getPerson(id);
             if (assignedTech == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Refit on Unit %s references missing tech %s",
                         getUnit().getId(), id));
             }

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -22,11 +22,11 @@ import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.ITechnology;
 import megamek.common.TechAdvancement;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.work.IAcquisitionWork;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 
 import java.io.PrintWriter;
@@ -193,7 +193,7 @@ public class SVArmor extends Armor {
                         break;
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVEnginePart.java
@@ -19,12 +19,12 @@
 package mekhq.campaign.parts;
 
 import megamek.common.*;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -178,7 +178,7 @@ public class SVEnginePart extends Part {
                         break;
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/SpacecraftCoolingSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/SpacecraftCoolingSystem.java
@@ -20,23 +20,18 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.Jumpship;
-import megamek.common.SmallCraft;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
 import megamek.common.verifier.TestAdvancedAerospace;
 import megamek.common.verifier.TestSmallCraft;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * Container for SC/DS/JS/WS/SS heat sinks. Eliminates need for tracking hundreds/thousands
@@ -301,7 +296,7 @@ public class SpacecraftCoolingSystem extends Part {
                     currentSinks = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
+++ b/MekHQ/src/mekhq/campaign/parts/StructuralIntegrity.java
@@ -20,22 +20,15 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Aero;
-import megamek.common.ConvFighter;
-import megamek.common.Dropship;
-import megamek.common.Entity;
-import megamek.common.SimpleTechLevel;
-import megamek.common.SmallCraft;
-import megamek.common.TechAdvancement;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -118,7 +111,7 @@ public class StructuralIntegrity extends Part {
                     pointsNeeded = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -20,26 +20,18 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.enums.PartRepairType;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.CriticalSlot;
-import megamek.common.IArmorState;
-import megamek.common.ILocationExposureStatus;
-import megamek.common.Mounted;
-import megamek.common.SimpleTechLevel;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.SkillType;
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -152,7 +144,7 @@ public class TankLocation extends Part {
                     breached = Boolean.parseBoolean(wn2.getTextContent().trim());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/Turret.java
+++ b/MekHQ/src/mekhq/campaign/parts/Turret.java
@@ -20,21 +20,16 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.CriticalSlot;
-import megamek.common.IArmorState;
-import megamek.common.Mounted;
-import megamek.common.Tank;
-import megamek.common.WeaponType;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.unit.Unit;
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -125,7 +120,7 @@ public class Turret extends TankLocation {
                     damage = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeStabiliser.java
@@ -20,20 +20,19 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-
-import mekhq.MekHQ;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.EquipmentType;
 import megamek.common.Tank;
 import megamek.common.TechAdvancement;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -87,7 +86,7 @@ public class VeeStabiliser extends Part {
                     loc = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/parts/enums/PartRepairType.java
+++ b/MekHQ/src/mekhq/campaign/parts/enums/PartRepairType.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.parts.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -111,10 +111,10 @@ public enum PartRepairType {
                     return POD_SPACE;
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
-        MekHQ.getLogger().error("Unknown part repair type, returning GENERAL_LOCATION");
+        LogManager.getLogger().error("Unknown part repair type, returning GENERAL_LOCATION");
 
         return GENERAL_LOCATION;
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -20,36 +20,25 @@
  */
 package mekhq.campaign.parts.equipment;
 
-import java.io.PrintWriter;
-import java.util.Objects;
-
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.enums.PartRepairType;
-import mekhq.campaign.unit.Unit;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.CriticalSlot;
-import megamek.common.EquipmentType;
-import megamek.common.ITechnology;
-import megamek.common.Jumpship;
-import megamek.common.Mounted;
-import megamek.common.Protomech;
-import megamek.common.SmallCraft;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Availability;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.PartInventory;
+import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.Objects;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -239,7 +228,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                     oneShot = Boolean.parseBoolean(wn2.getTextContent().trim());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
@@ -306,7 +295,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
                 return mounted;
             }
 
-            MekHQ.getLogger().warning("Missing valid equipment for " + getName() + " to manage ammo on unit " + getUnit().getName());
+            LogManager.getLogger().warn("Missing valid equipment for " + getName() + " to manage ammo on unit " + getUnit().getName());
         }
 
         return null;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -20,16 +20,12 @@
  */
 package mekhq.campaign.parts.equipment;
 
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.CriticalSlot;
-import megamek.common.EquipmentType;
-import megamek.common.Mounted;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.PartInventory;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -255,13 +251,13 @@ public class BattleArmorAmmoBin extends AmmoBin {
         }*/
 
         if (type == null) {
-            MekHQ.getLogger().error("Mounted.restore: could not restore equipment type \"" + typeName + "\"");
+            LogManager.getLogger().error("Mounted.restore: could not restore equipment type \"" + typeName + "\"");
             return;
         }
         try {
             equipTonnage = type.getTonnage(null);
         } catch (NullPointerException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorEquipmentPart.java
@@ -23,11 +23,11 @@ package mekhq.campaign.parts.equipment;
 import megamek.common.EquipmentType;
 import megamek.common.MiscType;
 import megamek.common.Mounted;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -104,7 +104,7 @@ public class BattleArmorEquipmentPart extends EquipmentPart {
                     trooper = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         restore();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -21,27 +21,19 @@
  */
 package mekhq.campaign.parts.equipment;
 
-import java.io.PrintWriter;
-
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megamek.common.weapons.bayweapons.BayWeapon;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Compute;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.TechAdvancement;
-import megamek.common.WeaponType;
-import megamek.common.annotations.Nullable;
-import megamek.common.weapons.bayweapons.BayWeapon;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.parts.Part;
-import mekhq.campaign.unit.Unit;
+import java.io.PrintWriter;
 
 /**
  * This part covers most of the equipment types in WeaponType, AmmoType, and
@@ -99,7 +91,7 @@ public class EquipmentPart extends Part {
             try {
                 equipTonnage = type.getTonnage(null, size);
             } catch (NullPointerException ex) {
-                MekHQ.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
     }
@@ -140,7 +132,7 @@ public class EquipmentPart extends Part {
         }
 
         if (type == null) {
-            MekHQ.getLogger().error("Mounted.restore: could not restore equipment type \"" + typeName + "\"");
+            LogManager.getLogger().error("Mounted.restore: could not restore equipment type \"" + typeName + "\"");
         }
     }
 
@@ -343,7 +335,7 @@ public class EquipmentPart extends Part {
                 return mounted;
             }
 
-            MekHQ.getLogger().warning("Missing valid equipment for " + getName() + " on unit " + getUnit().getName());
+            LogManager.getLogger().warn("Missing valid equipment for " + getName() + " on unit " + getUnit().getName());
         }
 
         return null;
@@ -564,7 +556,7 @@ public class EquipmentPart extends Part {
         }
         if (varCost.isZero()) {
             // if we don't know what it is...
-            MekHQ.getLogger().debug("I don't know how much " + name + " costs.");
+            LogManager.getLogger().debug("I don't know how much " + name + " costs.");
         }
         return varCost;
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/InfantryWeaponPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/InfantryWeaponPart.java
@@ -21,10 +21,10 @@
 package mekhq.campaign.parts.equipment;
 
 import megamek.common.EquipmentType;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartRepairType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -99,7 +99,7 @@ public class InfantryWeaponPart extends EquipmentPart {
                     primary = Boolean.parseBoolean(wn2.getTextContent().trim());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         restore();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -18,25 +18,24 @@
  */
 package mekhq.campaign.parts.equipment;
 
-import java.io.PrintWriter;
-
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.AmmoType;
 import megamek.common.CriticalSlot;
 import megamek.common.Mounted;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.PartInventory;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * Ammo bin for a weapon bay that combines multiple tons of ammo into a single bin. Reload times
- * are calculated per ton, and a  reload tech action handles a single ton of ammo (or whatever the
+ * are calculated per ton, and a reload tech action handles a single ton of ammo (or whatever the
  * smallest amount is for capital weapon ammo).
  *
  * When the munition type is changed, fix actions diminish the capacity of this bay and add to
@@ -97,7 +96,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
             }
         }
 
-        MekHQ.getLogger().warning("Could not find weapon bay for " + typeName + " for " + unit.getName());
+        LogManager.getLogger().warn("Could not find weapon bay for " + typeName + " for " + unit.getName());
         return null;
     }
 
@@ -195,7 +194,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
                     bayEqNum = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
@@ -23,19 +23,18 @@ package mekhq.campaign.parts.equipment;
 import megamek.common.EquipmentType;
 import megamek.common.MiscType;
 import megamek.common.TechConstants;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.PrintWriter;
 
 /**
- *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class MASC extends EquipmentPart {
@@ -147,7 +146,7 @@ public class MASC extends EquipmentPart {
                     engineRating = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
 		}
 		restore();

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingEquipmentPart.java
@@ -13,38 +13,29 @@
  *
  * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.parts.equipment;
 
-import java.io.PrintWriter;
-import java.util.Objects;
-
-import mekhq.MekHQ;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.TechAdvancement;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.Objects;
 
 /**
- *
  * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class MissingEquipmentPart extends MissingPart {
@@ -122,7 +113,7 @@ public class MissingEquipmentPart extends MissingPart {
         }
 
         if (type == null) {
-            MekHQ.getLogger().error("Mounted.restore: could not restore equipment type \"" + name + "\"");
+            LogManager.getLogger().error("Mounted.restore: could not restore equipment type \"" + name + "\"");
         }
     }
 
@@ -214,7 +205,7 @@ public class MissingEquipmentPart extends MissingPart {
                 return mounted;
             }
 
-            MekHQ.getLogger().warning("Missing valid equipment for " + getName() + " on unit " + getUnit().getName());
+            LogManager.getLogger().warn("Missing valid equipment for " + getName() + " on unit " + getUnit().getName());
         }
 
         return null;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingInfantryAmmoBin.java
@@ -25,10 +25,10 @@ import megamek.common.EquipmentType;
 import megamek.common.Mounted;
 import megamek.common.annotations.Nullable;
 import megamek.common.weapons.infantry.InfantryWeapon;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.Part;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -76,7 +76,7 @@ public class MissingInfantryAmmoBin extends MissingAmmoBin {
         if (getWeaponType() != null) {
             name = getWeaponType().getName() + " Ammo Bin";
         } else {
-            MekHQ.getLogger().error("MissingInfantryAmmoBin does not have a weapon type!");
+            LogManager.getLogger().error("MissingInfantryAmmoBin does not have a weapon type!");
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingLargeCraftAmmoBin.java
@@ -18,19 +18,18 @@
  */
 package mekhq.campaign.parts.equipment;
 
-import java.io.PrintWriter;
-import java.util.Objects;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.AmmoType;
 import megamek.common.Mounted;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.Part;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.Objects;
 
 /**
  * @author cwspain
@@ -77,7 +76,7 @@ public class MissingLargeCraftAmmoBin extends MissingAmmoBin {
             }
         }
 
-        MekHQ.getLogger().warning("Could not find weapon bay for " + typeName + " for " + unit.getName());
+        LogManager.getLogger().warn("Could not find weapon bay for " + typeName + " for " + unit.getName());
         return null;
     }
 
@@ -172,7 +171,7 @@ public class MissingLargeCraftAmmoBin extends MissingAmmoBin {
                     bayEqNum = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/Award.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Award.java
@@ -18,12 +18,6 @@
  */
 package mekhq.campaign.personnel;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
 import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
@@ -32,6 +26,11 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class represents an award given to a person

--- a/MekHQ/src/mekhq/campaign/personnel/AwardsFactory.java
+++ b/MekHQ/src/mekhq/campaign/personnel/AwardsFactory.java
@@ -18,26 +18,27 @@
  */
 package mekhq.campaign.personnel;
 
-import java.io.*;
+import megamek.common.annotations.Nullable;
+import mekhq.MekHqConstants;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.AwardSet;
+import mekhq.campaign.io.Migration.PersonMigrator;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-
-import megamek.common.annotations.Nullable;
-import mekhq.MekHqConstants;
-import mekhq.campaign.io.Migration.PersonMigrator;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.AwardSet;
 
 /**
  * This class is responsible to control the awards. It loads one instance of each awards, then it creates a copy of it
@@ -124,7 +125,7 @@ public class AwardsFactory {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         if (defaultSetMigration && "Default Set".equalsIgnoreCase(set)) {
@@ -158,7 +159,7 @@ public class AwardsFactory {
             try (InputStream inputStream = new FileInputStream(file)) {
                 loadAwardsFromStream(inputStream, file.getName());
             } catch (IOException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }
@@ -183,7 +184,7 @@ public class AwardsFactory {
             }
             awardsMap.put(currentSetName, tempAwardMap);
         } catch (JAXBException e) {
-            MekHQ.getLogger().error("Error loading XML for awards", e);
+            LogManager.getLogger().error("Error loading XML for awards", e);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodname.java
@@ -23,9 +23,9 @@ package mekhq.campaign.personnel;
 
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.personnel.enums.Phenotype;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -214,7 +214,7 @@ public class Bloodname implements Serializable {
                     retVal.startDate = Integer.parseInt(wn.getTextContent().trim()) + 20;
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
@@ -249,12 +249,12 @@ public class Bloodname implements Serializable {
      */
     public static @Nullable Bloodname randomBloodname(Clan faction, Phenotype phenotype, int year) {
         if (faction == null) {
-            MekHQ.getLogger().error("Random Bloodname attempted for a clan that does not exist."
+            LogManager.getLogger().error("Random Bloodname attempted for a clan that does not exist."
                     + System.lineSeparator()
                     + "Please ensure that your clan exists in both the clans.xml and bloodnames.xml files as appropriate.");
             return null;
         } else if (phenotype == null) {
-            MekHQ.getLogger().error("Random Bloodname attempted for an unknown phenotype. Please open a bug report so this issue may be fixed.");
+            LogManager.getLogger().error("Random Bloodname attempted for an unknown phenotype. Please open a bug report so this issue may be fixed.");
             return null;
         }
 
@@ -422,7 +422,7 @@ public class Bloodname implements Serializable {
         try {
             fis = new FileInputStream(f);
         } catch (FileNotFoundException e) {
-            MekHQ.getLogger().error("Cannot find file bloodnames.xml");
+            LogManager.getLogger().error("Cannot find file bloodnames.xml");
             return;
         }
 
@@ -433,7 +433,7 @@ public class Bloodname implements Serializable {
             doc = db.parse(fis);
             fis.close();
         } catch (Exception ex) {
-            MekHQ.getLogger().error("Could not parse bloodnames.xml", ex);
+            LogManager.getLogger().error("Could not parse bloodnames.xml", ex);
             return;
         }
 
@@ -449,7 +449,7 @@ public class Bloodname implements Serializable {
                 }
             }
         }
-        MekHQ.getLogger().info("Loaded " + bloodnames.size() + " Bloodname records.");
+        LogManager.getLogger().info("Loaded " + bloodnames.size() + " Bloodname records.");
     }
 
     private static class NameAcquired {

--- a/MekHQ/src/mekhq/campaign/personnel/Clan.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Clan.java
@@ -19,8 +19,8 @@ package mekhq.campaign.personnel;
 
 import megamek.common.Compute;
 import megamek.common.util.StringUtil;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -222,7 +222,7 @@ public class Clan {
         try {
             fis = new FileInputStream(f);
         } catch (FileNotFoundException e) {
-            MekHQ.getLogger().error("Cannot find file clans.xml");
+            LogManager.getLogger().error("Cannot find file clans.xml");
             return;
         }
 
@@ -233,7 +233,7 @@ public class Clan {
             doc = db.parse(fis);
             fis.close();
         } catch (Exception ex) {
-            MekHQ.getLogger().error("Could not parse clans.xml", ex);
+            LogManager.getLogger().error("Could not parse clans.xml", ex);
             return;
         }
 
@@ -298,7 +298,7 @@ public class Clan {
                     retVal.generationCode = wn.getTextContent().trim();
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
+++ b/MekHQ/src/mekhq/campaign/personnel/CustomOption.java
@@ -19,8 +19,8 @@
 package mekhq.campaign.personnel;
 
 import megamek.common.options.IOption;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -94,7 +94,7 @@ public class CustomOption {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(is);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return;
         }
 
@@ -134,7 +134,7 @@ public class CustomOption {
     public static CustomOption generateInstanceFromXML(Node wn) {
         String key = wn.getAttributes().getNamedItem("name").getTextContent();
         if (null == key) {
-            MekHQ.getLogger().error("Custom ability does not have a 'name' attribute.");
+            LogManager.getLogger().error("Custom ability does not have a 'name' attribute.");
             return null;
         }
 
@@ -168,7 +168,7 @@ public class CustomOption {
                     break;
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error("Error parsing custom ability " + retVal.name, ex);
+            LogManager.getLogger().error("Error parsing custom ability " + retVal.name, ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/personnel/Injury.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Injury.java
@@ -20,33 +20,27 @@
  */
 package mekhq.campaign.personnel;
 
-import java.io.PrintWriter;
-import java.time.LocalDate;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.UUID;
+import mekhq.Utilities;
+import mekhq.adapter.DateAdapter;
+import mekhq.campaign.ExtraData;
+import mekhq.campaign.mod.am.InjuryTypes;
+import mekhq.campaign.personnel.enums.BodyLocation;
+import mekhq.campaign.personnel.enums.InjuryHiding;
+import mekhq.campaign.personnel.enums.InjuryLevel;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import mekhq.campaign.personnel.enums.BodyLocation;
-import mekhq.campaign.personnel.enums.InjuryHiding;
-import mekhq.campaign.personnel.enums.InjuryLevel;
-import org.w3c.dom.Node;
-
-import mekhq.MekHQ;
-import mekhq.Utilities;
-import mekhq.adapter.DateAdapter;
-import mekhq.campaign.ExtraData;
-import mekhq.campaign.mod.am.InjuryTypes;
+import java.io.PrintWriter;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.UUID;
 
 // Injury class based on Jayof9s' <jayof9s@gmail.com> Advanced Medical documents
 @XmlRootElement(name = "injury")
@@ -67,7 +61,7 @@ public class Injury {
             // For debugging only!
             // unmarshaller.setEventHandler(new javax.xml.bind.helpers.DefaultValidationEventHandler());
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -80,7 +74,7 @@ public class Injury {
         try {
             return unmarshaller.unmarshal(wn, Injury.class).getValue();
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         return null;
     }
@@ -293,7 +287,7 @@ public class Injury {
         try {
             marshaller.marshal(this, pw1);
         } catch (JAXBException ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -57,6 +57,7 @@ import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.work.IPartWork;
 import mekhq.io.idReferenceClasses.PersonIdReference;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -1597,7 +1598,7 @@ public class Person implements Serializable {
                 extraData.writeToXml(pw1);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("Failed to write " + getFullName() + " to the XML File", e);
+            LogManager.getLogger().error("Failed to write " + getFullName() + " to the XML File", e);
             throw e; // we want to rethrow to ensure that that the save fails
         }
         pw1.println(MekHqXmlUtil.indentStr(indent) + "</person>");
@@ -1789,7 +1790,7 @@ public class Person implements Serializable {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("id")) {
-                            MekHQ.getLogger().error("Unknown node type not loaded in techUnitIds nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in techUnitIds nodes: " + wn3.getNodeName());
                             continue;
                         }
                         retVal.addTechUnit(new PersonUnitRef(UUID.fromString(wn3.getTextContent())));
@@ -1804,7 +1805,7 @@ public class Person implements Serializable {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            MekHQ.getLogger().error("Unknown node type not loaded in personnel log nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in personnel log nodes: " + wn3.getNodeName());
                             continue;
                         }
 
@@ -1833,7 +1834,7 @@ public class Person implements Serializable {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            MekHQ.getLogger().error("Unknown node type not loaded in mission log nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in mission log nodes: " + wn3.getNodeName());
                             continue;
                         }
                         retVal.addMissionLogEntry(LogEntryFactory.getInstance().generateInstanceFromXML(wn3));
@@ -1850,7 +1851,7 @@ public class Person implements Serializable {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("award")) {
-                            MekHQ.getLogger().error("Unknown node type not loaded in personnel log nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in personnel log nodes: " + wn3.getNodeName());
                             continue;
                         }
 
@@ -1868,7 +1869,7 @@ public class Person implements Serializable {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("injury")) {
-                            MekHQ.getLogger().error("Unknown node type not loaded in injury nodes: " + wn3.getNodeName());
+                            LogManager.getLogger().error("Unknown node type not loaded in injury nodes: " + wn3.getNodeName());
                             continue;
                         }
                         retVal.injuries.add(Injury.generateInstanceFromXML(wn3));
@@ -1908,7 +1909,7 @@ public class Person implements Serializable {
                     try {
                         retVal.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Error restoring advantage: " + adv);
+                        LogManager.getLogger().error("Error restoring advantage: " + adv);
                     }
                 }
             }
@@ -1922,7 +1923,7 @@ public class Person implements Serializable {
                     try {
                         retVal.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Error restoring edge: " + adv);
+                        LogManager.getLogger().error("Error restoring edge: " + adv);
                     }
                 }
             }
@@ -1936,7 +1937,7 @@ public class Person implements Serializable {
                     try {
                         retVal.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Error restoring implants: " + adv);
+                        LogManager.getLogger().error("Error restoring implants: " + adv);
                     }
                 }
             }
@@ -1949,7 +1950,7 @@ public class Person implements Serializable {
                 retVal.setRank(0);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("Failed to read person " + retVal.getFullName() + " from file", e);
+            LogManager.getLogger().error("Failed to read person " + retVal.getFullName() + " from file", e);
             retVal = null;
         }
 
@@ -3387,7 +3388,7 @@ public class Person implements Serializable {
             UUID id = unit.getId();
             unit = campaign.getUnit(id);
             if (unit == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Person %s ('%s') references missing unit %s",
                         getId(), getFullName(), id));
             }
@@ -3399,7 +3400,7 @@ public class Person implements Serializable {
                 if (realUnit != null) {
                     techUnits.set(ii, realUnit);
                 } else {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Person %s ('%s') techs missing unit %s",
                             getId(), getFullName(), techUnit.getId()));
                     techUnits.remove(ii);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
@@ -24,6 +24,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.log.AwardLogger;
 import mekhq.campaign.log.PersonalLogger;
+import org.apache.logging.log4j.LogManager;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -110,7 +111,7 @@ public class PersonAwardController {
         } else {
             award = AwardsFactory.getInstance().generateNew(setName, awardName);
             if (award == null) {
-                MekHQ.getLogger().error("Cannot award a null award, returning.");
+                LogManager.getLogger().error("Cannot award a null award, returning.");
                 return;
             }
             awards.add(award);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -13,20 +13,14 @@
  */
 package mekhq.campaign.personnel;
 
+import megamek.common.annotations.Nullable;
+import megamek.common.options.*;
+import org.apache.logging.log4j.LogManager;
+
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
-
-import megamek.common.annotations.Nullable;
-import megamek.common.options.AbstractOptionsInfo;
-import megamek.common.options.IBasicOptionGroup;
-import megamek.common.options.IOption;
-import megamek.common.options.IOptionGroup;
-import megamek.common.options.IOptionInfo;
-import megamek.common.options.OptionsConstants;
-import megamek.common.options.PilotOptions;
-import mekhq.MekHQ;
 
 /**
  * An extension of PilotOptions that adds MekHQ-specific SPAs and edge triggers for support and command
@@ -71,18 +65,18 @@ public class PersonnelOptions extends PilotOptions {
 
         if (null == l3a) {
             // This really shouldn't happen.
-            MekHQ.getLogger().warning("Could not find L3Advantage group");
+            LogManager.getLogger().warn("Could not find L3Advantage group");
             l3a = addGroup("adv", PilotOptions.LVL3_ADVANTAGES);
         }
         if (null == edge) {
             // This really shouldn't happen.
-            MekHQ.getLogger().warning("Could not find edge group");
+            LogManager.getLogger().warn("Could not find edge group");
             edge = addGroup("edge", PilotOptions.EDGE_ADVANTAGES);
             addOption(edge, OptionsConstants.EDGE, 0);
         }
         if (null == md) {
             // This really shouldn't happen.
-            MekHQ.getLogger().warning("Could not find augmentation (MD) group");
+            LogManager.getLogger().warn("Could not find augmentation (MD) group");
             md = addGroup("md", PilotOptions.MD_ADVANTAGES);
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -23,7 +23,6 @@ package mekhq.campaign.personnel;
 import megamek.common.Compute;
 import megamek.common.TargetRoll;
 import megamek.common.options.IOption;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
@@ -34,6 +33,7 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Profession;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -698,7 +698,7 @@ public class RetirementDefectionTracker implements Serializable, MekHqXmlSeriali
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         if (retVal != null) {

--- a/MekHQ/src/mekhq/campaign/personnel/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Skill.java
@@ -20,16 +20,15 @@
  */
 package mekhq.campaign.personnel;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-
 import megamek.common.Compute;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
-
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
 
 /**
  * As ov v0.1.9, we will be tracking a group of skills on the person. These skills will define
@@ -219,7 +218,7 @@ public class Skill implements Serializable, MekHqXmlSerializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
@@ -20,18 +20,16 @@
  */
 package mekhq.campaign.personnel;
 
-import java.io.PrintWriter;
-import java.util.Enumeration;
-import java.util.Hashtable;
-
-import mekhq.MekHQ;
+import megamek.common.UnitType;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
-
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.UnitType;
+import java.io.PrintWriter;
+import java.util.Enumeration;
+import java.util.Hashtable;
 
 /**
  * This object tracks a specific skill prerequisite for a special ability. This object can list more
@@ -211,7 +209,7 @@ public class SkillPrereq implements MekHqXmlSerializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillType.java
@@ -20,26 +20,17 @@
  */
 package mekhq.campaign.personnel;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.util.Hashtable;
-
+import megamek.Version;
+import megamek.common.*;
+import mekhq.MekHqXmlUtil;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.common.Aero;
-import megamek.common.BattleArmor;
-import megamek.common.ConvFighter;
-import megamek.common.Entity;
-import megamek.common.Infantry;
-import megamek.common.Jumpship;
-import megamek.common.Protomech;
-import megamek.common.SmallCraft;
-import megamek.common.Tank;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import megamek.Version;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.util.Hashtable;
 
 /**
  * Skill type will hold static information for each skill type like base target number,
@@ -54,7 +45,7 @@ public class SkillType implements Serializable {
     public static final String REGULAR_NM = "Regular";
     public static final String VETERAN_NM = "Veteran";
     public static final String ELITE_NM = "Elite";
-    public static final String[] SKILL_LEVEL_NAMES = {ULTRA_GREEN_NM, GREEN_NM, REGULAR_NM, VETERAN_NM, ELITE_NM};
+    public static final String[] SKILL_LEVEL_NAMES = { ULTRA_GREEN_NM, GREEN_NM, REGULAR_NM, VETERAN_NM, ELITE_NM };
 
     //combat skills
     public static final String S_PILOT_MECH  = "Piloting/Mech";
@@ -429,7 +420,7 @@ public class SkillType implements Serializable {
 
             lookupHash.put(retVal.name, retVal);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -464,7 +455,7 @@ public class SkillType implements Serializable {
 
             hash.put(retVal.name, retVal);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -34,12 +34,12 @@ import megamek.common.weapons.autocannons.LBXACWeapon;
 import megamek.common.weapons.autocannons.UACWeapon;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.Utilities;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -386,7 +386,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
             // Errrr, apparently either the class name was invalid...
             // Or the listed name doesn't exist.
             // Doh!
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -441,7 +441,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
             }
             spHash.put(retVal.lookupName, retVal);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -459,7 +459,7 @@ public class SpecialAbility implements MekHqXmlSerializable {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(is);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return;
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Divorce.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Divorce.java
@@ -23,8 +23,8 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.log.PersonalLogger;
-import mekhq.campaign.personnel.familyTree.FormerSpouse;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.familyTree.FormerSpouse;
 
 import java.util.ResourceBundle;
 

--- a/MekHQ/src/mekhq/campaign/personnel/enums/FamilialRelationshipDisplayLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/FamilialRelationshipDisplayLevel.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -83,7 +83,7 @@ public enum FamilialRelationshipDisplayLevel {
 
         }
 
-        MekHQ.getLogger().error("Failed to parse " + text + " into a FamilialRelationshipDisplayLevel");
+        LogManager.getLogger().error("Failed to parse " + text + " into a FamilialRelationshipDisplayLevel");
 
         return PARENTS_CHILDREN_SIBLINGS;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/FormerSpouseReason.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/FormerSpouseReason.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -61,7 +61,7 @@ public enum FormerSpouseReason {
 
         }
 
-        MekHQ.getLogger().error("Unable to parse the former spouse reason from string " + text
+        LogManager.getLogger().error("Unable to parse the former spouse reason from string " + text
                 + ". Returning FormerSpouseReason.WIDOWED");
         return WIDOWED;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ManeiDominiClass.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ManeiDominiClass.java
@@ -19,8 +19,7 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.personnel.Person;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -73,7 +72,7 @@ public enum ManeiDominiClass {
 
         }
 
-        MekHQ.getLogger().error("Unable to parse " + text + "into a ManeiDominiClass. Returning NONE.");
+        LogManager.getLogger().error("Unable to parse " + text + "into a ManeiDominiClass. Returning NONE.");
 
         return NONE;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ManeiDominiRank.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ManeiDominiRank.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -72,7 +72,7 @@ public enum ManeiDominiRank {
 
         }
 
-        MekHQ.getLogger().error("Unable to parse " + text + "into a ManeiDominiRank. Returning NONE.");
+        LogManager.getLogger().error("Unable to parse " + text + "into a ManeiDominiRank. Returning NONE.");
 
         return NONE;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Marriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Marriage.java
@@ -26,6 +26,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.log.PersonalLogger;
 import mekhq.campaign.personnel.Person;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -179,7 +180,7 @@ public enum Marriage {
                 break;
             case WEIGHTED:
             default:
-                MekHQ.getLogger().error(String.format("Marriage Surname Style is not defined, and cannot be used \"%s\" and \"%s\"",
+                LogManager.getLogger().error(String.format("Marriage Surname Style is not defined, and cannot be used \"%s\" and \"%s\"",
                         origin.getFullName(), spouse.getFullName()));
                 break;
         }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.awt.event.KeyEvent;
 import java.util.List;
@@ -440,7 +440,7 @@ public enum PersonnelRole {
 
         }
 
-        MekHQ.getLogger().error("Unable to parse " + text + " into a PersonnelRole. Returning NONE.");
+        LogManager.getLogger().error("Unable to parse " + text + " into a PersonnelRole. Returning NONE.");
 
         return NONE;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +117,7 @@ public enum Phenotype {
 
         }
 
-        MekHQ.getLogger().error("Unable to parse the phenotype from string " + text
+        LogManager.getLogger().error("Unable to parse the phenotype from string " + text
                 + ". Returning Phenotype.NONE");
 
         return NONE;

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PrisonerStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PrisonerStatus.java
@@ -19,7 +19,7 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -115,7 +115,7 @@ public enum PrisonerStatus {
 
         }
 
-        MekHQ.getLogger().error("Unable to parse " + text + " into a PrisonerStatus. Returning FREE.");
+        LogManager.getLogger().error("Unable to parse " + text + " into a PrisonerStatus. Returning FREE.");
 
         return FREE;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ROMDesignation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ROMDesignation.java
@@ -22,10 +22,9 @@ import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.Jumpship;
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -150,7 +149,7 @@ public enum ROMDesignation {
         }
 
         // Could not parse based on either method, so return NONE
-        MekHQ.getLogger().error("Unable to parse " + information + " into a ROMDesignation. Returning NONE");
+        LogManager.getLogger().error("Unable to parse " + information + " into a ROMDesignation. Returning NONE");
 
         return ROMDesignation.NONE;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RankSystemType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RankSystemType.java
@@ -19,8 +19,8 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
 import mekhq.MekHqConstants;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ResourceBundle;
 
@@ -73,7 +73,7 @@ public enum RankSystemType {
                 return MekHqConstants.USER_RANKS_FILE_PATH;
             case CAMPAIGN:
             default:
-                MekHQ.getLogger().error("Attempted to load an illegal file path. Returning a blank String, which will cause the load to fail.");
+                LogManager.getLogger().error("Attempted to load an illegal file path. Returning a blank String, which will cause the load to fail.");
                 return "";
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/familyTree/FormerSpouse.java
+++ b/MekHQ/src/mekhq/campaign/personnel/familyTree/FormerSpouse.java
@@ -24,6 +24,7 @@ import mekhq.MekHqXmlUtil;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.FormerSpouseReason;
 import mekhq.io.idReferenceClasses.PersonIdReference;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -135,7 +136,7 @@ public class FormerSpouse implements Serializable {
                 }
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/personnel/familyTree/Genealogy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/familyTree/Genealogy.java
@@ -20,24 +20,18 @@ package mekhq.campaign.personnel.familyTree;
 
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.FamilialRelationshipType;
 import mekhq.io.idReferenceClasses.PersonIdReference;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 /**
  * The Genealogy class is used to track immediate familial relationships, spouses, and former spouses.
@@ -158,7 +152,7 @@ public class Genealogy implements Serializable {
                 }
             }
         } else if (getFamily().get(relationshipType) == null) {
-            MekHQ.getLogger().error("Could not remove unknown family member of relationship "
+            LogManager.getLogger().error("Could not remove unknown family member of relationship "
                     + relationshipType.name() + " and person " + person.getFullTitle() + " " + person.getId() + ".");
         } else {
             List<Person> familyTypeMembers = getFamily().get(relationshipType);
@@ -467,7 +461,7 @@ public class Genealogy implements Serializable {
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error("Failed to parse " + wn.getTextContent() + " for " + getOrigin().getId());
+                LogManager.getLogger().error("Failed to parse " + wn.getTextContent() + " for " + getOrigin().getId());
             }
         }
     }
@@ -486,7 +480,7 @@ public class Genealogy implements Serializable {
             }
 
             if (!wn.getNodeName().equalsIgnoreCase("formerSpouse")) {
-                MekHQ.getLogger().error("Unknown node type not loaded in formerSpouses nodes: "
+                LogManager.getLogger().error("Unknown node type not loaded in formerSpouses nodes: "
                         + wn.getNodeName());
                 continue;
             }

--- a/MekHQ/src/mekhq/campaign/personnel/generator/RandomPortraitGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/RandomPortraitGenerator.java
@@ -21,8 +21,8 @@ package mekhq.campaign.personnel.generator;
 import megamek.common.Compute;
 import megamek.common.icons.Portrait;
 import mekhq.MHQStaticDirectoryManager;
-import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.util.*;
@@ -91,11 +91,11 @@ public class RandomPortraitGenerator {
             if (temp.length == 2) {
                 return new Portrait(temp[0], temp[1]);
             } else {
-                MekHQ.getLogger().error("Failed to generate portrait for " + p.getFullTitle() + ". "
+                LogManager.getLogger().error("Failed to generate portrait for " + p.getFullTitle() + ". "
                         + chosenPortrait + " does not split into an array of length 2.");
             }
         } else {
-            MekHQ.getLogger().warning("Failed to generate portrait for " + p.getFullTitle()
+            LogManager.getLogger().warn("Failed to generate portrait for " + p.getFullTitle()
                     + ". No possible portraits found.");
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/Rank.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/Rank.java
@@ -19,11 +19,11 @@
  */
 package mekhq.campaign.personnel.ranks;
 
-import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
 import megamek.Version;
+import megamek.common.annotations.Nullable;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.personnel.enums.Profession;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -133,7 +133,7 @@ public class Rank implements Serializable {
                 try {
                     level = Integer.parseInt(split[1].trim());
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             }
             getRankNames().put(profession, name);
@@ -222,7 +222,7 @@ public class Rank implements Serializable {
                 }
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return null;
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/RankSystem.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/RankSystem.java
@@ -18,30 +18,21 @@
  */
 package mekhq.campaign.personnel.ranks;
 
+import megamek.Version;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
 import mekhq.campaign.io.Migration.PersonMigrator;
 import mekhq.campaign.personnel.enums.RankSystemType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.Serializable;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ResourceBundle;
 import java.util.stream.Stream;
 
 public class RankSystem implements Serializable {
@@ -179,7 +170,7 @@ public class RankSystem implements Serializable {
             writeToXML(pw, 1, true);
             MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw, 0, "individualRankSystem");
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -226,7 +217,7 @@ public class RankSystem implements Serializable {
         try (InputStream is = new FileInputStream(file)) {
             element = MekHqXmlUtil.newSafeDocumentBuilder().parse(is).getDocumentElement();
         } catch (Exception e) {
-            MekHQ.getLogger().error("Failed to open file, returning null", e);
+            LogManager.getLogger().error("Failed to open file, returning null", e);
             return null;
         }
         element.normalize();
@@ -240,7 +231,7 @@ public class RankSystem implements Serializable {
                 return generateInstanceFromXML(wn.getChildNodes(), version);
             }
         }
-        MekHQ.getLogger().error("Failed to parse file, returning null");
+        LogManager.getLogger().error("Failed to parse file, returning null");
         return null;
     }
 
@@ -312,7 +303,7 @@ public class RankSystem implements Serializable {
                 rankSystem.setName(PersonMigrator.migrateRankSystemName(rankSystemId));
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return null;
         }
         return rankSystem;

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/RankValidator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/RankValidator.java
@@ -19,10 +19,10 @@
 package mekhq.campaign.personnel.ranks;
 
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.Profession;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.util.HashSet;
@@ -69,11 +69,11 @@ public class RankValidator {
 
             if (duplicateKey) {
                 if (rankSystem.getType().isUserData()) {
-                    MekHQ.getLogger().error("Duplicate Rank System Code: " + rankSystem.getCode()
+                    LogManager.getLogger().error("Duplicate Rank System Code: " + rankSystem.getCode()
                             + ". Current " + Ranks.getRankSystems().get(rankSystem.getCode())
                             + " is duplicated by userData Rank System " + rankSystem);
                 } else {
-                    MekHQ.getLogger().error("Duplicate Rank System Code: " + rankSystem.getCode()
+                    LogManager.getLogger().error("Duplicate Rank System Code: " + rankSystem.getCode()
                             + ". Current " + Ranks.getRankSystems().get(rankSystem.getCode())
                             + " is duplicated by " + rankSystem);
                 }
@@ -90,7 +90,7 @@ public class RankValidator {
         // First, let's check the size, as we currently require a size equal to the total number of
         // rank tiers
         if (rankSystem.getRanks().size() != Rank.RC_NUM) {
-            MekHQ.getLogger().error(String.format("Illegal number of ranks of %d when %d is required",
+            LogManager.getLogger().error(String.format("Illegal number of ranks of %d when %d is required",
                     rankSystem.getRanks().size(), Rank.RC_NUM));
             return false;
         }
@@ -102,7 +102,7 @@ public class RankValidator {
         final Set<Profession> defaultProfessions = new HashSet<>(); // Professions with legal level 1 names
         for (final Profession profession : professions) {
             if (initialRank.isEmpty(profession)) {
-                MekHQ.getLogger().error("Illegal Rank index 0 empty profession of " + profession + " for " + rankSystem);
+                LogManager.getLogger().error("Illegal Rank index 0 empty profession of " + profession + " for " + rankSystem);
                 return false;
             } else if (!initialRank.indicatesAlternativeSystem(profession)) {
                 defaultProfessions.add(profession);
@@ -111,7 +111,7 @@ public class RankValidator {
 
         // We do require a single default profession
         if (defaultProfessions.isEmpty()) {
-            MekHQ.getLogger().error("You cannot have Rank Index 0 all indicate alternative professions for " + rankSystem);
+            LogManager.getLogger().error("You cannot have Rank Index 0 all indicate alternative professions for " + rankSystem);
         }
 
         // Now, we need to check each profession
@@ -155,10 +155,10 @@ public class RankValidator {
     private boolean validateRankAlternatives(final Rank rank, final Profession profession,
                                              final int maxRecursions, final int recursion) {
         if (recursion > maxRecursions) {
-            MekHQ.getLogger().error("Hit max recursions, rank system contains an infinite loop");
+            LogManager.getLogger().error("Hit max recursions, rank system contains an infinite loop");
             return false;
         } else if (rank.isEmpty(profession)) {
-            MekHQ.getLogger().error("Cannot have an empty value as an alternative");
+            LogManager.getLogger().error("Cannot have an empty value as an alternative");
             return false;
         } else if (rank.indicatesAlternativeSystem(profession)) {
             return validateRankAlternatives(rank, profession.getAlternateProfession(rank),

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
@@ -21,33 +21,21 @@
  */
 package mekhq.campaign.personnel.ranks;
 
+import megamek.Version;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.MekHqXmlUtil;
-import megamek.Version;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.enums.RankSystemType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
+import java.util.*;
 
 /**
  * Ranks keeps track of all data-file loaded rank systems. It does not include the campaign rank
@@ -116,12 +104,12 @@ public class Ranks {
             }
             MekHqXmlUtil.writeSimpleXMLCloseIndentedLine(pw, 0, "rankSystems");
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
     public static void initializeRankSystems() {
-        MekHQ.getLogger().info("Starting Rank Systems XML load...");
+        LogManager.getLogger().info("Starting Rank Systems XML load...");
         setRankSystems(new HashMap<>());
         final RankValidator rankValidator = new RankValidator();
         for (final RankSystemType type : RankSystemType.values()) {
@@ -137,12 +125,12 @@ public class Ranks {
         }
 
         if (!getRankSystems().containsKey(DEFAULT_SYSTEM_CODE)) {
-            MekHQ.getLogger().fatal("Ranks MUST load the " + DEFAULT_SYSTEM_CODE
+            LogManager.getLogger().fatal("Ranks MUST load the " + DEFAULT_SYSTEM_CODE
                     + " system. Initialization failure, shutting MekHQ down.");
             System.exit(-1);
         }
 
-        MekHQ.getLogger().info("Completed Rank System XML Load");
+        LogManager.getLogger().info("Completed Rank System XML Load");
     }
 
     public static void reinitializeRankSystems(final Campaign campaign) {
@@ -165,7 +153,7 @@ public class Ranks {
         try (InputStream is = new FileInputStream(file)) {
             xmlDoc = MekHqXmlUtil.newSafeDocumentBuilder().parse(is);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return new ArrayList<>();
         }
 

--- a/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
@@ -20,6 +20,14 @@
  */
 package mekhq.campaign.rating;
 
+import megamek.common.*;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.Mission;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.Skill;
+import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
@@ -27,34 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import megamek.common.ASFBay;
-import megamek.common.BattleArmor;
-import megamek.common.BattleArmorBay;
-import megamek.common.Bay;
-import megamek.common.Dropship;
-import megamek.common.ProtomechBay;
-import megamek.common.SpaceStation;
-import megamek.common.Entity;
-import megamek.common.HeavyVehicleBay;
-import megamek.common.SuperHeavyVehicleBay;
-import megamek.common.Infantry;
-import megamek.common.InfantryBay;
-import megamek.common.Jumpship;
-import megamek.common.LightVehicleBay;
-import megamek.common.MechBay;
-import megamek.common.SmallCraftBay;
-import megamek.common.UnitType;
-
-import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.Mission;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.Skill;
-import mekhq.campaign.unit.Unit;
-
 /**
  * @author Deric Page (deric (dot) page (at) usa.net)
- * @version %Id%
  * @since 3/15/2012
  */
 @SuppressWarnings(value = "SameParameterValue")
@@ -879,16 +861,16 @@ public abstract class AbstractUnitRating implements IUnitRating {
         if (u.isMothballed()) {
             return;
         }
-        MekHQ.getLogger().debug("Adding " + u.getName() + " to unit counts.");
+        LogManager.getLogger().debug("Adding " + u.getName() + " to unit counts.");
 
         Entity e = u.getEntity();
         if (null == e) {
-            MekHQ.getLogger().debug("Unit " + u.getName() + " is not an Entity.  Skipping.");
+            LogManager.getLogger().debug("Unit " + u.getName() + " is not an Entity.  Skipping.");
             return;
         }
 
         int unitType = e.getUnitType();
-        MekHQ.getLogger().debug("Unit " + u.getName() + " is a " + UnitType.getTypeDisplayableName(unitType));
+        LogManager.getLogger().debug("Unit " + u.getName() + " is a " + UnitType.getTypeDisplayableName(unitType));
         // TODO : Add Airship when MegaMek supports it.
         switch (unitType) {
             case UnitType.MEK:
@@ -900,7 +882,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
             case UnitType.GUN_EMPLACEMENT:
             case UnitType.VTOL:
             case UnitType.TANK:
-                MekHQ.getLogger().debug("Unit " + u.getName() + " weight is " + e.getWeight());
+                LogManager.getLogger().debug("Unit " + u.getName() + " weight is " + e.getWeight());
                 if (e.getWeight() <= 50f) {
                     incrementLightVeeCount();
                 } else if (e.getWeight() <= 100f) {

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -20,33 +20,18 @@
  */
 package mekhq.campaign.rating;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.util.Map;
-
-import megamek.common.Aero;
-import megamek.common.BattleArmor;
-import megamek.common.ConvFighter;
-import megamek.common.Crew;
-import megamek.common.Dropship;
-import megamek.common.Entity;
-import megamek.common.Infantry;
-import megamek.common.Jumpship;
-import megamek.common.Mech;
-import megamek.common.Protomech;
-import megamek.common.SmallCraft;
-import megamek.common.Tank;
-import megamek.common.TechConstants;
-import megamek.common.UnitType;
-import megamek.common.VTOL;
-import megamek.common.Warship;
+import megamek.common.*;
 import megamek.common.options.OptionsConstants;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Skill;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Map;
 
 /**
  * @author Deric Page (deric (dot) page (at) usa.net)
@@ -95,20 +80,20 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
                 continue;
             }
 
-            MekHQ.getLogger().debug("Processing unit " + u.getName());
+            LogManager.getLogger().debug("Processing unit " + u.getName());
             if (u.isMothballed()) {
-                MekHQ.getLogger().debug("Unit " + u.getName() + " is mothballed. Skipping.");
+                LogManager.getLogger().debug("Unit " + u.getName() + " is mothballed. Skipping.");
                 continue;
             }
 
             updateUnitCounts(u);
             BigDecimal value = getUnitValue(u);
-            MekHQ.getLogger().debug("Unit " + u.getName() + " -- Value = " + value.toPlainString());
+            LogManager.getLogger().debug("Unit " + u.getName() + " -- Value = " + value.toPlainString());
             setNumberUnits(getNumberUnits().add(value));
 
             Person p = u.getCommander();
             if (null != p) {
-                MekHQ.getLogger().debug("Unit " + u.getName()
+                LogManager.getLogger().debug("Unit " + u.getName()
                         + " -- Adding commander (" + p.getFullTitle() + "" + ") to commander list.");
                 getCommanderList().add(p);
             }
@@ -163,23 +148,23 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             return;
         }
 
-        MekHQ.getLogger().debug("Unit " + u.getName() + " updating tech support needs.");
+        LogManager.getLogger().debug("Unit " + u.getName() + " updating tech support needs.");
 
         double timeMult = 1.0;
         int needed = 0;
         if (getCampaign().getCampaignOptions().useQuirks()) {
             if (en.hasQuirk(OptionsConstants.QUIRK_POS_EASY_MAINTAIN)) {
-                MekHQ.getLogger().debug("Unit " + u.getName() + " is easy to maintain.");
+                LogManager.getLogger().debug("Unit " + u.getName() + " is easy to maintain.");
                 timeMult = 0.8;
             } else if (en.hasQuirk(OptionsConstants.QUIRK_NEG_DIFFICULT_MAINTAIN)) {
-                MekHQ.getLogger().debug("Unit " + u.getName() + " is difficult to maintain.");
+                LogManager.getLogger().debug("Unit " + u.getName() + " is difficult to maintain.");
                 timeMult = 1.2;
             }
         }
 
         if (en instanceof Mech) {
             needed += (int) Math.ceil((Math.floor(en.getWeight() / 5) + 40) * timeMult);
-            MekHQ.getLogger().debug("Unit " + u.getName() + " needs " + needed + " mech tech hours.");
+            LogManager.getLogger().debug("Unit " + u.getName() + " needs " + needed + " mech tech hours.");
             mechSupportNeeded += needed;
         } else if (en instanceof Jumpship || en instanceof Dropship) {
             // according to FM:M(r), this should be tracked separately because it only applies to admin support but not
@@ -193,27 +178,27 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             } else {
                 needed += (int) Math.ceil((Math.floor(en.getWeight() / 10) + 80) * timeMult);
             }
-            MekHQ.getLogger().debug("Unit " + u.getName() + " needs " + needed + " small craft tech hours.");
+            LogManager.getLogger().debug("Unit " + u.getName() + " needs " + needed + " small craft tech hours.");
             smallCraftSupportNeeded += needed;
         } else if (en instanceof ConvFighter) {
             needed += (int) Math.ceil((Math.floor(en.getWeight() / 2.5) + 20) * timeMult);
-            MekHQ.getLogger().debug("Unit " + u.getName() + " needs " + needed + " conv. fighter tech hours.");
+            LogManager.getLogger().debug("Unit " + u.getName() + " needs " + needed + " conv. fighter tech hours.");
             convFighterSupportNeeded += needed;
         } else if (en instanceof Aero) {
             needed += (int) Math.ceil((Math.floor(en.getWeight() / 2.5) + 40) * timeMult);
-            MekHQ.getLogger().debug("Unit " + u.getName() + " needs " + needed + " aero tech hours.");
+            LogManager.getLogger().debug("Unit " + u.getName() + " needs " + needed + " aero tech hours.");
             aeroFighterSupportNeeded += needed;
         } else if (en instanceof VTOL) {
             needed += (int) Math.ceil((Math.floor(en.getWeight() / 5) + 30) * timeMult);
-            MekHQ.getLogger().debug("Unit " + u.getName() + " needs " + needed + " VTOL tech hours.");
+            LogManager.getLogger().debug("Unit " + u.getName() + " needs " + needed + " VTOL tech hours.");
             vtolSupportNeeded += needed;
         } else if (en instanceof Tank) {
             needed += (int) Math.ceil((Math.floor(en.getWeight() / 5) + 20) * timeMult);
-            MekHQ.getLogger().debug("Unit " + u.getName() + " needs " + needed + " tank tech hours.");
+            LogManager.getLogger().debug("Unit " + u.getName() + " needs " + needed + " tank tech hours.");
             tankSupportNeeded += needed;
         } else if (en instanceof BattleArmor) {
             needed += (int) Math.ceil(((en.getTotalArmor() * 2) + 5) * timeMult);
-            MekHQ.getLogger().debug("Unit " + u.getName() + " needs " + needed + " BA tech hours.");
+            LogManager.getLogger().debug("Unit " + u.getName() + " needs " + needed + " BA tech hours.");
             baSupportNeeded += needed;
         }
 
@@ -249,7 +234,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
                 hours *= 1.2;
             }
         }
-        MekHQ.getLogger().debug("Unit " + en.getId() + " needs " + hours + " ship tech hours.");
+        LogManager.getLogger().debug("Unit " + en.getId() + " needs " + hours + " ship tech hours.");
 
         dropJumpShipSupportNeeded += (int) Math.ceil(hours);
     }
@@ -331,7 +316,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             hours = (int) Math.floor(hours / 2.0);
         }
 
-        MekHQ.getLogger().debug("Person, " + p.getFullTitle() + ", provides " + hours + " tech support hours.");
+        LogManager.getLogger().debug("Person, " + p.getFullTitle() + ", provides " + hours + " tech support hours.");
         techSupportHours += hours;
     }
 
@@ -345,7 +330,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             hours = (int) Math.floor(hours / 2.0);
         }
 
-        MekHQ.getLogger().debug("Person, " + p.getFullTitle() + " provides " + hours + " medical support hours.");
+        LogManager.getLogger().debug("Person, " + p.getFullTitle() + " provides " + hours + " medical support hours.");
         medSupportHours += hours;
     }
 
@@ -359,7 +344,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             hours = (int) Math.floor(hours / 2.0);
         }
 
-        MekHQ.getLogger().debug("Person, " + p.getFullTitle() + ", provides " + hours + " admin support hours.");
+        LogManager.getLogger().debug("Person, " + p.getFullTitle() + ", provides " + hours + " admin support hours.");
         adminSupportHours += hours;
     }
 
@@ -369,7 +354,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             return;
         }
 
-        MekHQ.getLogger().debug("Unit " + u.getName() + " updating unit skill rating.");
+        LogManager.getLogger().debug("Unit " + u.getName() + " updating unit skill rating.");
 
         //Calculate the unit's average combat skill.
         Crew p = u.getEntity().getCrew();
@@ -386,7 +371,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         }
 
         String experience = getExperienceLevelName(combatSkillAverage);
-        MekHQ.getLogger().debug("Unit " + u.getName() + " combat skill average = "
+        LogManager.getLogger().debug("Unit " + u.getName() + " combat skill average = "
                 + combatSkillAverage.toPlainString() + "(" + experience + ")");
 
         //Add to the running total.
@@ -953,7 +938,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         if (u.isMothballed()) {
             return;
         }
-        MekHQ.getLogger().debug("Unit " + u.getName() + " updating advanced tech count.");
+        LogManager.getLogger().debug("Unit " + u.getName() + " updating advanced tech count.");
 
         int unitType = u.getEntity().getUnitType();
         switch (unitType) {
@@ -969,7 +954,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             case UnitType.WARSHIP:
             case UnitType.JUMPSHIP:
                 int techLevel = u.getEntity().getTechLevel();
-                MekHQ.getLogger().debug("Unit " + u.getName() + " TL = " + TechConstants.getLevelDisplayableName(techLevel));
+                LogManager.getLogger().debug("Unit " + u.getName() + " TL = " + TechConstants.getLevelDisplayableName(techLevel));
                 if (techLevel > TechConstants.T_INTRO_BOXSET) {
                     if (TechConstants.isClan(techLevel)) {
                         setNumberClan(getNumberClan().add(value));
@@ -986,7 +971,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
                 break;
             default:
                 // not counted for tech level purposes.
-                MekHQ.getLogger().debug("Unit " + u.getName() + " not counted for tech level.");
+                LogManager.getLogger().debug("Unit " + u.getName() + " not counted for tech level.");
                 break;
         }
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
@@ -19,9 +19,9 @@
 
 package mekhq.campaign.stratcon;
 
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
+import mekhq.campaign.mission.AtBContract;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -32,11 +32,9 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.namespace.QName;
-
-import org.w3c.dom.Node;
-
-import mekhq.MekHQ;
-import mekhq.campaign.mission.AtBContract;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Contract-level state object for a StratCon campaign.
@@ -45,7 +43,7 @@ import mekhq.campaign.mission.AtBContract;
 @XmlRootElement(name = "StratconCampaignState")
 public class StratconCampaignState {
     public static final String ROOT_XML_ELEMENT_NAME = "StratconCampaignState";
-    
+
     @XmlTransient
     private AtBContract contract;
 
@@ -55,10 +53,10 @@ public class StratconCampaignState {
     private int victoryPoints;
     private String briefingText;
     private boolean allowEarlyVictory;
-    
+
     // these are applied to any scenario generated in the campaign; use sparingly
-    private List<String> globalScenarioModifiers = new ArrayList<>(); 
-    
+    private List<String> globalScenarioModifiers = new ArrayList<>();
+
     @XmlElementWrapper(name = "campaignTracks")
     @XmlElement(name = "campaignTrack")
     private List<StratconTrackState> tracks;
@@ -75,7 +73,7 @@ public class StratconCampaignState {
     public StratconCampaignState() {
         tracks = new ArrayList<>();
     }
-    
+
     public StratconCampaignState(AtBContract contract) {
         tracks = new ArrayList<>();
         setContract(contract);
@@ -88,27 +86,27 @@ public class StratconCampaignState {
     public double getGlobalOpforBVMultiplier() {
         return globalOpforBVMultiplier;
     }
-    
+
     public StratconTrackState getTrack(int index) {
         return tracks.get(index);
     }
-    
+
     public List<StratconTrackState> getTracks() {
         return tracks;
     }
-    
+
     public void addTrack(StratconTrackState track) {
         tracks.add(track);
     }
-    
+
     public int getSupportPoints() {
         return supportPoints;
     }
-    
+
     public void addSupportPoints(int number) {
         supportPoints += number;
     }
-    
+
     public void setSupportPoints(int supportPoints) {
         this.supportPoints = supportPoints;
     }
@@ -120,7 +118,7 @@ public class StratconCampaignState {
     public void setVictoryPoints(int victoryPoints) {
         this.victoryPoints = victoryPoints;
     }
-    
+
     public void updateVictoryPoints(int increment) {
         victoryPoints += increment;
     }
@@ -152,12 +150,12 @@ public class StratconCampaignState {
     public void useSupportPoint() {
         supportPoints--;
     }
-    
+
     public void convertVictoryToSupportPoint() {
         victoryPoints--;
         supportPoints++;
     }
-    
+
     /**
      * Convenience/speed method of determining whether or not a force with the given ID has been deployed to a track in this campaign.
      * @param forceID the force ID to check
@@ -169,10 +167,10 @@ public class StratconCampaignState {
                 return true;
             }
         }
-        
+
         return false;
     }
-    
+
     /**
      * Serialize this instance of a campaign state to a PrintWriter
      * Omits initial xml declaration
@@ -187,27 +185,27 @@ public class StratconCampaignState {
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             m.marshal(stateElement, pw);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
-    
+
     /**
      * Attempt to deserialize an instance of a Campaign State from the passed-in XML Node
      * @param xmlNode The node with the campaign state
      * @return Possibly an instance of a StratconCampaignState
      */
-    public static StratconCampaignState Deserialize(Node xmlNode) {        
+    public static StratconCampaignState Deserialize(Node xmlNode) {
         StratconCampaignState resultingCampaignState = null;
-        
+
         try {
             JAXBContext context = JAXBContext.newInstance(StratconCampaignState.class);
             Unmarshaller um = context.createUnmarshaller();
             JAXBElement<StratconCampaignState> templateElement = um.unmarshal(xmlNode, StratconCampaignState.class);
             resultingCampaignState = templateElement.getValue();
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Campaign State", e);
+            LogManager.getLogger().error("Error Deserializing Campaign State", e);
         }
-        
+
         // Hack: LocalDate doesn't serialize/deserialize nicely within a map, so we store it as a int-string map instead
         // while we're here, manually restore the coordinate-force lookup
         if (resultingCampaignState != null) {
@@ -216,7 +214,7 @@ public class StratconCampaignState {
                 track.restoreAssignedCoordForces();
             }
         }
-        
+
         return resultingCampaignState;
     }
 }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
@@ -18,13 +18,10 @@
  */
 package mekhq.campaign.stratcon;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import mekhq.MekHqConstants;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.mission.enums.AtBContractType;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -35,11 +32,13 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
-
-import mekhq.MekHQ;
-import mekhq.MekHqConstants;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.mission.enums.AtBContractType;
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class holds data relevant to the various types of contract
@@ -77,7 +76,7 @@ public class StratconContractDefinition {
             StratconContractDefinition def = Deserialize(new File(filePath));
 
             if (def == null) {
-                MekHQ.getLogger().error(String.format("Unable to load contract definition %s", filePath));
+                LogManager.getLogger().error(String.format("Unable to load contract definition %s", filePath));
                 return null;
             }
 
@@ -151,7 +150,7 @@ public class StratconContractDefinition {
     private double hostileFacilityCount;
 
     private boolean allowEarlyVictory;
-    
+
     /**
      * List of scenario IDs (file names) that are allowed for this contract type
      */
@@ -347,7 +346,7 @@ public class StratconContractDefinition {
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             m.marshal(templateElement, outputFile);
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error serializing " + outputFile.getPath(), e);
+            LogManager.getLogger().error("Error serializing " + outputFile.getPath(), e);
         }
     }
 
@@ -368,7 +367,7 @@ public class StratconContractDefinition {
                 resultingDefinition = definitionElement.getValue();
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error deserializing contract definition " + inputFile.getPath(), e);
+            LogManager.getLogger().error("Error deserializing contract definition " + inputFile.getPath(), e);
         }
 
         return resultingDefinition;
@@ -392,7 +391,7 @@ public class StratconContractDefinition {
             ContractDefinitionManifest resultingManifest = null;
             File inputFile = new File(fileName);
             if (!inputFile.exists()) {
-                MekHQ.getLogger().warning(String.format("Specified file %s does not exist", fileName));
+                LogManager.getLogger().warn(String.format("Specified file %s does not exist", fileName));
                 return null;
             }
 
@@ -405,7 +404,7 @@ public class StratconContractDefinition {
                     resultingManifest = manifestElement.getValue();
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error("Error deserializing contract definition manifest", e);
+                LogManager.getLogger().error("Error deserializing contract definition manifest", e);
             }
 
             return resultingManifest;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -16,26 +16,21 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.stratcon;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import megamek.common.Compute;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.Mission;
-import mekhq.campaign.mission.Scenario;
-import mekhq.campaign.mission.ScenarioTemplate;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.mission.atb.AtBScenarioModifier;
 import mekhq.campaign.stratcon.StratconContractDefinition.ObjectiveParameters;
 import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * This class handles StratCon state initialization when a contract is signed.
@@ -50,7 +45,7 @@ public class StratconContractInitializer {
         StratconCampaignState campaignState = new StratconCampaignState(contract);
         campaignState.setBriefingText(contractDefinition.getBriefing() + "<br/>" + contract.getCommandRights().getStratConText());
         campaignState.setAllowEarlyVictory(contractDefinition.isAllowEarlyVictory());
-        
+
         // dependency: this is required here in order for scenario initialization to work properly
         contract.setStratconCampaignState(campaignState);
 
@@ -103,12 +98,12 @@ public class StratconContractInitializer {
                                 objectiveParams.objectiveScenarios, objectiveParams.objectiveScenarioModifiers);
                         break;
                     case AlliedFacilityControl:
-                        initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Allied, 
+                        initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Allied,
                                 true, objectiveParams.objectiveScenarioModifiers);
                         break;
                     case HostileFacilityControl:
                     case FacilityDestruction:
-                        initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Opposing, 
+                        initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Opposing,
                                 true, objectiveParams.objectiveScenarioModifiers);
                         break;
                     case AnyScenarioVictory:
@@ -117,7 +112,7 @@ public class StratconContractInitializer {
                         sso.setDesiredObjectiveCount(numObjects);
                         sso.setObjectiveType(StrategicObjectiveType.AnyScenarioVictory);
                         campaignState.getTrack(x).addStrategicObjective(sso);
-                        
+
                         // modifiers defined for "any scenario" by definition apply to any scenario
                         // so they get added to the global campaign modifiers. Use sparingly since
                         // this can snowball pretty quickly.
@@ -128,12 +123,12 @@ public class StratconContractInitializer {
                                 }
                             }
                         }
-                        
+
                         break;
                 }
             }
         }
-        
+
         // if any modifiers are to be applied across all scenarios in the campaign
         // do so here; do not add duplicates
         if (contractDefinition.getGlobalScenarioModifiers() != null) {
@@ -154,7 +149,7 @@ public class StratconContractInitializer {
         for (int x = 0; x < trackObjects.size(); x++) {
             int numObjects = trackObjects.get(x);
 
-            initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Allied, 
+            initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Allied,
                     false, Collections.emptyList());
         }
 
@@ -168,7 +163,7 @@ public class StratconContractInitializer {
         for (int x = 0; x < trackObjects.size(); x++) {
             int numObjects = trackObjects.get(x);
 
-            initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Opposing, 
+            initializeTrackFacilities(campaignState.getTrack(x), numObjects, ForceAlignment.Opposing,
                     false, Collections.emptyList());
         }
 
@@ -367,7 +362,7 @@ public class StratconContractInitializer {
                         if ((campaignScenario instanceof AtBDynamicScenario)) {
                             scenario.setBackingScenario((AtBDynamicScenario) campaignScenario);
                         } else {
-                            MekHQ.getLogger().warning(String.format("Unable to set backing scenario for stratcon scenario in track %s ID %d",
+                            LogManager.getLogger().warn(String.format("Unable to set backing scenario for stratcon scenario in track %s ID %d",
                                             track.getDisplayableName(), scenario.getBackingScenarioID()));
                         }
                     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
@@ -11,23 +11,21 @@
 * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
 * details.
 */
-
 package mekhq.campaign.stratcon;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.ArrayList;
-import java.util.List;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.transform.Source;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This represents a facility in the StratCon context
@@ -48,7 +46,7 @@ public class StratconFacility implements Cloneable {
         OrbitalDefense,
         BaseOfOperations
     }
-    
+
     private ForceAlignment owner;
     private String displayableName;
     private FacilityType facilityType;
@@ -64,13 +62,13 @@ public class StratconFacility implements Cloneable {
     //TODO: post-MVP
     //private Map<String, Integer> fixedGarrisonUnitStates = new HashMap<>();
     private boolean isStrategicObjective;
-    
+
     /**
      * A temporary variable used to track situations where changing the ownership of this facility
      * hinges upon multiple objectives
      */
     private transient int ownershipChangeScore;
-    
+
     @Override
     public StratconFacility clone() {
         StratconFacility clone = new StratconFacility();
@@ -80,14 +78,14 @@ public class StratconFacility implements Cloneable {
         clone.visible = visible;
         clone.sharedModifiers = new ArrayList<>(sharedModifiers);
         clone.localModifiers = new ArrayList<>(localModifiers);
-        clone.setCapturedDefinition(capturedDefinition); 
+        clone.setCapturedDefinition(capturedDefinition);
         clone.revealTrack = revealTrack;
         clone.scenarioOddsModifier = scenarioOddsModifier;
         clone.weeklySPModifier = weeklySPModifier;
         clone.preventAerospace = preventAerospace;
         return clone;
     }
-    
+
     /**
      * Copies data from the source facility to here. Does not copy transient or cosmetic data.
      */
@@ -101,23 +99,23 @@ public class StratconFacility implements Cloneable {
         setWeeklySPModifier(facility.getWeeklySPModifier());
         setPreventAerospace(facility.preventAerospace());
     }
-    
+
     public ForceAlignment getOwner() {
         return owner;
     }
-    
+
     public void setOwner(ForceAlignment owner) {
         this.owner = owner;
     }
-    
+
     public String getFormattedDisplayableName() {
         return String.format("%s %s", getOwner() == ForceAlignment.Allied ? "Allied" : "Hostile", getDisplayableName());
     }
-    
+
     public String getDisplayableName() {
         return displayableName;
     }
-    
+
     public void setDisplayableName(String displayableName) {
         this.displayableName = displayableName;
     }
@@ -137,7 +135,7 @@ public class StratconFacility implements Cloneable {
     public void setVisible(boolean visible) {
         this.visible = visible;
     }
-    
+
     public boolean isVisible() {
         return (owner == ForceAlignment.Allied) || visible;
     }
@@ -154,7 +152,7 @@ public class StratconFacility implements Cloneable {
     }
 
     /**
-     * This is a list of scenario modifier IDs that affect scenarios involving this facility directly. 
+     * This is a list of scenario modifier IDs that affect scenarios involving this facility directly.
      */
     public List<String> getLocalModifiers() {
         return localModifiers;
@@ -163,39 +161,39 @@ public class StratconFacility implements Cloneable {
     public void setLocalModifiers(List<String> localModifiers) {
         this.localModifiers = localModifiers;
     }
-    
+
     public int getAggroRating() {
         return aggroRating;
     }
-    
+
     public void setAggroRating(int rating) {
         aggroRating = rating;
     }
-    
+
     public boolean isStrategicObjective() {
         return isStrategicObjective;
     }
-    
+
     public void setStrategicObjective(boolean isStrategicObjective) {
         this.isStrategicObjective = isStrategicObjective;
     }
-    
+
     public void incrementOwnershipChangeScore() {
         ownershipChangeScore++;
     }
-    
+
     public void decrementOwnershipChangeScore() {
         ownershipChangeScore--;
     }
-    
+
     public void clearOwnershipChangeScore() {
         ownershipChangeScore = 0;
     }
-    
+
     public int getOwnershipChangeScore() {
         return ownershipChangeScore;
     }
-    
+
     /**
      * If present, this is the name of the definition file to draw from
      * when switching facility ownership.
@@ -240,7 +238,7 @@ public class StratconFacility implements Cloneable {
         StratconFacility resultingFacility = null;
         File inputFile = new File(fileName);
         if (!inputFile.exists()) {
-            MekHQ.getLogger().warning(String.format("Specified file %s does not exist", fileName));
+            LogManager.getLogger().warn(String.format("Specified file %s does not exist", fileName));
             return null;
         }
 
@@ -253,7 +251,7 @@ public class StratconFacility implements Cloneable {
                 resultingFacility = facilityElement.getValue();
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(String.format("Error Deserializing Facility %s", fileName), e);
+            LogManager.getLogger().error(String.format("Error Deserializing Facility %s", fileName), e);
         }
 
         return resultingFacility;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconFacilityFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconFacilityFactory.java
@@ -14,18 +14,14 @@
 
 package mekhq.campaign.stratcon;
 
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.Utilities;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
+import org.apache.logging.log4j.LogManager;
+
+import java.nio.file.Paths;
+import java.util.*;
 
 /**
  * This class handles functionality related to loading and stratcon facility definitions.
@@ -33,23 +29,23 @@ import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
  */
 public class StratconFacilityFactory {
     // loaded facility definitions
-    
+
     // map of filename -> facility definition, for specific facility retrieval
     private static Map<String, StratconFacility> stratconFacilityMap = new HashMap<>();
-    
+
     // list of all loaded facility definitions
     private static List<StratconFacility> stratconFacilityList = new ArrayList<>();
-    
+
     // list of all hostile facility defs for convenience
     private static List<StratconFacility> hostileFacilities = new ArrayList<>();
-    
+
     // list of all allied facility defs for convenience
     private static List<StratconFacility> alliedFacilities = new ArrayList<>();
-    
+
     static {
         reloadFacilities();
     }
-    
+
     /**
      * Worker function that reloads all the facilities from disk
      */
@@ -58,22 +54,22 @@ public class StratconFacilityFactory {
         hostileFacilities.clear();
         alliedFacilities.clear();
         stratconFacilityMap.clear();
-        
+
         // load dynamic scenarios
         StratconFacilityManifest facilityManifest = StratconFacilityManifest.deserialize(MekHqConstants.STRATCON_FACILITY_MANIFEST);
-        
+
         // load user-specified scenario list
         StratconFacilityManifest userManifest = StratconFacilityManifest.deserialize(MekHqConstants.STRATCON_USER_FACILITY_MANIFEST);
-        
+
         if (facilityManifest != null) {
             loadFacilitiesFromManifest(facilityManifest);
         }
-        
+
         if (userManifest != null) {
             loadFacilitiesFromManifest(userManifest);
         }
     }
-    
+
     /**
      * Helper function that loads scenario templates from the given manifest.
      * @param manifest The manifest to process
@@ -82,17 +78,17 @@ public class StratconFacilityFactory {
         if (manifest == null) {
             return;
         }
-        
+
         for (String fileName : manifest.facilityFileNames) {
             String filePath = Paths.get(MekHqConstants.STRATCON_FACILITY_PATH, fileName.trim()).toString();
-            
+
             try {
                 StratconFacility facility = StratconFacility.deserialize(filePath);
-                
+
                 if (facility != null) {
                     stratconFacilityList.add(facility);
                     stratconFacilityMap.put(fileName.trim(), facility);
-                    
+
                     if (facility.getOwner() == ForceAlignment.Allied) {
                         alliedFacilities.add(facility);
                     } else {
@@ -100,11 +96,11 @@ public class StratconFacilityFactory {
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(String.format("Error loading file: %s", filePath), e);
+                LogManager.getLogger().error(String.format("Error loading file: %s", filePath), e);
             }
         }
     }
-    
+
     /**
      * Gets a specific facility given an "ID" (the file name).
      * This method does not clone the facility and should not be used to put one on the board
@@ -112,7 +108,7 @@ public class StratconFacilityFactory {
     public static StratconFacility getFacilityByName(String name) {
         return stratconFacilityMap.get(name);
     }
-    
+
     /**
      * Gets a clone of a specific facility given the "ID" (file name), null if it doesn't exist.
      */
@@ -120,18 +116,18 @@ public class StratconFacilityFactory {
     public static StratconFacility getFacilityCloneByName(String name) {
         return stratconFacilityMap.containsKey(name) ? stratconFacilityMap.get(name).clone() : null;
     }
-    
+
     /**
      * Retrieves a random facility
      */
     public static StratconFacility getRandomFacility() {
     	return Utilities.getRandomItem(stratconFacilityList).clone();
     }
-    
+
     public static StratconFacility getRandomHostileFacility() {
         return Utilities.getRandomItem(hostileFacilities).clone();
     }
-    
+
     public static StratconFacility getRandomAlliedFacility() {
     	return Utilities.getRandomItem(alliedFacilities).clone();
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconFacilityManifest.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconFacilityManifest.java
@@ -14,9 +14,8 @@
 
 package mekhq.campaign.stratcon;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.List;
+import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -25,9 +24,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.transform.Source;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.List;
 
 /**
  * A manifest containing IDs and file names of stratcon facility definitions
@@ -38,7 +37,7 @@ public class StratconFacilityManifest {
     @XmlElementWrapper(name = "facilityFileNames")
     @XmlElement(name = "facilityFileName")
     public List<String> facilityFileNames;
-    
+
     /**
      * Attempt to deserialize an instance of a StratconFacilityManifest from the passed-in file path
      * @return Possibly an instance of a StratconFacilityManifest
@@ -47,7 +46,7 @@ public class StratconFacilityManifest {
         StratconFacilityManifest resultingManifest = null;
         File inputFile = new File(fileName);
         if (!inputFile.exists()) {
-            MekHQ.getLogger().warning(String.format("Specified file %s does not exist", fileName));
+            LogManager.getLogger().warn(String.format("Specified file %s does not exist", fileName));
             return null;
         }
 
@@ -60,7 +59,7 @@ public class StratconFacilityManifest {
                 resultingManifest = manifestElement.getValue();
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("Error Deserializing Facility Manifest", e);
+            LogManager.getLogger().error("Error Deserializing Facility Manifest", e);
         }
 
         return resultingManifest;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -28,33 +28,21 @@ import mekhq.campaign.event.ScenarioChangedEvent;
 import mekhq.campaign.event.StratconDeploymentEvent;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.Lance;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.ScenarioForceTemplate;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
 import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
-import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.mission.atb.AtBScenarioModifier;
 import mekhq.campaign.mission.atb.AtBScenarioModifier.EventTiming;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
 import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * This class contains "rules" logic for the AtB-Stratcon state
@@ -758,7 +746,7 @@ public class StratconRulesManager {
             AtBScenarioModifier modifier = AtBScenarioModifier.getScenarioModifier(modifierName);
 
             if (modifier == null) {
-                MekHQ.getLogger().error(String.format("Modifier %s not found; ignoring", modifierName));
+                LogManager.getLogger().error(String.format("Modifier %s not found; ignoring", modifierName));
                 continue;
             }
 
@@ -790,7 +778,7 @@ public class StratconRulesManager {
             for (String modifierID : modifierIDs) {
                 AtBScenarioModifier modifier = AtBScenarioModifier.getScenarioModifier(modifierID);
                 if (modifier == null) {
-                    MekHQ.getLogger().error(String.format("Modifier %s not found for facility %s", modifierID,
+                    LogManager.getLogger().error(String.format("Modifier %s not found for facility %s", modifierID,
                             facility.getFormattedDisplayableName()));
                     continue;
                 }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -14,16 +14,6 @@
 
 package mekhq.campaign.stratcon;
 
-import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import mekhq.MekHQ;
 import mekhq.adapter.DateAdapter;
 import mekhq.campaign.event.DeploymentChangedEvent;
@@ -33,6 +23,11 @@ import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.mission.ScenarioTemplate;
 import mekhq.campaign.unit.Unit;
+
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.time.LocalDate;
+import java.util.*;
 
 /**
  * Class that handles scenario metadata and interaction at the StratCon level
@@ -50,9 +45,9 @@ public class StratconScenario implements IStratconDisplayable {
         COMPLETED,
         IGNORED,
         DEFEATED;
-    
+
         private final static Map<ScenarioState, String> scenarioStateNames;
-        
+
         static {
             scenarioStateNames = new HashMap<>();
             scenarioStateNames.put(ScenarioState.NONEXISTENT, "Shouldn't be seen");
@@ -62,15 +57,15 @@ public class StratconScenario implements IStratconDisplayable {
             scenarioStateNames.put(ScenarioState.IGNORED, "Ignored");
             scenarioStateNames.put(ScenarioState.DEFEATED, "Defeat");
         }
-        
+
         public String getScenarioStateName() {
             return scenarioStateNames.get(this);
         }
     }
-    
+
     private AtBDynamicScenario backingScenario;
-    
-    private int backingScenarioID; 
+
+    private int backingScenarioID;
     private ScenarioState currentState = ScenarioState.UNRESOLVED;
     private int requiredPlayerLances;
     private boolean requiredScenario;
@@ -93,7 +88,7 @@ public class StratconScenario implements IStratconDisplayable {
         backingScenario.addForce(forceID, ScenarioForceTemplate.PRIMARY_FORCE_TEMPLATE_ID);
         primaryForceIDs.add(forceID);
     }
-    
+
     /**
      * Add a force to the backing scenario, trying to associate it with the given template.
      * Does some scenario and force house-keeping, fires a deployment changed event.
@@ -105,7 +100,7 @@ public class StratconScenario implements IStratconDisplayable {
             MekHQ.triggerEvent(new DeploymentChangedEvent(force, getBackingScenario()));
         }
     }
-    
+
     /**
      * Add an individual unit to the backing scenario, trying to associate it with the given template.
      * Performs house keeping on the unit and scenario and invokes a deployment changed event.
@@ -114,11 +109,11 @@ public class StratconScenario implements IStratconDisplayable {
         if (!backingScenario.containsPlayerUnit(unit.getId())) {
             backingScenario.addUnit(unit.getId(), templateID);
             unit.setScenarioId(getBackingScenarioID());
-            
+
             if (useLeadershipPoint) {
                 useLeadershipPoint();
             }
-            
+
             MekHQ.triggerEvent(new DeploymentChangedEvent(unit, getBackingScenario()));
         }
     }
@@ -126,7 +121,7 @@ public class StratconScenario implements IStratconDisplayable {
     public List<Integer> getAssignedForces() {
         return backingScenario.getForceIDs();
     }
-    
+
     /**
      * These are all of the force IDs that have been matched up to a template
      * Note: since there's a default Reinforcements template, this is all forces
@@ -135,7 +130,7 @@ public class StratconScenario implements IStratconDisplayable {
     public List<Integer> getPlayerTemplateForceIDs() {
         return backingScenario.getPlayerTemplateForceIDs();
     }
-    
+
     /**
      * These are all the "primary" force IDs, meaning forces that have been used
      * by the scenario to drive the generation of the OpFor.
@@ -143,11 +138,11 @@ public class StratconScenario implements IStratconDisplayable {
     public Set<Integer> getPrimaryForceIDs() {
         return primaryForceIDs;
     }
-    
+
     public void setPrimaryForceIDs(Set<Integer> primaryForceIDs) {
         this.primaryForceIDs = primaryForceIDs;
     }
-    
+
     /**
      * This convenience method sets the scenario's current state to PRIMARY_FORCES_COMMITTED
      * and fixes the forces that were assigned to this scenario prior as "primary".
@@ -155,7 +150,7 @@ public class StratconScenario implements IStratconDisplayable {
     public void commitPrimaryForces() {
         currentState = ScenarioState.PRIMARY_FORCES_COMMITTED;
         getPrimaryForceIDs().clear();
-        
+
         for (int forceID : backingScenario.getPlayerTemplateForceIDs()) {
             getPrimaryForceIDs().add(forceID);
         }
@@ -173,34 +168,34 @@ public class StratconScenario implements IStratconDisplayable {
     public String getInfo() {
         return getInfo(true);
     }
-    
+
     public String getInfo(boolean html) {
         StringBuilder stateBuilder = new StringBuilder();
 
         if (isStrategicObjective()) {
             stateBuilder.append("<span color='red'>Contract objective located</span>").append(html ? "<br/>" : "");
         }
-        
+
         stateBuilder.append("Scenario: ")
             .append(backingScenario.getName())
             .append(html ? "<br/>" : "");
-            
+
         if (backingScenario.getTemplate() != null) {
             stateBuilder.append(backingScenario.getTemplate().shortBriefing)
                 .append(html ? "<br/>" : "");
         }
-        
+
         if (isRequiredScenario()) {
             stateBuilder.append("<span color='red'>Deployment required by contract</span>").append(html ? "<br/>" : "")
                 .append("<span color='red'>-1 VP if lost/ignored; +1 VP if won</span>").append(html ? "<br/>" : "");
         }
-        
+
         stateBuilder.append("Status: ")
             .append(currentState.getScenarioStateName())
             .append("<br/>");
-        
+
         stateBuilder.append("Terrain: ");
-        if ((backingScenario.getTerrainType() >= 0) && 
+        if ((backingScenario.getTerrainType() >= 0) &&
                 (backingScenario.getTerrainType() < AtBScenario.terrainTypes.length)) {
             stateBuilder.append(AtBScenario.terrainTypes[backingScenario.getTerrainType()])
                 .append(" : ")
@@ -213,23 +208,23 @@ public class StratconScenario implements IStratconDisplayable {
                 .append(deploymentDate.toString())
                 .append("<br/>");
         }
-        
+
         if (actionDate != null) {
             stateBuilder.append("Battle Date: ")
                 .append(actionDate.toString())
                 .append("<br/>");
         }
-        
+
         if (returnDate != null) {
             stateBuilder.append("Return Date: ")
                 .append(returnDate.toString())
                 .append("<br/>");
-        }    
+        }
 
         stateBuilder.append("</html>");
         return stateBuilder.toString();
     }
-    
+
     public void updateMinefieldCount(int minefieldType, int number) {
         backingScenario.setNumPlayerMinefields(minefieldType, number);
     }
@@ -237,16 +232,16 @@ public class StratconScenario implements IStratconDisplayable {
     public String getName() {
         return backingScenario.getName();
     }
-    
+
     public int getRequiredPlayerLances() {
         return requiredPlayerLances;
     }
-    
+
 
     public void setRequiredPlayerLances(int requiredPlayerLances) {
         this.requiredPlayerLances = requiredPlayerLances;
     }
-    
+
     public void incrementRequiredPlayerLances() {
         requiredPlayerLances++;
     }
@@ -258,7 +253,7 @@ public class StratconScenario implements IStratconDisplayable {
     public void setRequiredScenario(boolean requiredScenario) {
         this.requiredScenario = requiredScenario;
     }
-    
+
     @XmlTransient
     public AtBDynamicScenario getBackingScenario() {
         return backingScenario;
@@ -291,7 +286,7 @@ public class StratconScenario implements IStratconDisplayable {
     public void setReturnDate(LocalDate returnDate) {
         this.returnDate = returnDate;
     }
-    
+
     public StratconCoords getCoords() {
         return coords;
     }
@@ -299,15 +294,15 @@ public class StratconScenario implements IStratconDisplayable {
     public void setCoords(StratconCoords coords) {
         this.coords = coords;
     }
-    
+
     public boolean isStrategicObjective() {
         return isStrategicObjective;
     }
-    
+
     public void setStrategicObjective(boolean value) {
         isStrategicObjective = value;
     }
-    
+
     public ScenarioTemplate getScenarioTemplate() {
         return backingScenario.getTemplate();
     }
@@ -315,10 +310,10 @@ public class StratconScenario implements IStratconDisplayable {
     public int getBackingScenarioID() {
         return backingScenarioID;
     }
-    
+
     public void setBackingScenario(AtBDynamicScenario backingScenario) {
         this.backingScenario = backingScenario;
-        
+
         setBackingScenarioID(backingScenario.getId());
     }
 
@@ -333,7 +328,7 @@ public class StratconScenario implements IStratconDisplayable {
     public void setNumDefensivePoints(int numDefensivePoints) {
         this.numDefensivePoints = numDefensivePoints;
     }
-    
+
     public void useDefensivePoint() {
         numDefensivePoints--;
     }
@@ -345,7 +340,7 @@ public class StratconScenario implements IStratconDisplayable {
     public void setFailedReinforcements(Set<Integer> failedReinforcements) {
         this.failedReinforcements = failedReinforcements;
     }
-    
+
     public void addFailedReinforcements(int forceID) {
         failedReinforcements.add(forceID);
     }
@@ -365,7 +360,7 @@ public class StratconScenario implements IStratconDisplayable {
     public void setLeadershipPointsUsed(int leadershipPointsUsed) {
         this.leadershipPointsUsed = leadershipPointsUsed;
     }
-    
+
     public void useLeadershipPoint() {
         leadershipPointsUsed++;
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenarioFactory.java
@@ -14,20 +14,20 @@
 
 package mekhq.campaign.stratcon;
 
+import megamek.common.UnitType;
+import mekhq.MekHqConstants;
+import mekhq.Utilities;
+import mekhq.campaign.mission.ScenarioForceTemplate;
+import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
+import mekhq.campaign.mission.ScenarioTemplate;
+import mekhq.campaign.mission.atb.AtBScenarioManifest;
+import org.apache.logging.log4j.LogManager;
+
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import megamek.common.UnitType;
-import mekhq.campaign.mission.ScenarioForceTemplate;
-import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
-import mekhq.MekHQ;
-import mekhq.MekHqConstants;
-import mekhq.Utilities;
-import mekhq.campaign.mission.ScenarioTemplate;
-import mekhq.campaign.mission.atb.AtBScenarioManifest;
 
 /**
  * This class handles functionality related to loading and sorting scenario templates.
@@ -38,33 +38,33 @@ public class StratconScenarioFactory {
     private static Map<MapLocation, List<ScenarioTemplate>> dynamicScenarioLocationMap = new HashMap<>();
     private static Map<Integer, List<ScenarioTemplate>> dynamicScenarioUnitTypeMap = new HashMap<>();
     private static Map<String, ScenarioTemplate> dynamicScenarioNameMap = new HashMap<>();
-    
+
     static {
         reloadScenarios();
     }
-    
+
     /**
-     * Reload the dynamic scenarios. 
+     * Reload the dynamic scenarios.
      */
     public static void reloadScenarios() {
         dynamicScenarioLocationMap.clear();
         dynamicScenarioUnitTypeMap.clear();
-        
+
         // load dynamic scenarios
         AtBScenarioManifest scenarioManifest = AtBScenarioManifest.Deserialize(MekHqConstants.STRATCON_SCENARIO_MANIFEST);
-        
+
         // load user-specified scenario list
         AtBScenarioManifest userManifest = AtBScenarioManifest.Deserialize(MekHqConstants.STRATCON_USER_SCENARIO_MANIFEST);
-        
+
         if (scenarioManifest != null) {
             loadScenariosFromManifest(scenarioManifest);
         }
-        
+
         if (userManifest != null) {
             loadScenariosFromManifest(userManifest);
         }
     }
-    
+
     /**
      * Helper function that loads scenario templates from the given manifest.
      * @param manifest The manifest to process
@@ -73,41 +73,41 @@ public class StratconScenarioFactory {
         if (manifest == null) {
             return;
         }
-        
+
         for (int key : manifest.scenarioFileNames.keySet()) {
             String fileName = manifest.scenarioFileNames.get(key).trim();
-            String filePath = Paths.get(MekHqConstants.STRATCON_SCENARIO_TEMPLATE_PATH, 
+            String filePath = Paths.get(MekHqConstants.STRATCON_SCENARIO_TEMPLATE_PATH,
             		manifest.scenarioFileNames.get(key).trim()).toString();
-            
+
             try {
                 ScenarioTemplate template = ScenarioTemplate.Deserialize(filePath);
-                
+
                 if (template != null) {
                     MapLocation locationKey = template.mapParameters.getMapLocation();
-                    
+
                     // sort templates by location
                     if (!dynamicScenarioLocationMap.containsKey(locationKey)) {
                         dynamicScenarioLocationMap.put(locationKey, new ArrayList<>());
                     }
-                    
+
                     dynamicScenarioLocationMap.get(locationKey).add(template);
-                    
+
                     // sort templates by primary force unit type
                     int playerForceUnitType = template.getPrimaryPlayerForce().getAllowedUnitType();
                     if (!dynamicScenarioUnitTypeMap.containsKey(playerForceUnitType)) {
                         dynamicScenarioUnitTypeMap.put(playerForceUnitType, new ArrayList<>());
                     }
-                    
+
                     dynamicScenarioUnitTypeMap.get(playerForceUnitType).add(template);
-                    
+
                     dynamicScenarioNameMap.put(fileName, template);
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(String.format("Error loading file: %s", filePath), e);
+                LogManager.getLogger().error(String.format("Error loading file: %s", filePath), e);
             }
         }
     }
-    
+
     /**
      * Retrieves a random scenario template in the appropriate location.
      * @param location The location (ground/low atmo/space) category of the scenario.
@@ -116,14 +116,14 @@ public class StratconScenarioFactory {
     public static ScenarioTemplate getRandomScenario(MapLocation location) {
     	return Utilities.getRandomItem(dynamicScenarioLocationMap.get(location)).clone();
     }
-    
+
     /**
      * Retrieves a specific scenario given the key (file name)
      */
     public static ScenarioTemplate getSpecificScenario(String name) {
         return dynamicScenarioNameMap.get(name).clone();
     }
-    
+
     /**
      * Retrieves a random scenario template appropriate for the given unit type.
      * This includes the more general ATB_MIX and ATB_AERO_MIX where appropriate
@@ -132,28 +132,28 @@ public class StratconScenarioFactory {
      */
     public static ScenarioTemplate getRandomScenario(int unitType) {
         int generalUnitType = convertSpecificUnitTypeToGeneral(unitType);
-        
+
         // if the specific unit type doesn't have any scenario templates for it
         // then we can't generate a scenario.
         if (!dynamicScenarioUnitTypeMap.containsKey(unitType) &&
                 !dynamicScenarioUnitTypeMap.containsKey(generalUnitType)) {
-            MekHQ.getLogger().warning(String.format("No scenarios configured for unit type %d", unitType));
+            LogManager.getLogger().warn(String.format("No scenarios configured for unit type %d", unitType));
             return null;
         }
-        
+
         List<ScenarioTemplate> jointList = new ArrayList<>();
-        
+
         if (dynamicScenarioUnitTypeMap.containsKey(unitType)) {
             jointList.addAll(dynamicScenarioUnitTypeMap.get(unitType));
         }
-        
+
         if (dynamicScenarioUnitTypeMap.containsKey(generalUnitType)) {
             jointList.addAll(dynamicScenarioUnitTypeMap.get(generalUnitType));
         }
-        
+
         return Utilities.getRandomItem(jointList).clone();
     }
-    
+
     /**
      * Get an allied or hostile facility scenario, depending on passed on parameter.
      */
@@ -164,7 +164,7 @@ public class StratconScenarioFactory {
             return getSpecificScenario(MekHqConstants.HOSTILE_FACILITY_SCENARIO);
         }
     }
-    
+
     /**
      * Converts a specific unit type (AERO, MEK, etc) to a generic unit type (ATB_MIX, ATB_AERO_MIX)
      * @param unitType The unit type to convert.

--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -20,20 +20,19 @@
  */
 package mekhq.campaign.unit;
 
+import megamek.Version;
+import mekhq.MekHqXmlSerializable;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlSerializable;
-import mekhq.MekHqXmlUtil;
-import megamek.Version;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.Person;
 
 /**
  * This class is used to store information about a particular unit that is
@@ -187,7 +186,7 @@ public class MothballInfo implements MekHqXmlSerializable {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return retVal;
@@ -209,7 +208,7 @@ public class MothballInfo implements MekHqXmlSerializable {
             UUID id = tech.getId();
             tech = campaign.getPerson(id);
             if (tech == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Mothball info references missing tech %s", id));
             }
         }
@@ -218,7 +217,7 @@ public class MothballInfo implements MekHqXmlSerializable {
             if (driver instanceof MothballInfoPersonRef) {
                 drivers.set(ii, campaign.getPerson(driver.getId()));
                 if (drivers.get(ii) == null) {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Mothball info references missing driver %s",
                             driver.getId()));
                     drivers.remove(ii);
@@ -230,7 +229,7 @@ public class MothballInfo implements MekHqXmlSerializable {
             if (gunner instanceof MothballInfoPersonRef) {
                 gunners.set(ii, campaign.getPerson(gunner.getId()));
                 if (gunners.get(ii) == null) {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Mothball info references missing gunner %s",
                             gunner.getId()));
                     gunners.remove(ii);
@@ -242,7 +241,7 @@ public class MothballInfo implements MekHqXmlSerializable {
             if (crew instanceof MothballInfoPersonRef) {
                 vesselCrew.set(ii, campaign.getPerson(crew.getId()));
                 if (vesselCrew.get(ii) == null) {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Mothball info references missing vessel crew %s",
                             crew.getId()));
                     vesselCrew.remove(ii);
@@ -253,7 +252,7 @@ public class MothballInfo implements MekHqXmlSerializable {
             UUID id = navigator.getId();
             navigator = campaign.getPerson(id);
             if (navigator == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Mothball info references missing navigator %s", id));
             }
         }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -52,6 +52,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -1285,7 +1286,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     return getCurrentSuperHeavyVehicleCapacity();
                 }
             default:
-                MekHQ.getLogger().error("No transport bay defined for specified unit type.");
+                LogManager.getLogger().error("No transport bay defined for specified unit type.");
                 return 0;
         }
     }
@@ -1324,12 +1325,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                         break;
                     } else {
                         //This shouldn't happen
-                        MekHQ.getLogger().error("Fighter got assigned to a non-ASF, non-SC bay.");
+                        LogManager.getLogger().error("Fighter got assigned to a non-ASF, non-SC bay.");
                         break;
                     }
                 }
                 //This shouldn't happen either
-                MekHQ.getLogger().error("Fighter's bay number assignment produced a null bay");
+                LogManager.getLogger().error("Fighter's bay number assignment produced a null bay");
                 break;
             case UnitType.DROPSHIP:
                 setDocks(Math.min((getCurrentDocks() + amount),getDocks()));
@@ -1361,12 +1362,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                         break;
                     } else {
                         //This shouldn't happen
-                        MekHQ.getLogger().error("Vehicle got assigned to a non-light/heavy/super heavy vehicle bay.");
+                        LogManager.getLogger().error("Vehicle got assigned to a non-light/heavy/super heavy vehicle bay.");
                         break;
                     }
                 }
                 //This shouldn't happen either
-                MekHQ.getLogger().error("Vehicle's bay number assignment produced a null bay");
+                LogManager.getLogger().error("Vehicle's bay number assignment produced a null bay");
                 break;
         }
     }
@@ -1979,7 +1980,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error("Could not parse unit " + idNode.getTextContent().trim(), ex);
+            LogManager.getLogger().error("Could not parse unit " + idNode.getTextContent().trim(), ex);
             return null;
         }
 
@@ -1988,7 +1989,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         }
 
         if (retVal.id == null) {
-            MekHQ.getLogger().warning("ID not pre-defined; generating unit's ID.");
+            LogManager.getLogger().warn("ID not pre-defined; generating unit's ID.");
             retVal.id = UUID.randomUUID();
         }
 
@@ -2391,7 +2392,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     } else if (loc == Mech.LOC_CLEG) {
                         centerUpperLeg = part;
                     } else {
-                        MekHQ.getLogger().error("Unknown location of " + loc + " for a Upper Leg Actuator.");
+                        LogManager.getLogger().error("Unknown location of " + loc + " for a Upper Leg Actuator.");
                     }
                 } else if (type == Mech.ACTUATOR_LOWER_LEG) {
                     if (loc == Mech.LOC_LARM) {
@@ -2405,7 +2406,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     } else if (loc == Mech.LOC_CLEG) {
                         centerLowerLeg = part;
                     } else {
-                        MekHQ.getLogger().error("Unknown location of " + loc + " for a Lower Leg Actuator.");
+                        LogManager.getLogger().error("Unknown location of " + loc + " for a Lower Leg Actuator.");
                     }
                 } else if (type == Mech.ACTUATOR_FOOT) {
                     if (loc == Mech.LOC_LARM) {
@@ -2419,7 +2420,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     } else if (loc == Mech.LOC_CLEG) {
                         centerFoot = part;
                     } else {
-                        MekHQ.getLogger().error("Unknown location of " + loc + " for a Foot Actuator.");
+                        LogManager.getLogger().error("Unknown location of " + loc + " for a Foot Actuator.");
                     }
                 }
             } else if (part instanceof QuadVeeGear || part instanceof MissingQuadVeeGear) {
@@ -4246,7 +4247,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         Objects.requireNonNull(p);
 
         if (null != tech) {
-            MekHQ.getLogger().warning(String.format("New tech assigned %s without removing previous tech %s", p.getFullName(), tech));
+            LogManager.getLogger().warn(String.format("New tech assigned %s without removing previous tech %s", p.getFullName(), tech));
         }
         ensurePersonIsRegistered(p);
         tech = p;
@@ -4268,7 +4269,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
         Objects.requireNonNull(p);
         if (null == getCampaign().getPerson(p.getId())) {
             getCampaign().recruitPerson(p, p.getPrisonerStatus(), true,  false);
-            MekHQ.getLogger().warning(String.format("The person %s added this unit %s, was not in the campaign.", p.getFullName(), getName()));
+            LogManager.getLogger().warn(String.format("The person %s added this unit %s, was not in the campaign.", p.getFullName(), getName()));
         }
     }
 
@@ -5112,12 +5113,12 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 partsCost = partsCost.plus(6 * .002 * 10000);
             } else {
                 partsCost = partsCost.plus(entity.getWeight() * .002 * 10000);
-                MekHQ.getLogger().error(getName() + " is not a generic CI. Movement mode is " + entity.getMovementModeAsString());
+                LogManager.getLogger().error(getName() + " is not a generic CI. Movement mode is " + entity.getMovementModeAsString());
             }
         } else {
             // Only ProtoMechs should fall here. Anything else needs to be logged
             if (!(entity instanceof Protomech)) {
-                MekHQ.getLogger().error(getName() + " has no Spare Parts value for unit type " + Entity.getEntityTypeName(entity.getEntityType()));
+                LogManager.getLogger().error(getName() + " has no Spare Parts value for unit type " + Entity.getEntityTypeName(entity.getEntityType()));
             }
         }
 
@@ -5464,7 +5465,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             UUID id = tech.getId();
             tech = campaign.getPerson(id);
             if (tech == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Unit %s ('%s') references missing tech %s",
                         getId(), getName(), id));
             }
@@ -5474,7 +5475,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             if (driver instanceof UnitPersonRef) {
                 drivers.set(ii, campaign.getPerson(driver.getId()));
                 if (drivers.get(ii) == null) {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Unit %s ('%s') references missing driver %s",
                             getId(), getName(), driver.getId()));
                     drivers.remove(ii);
@@ -5486,7 +5487,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             if (gunner instanceof UnitPersonRef) {
                 gunners.set(ii, campaign.getPerson(gunner.getId()));
                 if (gunners.get(ii) == null) {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Unit %s ('%s') references missing gunner %s",
                             getId(), getName(), gunner.getId()));
                     gunners.remove(ii);
@@ -5498,7 +5499,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             if (crew instanceof UnitPersonRef) {
                 vesselCrew.set(ii, campaign.getPerson(crew.getId()));
                 if (vesselCrew.get(ii) == null) {
-                    MekHQ.getLogger().error(
+                    LogManager.getLogger().error(
                         String.format("Unit %s ('%s') references missing vessel crew %s",
                             getId(), getName(), crew.getId()));
                     vesselCrew.remove(ii);
@@ -5510,7 +5511,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             UUID id = engineer.getId();
             engineer = campaign.getPerson(id);
             if (engineer == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Unit %s ('%s') references missing engineer %s",
                         getId(), getName(), id));
             }
@@ -5520,7 +5521,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             UUID id = navigator.getId();
             navigator = campaign.getPerson(id);
             if (navigator == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Unit %s ('%s') references missing navigator %s",
                         getId(), getName(), id));
             }
@@ -5530,7 +5531,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
             final UUID id = getTechOfficer().getId();
             techOfficer = campaign.getPerson(id);
             if (getTechOfficer() == null) {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                         String.format("Unit %s ('%s') references missing tech officer %s",
                                 getId(), getName(), id));
             }
@@ -5547,7 +5548,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                 transportShipAssignment =
                         new TransportShipAssignment(transportShip, transportShipAssignment.getBayNumber());
             } else {
-                MekHQ.getLogger().error(
+                LogManager.getLogger().error(
                     String.format("Unit %s ('%s') references missing transport ship %s",
                         getId(), getName(), transportShipAssignment.getTransportShip().getId()));
 
@@ -5563,7 +5564,7 @@ public class Unit implements MekHqXmlSerializable, ITechnology {
                     if (realUnit != null) {
                         newTransportedUnits.add(realUnit);
                     } else {
-                        MekHQ.getLogger().error(
+                        LogManager.getLogger().error(
                             String.format("Unit %s ('%s') references missing transported unit %s",
                                 getId(), getName(), transportedUnit.getId()));
                     }

--- a/MekHQ/src/mekhq/campaign/unit/UnitOrder.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitOrder.java
@@ -20,31 +20,8 @@
  */
 package mekhq.campaign.unit;
 
-
-import java.io.PrintWriter;
-
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Aero;
-import megamek.common.BattleArmor;
-import megamek.common.ConvFighter;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityWeightClass;
-import megamek.common.EquipmentType;
-import megamek.common.ITechnology;
-import megamek.common.Infantry;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.Protomech;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
+import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlSerializable;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.Campaign;
@@ -52,6 +29,12 @@ import mekhq.campaign.parts.Availability;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.work.IAcquisitionWork;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * We use an extension of unit to create a unit order acquisition work
@@ -137,13 +120,13 @@ public class UnitOrder extends Unit implements IAcquisitionWork, MekHqXmlSeriali
         name = name.trim();
         MechSummary summary = MechSummaryCache.getInstance().getMech(name);
         if (null == summary) {
-            MekHQ.getLogger().error("Could not find a mech summary for " + name);
+            LogManager.getLogger().error("Could not find a mech summary for " + name);
             return null;
         }
         try {
             return new MechFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
         } catch (EntityLoadingException e) {
-            MekHQ.getLogger().error("Could not load " + summary.getEntryName());
+            LogManager.getLogger().error("Could not load " + summary.getEntryName());
             return null;
         }
     }
@@ -368,7 +351,7 @@ public class UnitOrder extends Unit implements IAcquisitionWork, MekHqXmlSeriali
                 }
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         retVal.initializeParts(false);

--- a/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
+++ b/MekHQ/src/mekhq/campaign/unit/UnitTechProgression.java
@@ -13,19 +13,15 @@
  */
 package mekhq.campaign.unit;
 
+import megamek.common.*;
+import megamek.common.loaders.EntityLoadingException;
+import org.apache.logging.log4j.LogManager;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
-
-import megamek.common.Entity;
-import megamek.common.ITechnology;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.loaders.EntityLoadingException;
-import mekhq.MekHQ;
 
 /**
  * Provides an ITechnology interface for every MechSummary, optionally customized for a particular
@@ -116,7 +112,7 @@ public class UnitTechProgression {
         } catch (InterruptedException e) {
             task.cancel(true);
         } catch (ExecutionException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         return null;
     }
@@ -125,12 +121,12 @@ public class UnitTechProgression {
         try {
             Entity en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
             if (null == en) {
-                MekHQ.getLogger().error("Entity was null: " + ms.getName());
+                LogManager.getLogger().error("Entity was null: " + ms.getName());
                 return null;
             }
             return en.factionTechLevel(techFaction);
         } catch (EntityLoadingException ex) {
-            MekHQ.getLogger().error("Exception loading entity " + ms.getName(), ex);
+            LogManager.getLogger().error("Exception loading entity " + ms.getName(), ex);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -16,10 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package mekhq.campaign.unit.actions;
-
-import java.util.*;
 
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
@@ -27,9 +24,17 @@ import megamek.common.loaders.EntityLoadingException;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.UnitChangedEvent;
-import mekhq.campaign.parts.*;
-import mekhq.campaign.parts.equipment.*;
+import mekhq.campaign.parts.Armor;
+import mekhq.campaign.parts.MissingPart;
+import mekhq.campaign.parts.MissingThrusters;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Restores a unit to an undamaged state.
@@ -139,7 +144,7 @@ public class RestoreUnitAction implements IUnitAction {
      * @param unit The unit to restore.
      */
     private void oldUnitRestoration(Campaign campaign, Unit unit) {
-        MekHQ.getLogger().warning("Falling back to old unit restoration logic");
+        LogManager.getLogger().warn("Falling back to old unit restoration logic");
 
         unit.setSalvage(false);
 
@@ -242,7 +247,7 @@ public class RestoreUnitAction implements IUnitAction {
                     return new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
                 }
             } catch (EntityLoadingException e) {
-                MekHQ.getLogger().error("Cannot restore unit from entity, could not find: " + entity.getShortNameRaw(), e);
+                LogManager.getLogger().error("Cannot restore unit from entity, could not find: " + entity.getShortNameRaw(), e);
             }
 
             return null;

--- a/MekHQ/src/mekhq/campaign/unit/actions/SwapAmmoTypeAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/SwapAmmoTypeAction.java
@@ -18,8 +18,6 @@
  */
 package mekhq.campaign.unit.actions;
 
-import java.util.Objects;
-
 import megamek.common.AmmoType;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -27,6 +25,8 @@ import mekhq.campaign.event.PartChangedEvent;
 import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.unit.Unit;
+
+import java.util.Objects;
 
 /**
  * Swaps the {@code AmmoType} for an {@code AmmoBin} on a {@code Unit}.

--- a/MekHQ/src/mekhq/campaign/universe/AbstractUnitGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/AbstractUnitGenerator.java
@@ -18,18 +18,13 @@
  */
 package mekhq.campaign.universe;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeSet;
-
 import megamek.client.generator.RandomUnitGenerator;
 import megamek.common.MechSummary;
 import megamek.common.enums.SkillLevel;
-import mekhq.MekHQ;
 import mekhq.campaign.rating.IUnitRating;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.*;
 
 /**
  * Base class for unit generators containing common functionality.
@@ -99,10 +94,10 @@ public abstract class AbstractUnitGenerator implements IUnitGenerator {
         // RAT for the current or previous year, use the earliest available.
         // If there are no turret RATs, return an empty list
         if (turretRatYears.isEmpty()) {
-            MekHQ.getLogger().warning("No turret RATs found.");
+            LogManager.getLogger().warn("No turret RATs found.");
             return Collections.emptyList();
         } else if (currentYear < turretRatYears.first()) {
-            MekHQ.getLogger().warning("Earliest turret RAT is later than campaign year.");
+            LogManager.getLogger().warn("Earliest turret RAT is later than campaign year.");
             ratYear = turretRatYears.first();
         } else {
             ratYear = turretRatYears.floor(currentYear);

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -21,28 +21,18 @@
  */
 package mekhq.campaign.universe;
 
-import java.awt.Color;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Set;
-import java.util.TreeMap;
-
 import megamek.common.annotations.Nullable;
+import mekhq.MekHqXmlUtil;
+import mekhq.Utilities;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.Utilities;
+import java.awt.*;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.*;
 
 /**
  * @author Jay Lawson <jaylawson39 at yahoo.com>
@@ -313,12 +303,12 @@ public class Faction {
                     retVal.end = Integer.parseInt(wn2.getTextContent());
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
         if ((retVal.eraMods != null) && (retVal.eraMods.length < 9)) {
-            MekHQ.getLogger().warning(retVal.fullName + " faction did not have a long enough eraMods vector");
+            LogManager.getLogger().warn(retVal.fullName + " faction did not have a long enough eraMods vector");
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
@@ -18,24 +18,17 @@
  */
 package mekhq.campaign.universe;
 
+import megamek.common.annotations.Nullable;
+import megamek.common.event.Subscribe;
+import mekhq.campaign.event.LocationChangedEvent;
+import mekhq.campaign.event.NewDayEvent;
+import org.apache.logging.log4j.LogManager;
+
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import megamek.common.annotations.Nullable;
-import megamek.common.event.Subscribe;
-import mekhq.MekHQ;
-import mekhq.campaign.event.LocationChangedEvent;
-import mekhq.campaign.event.NewDayEvent;
 
 /**
  * Checks all planets within a given region of space and can report which factions control one or more
@@ -468,7 +461,7 @@ public class FactionBorderTracker {
             }
             lastUpdate = now;
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         } finally {
             invalid = false;
             notify();

--- a/MekHQ/src/mekhq/campaign/universe/FactionHints.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionHints.java
@@ -18,29 +18,18 @@
  */
 package mekhq.campaign.universe;
 
+import megamek.common.annotations.Nullable;
+import mekhq.MekHqConstants;
+import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.*;
+
+import javax.xml.parsers.DocumentBuilder;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
-
-import javax.xml.parsers.DocumentBuilder;
-
-import mekhq.MekHqConstants;
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
 
 /**
  * @author Neoancient
@@ -80,7 +69,7 @@ public class FactionHints {
         try {
             loadFactionHints();
         } catch (DOMException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -404,7 +393,7 @@ public class FactionHints {
     }
 
     private void loadFactionHints() throws DOMException {
-        MekHQ.getLogger().info("Starting load of faction hint data from XML...");
+        LogManager.getLogger().info("Starting load of faction hint data from XML...");
         Document xmlDoc;
 
         try (InputStream is = new FileInputStream(MekHqConstants.FACTION_HINTS_FILE)) {
@@ -412,7 +401,7 @@ public class FactionHints {
 
             xmlDoc = db.parse(is);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return;
         }
 
@@ -434,7 +423,7 @@ public class FactionHints {
                     String fKey = wn.getAttributes().getNamedItem("faction").getTextContent().trim();
                     Faction f = Factions.getInstance().getFaction(fKey);
                     if (f.getShortName().equalsIgnoreCase(Faction.DEFAULT_CODE)) {
-                        MekHQ.getLogger().error("Invalid faction code in factionhints.xml: " + fKey);
+                        LogManager.getLogger().error("Invalid faction code in factionhints.xml: " + fKey);
                     } else {
                         neutralFactions.add(f);
                         addNeutralExceptions(f, wn);
@@ -482,7 +471,7 @@ public class FactionHints {
                                     break;
                             }
                         } catch (Exception e) {
-                            MekHQ.getLogger().error(e);
+                            LogManager.getLogger().error(e);
                         }
                     }
 
@@ -490,7 +479,7 @@ public class FactionHints {
                     final Faction inner = Factions.getInstance().getFaction(innerCode);
                     if (outer.getShortName().equalsIgnoreCase(Faction.DEFAULT_CODE)
                             || inner.getShortName().equalsIgnoreCase(Faction.DEFAULT_CODE)) {
-                        MekHQ.getLogger().error("Invalid faction code in factionhints.xml: "
+                        LogManager.getLogger().error("Invalid faction code in factionhints.xml: "
                                 + outerCode + "/" + innerCode);
                     } else {
                         addContainedFaction(outer, inner, start, end, fraction, opponents);
@@ -530,7 +519,7 @@ public class FactionHints {
                 for (int i = 0; i < factionKeys.length; i++) {
                     final Faction faction = Factions.getInstance().getFaction(factionKeys[i]);
                     if (faction.getShortName().equalsIgnoreCase(Faction.DEFAULT_CODE)) {
-                        MekHQ.getLogger().error("Invalid faction code in factionhints.xml: " + factionKeys[i]);
+                        LogManager.getLogger().error("Invalid faction code in factionhints.xml: " + factionKeys[i]);
                         continue;
                     }
                     parties[i] = faction;
@@ -564,7 +553,7 @@ public class FactionHints {
                 for (String party : parties) {
                     final Faction f = Factions.getInstance().getFaction(party);
                     if (f.getShortName().equalsIgnoreCase(Faction.DEFAULT_CODE)) {
-                        MekHQ.getLogger().error("Invalid faction code in factionhints.xml: " + party);
+                        LogManager.getLogger().error("Invalid faction code in factionhints.xml: " + party);
                         continue;
                     }
                     addNeutralExceptions("", localStart, localEnd, faction, f);

--- a/MekHQ/src/mekhq/campaign/universe/Factions.java
+++ b/MekHQ/src/mekhq/campaign/universe/Factions.java
@@ -18,31 +18,20 @@
  */
 package mekhq.campaign.universe;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
-
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.client.ratgenerator.RATGenerator;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.*;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class Factions {
     //region Variable Declarations
@@ -137,7 +126,7 @@ public class Factions {
             }
 
             if (fRec == null) {
-                MekHQ.getLogger().error("Could not locate faction record for " + faction);
+                LogManager.getLogger().error("Could not locate faction record for " + faction);
             }
         }
 
@@ -154,11 +143,11 @@ public class Factions {
      */
     public static Factions loadDefault()
             throws DOMException, SAXException, IOException, ParserConfigurationException {
-        MekHQ.getLogger().info("Starting load of faction data from XML...");
+        LogManager.getLogger().info("Starting load of faction data from XML...");
 
         Factions factions = load("data/universe/factions.xml");
 
-        MekHQ.getLogger().info("Loaded a total of " + factions.factions.size() + " factions");
+        LogManager.getLogger().info("Loaded a total of " + factions.factions.size() + " factions");
 
         return factions;
     }
@@ -212,7 +201,7 @@ public class Factions {
                     if (!retVal.factions.containsKey(faction.getShortName())) {
                         retVal.factions.put(faction.getShortName(), faction);
                     } else {
-                        MekHQ.getLogger().error(
+                        LogManager.getLogger().error(
                                 String.format("Faction code \"%s\" already used for faction %s, can't re-use it for %s",
                                         faction.getShortName(), retVal.factions.get(faction.getShortName()).getFullName(0), faction.getFullName(0)));
                     }

--- a/MekHQ/src/mekhq/campaign/universe/News.java
+++ b/MekHQ/src/mekhq/campaign/universe/News.java
@@ -18,27 +18,25 @@
  */
 package mekhq.campaign.universe;
 
-import java.io.FileInputStream;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import megamek.common.util.StringUtil;
+import mekhq.MekHqXmlUtil;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.parsers.DocumentBuilder;
-
-import megamek.common.util.StringUtil;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
+import java.io.FileInputStream;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Instead of making this a static like Planets, we are just going to reload a years
@@ -62,7 +60,7 @@ public class News {
             // For debugging only!
             //unmarshaller.setEventHandler(new javax.xml.bind.helpers.DefaultValidationEventHandler());
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -94,7 +92,7 @@ public class News {
             archive = new HashMap<>();
             news = new HashMap<>();
             int id = 0;
-            MekHQ.getLogger().debug("Starting load of news data for " + year + " from XML...");
+            LogManager.getLogger().debug("Starting load of news data for " + year + " from XML...");
 
             // Initialize variables.
             Document xmlDoc;
@@ -106,7 +104,7 @@ public class News {
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(fis);
             } catch (Exception ex) {
-                MekHQ.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
                 return;
             }
 
@@ -139,17 +137,17 @@ public class News {
                         try {
                             newsItem = (NewsItem) unmarshaller.unmarshal(wn);
                         } catch (JAXBException e) {
-                            MekHQ.getLogger().error(e);
+                            LogManager.getLogger().error(e);
                             continue;
                         }
                         if (StringUtil.isNullOrEmpty(newsItem.getHeadline())) {
-                            MekHQ.getLogger().error("Null or empty headline for a news item");
+                            LogManager.getLogger().error("Null or empty headline for a news item");
                             continue;
                         } else if (null == newsItem.getDate()) {
-                            MekHQ.getLogger().error("The date is null for news Item " + newsItem.getHeadline());
+                            LogManager.getLogger().error("The date is null for news Item " + newsItem.getHeadline());
                             continue;
                         } else if (StringUtil.isNullOrEmpty(newsItem.getDescription())) {
-                            MekHQ.getLogger().error("Null or empty headline for a news item");
+                            LogManager.getLogger().error("Null or empty headline for a news item");
                             continue;
                         } else if (!newsItem.isInYear(year)) {
                             continue;
@@ -168,7 +166,7 @@ public class News {
                     }
                 }
             }
-            MekHQ.getLogger().debug("Loaded " + archive.size() + " days of news items for " + year);
+            LogManager.getLogger().debug("Loaded " + archive.size() + " days of news items for " + year);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/universe/Planet.java
+++ b/MekHQ/src/mekhq/campaign/universe/Planet.java
@@ -19,47 +19,23 @@
  */
 package mekhq.campaign.universe;
 
-import java.io.Serializable;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.UUID;
-
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import megamek.common.EquipmentType;
 import megamek.common.ITechnology;
 import megamek.common.PlanetaryConditions;
 import megamek.common.TargetRoll;
-import mekhq.MekHQ;
 import mekhq.Utilities;
-import mekhq.adapter.AtmosphereAdapter;
-import mekhq.adapter.BooleanValueAdapter;
-import mekhq.adapter.ClimateAdapter;
-import mekhq.adapter.DateAdapter;
-import mekhq.adapter.HPGRatingAdapter;
-import mekhq.adapter.LifeFormAdapter;
-import mekhq.adapter.PressureAdapter;
-import mekhq.adapter.SocioIndustrialDataAdapter;
-import mekhq.adapter.StringListAdapter;
+import mekhq.adapter.*;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.universe.Faction.Tag;
+import org.apache.logging.log4j.LogManager;
+
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.*;
 
 /**
  * This is the start of a planet object that will keep lots of information about
@@ -749,7 +725,7 @@ public class Planet implements Serializable {
     /** @return the average distance to the system's jump point in km */
     public double getDistanceToJumpPoint() {
         if (null == parentSystem) {
-        	MekHQ.getLogger().error("reference to planet with no parent system");
+        	LogManager.getLogger().error("reference to planet with no parent system");
             return 0;
         }
         return Math.sqrt(Math.pow(getOrbitRadiusKm(), 2) + Math.pow(parentSystem.getStarDistanceToJumpPoint(), 2));

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -21,19 +21,15 @@
  */
 package mekhq.campaign.universe;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Predicate;
-
 import megamek.client.ratgenerator.*;
 import megamek.common.EntityMovementMode;
 import megamek.common.MechSummary;
 import megamek.common.UnitType;
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.*;
+import java.util.function.Predicate;
 
 /**
  * Provides access to RATGenerator through the AbstractUnitGenerator and thus the IUnitGenerator interface.
@@ -48,7 +44,7 @@ public class RATGeneratorConnector extends AbstractUnitGenerator {
             try {
                 Thread.sleep(50);
             } catch (InterruptedException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         RATGenerator.getInstance().loadYear(year);

--- a/MekHQ/src/mekhq/campaign/universe/RATManager.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATManager.java
@@ -21,41 +21,26 @@
  */
 package mekhq.campaign.universe;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
-
-import javax.xml.parsers.DocumentBuilder;
-
+import megamek.client.generator.RandomUnitGenerator;
 import megamek.client.ratgenerator.MissionRole;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
+import megamek.common.event.Subscribe;
+import mekhq.MekHQ;
 import mekhq.MekHqConstants;
+import mekhq.MekHqXmlUtil;
+import mekhq.campaign.event.OptionsChangedEvent;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import megamek.client.generator.RandomUnitGenerator;
-import megamek.common.Compute;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityWeightClass;
-import megamek.common.MechSummary;
-import megamek.common.UnitType;
-import megamek.common.event.Subscribe;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.campaign.event.OptionsChangedEvent;
+import javax.xml.parsers.DocumentBuilder;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.*;
+import java.util.function.Predicate;
 
 /**
  * Provides a front end to RandomUnitGenerator that allows the user to generate units
@@ -132,7 +117,7 @@ public class RATManager extends AbstractUnitGenerator {
 
     private boolean loadCollection(String name) {
         if (!fileNames.containsKey(name)) {
-            MekHQ.getLogger().error("RAT collection " + name + " not found in " + MekHqConstants.RATINFO_DIR);
+            LogManager.getLogger().error("RAT collection " + name + " not found in " + MekHqConstants.RATINFO_DIR);
             return false;
         }
         /* Need RUG to be loaded for validation */
@@ -140,7 +125,7 @@ public class RATManager extends AbstractUnitGenerator {
             try {
                 Thread.sleep(50);
             } catch (InterruptedException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         File f = new File(MekHqConstants.RATINFO_DIR, fileNames.get(name));
@@ -152,7 +137,7 @@ public class RATManager extends AbstractUnitGenerator {
             db = MekHqXmlUtil.newSafeDocumentBuilder();
             xmlDoc = db.parse(fis);
         } catch (Exception ex) {
-            MekHQ.getLogger().error("While loading RAT info from " + f.getName() + ": ", ex);
+            LogManager.getLogger().error("While loading RAT info from " + f.getName() + ": ", ex);
             return false;
         }
 
@@ -177,16 +162,16 @@ public class RATManager extends AbstractUnitGenerator {
                             allRATs.get(name).put(era, new ArrayList<>());
                             parseEraNode(eraNode, name, era);
                         } catch (NumberFormatException ex) {
-                            MekHQ.getLogger().error("Could not parse year " + year + " in " + name);
+                            LogManager.getLogger().error("Could not parse year " + year + " in " + name);
                         }
                     } else {
-                        MekHQ.getLogger().error("year attribute not found for era in RAT collection " + name);
+                        LogManager.getLogger().error("year attribute not found for era in RAT collection " + name);
                     }
                 }
             }
             return !allRATs.get(name).isEmpty();
         } else {
-            MekHQ.getLogger().error("source attribute not found for RAT data in " + f.getName());
+            LogManager.getLogger().error("source attribute not found for RAT data in " + f.getName());
             return false;
         }
     }
@@ -230,7 +215,7 @@ public class RATManager extends AbstractUnitGenerator {
         FileInputStream fis;
 
         if (!dir.isDirectory()) {
-            MekHQ.getLogger().error("Ratinfo directory not found");
+            LogManager.getLogger().error("Ratinfo directory not found");
             return;
         }
         for (File f : dir.listFiles()) {
@@ -241,7 +226,7 @@ public class RATManager extends AbstractUnitGenerator {
                     xmlDoc = db.parse(fis);
                     fis.close();
                 } catch (Exception e) {
-                    MekHQ.getLogger().error("While loading RAT info from " + f.getName() + ": ", e);
+                    LogManager.getLogger().error("While loading RAT info from " + f.getName() + ": ", e);
                     continue;
                 }
                 Element elem = xmlDoc.getDocumentElement();
@@ -261,10 +246,10 @@ public class RATManager extends AbstractUnitGenerator {
                                 try {
                                     eras.add(Integer.parseInt(year));
                                 } catch (NumberFormatException ex) {
-                                    MekHQ.getLogger().error("Could not parse year " + year + " in " + f.getName());
+                                    LogManager.getLogger().error("Could not parse year " + year + " in " + f.getName());
                                 }
                             } else {
-                                MekHQ.getLogger().error("year attribute not found for era in " + f.getName());
+                                LogManager.getLogger().error("year attribute not found for era in " + f.getName());
                             }
                         }
                     }
@@ -272,7 +257,7 @@ public class RATManager extends AbstractUnitGenerator {
                     Collections.sort(eras);
                     allCollections.put(name, eras);
                 } else {
-                    MekHQ.getLogger().error("source attribute not found for RAT data in " + f.getName());
+                    LogManager.getLogger().error("source attribute not found for RAT data in " + f.getName());
                 }
             }
         }
@@ -466,7 +451,7 @@ public class RATManager extends AbstractUnitGenerator {
         public static RAT createFromXml(Node node) {
             RAT retVal = new RAT();
             if (node.getAttributes().getNamedItem("name") == null) {
-                MekHQ.getLogger().error("Name attribute missing");
+                LogManager.getLogger().error("Name attribute missing");
                 return null;
             }
             retVal.ratName = node.getAttributes().getNamedItem("name").getTextContent();

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -28,15 +28,11 @@ import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.OptionsChangedEvent;
+import org.apache.logging.log4j.LogManager;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -238,7 +234,7 @@ public class RandomFactionGenerator {
     public String getEnemy(String employer, boolean useRebels) {
         Faction employerFaction = Factions.getInstance().getFaction(employer);
         if (null == employerFaction) {
-            MekHQ.getLogger().error("Could not find enemy for " + employer); //$NON-NLS-1$
+            LogManager.getLogger().error("Could not find enemy for " + employer); //$NON-NLS-1$
             return "PIR";
         } else {
             return getEnemy(employerFaction, useRebels);
@@ -290,7 +286,7 @@ public class RandomFactionGenerator {
             return enemy.getShortName();
         }
 
-        MekHQ.getLogger().error("Could not find enemy for " + employerName);
+        LogManager.getLogger().error("Could not find enemy for " + employerName);
 
         // Fallback; there are always pirates.
         return "PIR";
@@ -378,7 +374,7 @@ public class RandomFactionGenerator {
     public List<String> getEnemyList(String employerName) {
         Faction employer = Factions.getInstance().getFaction(employerName);
         if (null == employer) {
-            MekHQ.getLogger().warning("Unknown faction key: " + employerName); //$NON-NLS-1$
+            LogManager.getLogger().warn("Unknown faction key: " + employerName); //$NON-NLS-1$
             return Collections.emptyList();
         }
         return getEnemyList(Factions.getInstance().getFaction(employerName));
@@ -481,11 +477,11 @@ public class RandomFactionGenerator {
         Faction f1 = Factions.getInstance().getFaction(attacker);
         Faction f2 = Factions.getInstance().getFaction(defender);
         if (null == f1) {
-            MekHQ.getLogger().error("Non-existent faction key: " + attacker); // $NON-NLS-1$
+            LogManager.getLogger().error("Non-existent faction key: " + attacker); // $NON-NLS-1$
             return null;
         }
         if (null == f2) {
-            MekHQ.getLogger().error("Non-existent faction key: " + attacker); // $NON-NLS-1$
+            LogManager.getLogger().error("Non-existent faction key: " + attacker); // $NON-NLS-1$
             return null;
         }
         List<PlanetarySystem> planetList = getMissionTargetList(f1, f2);
@@ -507,10 +503,10 @@ public class RandomFactionGenerator {
         Faction attacker = Factions.getInstance().getFaction(attackerKey);
         Faction defender = Factions.getInstance().getFaction(defenderKey);
         if (null == attacker) {
-            MekHQ.getLogger().error("Non-existent faction key: " + attackerKey); //$NON-NLS-1$
+            LogManager.getLogger().error("Non-existent faction key: " + attackerKey); //$NON-NLS-1$
         }
         if (null == defender) {
-            MekHQ.getLogger().error("Non-existent faction key: " + defenderKey); //$NON-NLS-1$
+            LogManager.getLogger().error("Non-existent faction key: " + defenderKey); //$NON-NLS-1$
         }
         if ((null != attacker) && (null != defender)) {
             return getMissionTargetList(attacker, defender);

--- a/MekHQ/src/mekhq/campaign/universe/StarUtil.java
+++ b/MekHQ/src/mekhq/campaign/universe/StarUtil.java
@@ -18,23 +18,15 @@
  */
 package mekhq.campaign.universe;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.TreeSet;
-
 import megamek.common.EquipmentType;
-import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.universe.PlanetarySystem.SpectralDefinition;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.*;
 
 /** Static method only helper class for stars */
 public final class StarUtil {
@@ -636,12 +628,12 @@ public final class StarUtil {
                 }
                 planetIconDataLoaded = true;
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
         if (!PLANET_ICON_DATA.containsKey(Utilities.nonNull(planet.getIcon(), "default"))) {
-            MekHQ.getLogger().error("no planet icon " + planet.getIcon());
+            LogManager.getLogger().error("no planet icon " + planet.getIcon());
         }
         return PLANET_ICON_DATA.get(Utilities.nonNull(planet.getIcon(), "default"));
     }
@@ -662,7 +654,7 @@ public final class StarUtil {
                 }
                 starIconDataLoaded = true;
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         return STAR_ICON_DATA.get(Utilities.nonNull(system.getIcon(), "default"));

--- a/MekHQ/src/mekhq/campaign/universe/Systems.java
+++ b/MekHQ/src/mekhq/campaign/universe/Systems.java
@@ -18,28 +18,12 @@
  */
 package mekhq.campaign.universe;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FilterInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Writer;
-import java.text.ParseException;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Consumer;
+import megamek.common.EquipmentType;
+import mekhq.MekHqXmlUtil;
+import mekhq.Utilities;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Node;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -48,14 +32,13 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
-
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Node;
-
-import megamek.common.EquipmentType;
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
-import mekhq.Utilities;
+import java.io.*;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
 
 /**
  * This will eventually replace the Planets object as our source of system/planetary information
@@ -79,7 +62,7 @@ public class Systems {
             // For debugging only!
             // unmarshaller.setEventHandler(new javax.xml.bind.helpers.DefaultValidationEventHandler());
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -94,7 +77,7 @@ public class Systems {
             planetMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             planetUnmarshaller = jContext.createUnmarshaller();
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -257,7 +240,7 @@ public class Systems {
 
     /**
      * Loads the default Systems data.
-     * 
+     *
      * @throws DOMException
      * @throws IOException
      * @throws FileNotFoundException
@@ -265,12 +248,12 @@ public class Systems {
      */
     public static Systems loadDefault()
             throws DOMException, FileNotFoundException, IOException, ParseException {
-        MekHQ.getLogger().info("Starting load of system data from XML...");
+        LogManager.getLogger().info("Starting load of system data from XML...");
         long currentTime = System.currentTimeMillis();
 
         Systems systems = load("data/universe/planetary_systems", "data/universe/systems.xml");
 
-        MekHQ.getLogger().info(String.format(Locale.ROOT, "Loaded a total of %d systems in %.3fs.",
+        LogManager.getLogger().info(String.format(Locale.ROOT, "Loaded a total of %d systems in %.3fs.",
                 systems.systemList.size(), (System.currentTimeMillis() - currentTime) / 1000.0));
 
         systems.logVeryCloseSystems();
@@ -280,10 +263,10 @@ public class Systems {
 
     /**
      * Loads Systems data from files.
-     * 
+     *
      * @param planetsPath The path to the folder containing planetary XML files.
      * @param defaultFilePath The path to the file with default systems data.
-     * 
+     *
      * @throws DOMException
      * @throws IOException
      * @throws FileNotFoundException
@@ -338,9 +321,9 @@ public class Systems {
                 }
             }
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         } catch (IOException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -348,13 +331,13 @@ public class Systems {
         List<PlanetarySystem> toRemove = new ArrayList<>();
         for (PlanetarySystem system : systemList.values()) {
             if ((null == system.getX()) || (null == system.getY())) {
-                MekHQ.getLogger().error(String.format("System \"%s\" is missing coordinates", system.getId()));
+                LogManager.getLogger().error(String.format("System \"%s\" is missing coordinates", system.getId()));
                 toRemove.add(system);
                 continue;
             }
             //make sure the primary slot is not larger than the number of planets
             if (system.getPrimaryPlanetPosition() > system.getPlanets().size()) {
-                MekHQ.getLogger().error(String.format("System \"%s\" has a primary slot greater than the number of planets", system.getId()));
+                LogManager.getLogger().error(String.format("System \"%s\" has a primary slot greater than the number of planets", system.getId()));
                 toRemove.add(system);
                 continue;
             }
@@ -376,7 +359,7 @@ public class Systems {
             if (veryCloseSystems.size() > 1) {
                 for (PlanetarySystem closeSystem : veryCloseSystems) {
                     if (!system.getId().equals(closeSystem.getId())) {
-                        MekHQ.getLogger().warning(String.format(Locale.ROOT,
+                        LogManager.getLogger().warn(String.format(Locale.ROOT,
                                 "Extremely close systems detected. Data error? %s <-> %s: %.3f ly", //$NON-NLS-1$
                                 system.getId(), closeSystem.getId(), system.getDistanceTo(closeSystem)));
                     }
@@ -476,7 +459,7 @@ public class Systems {
         try {
             planetMarshaller.marshal(event, out);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -489,7 +472,7 @@ public class Systems {
         try {
             marshaller.marshal(event, out);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 
@@ -503,7 +486,7 @@ public class Systems {
         try {
             return (Planet.PlanetaryEvent) planetUnmarshaller.unmarshal(node);
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         return null;
     }
@@ -518,7 +501,7 @@ public class Systems {
         try {
             return (PlanetarySystem.PlanetarySystemEvent) unmarshaller.unmarshal(node);
         } catch (JAXBException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         return null;
     }

--- a/MekHQ/src/mekhq/campaign/universe/eras/Era.java
+++ b/MekHQ/src/mekhq/campaign/universe/eras/Era.java
@@ -19,9 +19,9 @@
 package mekhq.campaign.universe.eras;
 
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.universe.enums.EraFlag;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -103,7 +103,7 @@ public class Era {
                         break;
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
                 return null;
             }
         }

--- a/MekHQ/src/mekhq/gui/BasicInfo.java
+++ b/MekHQ/src/mekhq/gui/BasicInfo.java
@@ -18,22 +18,14 @@
  */
 package mekhq.gui;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Image;
-import java.awt.Insets;
-
-import javax.swing.BorderFactory;
-import javax.swing.ImageIcon;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.UIManager;
-import javax.swing.border.LineBorder;
-
 import mekhq.MHQStaticDirectoryManager;
-import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.border.LineBorder;
+import java.awt.*;
 
 /**
  * An extension of JPanel that is intended to be used for visual table renderers
@@ -135,7 +127,7 @@ public class BasicInfo extends JPanel {
                     force.getIconFileName(), force.getIconMap())
                     .getScaledInstance(54, -1, Image.SCALE_SMOOTH);
         } catch (Exception e) {
-            MekHQ.getLogger().error("Failed to build force icon", e);
+            LogManager.getLogger().error("Failed to build force icon", e);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -18,20 +18,6 @@
  */
 package mekhq.gui;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import javax.swing.*;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.common.Entity;
 import megamek.common.EntityListFile;
@@ -42,46 +28,33 @@ import megamek.common.util.sorter.NaturalOrderComparator;
 import megameklab.com.util.UnitPrintManager;
 import mekhq.MekHQ;
 import mekhq.campaign.ResolveScenarioTracker;
-import mekhq.campaign.event.GMModeEvent;
-import mekhq.campaign.event.MissionChangedEvent;
-import mekhq.campaign.event.MissionCompletedEvent;
-import mekhq.campaign.event.MissionNewEvent;
-import mekhq.campaign.event.MissionRemovedEvent;
-import mekhq.campaign.event.OptionsChangedEvent;
-import mekhq.campaign.event.OrganizationChangedEvent;
-import mekhq.campaign.event.ScenarioChangedEvent;
-import mekhq.campaign.event.ScenarioNewEvent;
-import mekhq.campaign.event.ScenarioRemovedEvent;
-import mekhq.campaign.event.ScenarioResolvedEvent;
+import mekhq.campaign.event.*;
 import mekhq.campaign.force.Lance;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.Mission;
-import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.adapter.ScenarioTableMouseAdapter;
-import mekhq.gui.dialog.ChooseMulFilesDialog;
-import mekhq.gui.dialog.CompleteMissionDialog;
-import mekhq.gui.dialog.CustomizeAtBContractDialog;
-import mekhq.gui.dialog.CustomizeMissionDialog;
-import mekhq.gui.dialog.CustomizeScenarioDialog;
-import mekhq.gui.dialog.MissionTypeDialog;
-import mekhq.gui.dialog.NewAtBContractDialog;
-import mekhq.gui.dialog.NewContractDialog;
-import mekhq.gui.dialog.ResolveScenarioWizardDialog;
-import mekhq.gui.dialog.RetirementDefectionDialog;
+import mekhq.gui.dialog.*;
 import mekhq.gui.model.ScenarioTableModel;
 import mekhq.gui.sorter.DateStringComparator;
 import mekhq.gui.view.AtBScenarioViewPanel;
 import mekhq.gui.view.LanceAssignmentView;
 import mekhq.gui.view.MissionViewPanel;
 import mekhq.gui.view.ScenarioViewPanel;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Displays Mission/Contract and Scenario details.
@@ -425,10 +398,10 @@ public final class BriefingTab extends CampaignGuiTab {
     private void deleteMission() {
         final Mission mission = comboMission.getSelectedItem();
         if (mission == null) {
-            MekHQ.getLogger().error("Cannot remove null mission");
+            LogManager.getLogger().error("Cannot remove null mission");
             return;
         }
-        MekHQ.getLogger().debug("Attempting to Delete Mission, Mission ID: " + mission.getId());
+        LogManager.getLogger().debug("Attempting to Delete Mission, Mission ID: " + mission.getId());
         if (0 != JOptionPane.showConfirmDialog(null, "Are you sure you want to delete this mission?", "Delete mission?",
                 JOptionPane.YES_NO_OPTION)) {
             return;
@@ -777,7 +750,7 @@ public final class BriefingTab extends CampaignGuiTab {
             // FIXME: this is not working
             EntityListFile.saveTo(unitFile, chosen);
         } catch (IOException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         if (undeployed.length() > 0) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -66,6 +66,7 @@ import mekhq.gui.dialog.nagDialogs.*;
 import mekhq.gui.dialog.reportDialogs.*;
 import mekhq.gui.model.PartsTableModel;
 import mekhq.io.FileType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -1165,7 +1166,7 @@ public class CampaignGUI extends JPanel {
             Method method = clazz.getMethod(methodName, Window.class, boolean.class);
             method.invoke(null, window, true);
         } catch (Throwable t) {
-            MekHQ.getLogger().error("Full screen mode is not supported", t);
+            LogManager.getLogger().error("Full screen mode is not supported", t);
         }
     }
 
@@ -1280,7 +1281,7 @@ public class CampaignGUI extends JPanel {
 
     public void showUnitMarket() {
         if (getCampaign().getUnitMarket().getMethod().isNone()) {
-            MekHQ.getLogger().error("Attempted to show the unit market while it is disabled");
+            LogManager.getLogger().error("Attempted to show the unit market while it is disabled");
         } else {
             new UnitMarketDialog(getFrame(), getCampaign()).showDialog();
         }
@@ -1292,7 +1293,7 @@ public class CampaignGUI extends JPanel {
     }
 
     public boolean saveCampaign(ActionEvent evt) {
-        MekHQ.getLogger().info("Saving campaign...");
+        LogManager.getLogger().info("Saving campaign...");
         // Choose a file...
         File file = selectSaveCampaignFile();
         if (file == null) {
@@ -1341,9 +1342,9 @@ public class CampaignGUI extends JPanel {
             if (backupFile.exists()) {
                 backupFile.delete();
             }
-            MekHQ.getLogger().info("Campaign saved to " + file);
+            LogManager.getLogger().info("Campaign saved to " + file);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             JOptionPane.showMessageDialog(frame,
                     "Oh no! The program was unable to correctly save your game. We know this\n"
                             + "is annoying and apologize. Please help us out and submit a bug with the\n"
@@ -1544,7 +1545,7 @@ public class CampaignGUI extends JPanel {
             exportPlanets(FileType.XML, resourceMap.getString("dlgSavePlanetsXML.text"),
                     getCampaign().getName() + getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedPlanets");
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -1553,7 +1554,7 @@ public class CampaignGUI extends JPanel {
             exportFinances(FileType.CSV, resourceMap.getString("dlgSaveFinancesCSV.text"),
                     getCampaign().getName() + getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedFinances");
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -1562,7 +1563,7 @@ public class CampaignGUI extends JPanel {
             exportPersonnel(FileType.CSV, resourceMap.getString("dlgSavePersonnelCSV.text"),
                     getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedPersonnel");
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -1571,7 +1572,7 @@ public class CampaignGUI extends JPanel {
             exportUnits(FileType.CSV, resourceMap.getString("dlgSaveUnitsCSV.text"),
                     getCampaign().getName() + getCampaign().getLocalDate().format(DateTimeFormatter.ofPattern(MekHqConstants.FILENAME_DATE_FORMAT)) + "_ExportedUnits");
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -1924,12 +1925,12 @@ public class CampaignGUI extends JPanel {
             try (InputStream is = new FileInputStream(unitFile)) {
                 parser.parse(is);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
 
             // Was there any error in parsing?
             if (parser.hasWarningMessage()) {
-                MekHQ.getLogger().warning(parser.getWarningMessage());
+                LogManager.getLogger().warn(parser.getWarningMessage());
             }
 
             // Add the units from the file.
@@ -1951,7 +1952,7 @@ public class CampaignGUI extends JPanel {
         File personnelFile = FileDialogs.openPersonnel(frame).orElse(null);
 
         if (personnelFile != null) {
-            MekHQ.getLogger().info("Starting load of personnel file from XML...");
+            LogManager.getLogger().info("Starting load of personnel file from XML...");
             // Initialize variables.
             Document xmlDoc;
 
@@ -1963,7 +1964,7 @@ public class CampaignGUI extends JPanel {
                 // Parse using builder to get DOM representation of the XML file
                 xmlDoc = db.parse(is);
             } catch (Exception ex) {
-                MekHQ.getLogger().error("Cannot load person XML", ex);
+                LogManager.getLogger().error("Cannot load person XML", ex);
                 return; // otherwise we NPE out in the next line
             }
 
@@ -1987,13 +1988,13 @@ public class CampaignGUI extends JPanel {
                 }
 
                 if (!wn2.getNodeName().equalsIgnoreCase("person")) {
-                    MekHQ.getLogger().error("Unknown node type not loaded in Personnel nodes: " + wn2.getNodeName());
+                    LogManager.getLogger().error("Unknown node type not loaded in Personnel nodes: " + wn2.getNodeName());
                     continue;
                 }
 
                 Person p = Person.generateInstanceFromXML(wn2, getCampaign(), version);
                 if ((p != null) && (getCampaign().getPerson(p.getId()) != null)) {
-                    MekHQ.getLogger().error("ERROR: Cannot load person who exists, ignoring. (Name: "
+                    LogManager.getLogger().error("ERROR: Cannot load person who exists, ignoring. (Name: "
                             + p.getFullName() + ", Id " + p.getId() + ")");
                     p = null;
                 }
@@ -2033,7 +2034,7 @@ public class CampaignGUI extends JPanel {
                 }
             }
 
-            MekHQ.getLogger().info("Finished load of personnel file");
+            LogManager.getLogger().info("Finished load of personnel file");
         }
     }
 
@@ -2064,7 +2065,7 @@ public class CampaignGUI extends JPanel {
             PersonnelTab pt = (PersonnelTab)getTab(GuiTabType.PERSONNEL);
             int row = pt.getPersonnelTable().getSelectedRow();
             if (row < 0) {
-                MekHQ.getLogger().warning("ERROR: Cannot export person if no one is selected! Ignoring.");
+                LogManager.getLogger().warn("ERROR: Cannot export person if no one is selected! Ignoring.");
                 return;
             }
             Person selectedPerson = pt.getPersonModel().getPerson(pt.getPersonnelTable()
@@ -2096,9 +2097,9 @@ public class CampaignGUI extends JPanel {
             if (backupFile.exists()) {
                 backupFile.delete();
             }
-            MekHQ.getLogger().info("Personnel saved to " + file);
+            LogManager.getLogger().info("Personnel saved to " + file);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             JOptionPane.showMessageDialog(getFrame(),
                     "Oh no! The program was unable to correctly export your personnel. We know this\n"
                             + "is annoying and apologize. Please help us out and submit a bug with the\n"
@@ -2123,7 +2124,7 @@ public class CampaignGUI extends JPanel {
 
         File partsFile = maybeFile.get();
 
-        MekHQ.getLogger().info("Starting load of parts file from XML...");
+        LogManager.getLogger().info("Starting load of parts file from XML...");
         // Initialize variables.
         Document xmlDoc;
 
@@ -2135,7 +2136,7 @@ public class CampaignGUI extends JPanel {
             // Parse using builder to get DOM representation of the XML file
             xmlDoc = db.parse(is);
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return;
         }
 
@@ -2162,7 +2163,7 @@ public class CampaignGUI extends JPanel {
             if (!wn2.getNodeName().equalsIgnoreCase("part")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                MekHQ.getLogger().error("Unknown node type not loaded in Parts nodes: " + wn2.getNodeName());
+                LogManager.getLogger().error("Unknown node type not loaded in Parts nodes: " + wn2.getNodeName());
                 continue;
             }
 
@@ -2173,7 +2174,7 @@ public class CampaignGUI extends JPanel {
         }
 
         getCampaign().importParts(parts);
-        MekHQ.getLogger().info("Finished load of parts file");
+        LogManager.getLogger().info("Finished load of parts file");
     }
 
     private void savePartsFile() {
@@ -2206,7 +2207,7 @@ public class CampaignGUI extends JPanel {
                 PartsTableModel partsModel = ((WarehouseTab)getTab(GuiTabType.WAREHOUSE)).getPartsModel();
                 int row = partsTable.getSelectedRow();
                 if (row < 0) {
-                    MekHQ.getLogger().warning("ERROR: Cannot export parts if none are selected! Ignoring.");
+                    LogManager.getLogger().warn("ERROR: Cannot export parts if none are selected! Ignoring.");
                     return;
                 }
                 Part selectedPart = partsModel.getPartAt(partsTable
@@ -2242,9 +2243,9 @@ public class CampaignGUI extends JPanel {
                 if (backupFile.exists()) {
                     backupFile.delete();
                 }
-                MekHQ.getLogger().info("Parts saved to " + file);
+                LogManager.getLogger().info("Parts saved to " + file);
             } catch (Exception ex) {
-                MekHQ.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
                 JOptionPane.showMessageDialog(getFrame(),
                         "Oh no! The program was unable to correctly export your parts. We know this\n"
                                 + "is annoying and apologize. Please help us out and submit a bug with the\n"
@@ -2298,7 +2299,7 @@ public class CampaignGUI extends JPanel {
             try {
                 lab.refreshRefitSummary();
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -40,6 +40,7 @@ import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.TargetSorter;
 import mekhq.service.MassRepairMassSalvageMode;
 import mekhq.service.MassRepairService;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.table.TableColumn;
@@ -496,7 +497,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
                 }
                 lblIcon.setIcon(new ImageIcon(icon));
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -18,13 +18,6 @@
  */
 package mekhq.gui;
 
-import java.awt.*;
-
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JTree;
-import javax.swing.tree.DefaultTreeCellRenderer;
-
 import megamek.client.ui.Messages;
 import megamek.common.Entity;
 import megamek.common.GunEmplacement;
@@ -33,6 +26,11 @@ import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import java.awt.*;
 
 public class ForceRenderer extends DefaultTreeCellRenderer {
     //region Variable Declarations
@@ -150,7 +148,7 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
                 setOpaque(true);
             }
         } else {
-            MekHQ.getLogger().error("Attempted to render node with unknown node class of "
+            LogManager.getLogger().error("Attempted to render node with unknown node class of "
                     + ((value != null) ? value.getClass() : "null"));
         }
 
@@ -176,7 +174,7 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
                     force.getIconFileName(), force.getIconMap())
                     .getScaledInstance(58, -1, Image.SCALE_SMOOTH));
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return null;
         }
     }

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -18,77 +18,27 @@
  */
 package mekhq.gui;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Insets;
-import java.awt.LinearGradientPaint;
-import java.awt.MultipleGradientPaint;
-import java.awt.Paint;
-import java.awt.Point;
-import java.awt.RenderingHints;
-import java.awt.Shape;
-import java.awt.Stroke;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseWheelEvent;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Arc2D;
-import java.awt.geom.GeneralPath;
-import java.awt.geom.Line2D;
-import java.awt.geom.Point2D;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import javax.imageio.ImageIO;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JLayeredPane;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JRadioButton;
-import javax.swing.JViewport;
-import javax.swing.Timer;
-import javax.vecmath.Vector2d;
-
-import mekhq.MekHQ;
 import megamek.common.EquipmentType;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.*;
 import mekhq.campaign.universe.Faction.Tag;
-import mekhq.campaign.universe.SocioIndustrialData;
-import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.campaign.universe.Systems;
+import org.apache.logging.log4j.LogManager;
+
+import javax.imageio.ImageIO;
+import javax.swing.Timer;
+import javax.swing.*;
+import javax.vecmath.Vector2d;
+import java.awt.*;
+import java.awt.event.*;
+import java.awt.geom.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.*;
 
 /**
  * This is not functional yet. Just testing things out.
@@ -299,7 +249,7 @@ public class InterstellarMapPanel extends JPanel {
                                     ImageIO.write(img, "png", file.get());
                                 }
                             } catch (IOException e) {
-                                MekHQ.getLogger().error(e);
+                                LogManager.getLogger().error(e);
                             }
                             conf.centerX = originalX;
                             conf.centerY = originalY;

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -25,15 +25,14 @@ import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.verifier.*;
 import megameklab.com.MMLConstants;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.tabs.FluffTab;
 import megameklab.com.util.CConfig;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
-import mekhq.MekHQ;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -84,7 +83,7 @@ public class MekLabTab extends CampaignGuiTab {
         entityVerifier = EntityVerifier.getInstance(new File("data/mechfiles/UnitVerifierOptions.xml")); // TODO : Remove inline file path
         CConfig.load();
         UnitUtil.loadFonts();
-        MekHQ.getLogger().info("Starting MegaMekLab version: " + MMLConstants.VERSION);
+        LogManager.getLogger().info("Starting MegaMekLab version: " + MMLConstants.VERSION);
         btnRefit = new JButton("Begin Refit");
         btnRefit.addActionListener(evt -> {
             Entity entity = labPanel.getEntity();
@@ -182,7 +181,7 @@ public class MekLabTab extends CampaignGuiTab {
         try {
             entity = (new MechFileParser(mechSummary.getSourceFile(), mechSummary.getEntryName())).getEntity();
         } catch (EntityLoadingException ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return;
         }
         entity.setYear(unit.getCampaign().getGameYear());
@@ -217,7 +216,7 @@ public class MekLabTab extends CampaignGuiTab {
         try {
             entity = (new MechFileParser(mechSummary.getSourceFile(), mechSummary.getEntryName())).getEntity();
         } catch (EntityLoadingException ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return;
         }
         entity.setYear(unit.getCampaign().getGameYear());

--- a/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
+++ b/MekHQ/src/mekhq/gui/PlanetarySystemMapPanel.java
@@ -18,22 +18,22 @@
  */
 package mekhq.gui;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Image;
-import java.awt.Insets;
-import java.awt.RenderingHints;
-import java.awt.Stroke;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
+import megamek.common.Dropship;
+import megamek.common.Jumpship;
+import megamek.common.util.ImageUtil;
+import mekhq.Utilities;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Planet;
+import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.campaign.universe.StarUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Arc2D;
 import java.awt.image.AffineTransformOp;
@@ -43,29 +43,6 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.imageio.ImageIO;
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JLayeredPane;
-import javax.swing.JPanel;
-import javax.swing.KeyStroke;
-
-import megamek.client.ui.swing.tileset.EntityImage;
-import megamek.common.Dropship;
-import megamek.common.Jumpship;
-import megamek.common.util.ImageUtil;
-import mekhq.MHQStaticDirectoryManager;
-import mekhq.MekHQ;
-import mekhq.Utilities;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.JumpPath;
-import mekhq.campaign.unit.Unit;
-import mekhq.campaign.universe.Planet;
-import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.campaign.universe.StarUtil;
 
 /**
  * This panel displays a particular star system with suns and planets and information about
@@ -113,41 +90,41 @@ public class PlanetarySystemMapPanel extends JPanel {
             imgSpace = ImageIO.read(new File("data/images/universe/space.jpg")); // TODO : Remove inline file path
         } catch (IOException e1) {
             imgSpace = null;
-            MekHQ.getLogger().error("missing default space image");
+            LogManager.getLogger().error("missing default space image");
         }
         try {
             imgZenithPoint = ImageIO.read(new File("data/images/universe/default_zenithpoint.png")); // TODO : Remove inline file path
         } catch (IOException e) {
             imgZenithPoint = null;
-            MekHQ.getLogger().error("missing default zenith point image");
+            LogManager.getLogger().error("missing default zenith point image");
         }
 
         try {
             imgNadirPoint = ImageIO.read(new File("data/images/universe/default_nadirpoint.png")); // TODO : Remove inline file path
         } catch (IOException e) {
             imgNadirPoint = null;
-            MekHQ.getLogger().error("missing default nadir point image");
+            LogManager.getLogger().error("missing default nadir point image");
         }
 
         try {
             imgRechargeStation = ImageIO.read(new File("data/images/universe/default_recharge_station.png")); // TODO : Remove inline file path
         } catch (IOException e) {
             imgRechargeStation = null;
-            MekHQ.getLogger().error("missing default recharge station image");
+            LogManager.getLogger().error("missing default recharge station image");
         }
 
         try {
             imgDefaultDropshipFleet = ImageIO.read(new File("data/images/universe/default_dropship_fleet.png")); // TODO : Remove inline file path
         } catch (IOException e) {
             imgDefaultDropshipFleet = null;
-            MekHQ.getLogger().error("missing default dropship fleet image");
+            LogManager.getLogger().error("missing default dropship fleet image");
         }
 
         try {
             imgDefaultJumpshipFleet = ImageIO.read(new File("data/images/universe/default_jumpship_fleet.png")); // TODO : Remove inline file path
         } catch (IOException e) {
             imgDefaultJumpshipFleet = null;
-            MekHQ.getLogger().error("missing default jumpship fleet image");
+            LogManager.getLogger().error("missing default jumpship fleet image");
         }
 
         pane = new JLayeredPane();

--- a/MekHQ/src/mekhq/gui/ReportHyperlinkListener.java
+++ b/MekHQ/src/mekhq/gui/ReportHyperlinkListener.java
@@ -21,9 +21,9 @@
  */
 package mekhq.gui;
 
-import mekhq.MekHQ;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.dialog.reportDialogs.MaintenanceReportDialog;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
@@ -59,7 +59,7 @@ public class ReportHyperlinkListener implements HyperlinkListener {
                     final UUID id = UUID.fromString(evt.getDescription().split(":")[1]);
                     campaignGUI.focusOnUnit(id);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             } else if (evt.getDescription().startsWith(PERSONNEL_MARKET)) { // Must come before PERSON since it starts with PERSON as well
                 campaignGUI.hirePersonMarket();
@@ -68,33 +68,33 @@ public class ReportHyperlinkListener implements HyperlinkListener {
                     final UUID id = UUID.fromString(evt.getDescription().split(":")[1]);
                     campaignGUI.focusOnPerson(id);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             } else if (evt.getDescription().startsWith(NEWS)) {
                 try {
                     final int id = Integer.parseInt(evt.getDescription().split("\\|")[1]);
                     campaignGUI.showNews(id);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             } else if (evt.getDescription().startsWith(MAINTENANCE)) {
                 try {
                     final UUID id = UUID.fromString(evt.getDescription().split("\\|")[1]);
                     final Unit unit = campaignGUI.getCampaign().getUnit(id);
                     if (unit == null) {
-                        MekHQ.getLogger().error("Unit id determination failure for " + id);
+                        LogManager.getLogger().error("Unit id determination failure for " + id);
                         return;
                     }
                     new MaintenanceReportDialog(campaignGUI.getFrame(), unit).setVisible(true);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             } else if (evt.getDescription().startsWith(REPAIR)) {
                 try {
                     final UUID id = UUID.fromString(evt.getDescription().split("\\|")[1]);
                     campaignGUI.focusOnUnitInRepairBay(id);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             } else if (evt.getDescription().startsWith(CONTRACT_MARKET)) {
                 campaignGUI.showContractMarket();

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -55,6 +55,7 @@ import mekhq.gui.model.PersonnelTableModel;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.MultiLineTooltip;
 import mekhq.gui.utilities.StaticChecks;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -225,7 +226,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         person.changeRank(gui.getCampaign(), rank, level, true);
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
                 break;
             }
@@ -236,7 +237,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         person.setManeiDominiClass(mdClass);
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error("Failed to assign Manei Domini Class", e);
+                    LogManager.getLogger().error("Failed to assign Manei Domini Class", e);
                 }
                 break;
             }
@@ -254,7 +255,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         person.setPrimaryDesignator(romDesignation);
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error("Failed to assign ROM designator", e);
+                    LogManager.getLogger().error("Failed to assign ROM designator", e);
                 }
                 break;
             }
@@ -265,7 +266,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         person.setSecondaryDesignator(romDesignation);
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error("Failed to assign ROM secondary designator", e);
+                    LogManager.getLogger().error("Failed to assign ROM secondary designator", e);
                 }
                 break;
             }
@@ -339,7 +340,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                     gui.getCampaign().getLocalDate());
                         }
                     } catch (Exception e) {
-                        MekHQ.getLogger().error("Could not remove award.", e);
+                        LogManager.getLogger().error("Could not remove award.", e);
                     }
                 }
                 break;
@@ -494,7 +495,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         }
                     }
                 } catch (Exception e) {
-                    MekHQ.getLogger().error("Unknown PrisonerStatus Option. No changes will be made.", e);
+                    LogManager.getLogger().error("Unknown PrisonerStatus Option. No changes will be made.", e);
                 }
                 break;
             }

--- a/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
@@ -18,16 +18,6 @@
  */
 package mekhq.gui.adapter;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.ResourceBundle;
-
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.JTable;
-
 import megamek.common.Entity;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
@@ -37,6 +27,13 @@ import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.model.ProcurementTableModel;
 import mekhq.gui.utilities.JMenuHelpers;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.ResourceBundle;
 
 public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
     //region Variable Declarations
@@ -163,7 +160,7 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
      */
     private boolean tryProcureOneItem(final IAcquisitionWork acquisition) {
         if (acquisition.getQuantity() <= 0) {
-            MekHQ.getLogger().info("Attempted to acquire item with no quantity remaining, ignoring the attempt.");
+            LogManager.getLogger().info("Attempted to acquire item with no quantity remaining, ignoring the attempt.");
             return false;
         }
         final Object equipment = acquisition.getNewEquipment();
@@ -174,7 +171,7 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
         } else if (equipment instanceof Entity) {
             success = gui.getCampaign().getQuartermaster().buyUnit((Entity) equipment, transitTime);
         } else {
-            MekHQ.getLogger().error("Attempted to acquire unknown equipment of " + acquisition.getAcquisitionName());
+            LogManager.getLogger().error("Attempted to acquire unknown equipment of " + acquisition.getAcquisitionName());
             return false;
         }
 
@@ -191,7 +188,7 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
 
     private void addOneItem(final IAcquisitionWork acquisition) {
         if (acquisition.getQuantity() <= 0) {
-            MekHQ.getLogger().info("Attempted to add item with no quantity remaining, ignoring the attempt.");
+            LogManager.getLogger().info("Attempted to add item with no quantity remaining, ignoring the attempt.");
             return;
         }
 
@@ -201,7 +198,7 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
         } else if (equipment instanceof Entity) {
             gui.getCampaign().addNewUnit((Entity) equipment, false, 0);
         } else {
-            MekHQ.getLogger().error("Attempted to add unknown equipment of " + acquisition.getAcquisitionName());
+            LogManager.getLogger().error("Attempted to add unknown equipment of " + acquisition.getAcquisitionName());
             return;
         }
 

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -47,20 +47,12 @@ import mekhq.gui.dialog.ImageChoiceDialog;
 import mekhq.gui.dialog.MarkdownEditorDialog;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.StaticChecks;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.tree.TreePath;
 import java.awt.event.ActionEvent;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringJoiner;
-import java.util.StringTokenizer;
-import java.util.UUID;
-import java.util.Vector;
+import java.util.*;
 
 public class TOEMouseAdapter extends JPopupMenuAdapter {
     private final CampaignGUI gui;
@@ -1105,7 +1097,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     try {
                         nodesFree = Integer.parseInt(network[1]);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error(e);
+                        LogManager.getLogger().error(e);
                         continue;
                     }
 
@@ -1136,7 +1128,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     try {
                         nodesFree = Integer.parseInt(network[1]);
                     } catch (Exception e) {
-                        MekHQ.getLogger().error(e);
+                        LogManager.getLogger().error(e);
                         continue;
                     }
 
@@ -1189,7 +1181,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                         try {
                             nodesFree = Integer.parseInt(network[1]);
                         } catch (Exception e) {
-                            MekHQ.getLogger().error(e);
+                            LogManager.getLogger().error(e);
                             continue;
                         }
 
@@ -1242,7 +1234,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                         try {
                             nodesFree = Integer.parseInt(network[1]);
                         } catch (Exception e) {
-                            MekHQ.getLogger().error(e);
+                            LogManager.getLogger().error(e);
                             continue;
                         }
 

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -52,6 +52,7 @@ import mekhq.gui.menus.AssignUnitToPersonMenu;
 import mekhq.gui.model.UnitTableModel;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.StaticChecks;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
@@ -253,7 +254,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         } else if (command.equals(COMMAND_SALVAGE)) {
             for (Unit unit : units) {
@@ -350,7 +351,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                                 }
                             }
                         } catch (EntityLoadingException ex) {
-                            MekHQ.getLogger().error(ex);
+                            LogManager.getLogger().error(ex);
                         }
                     }
                 }
@@ -476,7 +477,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                     }
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }
@@ -993,7 +994,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
         File customsDir = new File(MekHqConstants.CUSTOM_MECHFILES_DIRECTORY_PATH);
         if (!customsDir.exists()) {
             if (!customsDir.mkdir()) {
-                MekHQ.getLogger().error("Unable to create directory "
+                LogManager.getLogger().error("Unable to create directory "
                         + MekHqConstants.CUSTOM_MECHFILES_DIRECTORY_PATH
                         + " to hold custom units, cannot assign custom unit tag");
                 return;
@@ -1002,7 +1003,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
         File customsDirCampaign = new File(sCustomsDirCampaign);
         if (!customsDirCampaign.exists()) {
             if (!customsDir.mkdir()) {
-                MekHQ.getLogger().error("Unable to create directory " + sCustomsDirCampaign
+                LogManager.getLogger().error("Unable to create directory " + sCustomsDirCampaign
                         + "to hold custom units, cannot assign custom unit tag");
                 return;
             }
@@ -1026,7 +1027,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
 
                     p.println(((Mech) unit.getEntity()).getMtf());
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             } else {
                 // if this file already exists then don't overwrite

--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -27,6 +27,7 @@ import mekhq.campaign.event.ReportEvent;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.DailyReportLogPanel;
 import mekhq.gui.baseComponents.AbstractMHQDialog;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -280,7 +281,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialog {
             days = Math.toIntExact(ChronoUnit.DAYS.between(today,
                     LocalDate.ofYearDay(today.getYear() + 10 - (today.getYear() % 10), 1)));
         } else {
-            MekHQ.getLogger().error("Unknown source to start advancing days. Advancing to tomorrow.");
+            LogManager.getLogger().error("Unknown source to start advancing days. Advancing to tomorrow.");
             days = 1;
         }
 
@@ -303,7 +304,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialog {
                 }
                 getGUI().getCampaign().fetchAndClearNewReports();
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
                 break;
             }
         }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -21,7 +21,6 @@ package mekhq.gui.dialog;
 import megamek.common.AmmoType;
 import megamek.common.UnitType;
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
 import mekhq.NullEntityException;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignFactory;
@@ -40,6 +39,7 @@ import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.FileDialogs;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -202,7 +202,7 @@ public class CampaignExportWizard extends JDialog {
                     destinationCampaignFile = FileDialogs.saveCampaign(null, sourceCampaign);
                     if (destinationCampaignFile.isPresent()) {
                         if (!exportToCampaign(destinationCampaignFile.get())) {
-                            MekHQ.getLogger().error("Failed to export campaign to new campaign file");
+                            LogManager.getLogger().error("Failed to export campaign to new campaign file");
                         }
                         setVisible(false);
                     }
@@ -215,7 +215,7 @@ public class CampaignExportWizard extends JDialog {
                     destinationCampaignFile = FileDialogs.openCampaign(null);
                     if (destinationCampaignFile.isPresent()) {
                         if (!exportToCampaign(destinationCampaignFile.get())) {
-                            MekHQ.getLogger().error("Failed to export campaign to existing campaign file");
+                            LogManager.getLogger().error("Failed to export campaign to existing campaign file");
                         }
                         setVisible(false);
                     }
@@ -444,13 +444,13 @@ public class CampaignExportWizard extends JDialog {
                 destinationCampaign.cleanUp();
                 fis.close();
             } catch (NullEntityException ex) {
-                MekHQ.getLogger().error("The following units could not be loaded by the campaign:\n" + ex.getError() + "\n\nPlease be sure to copy over any custom units before starting a new version of MekHQ.\nIf you believe the units listed are not customs, then try deleting the file data/mechfiles/units.cache and restarting MekHQ.\nIt is also possible that unit chassi and model names have changed across versions of MegaMek. You can check this by\nopening up MegaMek and searching for the units. Chassis and models can be edited in your MekHQ save file with a text editor.");
+                LogManager.getLogger().error("The following units could not be loaded by the campaign:\n" + ex.getError() + "\n\nPlease be sure to copy over any custom units before starting a new version of MekHQ.\nIf you believe the units listed are not customs, then try deleting the file data/mechfiles/units.cache and restarting MekHQ.\nIt is also possible that unit chassi and model names have changed across versions of MegaMek. You can check this by\nopening up MegaMek and searching for the units. Chassis and models can be edited in your MekHQ save file with a text editor.");
                 return false;
             } catch (Exception ex) {
-                MekHQ.getLogger().error("The campaign file could not be loaded.\nPlease check the log file for details.");
+                LogManager.getLogger().error("The campaign file could not be loaded.\nPlease check the log file for details.");
                 return false;
             } catch (OutOfMemoryError e) {
-                MekHQ.getLogger().error("MekHQ ran out of memory attempting to load the campaign file. \nTry increasing the memory allocated to MekHQ and reloading.\nSee the FAQ at http://megamek.org for details.");
+                LogManager.getLogger().error("MekHQ ran out of memory attempting to load the campaign file. \nTry increasing the memory allocated to MekHQ and reloading.\nSee the FAQ at http://megamek.org for details.");
                 return false;
             }
         }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -68,6 +68,7 @@ import mekhq.gui.displayWrappers.FactionDisplay;
 import mekhq.gui.panes.RankSystemsPane;
 import mekhq.module.PersonnelMarketServiceManager;
 import mekhq.module.api.PersonnelMarketMethod;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
@@ -6113,7 +6114,7 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
 
             MekHQ.triggerEvent(new OptionsChangedEvent(campaign, options));
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             JOptionPane.showMessageDialog(getFrame(),
                     "Campaign Options update failure, please check the logs for the exception reason.",
                     "Error Updating Campaign Options", JOptionPane.ERROR_MESSAGE);
@@ -6159,7 +6160,7 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
                     int cost = Integer.parseInt((String) tableXP.getValueAt(i, j));
                     SkillType.setCost(SkillType.skillList[i], cost, j);
                 } catch (NumberFormatException e) {
-                    MekHQ.getLogger().error("unreadable value in skill cost table for " + SkillType.skillList[i]);
+                    LogManager.getLogger().error("unreadable value in skill cost table for " + SkillType.skillList[i]);
                 }
             }
         }

--- a/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
@@ -20,10 +20,24 @@
  */
 package mekhq.gui.dialog;
 
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
+import megamek.client.ui.preferences.JWindowPreference;
+import megamek.client.ui.preferences.PreferencesNode;
+import megamek.common.*;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.util.EncodeControl;
+import mekhq.MekHQ;
+import mekhq.Utilities;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.Refit;
+import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
 import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.text.ParseException;
@@ -32,29 +46,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.ResourceBundle;
 
-import javax.swing.*;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-
-import megamek.common.Entity;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.MechView;
-import megamek.common.loaders.EntityLoadingException;
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.Utilities;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.parts.Refit;
-import mekhq.campaign.unit.Unit;
-import megamek.client.ui.preferences.JWindowPreference;
-import megamek.client.ui.preferences.PreferencesNode;
-
 /**
- * @author  Taharqa
+ * @author Taharqa
  */
 public class ChooseRefitDialog extends JDialog {
     //region Variable Declarations
@@ -279,7 +272,7 @@ public class ChooseRefitDialog extends JDialog {
                     }
                 }
             } catch (EntityLoadingException ex) {
-                MekHQ.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
         refitModel = new RefitTableModel(refits);
@@ -460,13 +453,13 @@ public class ChooseRefitDialog extends JDialog {
             try {
                 l0 = format.parse(s0).intValue();
             } catch (ParseException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
             int l1 = 0;
             try {
                 l1 = format.parse(s1).intValue();
             } catch (ParseException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
             return ((Comparable<Integer>) l0).compareTo(l1);
         }

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -42,6 +42,7 @@ import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.RATManager;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.eras.Eras;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -177,7 +178,7 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
                 InjuryTypes.registerAll();
                 campaign.setApp(app);
             } else {
-                MekHQ.getLogger().info(String.format("Loading campaign file from XML %s", fileCampaign));
+                LogManager.getLogger().info(String.format("Loading campaign file from XML %s", fileCampaign));
 
                 // And then load the campaign object from it.
                 try (FileInputStream fis = new FileInputStream(fileCampaign)) {
@@ -271,7 +272,7 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
                 cancelled = true;
                 cancel(true);
             } catch (ExecutionException e) {
-                MekHQ.getLogger().error(e.getCause());
+                LogManager.getLogger().error(e.getCause());
                 if (e.getCause() instanceof NullEntityException) {
                     NullEntityException nee = (NullEntityException) e.getCause();
                     JOptionPane.showMessageDialog(null,

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -1,27 +1,18 @@
 package mekhq.gui.dialog;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
+import megamek.client.ui.preferences.JWindowPreference;
+import megamek.client.ui.preferences.PreferencesNode;
+import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.text.DefaultFormatterFactory;
+import java.awt.*;
+import java.awt.event.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.swing.*;
-import javax.swing.text.DefaultFormatterFactory;
-
-import mekhq.MekHQ;
-import megamek.client.ui.preferences.JWindowPreference;
-import megamek.client.ui.preferences.PreferencesNode;
 
 /**
  * Hovanes Gambaryan Henry Demirchian CSUN, CS 585 Professor Mike Barnes
@@ -242,7 +233,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
                 try {
                     y = Integer.parseInt(yearLabel.getText());
                 } catch (NumberFormatException e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
                 yearLabel.setText(String.valueOf(--y));
                 updateDayGrid(false);
@@ -253,7 +244,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
                 try {
                     y = Integer.parseInt(yearLabel.getText());
                 } catch (NumberFormatException e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
                 yearLabel.setText(String.valueOf(++y));
                 updateDayGrid(false);
@@ -267,7 +258,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
                     y = Integer.parseInt(yearLabel.getText());
                     d = Integer.parseInt(label);
                 } catch (NumberFormatException e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
                 date = LocalDate.of(y, m, d);
                 ready = true;
@@ -309,7 +300,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         try {
             y = Integer.parseInt(yearLabel.getText());
         } catch (NumberFormatException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         // decide what day of the week is the first day of this month
@@ -398,7 +389,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         try {
             y = Integer.parseInt(yearLabel.getText());
         } catch (NumberFormatException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         return LocalDate.of(y, m, 1).lengthOfMonth();

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -44,6 +44,7 @@ import mekhq.gui.baseComponents.AbstractMHQDialog;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.displayWrappers.ClanDisplay;
 import mekhq.gui.displayWrappers.FactionDisplay;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -1342,7 +1343,7 @@ public class GMToolsDialog extends AbstractMHQDialog {
         } catch (Exception e) {
             final String message = String.format(Messages.getString("entityLoadFailure.error"),
                     summary.getName(), summary.getSourceFile());
-            MekHQ.getLogger().error(message, e);
+            LogManager.getLogger().error(message, e);
             getLblUnitPicked().setText(message);
             return null;
         }

--- a/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
@@ -30,6 +30,7 @@ import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Profession;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.displayWrappers.RankDisplay;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -265,7 +266,7 @@ public class HireBulkPersonnelDialog extends JDialog {
         int number = (Integer) spnNumber.getModel().getValue();
         PersonTypeItem selectedItem = (PersonTypeItem) choiceType.getSelectedItem();
         if (selectedItem == null) {
-            MekHQ.getLogger().error("Attempted to bulk hire for null PersonnelType!");
+            LogManager.getLogger().error("Attempted to bulk hire for null PersonnelType!");
             return;
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ImageChoiceDialog.java
@@ -29,6 +29,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.force.Force;
 import mekhq.gui.enums.LayeredForceIcon;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.event.MouseInputAdapter;
@@ -43,7 +44,7 @@ import java.util.List;
 import java.util.*;
 
 /**
- * @author  Jay Lawson <jaylawson39 at yahoo.com>
+ * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class ImageChoiceDialog extends JDialog {
     //region Variable Declarations
@@ -604,7 +605,7 @@ public class ImageChoiceDialog extends JDialog {
                     lblImage.setIcon(new ImageIcon(image));
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -18,19 +18,27 @@
  */
 package mekhq.gui.dialog;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontFormatException;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Image;
-import java.awt.Insets;
-import java.awt.Point;
-import java.awt.Window;
+import megamek.client.ui.preferences.JWindowPreference;
+import megamek.client.ui.preferences.PreferencesNode;
+import megamek.common.util.EncodeControl;
+import mekhq.MekHQ;
+import mekhq.Utilities;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.ExtraData;
+import mekhq.campaign.force.Force;
+import mekhq.campaign.log.LogEntry;
+import mekhq.campaign.log.LogEntryType;
+import mekhq.campaign.personnel.Injury;
+import mekhq.campaign.personnel.InjuryType;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.BodyLocation;
+import mekhq.campaign.personnel.enums.InjuryLevel;
+import mekhq.campaign.personnel.enums.Phenotype;
+import mekhq.gui.view.Paperdoll;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -38,43 +46,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Period;
+import java.util.List;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import javax.swing.UIManager;
-import megamek.common.util.EncodeControl;
-
-import mekhq.campaign.log.LogEntryType;
-import megamek.client.ui.preferences.JWindowPreference;
-import mekhq.gui.view.Paperdoll;
-import megamek.client.ui.preferences.PreferencesNode;
-import mekhq.MekHQ;
-import mekhq.Utilities;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.ExtraData;
-import mekhq.campaign.log.LogEntry;
-import mekhq.campaign.force.Force;
-import mekhq.campaign.personnel.Injury;
-import mekhq.campaign.personnel.enums.BodyLocation;
-import mekhq.campaign.personnel.enums.InjuryLevel;
-import mekhq.campaign.personnel.enums.Phenotype;
-import mekhq.campaign.personnel.InjuryType;
-import mekhq.campaign.personnel.Person;
 
 public class MedicalViewDialog extends JDialog {
     private static final long serialVersionUID = 6178230374580087883L;
@@ -113,12 +89,12 @@ public class MedicalViewDialog extends JDialog {
         try (InputStream fis = new FileInputStream(c.getApp().getIconPackage().getGuiElement("default_male_paperdoll"))) { // TODO : Remove inline file path
             defaultMaleDoll = new Paperdoll(fis);
         } catch (IOException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         try (InputStream fis = new FileInputStream(c.getApp().getIconPackage().getGuiElement("default_female_paperdoll"))) { // TODO : Remove inline file path
             defaultFemaleDoll = new Paperdoll(fis);
         } catch (IOException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         setPreferredSize(new Dimension(1024, 840));

--- a/MekHQ/src/mekhq/gui/dialog/MercRosterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MercRosterDialog.java
@@ -6,30 +6,20 @@
 
 package mekhq.gui.dialog;
 
-import java.awt.Frame;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.sql.SQLException;
-import java.util.ResourceBundle;
-
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JPasswordField;
-import javax.swing.JTextField;
-import javax.swing.ProgressMonitor;
-
+import megamek.client.ui.preferences.JWindowPreference;
+import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.MercRosterAccess;
-import megamek.client.ui.preferences.JWindowPreference;
-import megamek.client.ui.preferences.PreferencesNode;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.sql.SQLException;
+import java.util.ResourceBundle;
 
 /**
  * A dialog that sets up a connection with a mysql MercRoster database to upload campaign data
@@ -186,7 +176,7 @@ public class MercRosterDialog extends javax.swing.JDialog implements PropertyCha
                     "that you can connect to the database remotely.",
                     "Could not connect",
                     JOptionPane.ERROR_MESSAGE);
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return;
         }
         access.addPropertyChangeListener(this);

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -39,6 +39,7 @@ import mekhq.gui.FactionComboBox;
 import mekhq.gui.baseComponents.SortedComboBoxModel;
 import mekhq.gui.utilities.JSuggestField;
 import mekhq.gui.utilities.MarkdownEditorPanel;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -571,16 +572,16 @@ public class NewAtBContractDialog extends NewContractDialog {
             contract.setStartDate(null);
             needUpdatePayment = true;
         } else if (source.equals(cbEmployer)) {
-            MekHQ.getLogger().info("Setting employer code to " + getCurrentEmployerCode());
+            LogManager.getLogger().info("Setting employer code to " + getCurrentEmployerCode());
             long time = System.currentTimeMillis();
             contract.setEmployerCode(getCurrentEmployerCode(), campaign.getGameYear());
-            MekHQ.getLogger().info("to set employer code: " + (System.currentTimeMillis() - time));
+            LogManager.getLogger().info("to set employer code: " + (System.currentTimeMillis() - time));
             time = System.currentTimeMillis();
             updateEnemies();
-            MekHQ.getLogger().info("to update enemies: " + (System.currentTimeMillis() - time));
+            LogManager.getLogger().info("to update enemies: " + (System.currentTimeMillis() - time));
             time = System.currentTimeMillis();
             updatePlanets();
-            MekHQ.getLogger().info("to update planets: " + (System.currentTimeMillis() - time));
+            LogManager.getLogger().info("to update planets: " + (System.currentTimeMillis() - time));
             needUpdatePayment = true;
         } else if (source.equals(cbEnemy)) {
             contract.setEnemyCode(getCurrentEnemyCode());

--- a/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
@@ -30,6 +30,7 @@ import mekhq.campaign.finances.Loan;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.FinancialTerm;
 import mekhq.campaign.rating.IUnitRating;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
@@ -550,7 +551,7 @@ public class NewLoanDialog extends javax.swing.JDialog implements ActionListener
             lblTotalPayment.setText(loan.determineRemainingValue().toAmountAndSymbolString());
             lblCollateralAmount.setText(loan.determineCollateralAmount().toAmountAndSymbolString());
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -46,22 +46,13 @@ import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.gui.view.PersonViewPanel;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
-import java.awt.event.KeyEvent;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Hashtable;
+import java.awt.event.*;
 import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author Taharqa
@@ -1697,7 +1688,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
         Person person = isPrisoner ? ((OppositionPersonnelStatus) status).getPerson()
                 : tracker.getCampaign().getPerson(status.getId());
         if (person == null) {
-            MekHQ.getLogger().error("Failed to show person after selecting view personnel for a "
+            LogManager.getLogger().error("Failed to show person after selecting view personnel for a "
                     + (isPrisoner ? "Prisoner" : "member of the force") +
                     " because the person could not be found.");
             return;

--- a/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
+++ b/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
@@ -18,6 +18,15 @@
  */
 package mekhq.gui.handler;
 
+import mekhq.MekHQ;
+import mekhq.campaign.event.OrganizationChangedEvent;
+import mekhq.campaign.force.Force;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.CampaignGUI;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.tree.TreePath;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
@@ -25,17 +34,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.util.StringTokenizer;
 import java.util.UUID;
-
-import javax.swing.JComponent;
-import javax.swing.JTree;
-import javax.swing.TransferHandler;
-import javax.swing.tree.TreePath;
-
-import mekhq.MekHQ;
-import mekhq.campaign.event.OrganizationChangedEvent;
-import mekhq.campaign.force.Force;
-import mekhq.campaign.unit.Unit;
-import mekhq.gui.CampaignGUI;
 
 public class TOETransferHandler extends TransferHandler {
     private static final long serialVersionUID = -1276891849078287710L;
@@ -130,9 +128,9 @@ public class TOETransferHandler extends TransferHandler {
                 force = gui.getCampaign().getForce(Integer.parseInt(id));
             }
         } catch (UnsupportedFlavorException ufe) {
-            MekHQ.getLogger().error("UnsupportedFlavor: " + ufe.getMessage());
+            LogManager.getLogger().error("UnsupportedFlavor: " + ufe.getMessage());
         } catch (IOException ioe) {
-            MekHQ.getLogger().error("I/O error: " + ioe.getMessage());
+            LogManager.getLogger().error("I/O error: " + ioe.getMessage());
         }
 
         if ((force != null) && (superForce != null) && force.isAncestorOf(superForce)) {
@@ -162,9 +160,9 @@ public class TOETransferHandler extends TransferHandler {
                 force = gui.getCampaign().getForce(Integer.parseInt(id));
             }
         } catch (UnsupportedFlavorException ufe) {
-            MekHQ.getLogger().error("UnsupportedFlavor: " + ufe.getMessage());
+            LogManager.getLogger().error("UnsupportedFlavor: " + ufe.getMessage());
         } catch (IOException ioe) {
-            MekHQ.getLogger().error("I/O error: " + ioe.getMessage());
+            LogManager.getLogger().error("I/O error: " + ioe.getMessage());
         }
 
         // Get drop location info.

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -19,7 +19,6 @@
 package mekhq.gui.menus;
 
 import megamek.common.*;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
@@ -28,6 +27,7 @@ import mekhq.campaign.personnel.enums.Profession;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.JScrollableMenu;
 import mekhq.gui.sorter.PersonTitleSorter;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.util.ArrayList;
@@ -184,7 +184,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                             ? PersonnelRole.SOLDIER : PersonnelRole.BATTLE_ARMOUR))
                     .collect(Collectors.toList());
         } else {
-            MekHQ.getLogger().error("Unhandled entity type of " + units[0].getEntity().getClass().toString());
+            LogManager.getLogger().error("Unhandled entity type of " + units[0].getEntity().getClass().toString());
             return;
         }
 
@@ -226,7 +226,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                             .filter(person -> person.hasRole(PersonnelRole.VTOL_PILOT))
                             .collect(Collectors.toList());
                 } else {
-                    MekHQ.getLogger().warning("Attempting to assign pilot to unknown unit type of " + units[0].getEntity().getClass());
+                    LogManager.getLogger().warn("Attempting to assign pilot to unknown unit type of " + units[0].getEntity().getClass());
                     filteredPersonnel = new ArrayList<>();
                 }
 

--- a/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
@@ -18,16 +18,14 @@
  */
 package mekhq.gui.model;
 
-import java.awt.Component;
-import java.util.ArrayList;
-
-import javax.swing.JTable;
-import javax.swing.SwingConstants;
-
 import mekhq.MekHQ;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.Transaction;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
 
 /**
  * A table model for displaying financial transactions (i.e. a ledger)

--- a/MekHQ/src/mekhq/gui/model/LoanTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/LoanTableModel.java
@@ -18,17 +18,13 @@
  */
 package mekhq.gui.model;
 
-import java.awt.Component;
-import java.util.ArrayList;
-
-import javax.swing.JTable;
-import javax.swing.SwingConstants;
-import javax.swing.UIManager;
-import javax.swing.table.DefaultTableCellRenderer;
-
 import mekhq.MekHQ;
-import mekhq.campaign.finances.Finances;
 import mekhq.campaign.finances.Loan;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+import java.util.ArrayList;
 
 /**
  * A table model for displaying active loans

--- a/MekHQ/src/mekhq/gui/model/LogTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/LogTableModel.java
@@ -19,7 +19,6 @@
 package mekhq.gui.model;
 
 import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
 import mekhq.campaign.log.LogEntry;
 
 import javax.swing.*;

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -18,24 +18,19 @@
  */
 package mekhq.gui.model;
 
-import java.awt.Component;
-import java.awt.FontMetrics;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.ResourceBundle;
-
-import javax.swing.BorderFactory;
-import javax.swing.JTable;
-import javax.swing.JTextPane;
-import javax.swing.UIManager;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.text.SimpleAttributeSet;
-import javax.swing.text.StyleConstants;
-
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.log.LogEntry;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+
+import javax.swing.*;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import java.awt.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.ResourceBundle;
 
 public class PersonnelEventLogModel extends DataTableModel {
     private static final long serialVersionUID = 2930826794853379580L;

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -18,24 +18,19 @@
  */
 package mekhq.gui.model;
 
-import java.awt.Component;
-import java.awt.FontMetrics;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.ResourceBundle;
-
-import javax.swing.BorderFactory;
-import javax.swing.JTable;
-import javax.swing.JTextPane;
-import javax.swing.UIManager;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.text.SimpleAttributeSet;
-import javax.swing.text.StyleConstants;
-
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Kill;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+
+import javax.swing.*;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import java.awt.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.ResourceBundle;
 
 public class PersonnelKillLogModel extends DataTableModel {
     private static final long serialVersionUID = 2930826794853379579L;

--- a/MekHQ/src/mekhq/gui/model/RankTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RankTableModel.java
@@ -18,24 +18,22 @@
  */
 package mekhq.gui.model;
 
-import java.awt.Component;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ResourceBundle;
-import java.util.Vector;
-
-import javax.swing.JTable;
-import javax.swing.SwingConstants;
-import javax.swing.table.DefaultTableModel;
-import javax.swing.table.TableCellRenderer;
-
 import megamek.common.annotations.Nullable;
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
 import mekhq.campaign.personnel.enums.Profession;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.Vector;
 
 public class RankTableModel extends DefaultTableModel {
     //region Variable Declarations
@@ -78,7 +76,7 @@ public class RankTableModel extends DefaultTableModel {
      */
     public void setRankSystem(final @Nullable RankSystem rankSystem) {
         if (rankSystem == null) {
-            MekHQ.getLogger().error("Attempted to set based on a null rank system, returning without setting any data");
+            LogManager.getLogger().error("Attempted to set based on a null rank system, returning without setting any data");
             return;
         }
 
@@ -202,7 +200,7 @@ public class RankTableModel extends DefaultTableModel {
             case COL_PAYMULT:
                 return resources.getString("RankTableModel.COL_PAYMULT.toolTipText");
             default:
-                MekHQ.getLogger().error("Unknown column in RankTableModel of " + column);
+                LogManager.getLogger().error("Unknown column in RankTableModel of " + column);
                 return resources.getString("RankTableModel.defaultToolTip.toolTipText");
         }
     }
@@ -228,7 +226,7 @@ public class RankTableModel extends DefaultTableModel {
             }
             return ranks;
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
             return new ArrayList<>();
         }
     }

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -1,24 +1,6 @@
 package mekhq.gui.model;
 
-import java.awt.Component;
-import java.awt.Image;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import javax.swing.JTable;
-import javax.swing.SwingConstants;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableCellRenderer;
-
-import megamek.common.EntityWeightClass;
-import megamek.common.Jumpship;
-import megamek.common.SmallCraft;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.UnitType;
+import megamek.common.*;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -31,6 +13,14 @@ import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
 import mekhq.gui.dialog.RetirementDefectionDialog;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableCellRenderer;
+import java.awt.*;
+import java.util.List;
+import java.util.*;
 
 public class RetirementTableModel extends AbstractTableModel {
     private static final long serialVersionUID = 7461821036790309952L;
@@ -169,7 +159,7 @@ public class RetirementTableModel extends AbstractTableModel {
         try {
             retVal = getValueAt(0, col).getClass();
         } catch (NullPointerException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         return retVal;
     }

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -18,21 +18,7 @@
  */
 package mekhq.gui.model;
 
-import java.awt.Component;
-import java.awt.Image;
-import java.util.ArrayList;
-
-import javax.swing.JTable;
-import javax.swing.SwingConstants;
-import javax.swing.UIManager;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableCellRenderer;
-
-import megamek.common.Entity;
-import megamek.common.Jumpship;
-import megamek.common.SmallCraft;
-import megamek.common.TechConstants;
-import megamek.common.UnitType;
+import megamek.common.*;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -40,6 +26,12 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
+import java.awt.*;
+import java.util.ArrayList;
 
 /**
  * A table Model for displaying information about units

--- a/MekHQ/src/mekhq/gui/panes/RankSystemsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/RankSystemsPane.java
@@ -23,7 +23,6 @@ import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.baseComponents.SpinnerCellEditor;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.sorter.NaturalOrderComparator;
-import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.enums.RankSystemType;
@@ -36,16 +35,14 @@ import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.baseComponents.SortedComboBoxModel;
 import mekhq.gui.dialog.CustomRankSystemCreationDialog;
 import mekhq.gui.model.RankTableModel;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.table.TableColumn;
 import java.awt.*;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class RankSystemsPane extends AbstractMHQScrollPane {
     //region Variable Declarations
@@ -394,7 +391,7 @@ public class RankSystemsPane extends AbstractMHQScrollPane {
         // Then update the selected rank system, with null protection (although it shouldn't be null)
         setSelectedRankSystem(getRankSystemModel().getSelectedItem());
         if (getSelectedRankSystem() == null) {
-            MekHQ.getLogger().error("The selected rank system is null. Not changing the ranks, just returning.");
+            LogManager.getLogger().error("The selected rank system is null. Not changing the ranks, just returning.");
             getComboRankSystemType().setEnabled(false);
             return;
         }

--- a/MekHQ/src/mekhq/gui/panes/UnitMarketPane.java
+++ b/MekHQ/src/mekhq/gui/panes/UnitMarketPane.java
@@ -27,7 +27,6 @@ import megamek.common.UnitType;
 import megamek.common.annotations.Nullable;
 import megamek.common.icons.Camouflage;
 import megamek.common.util.sorter.NaturalOrderComparator;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
@@ -36,6 +35,7 @@ import mekhq.gui.baseComponents.AbstractMHQSplitPane;
 import mekhq.gui.model.UnitMarketTableModel;
 import mekhq.gui.model.XTableColumnModel;
 import mekhq.gui.sorter.WeightClassSorter;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.table.TableColumn;
@@ -393,7 +393,7 @@ public class UnitMarketPane extends AbstractMHQSplitPane {
 
             final Entity entity = offer.getEntity();
             if (entity == null) {
-                MekHQ.getLogger().error("Cannot purchase a null entity");
+                LogManager.getLogger().error("Cannot purchase a null entity");
                 offersIterator.remove();
                 continue;
             }

--- a/MekHQ/src/mekhq/gui/sorter/BonusSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/BonusSorter.java
@@ -1,6 +1,6 @@
 package mekhq.gui.sorter;
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -25,7 +25,7 @@ public class BonusSorter implements Comparator<String>, Serializable {
                 try {
                     t0 = temp[0].contains("-") ? 0 : Integer.parseInt(temp[0]);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     t0 = 0;
                 }
 
@@ -33,7 +33,7 @@ public class BonusSorter implements Comparator<String>, Serializable {
                 try {
                     t1 = temp[1].contains("-") ? 0 : Integer.parseInt(temp[1]);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     t1 = 0;
                 }
                 i0 = t0 + t1;
@@ -42,7 +42,7 @@ public class BonusSorter implements Comparator<String>, Serializable {
             try {
                 i0 = s0.equals("-") ? 90 : Integer.parseInt(s0);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
                 i0 = 90;
             }
         }
@@ -56,7 +56,7 @@ public class BonusSorter implements Comparator<String>, Serializable {
                 try {
                     t0 = temp[0].contains("-") ? 0 : Integer.parseInt(temp[0]);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     t0 = 0;
                 }
 
@@ -64,7 +64,7 @@ public class BonusSorter implements Comparator<String>, Serializable {
                 try {
                     t1 = temp[1].contains("-") ? 0 : Integer.parseInt(temp[1]);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     t1 = 0;
                 }
                 i1 = t0 + t1;
@@ -73,7 +73,7 @@ public class BonusSorter implements Comparator<String>, Serializable {
             try {
                 i1 = s1.equals("-") ? 90 : Integer.parseInt(s1);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
                 i1 = 90;
             }
         }

--- a/MekHQ/src/mekhq/gui/sorter/FormattedNumberSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/FormattedNumberSorter.java
@@ -1,6 +1,6 @@
 package mekhq.gui.sorter;
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.Serializable;
 import java.text.DecimalFormat;
@@ -40,13 +40,13 @@ public class FormattedNumberSorter implements Comparator<String>, Serializable {
         try {
             l0 = FORMAT.parse(s0).longValue();
         } catch (ParseException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         long l1 = 0;
         try {
             l1 = FORMAT.parse(s1).longValue();
         } catch (ParseException e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         return Long.compare(l0, l1);
     }

--- a/MekHQ/src/mekhq/gui/sorter/PersonRankStringSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/PersonRankStringSorter.java
@@ -18,16 +18,15 @@
  */
 package mekhq.gui.sorter;
 
+import megamek.common.util.sorter.NaturalOrderComparator;
+import mekhq.campaign.Campaign;
+import org.apache.logging.log4j.LogManager;
+
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import megamek.common.util.sorter.NaturalOrderComparator;
-import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.Person;
 
 /**
  * A comparator for ranks written as strings with "-" sorted to the bottom always
@@ -92,7 +91,7 @@ public class PersonRankStringSorter implements Comparator<String>, Serializable 
             return getPersonRankSorter().compare(getCampaign().getPerson(UUID.fromString(id0)),
                     getCampaign().getPerson(UUID.fromString(id1)));
         } catch (Exception e) {
-            MekHQ.getLogger().error(String.format("s0: %s, s1: %s", s0, s1), e);
+            LogManager.getLogger().error(String.format("s0: %s, s1: %s", s0, s1), e);
             return 0;
         }
     }

--- a/MekHQ/src/mekhq/gui/sorter/PersonTitleSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/PersonTitleSorter.java
@@ -20,15 +20,10 @@ package mekhq.gui.sorter;
 
 import megamek.common.annotations.Nullable;
 import megamek.common.util.sorter.NaturalOrderComparator;
-import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 
 import java.io.Serializable;
 import java.util.Comparator;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class PersonTitleSorter implements Comparator<Person>, Serializable {
     //region Variable Declarations

--- a/MekHQ/src/mekhq/gui/sorter/PersonTitleStringSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/PersonTitleStringSorter.java
@@ -19,8 +19,8 @@
 package mekhq.gui.sorter;
 
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -87,7 +87,7 @@ public class PersonTitleStringSorter implements Comparator<String>, Serializable
             return getPersonTitleSorter().compare(getCampaign().getPerson(UUID.fromString(id0)),
                     getCampaign().getPerson(UUID.fromString(id1)));
         } catch (Exception e) {
-            MekHQ.getLogger().error(String.format("s0: %s, s1: %s", s0, s1), e);
+            LogManager.getLogger().error(String.format("s0: %s, s1: %s", s0, s1), e);
             return 0;
         }
     }

--- a/MekHQ/src/mekhq/gui/sorter/TargetSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/TargetSorter.java
@@ -1,6 +1,6 @@
 package mekhq.gui.sorter;
 
-import mekhq.MekHQ;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -33,7 +33,7 @@ public class TargetSorter implements Comparator<String>, Serializable {
                 try {
                     r0 = Integer.parseInt(s0);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     r0 = Integer.MAX_VALUE - 1;
                 }
                 break;
@@ -53,7 +53,7 @@ public class TargetSorter implements Comparator<String>, Serializable {
                 try {
                     r1 = Integer.parseInt(s1);
                 } catch (Exception e) {
-                    MekHQ.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     r1 = Integer.MAX_VALUE - 1;
                 }
                 break;

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -18,34 +18,8 @@
  */
 package mekhq.gui.stratcon;
 
-import java.awt.Color;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.UUID;
-
-import javax.swing.DefaultListModel;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.event.ListSelectionEvent;
-
 import megamek.common.Minefield;
-import mekhq.campaign.stratcon.StratconScenario;
-import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
-import mekhq.campaign.stratcon.StratconTrackState;
-import mekhq.campaign.unit.Unit;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.event.DeploymentChangedEvent;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.ScenarioForceTemplate;
@@ -54,6 +28,17 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.stratcon.StratconRulesManager.ReinforcementEligibilityType;
+import mekhq.campaign.stratcon.StratconScenario;
+import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
+import mekhq.campaign.stratcon.StratconTrackState;
+import mekhq.campaign.unit.Unit;
+
+import javax.swing.*;
+import javax.swing.event.ListSelectionEvent;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.util.List;
+import java.util.*;
 
 /**
  * UI for managing force/unit assignments for individual StratCon scenarios.
@@ -577,15 +562,15 @@ public class StratconScenarioWizard extends JDialog {
                 unselectDuplicateUnits(unitList, changedList.getSelectedValuesList());
             }
         }
-        
+
         if (!changedList.equals(availableInfantryUnits)) {
             unselectDuplicateUnits(availableInfantryUnits, changedList.getSelectedValuesList());
         }
-        
+
         if (!changedList.equals(availableLeadershipUnits)) {
             unselectDuplicateUnits(availableLeadershipUnits, changedList.getSelectedValuesList());
         }
-        
+
         StringBuilder sb = new StringBuilder();
         sb.append("<html>");
 
@@ -598,7 +583,7 @@ public class StratconScenarioWizard extends JDialog {
         unitStatusLabel.setText(sb.toString());
         pack();
     }
-    
+
     /**
      * Worker function that de-selects duplicate units.
      * @param listToProcess
@@ -608,7 +593,7 @@ public class StratconScenarioWizard extends JDialog {
         for (Unit selectedUnit : selectedUnits) {
             for (int potentialClearIndex : listToProcess.getSelectedIndices()) {
                 Unit potentialClearTarget = listToProcess.getModel().getElementAt(potentialClearIndex);
-                
+
                 if (potentialClearTarget.getId().equals(selectedUnit.getId())) {
                     listToProcess.removeSelectionInterval(potentialClearIndex, potentialClearIndex);
                 }

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -21,41 +21,6 @@
  */
 package mekhq.gui.view;
 
-import java.awt.Component;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Image;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.ItemListener;
-import java.awt.event.MouseEvent;
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ResourceBundle;
-import java.util.UUID;
-import java.util.Vector;
-
-import javax.swing.BorderFactory;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JTextArea;
-import javax.swing.JTree;
-import javax.swing.event.MouseInputAdapter;
-import javax.swing.event.TreeModelListener;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeCellRenderer;
-import javax.swing.tree.TreeModel;
-import javax.swing.tree.TreePath;
-import javax.swing.tree.TreeSelectionModel;
-
 import megamek.client.ui.dialogs.BotConfigDialog;
 import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.swing.UnitEditorDialog;
@@ -63,17 +28,25 @@ import megamek.common.IStartingPositions;
 import megamek.common.PlanetaryConditions;
 import megamek.common.util.EncodeControl;
 import mekhq.MHQStaticDirectoryManager;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.ForceStub;
 import mekhq.campaign.force.UnitStub;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForceStub;
-import mekhq.campaign.mission.Loot;
-import mekhq.campaign.mission.ScenarioForceTemplate;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.mission.*;
 import mekhq.gui.baseComponents.JScrollablePanel;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.event.MouseInputAdapter;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemListener;
+import java.awt.event.MouseEvent;
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.*;
 
 /**
  * @author Neoancient
@@ -907,7 +880,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                         force.getIconFileName(), force.getIconMap())
                         .getScaledInstance(58, -1, Image.SCALE_SMOOTH));
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
                 return null;
             }
        }

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -21,13 +21,6 @@
  */
 package mekhq.gui.view;
 
-import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ResourceBundle;
-
-import javax.swing.*;
-
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -40,6 +33,12 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.universe.Systems;
 import mekhq.gui.GuiTabType;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ResourceBundle;
 
 /**
  * Contract summary view for ContractMarketDialog

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -18,22 +18,11 @@
  */
 package mekhq.gui.view;
 
-import java.awt.*;
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.ResourceBundle;
-import java.util.UUID;
-
-import javax.swing.BorderFactory;
-import javax.swing.ImageIcon;
-import javax.swing.JLabel;
-
 import megamek.client.ui.Messages;
 import megamek.common.Entity;
 import megamek.common.UnitType;
 import megamek.common.util.EncodeControl;
 import mekhq.MHQStaticDirectoryManager;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.Force;
@@ -41,10 +30,18 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.utilities.MarkdownRenderer;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.ResourceBundle;
+import java.util.UUID;
 
 /**
  * A custom panel that gets filled in with goodies from a Force record
- * @author  Jay Lawson <jaylawson39 at yahoo.com>
+ * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class ForceViewPanel extends JScrollablePanel {
     private static final long serialVersionUID = 7004741688464105277L;
@@ -154,7 +151,7 @@ public class ForceViewPanel extends JScrollablePanel {
                     force.getIconFileName(), force.getIconMap())
                     .getScaledInstance(scale, -1, Image.SCALE_SMOOTH));
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         lbl.setIcon(icon);

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -18,27 +18,26 @@
  */
 package mekhq.gui.view;
 
-import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ResourceBundle;
-
-import javax.swing.*;
-
 import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Contract;
+import mekhq.campaign.mission.Mission;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.GuiTabType;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.utilities.MarkdownRenderer;
 
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ResourceBundle;
+
 /**
  * A custom panel that gets filled in with goodies from a scenario object
- * @author  Jay Lawson <jaylawson39 at yahoo.com>
+ * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class MissionViewPanel extends JScrollablePanel {
     private static final long serialVersionUID = 7004741688464105277L;

--- a/MekHQ/src/mekhq/gui/view/Paperdoll.java
+++ b/MekHQ/src/mekhq/gui/view/Paperdoll.java
@@ -18,10 +18,10 @@
  */
 package mekhq.gui.view;
 
-import mekhq.MekHQ;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.personnel.enums.BodyLocation;
 import mekhq.gui.utilities.MultiplyComposite;
+import org.apache.logging.log4j.LogManager;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -74,7 +74,7 @@ public class Paperdoll extends Component {
         try {
             loadShapeData(is);
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         highlightColor = null;
@@ -106,7 +106,7 @@ public class Paperdoll extends Component {
             try {
                 mt.waitForAll();
             } catch(InterruptedException e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         } else {
             base = new BufferedImage(DEFAULT_WIDTH, DEFAULT_HEIGHT, BufferedImage.TYPE_INT_ARGB);

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -41,6 +41,7 @@ import mekhq.gui.model.PersonnelKillLogModel;
 import mekhq.gui.utilities.ImageHelpers;
 import mekhq.gui.utilities.MarkdownRenderer;
 import mekhq.gui.utilities.WrapLayout;
+import org.apache.logging.log4j.LogManager;
 
 import javax.accessibility.AccessibleRelation;
 import javax.swing.*;
@@ -307,7 +308,7 @@ public class PersonViewPanel extends JScrollablePanel {
                 ribbonLabel.setToolTipText(award.getTooltip());
                 rowRibbonsBox.add(ribbonLabel, 0);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
 
             i++;
@@ -352,7 +353,7 @@ public class PersonViewPanel extends JScrollablePanel {
                 medalLabel.setToolTipText(award.getTooltip());
                 pnlMedals.add(medalLabel);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 
@@ -384,7 +385,7 @@ public class PersonViewPanel extends JScrollablePanel {
                 miscLabel.setToolTipText(award.getTooltip());
                 pnlMiscAwards.add(miscLabel);
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
         return pnlMiscAwards;

--- a/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
@@ -20,22 +20,7 @@
  */
 package mekhq.gui.view;
 
-import java.awt.Component;
-import java.awt.Image;
-import java.util.Vector;
-
-import javax.swing.BorderFactory;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JLabel;
-import javax.swing.JTree;
-import javax.swing.event.TreeModelListener;
-import javax.swing.tree.DefaultTreeCellRenderer;
-import javax.swing.tree.TreeModel;
-import javax.swing.tree.TreePath;
-
 import mekhq.MHQStaticDirectoryManager;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.ForceStub;
 import mekhq.campaign.force.UnitStub;
@@ -43,10 +28,19 @@ import mekhq.campaign.mission.Loot;
 import mekhq.campaign.mission.Scenario;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.utilities.MarkdownRenderer;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreePath;
+import java.awt.*;
+import java.util.Vector;
 
 /**
  * A custom panel that gets filled in with goodies from a scenario object
- * @author  Jay Lawson <jaylawson39 at yahoo.com>
+ * @author Jay Lawson <jaylawson39 at yahoo.com>
  */
 public class ScenarioViewPanel extends JScrollablePanel {
     private static final long serialVersionUID = 7004741688464105277L;
@@ -294,7 +288,7 @@ public class ScenarioViewPanel extends JScrollablePanel {
                         force.getIconFileName(), force.getIconMap())
                         .getScaledInstance(58, -1, Image.SCALE_SMOOTH));
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
                 return null;
             }
         }

--- a/MekHQ/src/mekhq/io/idReferenceClasses/PersonIdReference.java
+++ b/MekHQ/src/mekhq/io/idReferenceClasses/PersonIdReference.java
@@ -18,17 +18,13 @@
  */
 package mekhq.io.idReferenceClasses;
 
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.familyTree.FormerSpouse;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.FamilialRelationshipType;
+import mekhq.campaign.personnel.familyTree.FormerSpouse;
+import org.apache.logging.log4j.LogManager;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 public class PersonIdReference extends Person {
     //region Variables
@@ -65,7 +61,7 @@ public class PersonIdReference extends Person {
             }
             final Person ex = campaign.getPerson(formerSpouse.getFormerSpouse().getId());
             if (ex == null) {
-                MekHQ.getLogger().warning("Failed to find a person with id " + formerSpouse.getFormerSpouse().getId());
+                LogManager.getLogger().warn("Failed to find a person with id " + formerSpouse.getFormerSpouse().getId());
                 unknownPersonnel.add(formerSpouse.getFormerSpouse());
             } else {
                 formerSpouse.setFormerSpouse(ex);
@@ -85,7 +81,7 @@ public class PersonIdReference extends Person {
                 final Person familyMember = (familyMemberRef instanceof PersonIdReference)
                         ? campaign.getPerson(familyMemberRef.getId()) : familyMemberRef;
                 if (familyMember == null) {
-                    MekHQ.getLogger().warning("Failed to find a person with id " + familyMemberRef.getId());
+                    LogManager.getLogger().warn("Failed to find a person with id " + familyMemberRef.getId());
                 } else {
                     family.putIfAbsent(entry.getKey(), new ArrayList<>());
                     family.get(entry.getKey()).add(familyMember);

--- a/MekHQ/src/mekhq/module/AbstractServiceManager.java
+++ b/MekHQ/src/mekhq/module/AbstractServiceManager.java
@@ -18,18 +18,12 @@
  */
 package mekhq.module;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-
 import megamek.common.annotations.Nullable;
-import mekhq.MekHQ;
 import mekhq.module.api.MekHQModule;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Common functionality for MekHQ module service managers.
@@ -52,12 +46,12 @@ abstract public class AbstractServiceManager<T extends MekHQModule> {
         try {
             for (Iterator<T> iter = loader.iterator(); iter.hasNext(); ) {
                 final T service = iter.next();
-                MekHQ.getLogger().debug("Found service " + service.getModuleName());
+                LogManager.getLogger().debug("Found service " + service.getModuleName());
 
                 services.put(service.getModuleName(), service);
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
 

--- a/MekHQ/src/mekhq/module/PluginManager.java
+++ b/MekHQ/src/mekhq/module/PluginManager.java
@@ -18,6 +18,8 @@
  */
 package mekhq.module;
 
+import org.apache.logging.log4j.LogManager;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -25,8 +27,6 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import mekhq.MekHQ;
 
 /**
  * Tracks which plugins are installed and which are active. Provides class loader for use by ServiceLoader.
@@ -48,21 +48,21 @@ public class PluginManager {
     }
 
     private PluginManager() {
-        MekHQ.getLogger().debug("Initializing plugin manager.");
+        LogManager.getLogger().debug("Initializing plugin manager.");
 
         scriptFiles = new ArrayList<>();
         File dir = new File(PLUGIN_DIR);
         if (!dir.exists()) {
-            MekHQ.getLogger().warning("Could not find plugin directory");
+            LogManager.getLogger().warn("Could not find plugin directory");
         }
         URL[] urls = new URL[0];
         if (dir.exists() && dir.isDirectory()) {
             List<URL> plugins = getPluginsFromDir(dir);
             urls = plugins.toArray(urls);
         } else {
-            MekHQ.getLogger().warning("Could not find plugin directory.");
+            LogManager.getLogger().warn("Could not find plugin directory.");
         }
-        MekHQ.getLogger().debug("Found " + urls.length + " plugins");
+        LogManager.getLogger().debug("Found " + urls.length + " plugins");
         classLoader = new URLClassLoader(urls);
     }
 
@@ -80,7 +80,7 @@ public class PluginManager {
             return new ArrayList<>();
         }
 
-        MekHQ.getLogger().debug("Now checking directory " + origin.getName());
+        LogManager.getLogger().debug("Now checking directory " + origin.getName());
         final List<URL> plugins = new ArrayList<>();
         for (final File file : files) {
             if (file.getName().startsWith(".")) {
@@ -90,7 +90,7 @@ public class PluginManager {
             plugins.addAll(getPluginsFromDir(file));
 
             if (file.getName().toLowerCase().endsWith(".jar")) {
-                MekHQ.getLogger().debug("Now adding plugin " + file.getName() + " to class loader.");
+                LogManager.getLogger().debug("Now adding plugin " + file.getName() + " to class loader.");
                 try {
                     plugins.add(file.toURI().toURL());
                 } catch (MalformedURLException ignored) {

--- a/MekHQ/src/mekhq/module/ScriptPluginManager.java
+++ b/MekHQ/src/mekhq/module/ScriptPluginManager.java
@@ -18,17 +18,18 @@
  */
 package mekhq.module;
 
-import java.io.*;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import mekhq.module.api.MekHQModule;
+import org.apache.logging.log4j.LogManager;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
-
-import mekhq.MekHQ;
-import mekhq.module.api.MekHQModule;
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Manages plugins requiring interpretation by a scripting engine. As scripts are encountered while
@@ -74,7 +75,7 @@ public class ScriptPluginManager {
     private void addModule(File script, String extension) {
         ScriptEngine engine = scriptEngineManager.getEngineByExtension(extension);
         if (null == engine) {
-            MekHQ.getLogger().warning("Could not find script engine for extension " + extension);
+            LogManager.getLogger().warn("Could not find script engine for extension " + extension);
             return;
         }
         try (Reader fileReader = new FileReader(script)) {
@@ -86,7 +87,7 @@ public class ScriptPluginManager {
                 }
             }
         } catch (Exception e) {
-            MekHQ.getLogger().error("While parsing script " + script.getName(), e);
+            LogManager.getLogger().error("While parsing script " + script.getName(), e);
         }
     }
 
@@ -94,10 +95,10 @@ public class ScriptPluginManager {
     private static void listEngines() {
         ScriptEngineManager mgr = new ScriptEngineManager(PluginManager.getInstance().getClassLoader());
         for (ScriptEngineFactory engine : mgr.getEngineFactories()) {
-            MekHQ.getLogger().info("Engine: " + engine.getEngineName());
-            MekHQ.getLogger().info("\tVersion: " + engine.getEngineVersion());
-            MekHQ.getLogger().info("\tAlias: " + engine.getNames());
-            MekHQ.getLogger().info("\tLanguage name: " + engine.getLanguageName() + "\n");
+            LogManager.getLogger().info("Engine: " + engine.getEngineName());
+            LogManager.getLogger().info("\tVersion: " + engine.getEngineVersion());
+            LogManager.getLogger().info("\tAlias: " + engine.getNames());
+            LogManager.getLogger().info("\tLanguage name: " + engine.getLanguageName() + "\n");
         }
     }
 }

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -36,6 +36,7 @@ import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.IUnitGenerator;
 import mekhq.campaign.universe.RandomFactionGenerator;
+import org.apache.logging.log4j.LogManager;
 
 import java.time.DayOfWeek;
 import java.util.ArrayList;
@@ -193,17 +194,17 @@ public class AtBEventProcessor {
             if (Factions.getInstance().getFaction(faction).isClan() && ms.getName().matches(".*Platoon.*")) {
                 String name = "Clan " + ms.getName().replaceAll("Platoon", "Point");
                 ms = MechSummaryCache.getInstance().getMech(name);
-                MekHQ.getLogger().info("looking for Clan infantry " + name);
+                LogManager.getLogger().info("looking for Clan infantry " + name);
             }
             try {
                 en = new MechFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
             } catch (EntityLoadingException ex) {
                 en = null;
-                MekHQ.getLogger().error("Unable to load entity: "
+                LogManager.getLogger().error("Unable to load entity: "
                         + ms.getSourceFile() + ": " + ms.getEntryName() + ": " + ex.getMessage(), ex);
             }
         } else {
-            MekHQ.getLogger().error("Personnel market could not find "
+            LogManager.getLogger().error("Personnel market could not find "
                     + UnitType.getTypeName(unitType) + " for recruit from faction " + faction);
             return;
         }

--- a/MekHQ/src/mekhq/service/AutosaveService.java
+++ b/MekHQ/src/mekhq/service/AutosaveService.java
@@ -24,6 +24,7 @@ import megamek.common.util.StringUtil;
 import mekhq.MekHQ;
 import mekhq.MekHqConstants;
 import mekhq.campaign.Campaign;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -34,7 +35,9 @@ import java.nio.file.Paths;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 
@@ -81,10 +84,10 @@ public class AutosaveService implements IAutosaveService {
                     writer.close();
                 }
             } else {
-                MekHQ.getLogger().error("Unable to perform an autosave because of a null or empty file name");
+                LogManager.getLogger().error("Unable to perform an autosave because of a null or empty file name");
             }
         } catch (Exception ex) {
-            MekHQ.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -107,7 +110,7 @@ public class AutosaveService implements IAutosaveService {
                 if (autosaveFiles.get(index).delete()) {
                     autosaveFiles.remove(index);
                 } else {
-                    MekHQ.getLogger().error("Unable to delete file " + autosaveFiles.get(index).getName());
+                    LogManager.getLogger().error("Unable to delete file " + autosaveFiles.get(index).getName());
                     index++;
                 }
             }

--- a/MekHQ/src/mekhq/service/MassRepairOption.java
+++ b/MekHQ/src/mekhq/service/MassRepairOption.java
@@ -18,11 +18,11 @@
  */
 package mekhq.service;
 
-import mekhq.MekHQ;
-import mekhq.MekHqXmlUtil;
 import megamek.Version;
+import mekhq.MekHqXmlUtil;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.personnel.SkillType;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -140,12 +140,12 @@ public class MassRepairOption {
                 }
 
                 if ((mro.getType() == PartRepairType.UNKNOWN_LOCATION) || !partRepairTypes.contains(mro.getType())) {
-                    MekHQ.getLogger().error("Attempted to load MassRepairOption with illegal type id of " + mro.getType());
+                    LogManager.getLogger().error("Attempted to load MassRepairOption with illegal type id of " + mro.getType());
                 } else {
                     massRepairOptions.add(mro);
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error("Failed to parse MassRepairOption from XML", e);
+                LogManager.getLogger().error("Failed to parse MassRepairOption from XML", e);
             }
         }
 
@@ -178,7 +178,7 @@ public class MassRepairOption {
                     mro.setBthMax(Integer.parseInt(mroItemNode.getTextContent().trim()));
                 }
             } catch (Exception e) {
-                MekHQ.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         }
 

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -18,30 +18,11 @@
  */
 package mekhq.service;
 
-import java.io.Serializable;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
-
-import megamek.common.Aero;
-import megamek.common.BattleArmor;
-import megamek.common.Mech;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
+import megamek.common.*;
 import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.parts.Armor;
-import mekhq.campaign.parts.MekLocation;
-import mekhq.campaign.parts.MissingMekLocation;
-import mekhq.campaign.parts.MissingPart;
-import mekhq.campaign.parts.Part;
-import mekhq.campaign.parts.PodSpace;
+import mekhq.campaign.parts.*;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.personnel.Person;
@@ -51,6 +32,11 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IPartWork;
 import mekhq.campaign.work.WorkTime;
 import mekhq.gui.sorter.UnitStatusSorter;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.Serializable;
+import java.text.MessageFormat;
+import java.util.*;
 
 public class MassRepairService {
     private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MassRepair", new EncodeControl());
@@ -1149,7 +1135,7 @@ public class MassRepairService {
             msg = String.format(msg, replacements);
         }
 
-        MekHQ.getLogger().debug(msg);
+        LogManager.getLogger().debug(msg);
     }
 
     private static class WorkTimeCalculation {


### PR DESCRIPTION
This swaps MegaMekLab to Log4j 2 and by doing so improves our logging implementation in MegaMekLab.

The MekHQ::showInfo method has been standardized with MegaMek and MegaMekLab, with both called to set up the individual logs.

All three are used in MekHQ, with logs being split between MegaMek.log, MegaMekLab.log, and MekHQ.log depending on their origins.

CI is expected to fail due to certain resources issues. If it continues after merge I'll need to investigate it again.