### PR TITLE
JUnit Update to 4.13.2 from 4.12

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.1.0'
 }
 


### PR DESCRIPTION
All tests work properly. We'll need to update to JUnit 5 at some point in the near future, but this is an easy update in the meantime.

