### PR TITLE
prevent NPE when adding a new contract manually

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -400,6 +400,7 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
         if ((cachedJumpPath == null) ||
                 (cachedJumpPath.size() == 0) ||
                 !cachedJumpPath.getFirstSystem().getId().equals(c.getCurrentSystem().getId()) ||
+                (getSystem() == null) ||
                 !cachedJumpPath.getLastSystem().getId().equals(getSystem().getId())) {
             cachedJumpPath = c.calculateJumpPath(c.getCurrentSystem(), getSystem());
         }

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -399,9 +399,8 @@ public class Contract extends Mission implements Serializable, MekHqXmlSerializa
         // no longer match the campaign's current location or contract's destination
         if ((cachedJumpPath == null) ||
                 (cachedJumpPath.size() == 0) ||
-                !cachedJumpPath.getFirstSystem().getId().equals(c.getCurrentSystem().getId()) ||
-                (getSystem() == null) ||
-                !cachedJumpPath.getLastSystem().getId().equals(getSystem().getId())) {
+                !cachedJumpPath.getFirstSystem().equals(c.getCurrentSystem()) ||
+                !cachedJumpPath.getLastSystem().equals(getSystem())) {
             cachedJumpPath = c.calculateJumpPath(c.getCurrentSystem(), getSystem());
         }
 


### PR DESCRIPTION
getSystem() in contract returns null if it's entered from the add mission -> new contract workflow.