### PR TITLE
Fixing missing files in the Windows MHQ build

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -303,6 +303,9 @@ distributions {
                 rename 'history.txt', 'mhq-history.txt'
                 into 'docs'
             }
+            from (fileStagingDir) {
+                exclude 'history.txt'
+            }
             from ("${buildDir}/launch4j") {
                 include '*.exe'
                 include '*.ini'


### PR DESCRIPTION
Found this was missing for MekHQ's windows build after the Log4j2 changes. Will merge immediately if the fix works