### PR TITLE
Fix NPE  bug on techId

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -472,7 +472,9 @@ public class Force implements Serializable {
         }
         MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "combatForce", combatForce);
         MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "scenarioId", scenarioId);
-        MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "techId", techId);
+        if(null != techId) {
+            MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "techId", techId);
+        }
         if (!units.isEmpty()) {
             MekHqXmlUtil.writeSimpleXMLOpenTag(pw1, indent++, "units");
             for (UUID uid : units) {


### PR DESCRIPTION
This PR should resolve #3026. This commit now checks for null status of techId before trying to write it to XML.