### PR TITLE
Fix DS_Store entry in gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,10 @@
 /out/
 /RemoteSystemsTempFiles/
 /.classpath
-/.DS_Store
 /.metadata
 /.project
 /.vscode
 /properties_local.gradle
 /settings_local.gradle
 /*.sav.gz
+.DS_Store


### PR DESCRIPTION
A very simple PR for the Mac people. The OSX operatin system puts a .DS_Store file in any directory visited through the finder, which git should ignore. The .DS_Store entry in the .gitignore file is only picking up .DS_Store in the top level directory and not in any sub-directories, meaning my `git status` checks are littered with .DS_Store entries. This just changes that to ignore .DS_Store in all sub-directories as well.