### PR TITLE
2974: Windows Build Unix Script MML Startup Script Missing

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -252,6 +252,7 @@ distributions {
             }
             from ("${mmlDir}/build/scripts") {
                 include 'lab*'
+                rename 'lab(.*)', 'mml-startup$1'
             }
             from ("${mmlDir}/docs/history.txt") {
                 rename 'history.txt', 'mml-history.txt'
@@ -269,6 +270,7 @@ distributions {
             }
             from (createStartScripts) {
                 include 'hq*'
+                rename 'hq(.*)', 'mhq-startup$1'
             }
             from(jar)
             from (project.sourceSets.main.runtimeClasspath.files


### PR DESCRIPTION
This fixes #2974 and standardizes the naming of the startup scripts.