### PR TITLE
2928: Return a Null Refit When The New Entity Can't Be Parsed

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1968,76 +1968,80 @@ public class Refit extends Part implements IAcquisitionWork {
         pw1.println(MekHqXmlUtil.indentStr(indentLvl) + "</refit>");
     }
 
-    public static Refit generateInstanceFromXML(final Node wn, final Version version,
-                                                final Campaign campaign, final Unit unit)
-            throws Exception {
+    public static @Nullable Refit generateInstanceFromXML(final Node wn, final Version version,
+                                                          final Campaign campaign, final Unit unit) {
         Refit retVal = new Refit();
         retVal.oldUnit = Objects.requireNonNull(unit);
 
         NodeList nl = wn.getChildNodes();
 
-        for (int x = 0; x < nl.getLength(); x++) {
-            Node wn2 = nl.item(x);
+        try {
+            for (int x = 0; x < nl.getLength(); x++) {
+                Node wn2 = nl.item(x);
 
-            if (wn2.getNodeName().equalsIgnoreCase("time")) {
-                retVal.time = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("refitClass")) {
-                retVal.refitClass = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("timeSpent")) {
-                retVal.timeSpent = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("quantity")) {
-                retVal.quantity = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("daysToWait")) {
-                retVal.daysToWait = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("cost")) {
-                retVal.cost = Money.fromXmlString(wn2.getTextContent().trim());
-            } else if (wn2.getNodeName().equalsIgnoreCase("newArmorSuppliesId")) {
-                retVal.newArmorSupplies = new RefitArmorRef(Integer.parseInt(wn2.getTextContent()));
-            } else if (wn2.getNodeName().equalsIgnoreCase("assignedTechId")) {
-                retVal.assignedTech = new RefitPersonRef(UUID.fromString(wn2.getTextContent()));
-            } else if (wn2.getNodeName().equalsIgnoreCase("failedCheck")) {
-                retVal.failedCheck = wn2.getTextContent().equalsIgnoreCase("true");
-            } else if (wn2.getNodeName().equalsIgnoreCase("customJob")) {
-                retVal.customJob = wn2.getTextContent().equalsIgnoreCase("true");
-            } else if (wn2.getNodeName().equalsIgnoreCase("kitFound")) {
-                retVal.kitFound = wn2.getTextContent().equalsIgnoreCase("true");
-            } else if (wn2.getNodeName().equalsIgnoreCase("isRefurbishing")) {
-                retVal.isRefurbishing = wn2.getTextContent().equalsIgnoreCase("true");
-            } else if (wn2.getNodeName().equalsIgnoreCase("armorNeeded")) {
-                retVal.armorNeeded = Integer.parseInt(wn2.getTextContent());
-            } else if (wn2.getNodeName().equalsIgnoreCase("sameArmorType")) {
-                retVal.sameArmorType = wn2.getTextContent().equalsIgnoreCase("true");
-            } else if (wn2.getNodeName().equalsIgnoreCase("entity")) {
-                retVal.newEntity = Objects.requireNonNull(MekHqXmlUtil.parseSingleEntityMul((Element) wn2, campaign.getGameOptions()));
-            } else if (wn2.getNodeName().equalsIgnoreCase("oldUnitParts")) {
-                NodeList nl2 = wn2.getChildNodes();
-                for (int y = 0; y < nl2.getLength(); y++) {
-                    Node wn3 = nl2.item(y);
-                    if (wn3.getNodeName().equalsIgnoreCase("pid")) {
-                        retVal.oldUnitParts.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
+                if (wn2.getNodeName().equalsIgnoreCase("time")) {
+                    retVal.time = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("refitClass")) {
+                    retVal.refitClass = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("timeSpent")) {
+                    retVal.timeSpent = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("quantity")) {
+                    retVal.quantity = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("daysToWait")) {
+                    retVal.daysToWait = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("cost")) {
+                    retVal.cost = Money.fromXmlString(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("newArmorSuppliesId")) {
+                    retVal.newArmorSupplies = new RefitArmorRef(Integer.parseInt(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("assignedTechId")) {
+                    retVal.assignedTech = new RefitPersonRef(UUID.fromString(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("failedCheck")) {
+                    retVal.failedCheck = wn2.getTextContent().equalsIgnoreCase("true");
+                } else if (wn2.getNodeName().equalsIgnoreCase("customJob")) {
+                    retVal.customJob = wn2.getTextContent().equalsIgnoreCase("true");
+                } else if (wn2.getNodeName().equalsIgnoreCase("kitFound")) {
+                    retVal.kitFound = wn2.getTextContent().equalsIgnoreCase("true");
+                } else if (wn2.getNodeName().equalsIgnoreCase("isRefurbishing")) {
+                    retVal.isRefurbishing = wn2.getTextContent().equalsIgnoreCase("true");
+                } else if (wn2.getNodeName().equalsIgnoreCase("armorNeeded")) {
+                    retVal.armorNeeded = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("sameArmorType")) {
+                    retVal.sameArmorType = wn2.getTextContent().equalsIgnoreCase("true");
+                } else if (wn2.getNodeName().equalsIgnoreCase("entity")) {
+                    retVal.newEntity = Objects.requireNonNull(MekHqXmlUtil.parseSingleEntityMul((Element) wn2, campaign.getGameOptions()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("oldUnitParts")) {
+                    NodeList nl2 = wn2.getChildNodes();
+                    for (int y = 0; y < nl2.getLength(); y++) {
+                        Node wn3 = nl2.item(y);
+                        if (wn3.getNodeName().equalsIgnoreCase("pid")) {
+                            retVal.oldUnitParts.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
+                        }
                     }
-                }
-            } else if (wn2.getNodeName().equalsIgnoreCase("newUnitParts")) {
-                NodeList nl2 = wn2.getChildNodes();
-                for (int y = 0; y < nl2.getLength(); y++) {
-                    Node wn3 = nl2.item(y);
-                    if (wn3.getNodeName().equalsIgnoreCase("pid")) {
-                        retVal.newUnitParts.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
+                } else if (wn2.getNodeName().equalsIgnoreCase("newUnitParts")) {
+                    NodeList nl2 = wn2.getChildNodes();
+                    for (int y = 0; y < nl2.getLength(); y++) {
+                        Node wn3 = nl2.item(y);
+                        if (wn3.getNodeName().equalsIgnoreCase("pid")) {
+                            retVal.newUnitParts.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
+                        }
                     }
-                }
-            } else if (wn2.getNodeName().equalsIgnoreCase("lcBinsToChange")) {
-                NodeList nl2 = wn2.getChildNodes();
-                for (int y=0; y<nl2.getLength(); y++) {
-                    Node wn3 = nl2.item(y);
-                    if (wn3.getNodeName().equalsIgnoreCase("pid")) {
-                        retVal.lcBinsToChange.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
+                } else if (wn2.getNodeName().equalsIgnoreCase("lcBinsToChange")) {
+                    NodeList nl2 = wn2.getChildNodes();
+                    for (int y=0; y<nl2.getLength(); y++) {
+                        Node wn3 = nl2.item(y);
+                        if (wn3.getNodeName().equalsIgnoreCase("pid")) {
+                            retVal.lcBinsToChange.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
+                        }
                     }
+                } else if (wn2.getNodeName().equalsIgnoreCase("shoppingList")) {
+                    processShoppingList(retVal, wn2, retVal.oldUnit, version);
+                } else if (wn2.getNodeName().equalsIgnoreCase("newArmorSupplies")) {
+                    processArmorSupplies(retVal, wn2, version);
                 }
-            } else if (wn2.getNodeName().equalsIgnoreCase("shoppingList")) {
-                processShoppingList(retVal, wn2, retVal.oldUnit, version);
-            } else if (wn2.getNodeName().equalsIgnoreCase("newArmorSupplies")) {
-                processArmorSupplies(retVal, wn2, version);
             }
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
+            return null;
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1969,78 +1969,75 @@ public class Refit extends Part implements IAcquisitionWork {
     }
 
     public static Refit generateInstanceFromXML(final Node wn, final Version version,
-                                                final Campaign campaign, final Unit unit) {
+                                                final Campaign campaign, final Unit unit)
+            throws Exception {
         Refit retVal = new Refit();
         retVal.oldUnit = Objects.requireNonNull(unit);
 
         NodeList nl = wn.getChildNodes();
 
-        try {
-            for (int x = 0; x < nl.getLength(); x++) {
-                Node wn2 = nl.item(x);
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn2 = nl.item(x);
 
-                if (wn2.getNodeName().equalsIgnoreCase("time")) {
-                    retVal.time = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("refitClass")) {
-                    retVal.refitClass = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("timeSpent")) {
-                    retVal.timeSpent = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("quantity")) {
-                    retVal.quantity = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("daysToWait")) {
-                    retVal.daysToWait = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("cost")) {
-                    retVal.cost = Money.fromXmlString(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("newArmorSuppliesId")) {
-                    retVal.newArmorSupplies = new RefitArmorRef(Integer.parseInt(wn2.getTextContent()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("assignedTechId")) {
-                    retVal.assignedTech = new RefitPersonRef(UUID.fromString(wn2.getTextContent()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("failedCheck")) {
-                    retVal.failedCheck = wn2.getTextContent().equalsIgnoreCase("true");
-                } else if (wn2.getNodeName().equalsIgnoreCase("customJob")) {
-                    retVal.customJob = wn2.getTextContent().equalsIgnoreCase("true");
-                } else if (wn2.getNodeName().equalsIgnoreCase("kitFound")) {
-                    retVal.kitFound = wn2.getTextContent().equalsIgnoreCase("true");
-                } else if (wn2.getNodeName().equalsIgnoreCase("isRefurbishing")) {
-                    retVal.isRefurbishing = wn2.getTextContent().equalsIgnoreCase("true");
-                } else if (wn2.getNodeName().equalsIgnoreCase("armorNeeded")) {
-                    retVal.armorNeeded = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("sameArmorType")) {
-                    retVal.sameArmorType = wn2.getTextContent().equalsIgnoreCase("true");
-                } else if (wn2.getNodeName().equalsIgnoreCase("entity")) {
-                    retVal.newEntity = MekHqXmlUtil.parseSingleEntityMul((Element) wn2, campaign.getGameOptions());
-                } else if (wn2.getNodeName().equalsIgnoreCase("oldUnitParts")) {
-                    NodeList nl2 = wn2.getChildNodes();
-                    for (int y = 0; y < nl2.getLength(); y++) {
-                        Node wn3 = nl2.item(y);
-                        if (wn3.getNodeName().equalsIgnoreCase("pid")) {
-                            retVal.oldUnitParts.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
-                        }
+            if (wn2.getNodeName().equalsIgnoreCase("time")) {
+                retVal.time = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("refitClass")) {
+                retVal.refitClass = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("timeSpent")) {
+                retVal.timeSpent = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("quantity")) {
+                retVal.quantity = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("daysToWait")) {
+                retVal.daysToWait = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("cost")) {
+                retVal.cost = Money.fromXmlString(wn2.getTextContent().trim());
+            } else if (wn2.getNodeName().equalsIgnoreCase("newArmorSuppliesId")) {
+                retVal.newArmorSupplies = new RefitArmorRef(Integer.parseInt(wn2.getTextContent()));
+            } else if (wn2.getNodeName().equalsIgnoreCase("assignedTechId")) {
+                retVal.assignedTech = new RefitPersonRef(UUID.fromString(wn2.getTextContent()));
+            } else if (wn2.getNodeName().equalsIgnoreCase("failedCheck")) {
+                retVal.failedCheck = wn2.getTextContent().equalsIgnoreCase("true");
+            } else if (wn2.getNodeName().equalsIgnoreCase("customJob")) {
+                retVal.customJob = wn2.getTextContent().equalsIgnoreCase("true");
+            } else if (wn2.getNodeName().equalsIgnoreCase("kitFound")) {
+                retVal.kitFound = wn2.getTextContent().equalsIgnoreCase("true");
+            } else if (wn2.getNodeName().equalsIgnoreCase("isRefurbishing")) {
+                retVal.isRefurbishing = wn2.getTextContent().equalsIgnoreCase("true");
+            } else if (wn2.getNodeName().equalsIgnoreCase("armorNeeded")) {
+                retVal.armorNeeded = Integer.parseInt(wn2.getTextContent());
+            } else if (wn2.getNodeName().equalsIgnoreCase("sameArmorType")) {
+                retVal.sameArmorType = wn2.getTextContent().equalsIgnoreCase("true");
+            } else if (wn2.getNodeName().equalsIgnoreCase("entity")) {
+                retVal.newEntity = Objects.requireNonNull(MekHqXmlUtil.parseSingleEntityMul((Element) wn2, campaign.getGameOptions()));
+            } else if (wn2.getNodeName().equalsIgnoreCase("oldUnitParts")) {
+                NodeList nl2 = wn2.getChildNodes();
+                for (int y = 0; y < nl2.getLength(); y++) {
+                    Node wn3 = nl2.item(y);
+                    if (wn3.getNodeName().equalsIgnoreCase("pid")) {
+                        retVal.oldUnitParts.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
                     }
-                } else if (wn2.getNodeName().equalsIgnoreCase("newUnitParts")) {
-                    NodeList nl2 = wn2.getChildNodes();
-                    for (int y = 0; y < nl2.getLength(); y++) {
-                        Node wn3 = nl2.item(y);
-                        if (wn3.getNodeName().equalsIgnoreCase("pid")) {
-                            retVal.newUnitParts.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
-                        }
-                    }
-                } else if (wn2.getNodeName().equalsIgnoreCase("lcBinsToChange")) {
-                    NodeList nl2 = wn2.getChildNodes();
-                    for (int y=0; y<nl2.getLength(); y++) {
-                        Node wn3 = nl2.item(y);
-                        if (wn3.getNodeName().equalsIgnoreCase("pid")) {
-                            retVal.lcBinsToChange.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
-                        }
-                    }
-                } else if (wn2.getNodeName().equalsIgnoreCase("shoppingList")) {
-                    processShoppingList(retVal, wn2, retVal.oldUnit, version);
-                } else if (wn2.getNodeName().equalsIgnoreCase("newArmorSupplies")) {
-                    processArmorSupplies(retVal, wn2, version);
                 }
+            } else if (wn2.getNodeName().equalsIgnoreCase("newUnitParts")) {
+                NodeList nl2 = wn2.getChildNodes();
+                for (int y = 0; y < nl2.getLength(); y++) {
+                    Node wn3 = nl2.item(y);
+                    if (wn3.getNodeName().equalsIgnoreCase("pid")) {
+                        retVal.newUnitParts.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
+                    }
+                }
+            } else if (wn2.getNodeName().equalsIgnoreCase("lcBinsToChange")) {
+                NodeList nl2 = wn2.getChildNodes();
+                for (int y=0; y<nl2.getLength(); y++) {
+                    Node wn3 = nl2.item(y);
+                    if (wn3.getNodeName().equalsIgnoreCase("pid")) {
+                        retVal.lcBinsToChange.add(new RefitPartRef(Integer.parseInt(wn3.getTextContent())));
+                    }
+                }
+            } else if (wn2.getNodeName().equalsIgnoreCase("shoppingList")) {
+                processShoppingList(retVal, wn2, retVal.oldUnit, version);
+            } else if (wn2.getNodeName().equalsIgnoreCase("newArmorSupplies")) {
+                processArmorSupplies(retVal, wn2, version);
             }
-        } catch (Exception ex) {
-            LogManager.getLogger().error("", ex);
         }
 
         return retVal;

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -187,7 +187,7 @@ public class RefitTest {
     }
 
     @Test
-    public void testLocust1Vto1EWriteToXml() throws ParserConfigurationException, SAXException, IOException {
+    public void testLocust1Vto1EWriteToXml() throws Exception {
         Campaign mockCampaign = mock(Campaign.class);
         when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
         Warehouse mockWarehouse = mock(Warehouse.class);
@@ -390,7 +390,7 @@ public class RefitTest {
     }
 
     @Test
-    public void testJavelinJVN10Nto10AWriteToXml() throws ParserConfigurationException, SAXException, IOException {
+    public void testJavelinJVN10Nto10AWriteToXml() throws Exception {
         Campaign mockCampaign = mock(Campaign.class);
         when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
@@ -448,7 +448,6 @@ public class RefitTest {
 
         // Deserialize the refit
         Refit deserialized = Refit.generateInstanceFromXML(refitElt, new Version(), mockCampaign, oldUnit);
-        assertNotNull(deserialized);
 
         // Spot check the values
         assertEquals(refit.getTime(), deserialized.getTime());
@@ -621,7 +620,7 @@ public class RefitTest {
     }
 
     @Test
-    public void testFleaFLE4toFLE15WriteToXml() throws ParserConfigurationException, SAXException, IOException {
+    public void testFleaFLE4toFLE15WriteToXml() throws Exception {
         Campaign mockCampaign = mock(Campaign.class);
         when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -187,7 +187,7 @@ public class RefitTest {
     }
 
     @Test
-    public void testLocust1Vto1EWriteToXml() throws Exception {
+    public void testLocust1Vto1EWriteToXml() throws ParserConfigurationException, SAXException, IOException {
         Campaign mockCampaign = mock(Campaign.class);
         when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
         Warehouse mockWarehouse = mock(Warehouse.class);
@@ -390,7 +390,7 @@ public class RefitTest {
     }
 
     @Test
-    public void testJavelinJVN10Nto10AWriteToXml() throws Exception {
+    public void testJavelinJVN10Nto10AWriteToXml() throws ParserConfigurationException, SAXException, IOException {
         Campaign mockCampaign = mock(Campaign.class);
         when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
@@ -448,6 +448,7 @@ public class RefitTest {
 
         // Deserialize the refit
         Refit deserialized = Refit.generateInstanceFromXML(refitElt, new Version(), mockCampaign, oldUnit);
+        assertNotNull(deserialized);
 
         // Spot check the values
         assertEquals(refit.getTime(), deserialized.getTime());
@@ -620,7 +621,7 @@ public class RefitTest {
     }
 
     @Test
-    public void testFleaFLE4toFLE15WriteToXml() throws Exception {
+    public void testFleaFLE4toFLE15WriteToXml() throws ParserConfigurationException, SAXException, IOException {
         Campaign mockCampaign = mock(Campaign.class);
         when(mockCampaign.getEntities()).thenReturn(new ArrayList<>());
         CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);


### PR DESCRIPTION
This fixes #2928, and everything for the refit is cleared after the load fails.