### PR TITLE
Fix faction codes

### DIFF
--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -1781,4 +1781,12 @@ successor - unimplemented tag describing another faction code as the specified f
         <start>3022</start>
         <end>3025</end>
     </faction>
+    <faction>
+        <shortname>TiC</shortname>
+        <fullname>Timbuktu Collective</fullname>
+        <startingPlanet>Timbuktu</startingPlanet>
+        <colorRGB>93,133,147</colorRGB>
+        <tags>periphery,minor</tags>
+        <start>3148</start>
+    </faction>
 </factions>

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -923,7 +923,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <startingPlanet>Granada</startingPlanet>
         <eraMods>1,1,1,1,2,3,2,2,1</eraMods>
         <colorRGB>238,232,170</colorRGB>
-        <tags>clan,deep_periphery</tags>
+        <tags>clan,deep_periphery,playable</tags>
         <start>3080</start>
     </faction>
     <faction>

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -918,6 +918,7 @@ successor - unimplemented tag describing another faction code as the specified f
     <faction>
         <shortname>CEI</shortname>
         <fullname>Escorpión Imperio</fullname>
+        <altNamesByYear year='3142'>Scorpion Empire</altNamesByYear>
         <alternativeFactionCodes>CGS,NC,UC</alternativeFactionCodes>
         <startingPlanet>Granada</startingPlanet>
         <eraMods>1,1,1,1,2,3,2,2,1</eraMods>


### PR DESCRIPTION
We are trying to line up faction codes as closely as possible with SUCS data. In looking through the existing list, it looks like we need to fix two things:

* Add Timbuktu Collective (new faction in 3151)
* Fix Escorpion Imperio entries. We have two codes for this, the old CGS codes and a new CEI code. However, we are not actually using the CEI codes. We already do something like this for the Ghost Bears where we switch all existing CGB codes to RD (Rassalhague Dominion) codes in 3103. So we just need to do that and then we need an alternate name of "Scorpion Empire" at some point.  