### PR TITLE
Blocker: Unit Testing EquipmentType NPE and ConMod Fixes

### DIFF
--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -21,6 +21,7 @@
 package mekhq.campaign;
 
 import megamek.common.Dropship;
+import megamek.common.EquipmentType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
@@ -46,12 +47,12 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Deric Page (dericdotpageatgmaildotcom)
- * @version %Id%
  * @since 6/10/14 10:23 AM
  */
 public class CampaignTest {
     @Before
     public void setup() {
+        EquipmentType.initializeTypes();
         Ranks.initializeRankSystems();
         try {
             Systems.setInstance(Systems.loadDefault());

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
@@ -18,37 +18,13 @@
  */
 package mekhq.campaign.market;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.UUID;
-import java.util.Vector;
-
-import javax.xml.parsers.ParserConfigurationException;
-
-import mekhq.campaign.mission.enums.AtBContractType;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.w3c.dom.DOMException;
-import org.xml.sax.SAXException;
-
-import megamek.common.Compute;
-import megamek.common.Crew;
-import megamek.common.CrewType;
-import megamek.common.EquipmentType;
-import megamek.common.MMRandom;
-import megamek.common.MMRoll;
-import megamek.common.Mech;
+import megamek.common.*;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Contract;
+import mekhq.campaign.mission.enums.AtBContractType;
 import mekhq.campaign.mission.enums.ContractCommandRights;
 import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.personnel.Person;
@@ -60,30 +36,33 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.RandomFactionGenerator;
 import mekhq.campaign.universe.Systems;
+import org.apache.logging.log4j.LogManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.Vector;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 public class ContractMarketIntegrationTest {
     private static final int REASONABLE_GENERATION_ATTEMPTS = 3;
 
     private Campaign campaign;
 
-    @BeforeClass
-    public static void setupStatics()
-            throws DOMException, SAXException, IOException, ParserConfigurationException, ParseException {
-        EquipmentType.initializeTypes();
-        Factions.setInstance(Factions.loadDefault());
-        Systems.setInstance(Systems.loadDefault());
-        Ranks.initializeRankSystems();
-    }
-
-    @AfterClass
-    public static void cleanupStatics() {
-        Systems.setInstance(null);
-        RandomFactionGenerator.setInstance(null);
-        Factions.setInstance(null);
-    }
-
     @Before
-    public void setupCampaign() {
+    public void setup() {
+        EquipmentType.initializeTypes();
+        try {
+            Factions.setInstance(Factions.loadDefault());
+            Systems.setInstance(Systems.loadDefault());
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
+        }
+        Ranks.initializeRankSystems();
         CampaignOptions options = new CampaignOptions();
         options.setUnitRatingMethod(UnitRatingMethod.NONE);
 

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingHeatSinkTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/MissingHeatSinkTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -37,6 +38,11 @@ import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
 
 public class MissingHeatSinkTest {
+    @Before
+    public void setup() {
+        EquipmentType.initializeTypes();
+    }
+
     /**
      * https://github.com/MegaMek/mekhq/issues/2365
      */

--- a/MekHQ/unittests/mekhq/campaign/unit/actions/StripUnitActionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/actions/StripUnitActionTest.java
@@ -20,6 +20,7 @@
  */
 package mekhq.campaign.unit.actions;
 
+import megamek.common.EquipmentType;
 import mekhq.TestUtilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.ranks.Ranks;
@@ -34,6 +35,7 @@ import org.junit.Test;
 public class StripUnitActionTest {
     @Before
     public void setup() {
+        EquipmentType.initializeTypes();
         Ranks.initializeRankSystems();
         try {
             Systems.setInstance(Systems.loadDefault());


### PR DESCRIPTION
This prevents issues with EquipmentType not loading fast enough by just forcing it to load before tests the require it.