### PR TITLE
Adding PIND Migration Post-Removal

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -165,19 +165,19 @@ public class Campaign implements Serializable, ITechManager {
 
     // hierarchically structured Force object to define TO&E
     private Force forces;
-    private Hashtable<Integer, Lance> lances; //AtB
+    private Hashtable<Integer, Lance> lances; // AtB
 
     private String factionCode;
     private int techFactionCode;
-    private String retainerEmployerCode; //AtB
+    private String retainerEmployerCode; // AtB
     private RankSystem rankSystem;
 
     private ArrayList<String> currentReport;
     private transient String currentReportHTML;
     private transient List<String> newReports;
 
-    //this is updated and used per gaming session, it is enabled/disabled via the Campaign options
-    //we're re-using the LogEntry class that is used to store Personnel entries
+    // this is updated and used per gaming session, it is enabled/disabled via the Campaign options
+    // we're re-using the LogEntry class that is used to store Personnel entries
     public LinkedList<LogEntry> inMemoryLogHistory = new LinkedList<>();
 
     private boolean overtime;

--- a/MekHQ/src/mekhq/campaign/CampaignPreset.java
+++ b/MekHQ/src/mekhq/campaign/CampaignPreset.java
@@ -36,6 +36,7 @@ import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.Systems;
+import mekhq.io.migration.FactionMigrator;
 import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -417,7 +418,12 @@ public class CampaignPreset implements Serializable {
                         preset.setDate(MekHqXmlUtil.parseDate(wn.getTextContent().trim()));
                         break;
                     case "faction":
-                        preset.setFaction(Factions.getInstance().getFaction(wn.getTextContent().trim()));
+                        if (version.isLowerThan("0.49.7")) {
+                            preset.setFaction(Factions.getInstance().getFaction(
+                                    FactionMigrator.migrateCodePINDRemoval(wn.getTextContent().trim())));
+                        } else {
+                            preset.setFaction(Factions.getInstance().getFaction(wn.getTextContent().trim()));
+                        }
                         break;
                     case "planet":
                         preset.setPlanet(Systems.getInstance()

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -57,6 +57,7 @@ import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.universe.Systems;
 import mekhq.io.idReferenceClasses.PersonIdReference;
 import mekhq.io.migration.CamouflageMigrator;
+import mekhq.io.migration.FactionMigrator;
 import mekhq.io.migration.ForceIconMigrator;
 import mekhq.io.migration.PersonMigrator;
 import mekhq.module.atb.AtBEventProcessor;
@@ -297,6 +298,10 @@ public class CampaignXmlParser {
             retVal.setUnitIcon(ForceIconMigrator.migrateForceIconToKailans(retVal.getUnitIcon()));
         } else if (version.isLowerThan("0.49.7")) {
             retVal.setUnitIcon(ForceIconMigrator.migrateForceIcon0496To0497(retVal.getUnitIcon()));
+        }
+
+        if (version.isLowerThan("0.49.7")) {
+            FactionMigrator.migrateFactionCode(retVal);
         }
 
         // We need to do a post-process pass to restore a number of references.
@@ -672,7 +677,6 @@ public class CampaignXmlParser {
                     }
                 } else if (xn.equalsIgnoreCase("faction")) {
                     retVal.setFactionCode(wn.getTextContent());
-                    retVal.updateTechFactionCode();
                 } else if (xn.equalsIgnoreCase("retainerEmployerCode")) {
                     retVal.setRetainerEmployerCode(wn.getTextContent());
                 } else if (xn.equalsIgnoreCase("rankSystem")) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -952,6 +952,11 @@ public class AtBContract extends Contract implements Serializable {
         return employerCode;
     }
 
+    public void setEmployerCode(final String code, final LocalDate date) {
+        employerCode = code;
+        setEmployer(getEmployerName(date.getYear()));
+    }
+
     public void setEmployerCode(String code, int year) {
         employerCode = code;
         setEmployer(getEmployerName(year));

--- a/MekHQ/src/mekhq/campaign/mission/BotForceRandomizer.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForceRandomizer.java
@@ -48,8 +48,6 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.*;
 
-import org.apache.commons.math3.*;
-
 /**
  * A class that can be used to generate a random force with some parameters. Provides a simpler approach
  * to opfor generation than AtBDynamicScenarioFactory. Intended for use by StoryArc but written generally
@@ -130,6 +128,16 @@ public class BotForceRandomizer implements Serializable, MekHqXmlSerializable {
         lanceSize = 1;
     }
     //endregion Constructors
+
+    //region Getters/Setters
+    public String getFactionCode() {
+        return factionCode;
+    }
+
+    public void setFactionCode(final String factionCode) {
+        this.factionCode = factionCode;
+    }
+    //endregion Getters/Setters
 
     /**
      * This is the primary function that generates a force of entities from the given parameters. The
@@ -499,7 +507,7 @@ public class BotForceRandomizer implements Serializable, MekHqXmlSerializable {
     @Override
     public void writeToXml(PrintWriter pw1, int indent) {
         MekHqXmlUtil.writeSimpleXMLOpenTag(pw1, indent++, "botForceRandomizer");
-        MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "factionCode", factionCode);
+        MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "factionCode", getFactionCode());
         MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "quality", quality);
         MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "skill", skill.name());
         MekHqXmlUtil.writeSimpleXMLTag(pw1, indent, "unitType", unitType);
@@ -524,7 +532,7 @@ public class BotForceRandomizer implements Serializable, MekHqXmlSerializable {
                 Node wn2 = nl.item(x);
 
                 if (wn2.getNodeName().equalsIgnoreCase("factionCode")) {
-                    retVal.factionCode = wn2.getTextContent().trim();
+                    retVal.setFactionCode(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("quality")) {
                     retVal.quality = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("unitType")) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -56,6 +56,7 @@ import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.work.IPartWork;
 import mekhq.io.idReferenceClasses.PersonIdReference;
+import mekhq.io.migration.FactionMigrator;
 import mekhq.io.migration.PersonMigrator;
 import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Node;
@@ -1585,7 +1586,12 @@ public class Person implements Serializable {
                         retVal.setPrimaryRoleDirect(PersonnelRole.DEPENDENT);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("faction")) {
-                    retVal.originFaction = Factions.getInstance().getFaction(wn2.getTextContent().trim());
+                    if (version.isLowerThan("0.49.7")) {
+                        retVal.setOriginFaction(Factions.getInstance().getFaction(
+                                FactionMigrator.migrateCodePINDRemoval(wn2.getTextContent().trim())));
+                    } else {
+                        retVal.setOriginFaction(Factions.getInstance().getFaction(wn2.getTextContent().trim()));
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("planetId")) {
                     String systemId = wn2.getAttributes().getNamedItem("systemId").getTextContent().trim();
                     String planetId = wn2.getTextContent().trim();

--- a/MekHQ/src/mekhq/io/migration/FactionMigrator.java
+++ b/MekHQ/src/mekhq/io/migration/FactionMigrator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.io.migration;
+
+public class FactionMigrator {
+    public static String migrateCodeToAlignWithSUCS(final String originalCode) {
+        switch (originalCode) {
+            case "PIND":
+            case "IND":
+                return "I";
+            case "DoL":
+                return "DL";
+            case "SCW":
+                return "SCo";
+
+            case "SSUP":
+                return "SS";
+            case "CTL":
+                return "CTF";
+            case "ABN":
+                return "A";
+            case "ARD":
+                return "AuD";
+            case "DIS":
+                return "D";
+            case "CCO":
+                return "CCY";
+            case "RWR":
+                return "RW";
+            case "RIM":
+                return "RC";
+            case "CIR":
+                return "CF";
+            case "CB":
+                return "CBR";
+            case "CLAN":
+                return "C";
+            case "CWI":
+                return "CWM";
+            case "FR":
+                return "FrR";
+            case "CWOV":
+                return "CWV";
+            case "WOB":
+                return "WB";
+            case "CEI":
+                return "EI";
+            case "AXP":
+                return "AP";
+            case "FoO":
+                return "FO";
+            case "MRep":
+                return "MR";
+            case "CMG":
+                return "CMN";
+            case "FVC":
+                return "FvC";
+            case "TB":
+                return "RB";
+            case "CWIE":
+                return "CWX";
+            case "CW":
+                return "CWF";
+            case "CWE":
+                return "WE";
+            case "ARC":
+                return "AuC";
+            case "Stone":
+                return "CoF";
+            case "ROS":
+                return "RS";
+            case "UND":
+                return "U";
+            case "RR":
+                return "TR";
+            case "ME":
+                return "MuC";
+            case "Mara":
+                return "MarA";
+
+            default:
+                return originalCode;
+        }
+    }
+}


### PR DESCRIPTION
We missed migrating the player data during the PIND removal, so this handles that bug. It also handles a bug in CampaignXmlParser, namely a duplicated call to Campaign::updateTechFactionCode, that I found while investigating our internals.

I specifically coded this to make it extremely easy to swap to the SUCS setup and migrate from there. FactionMigrator::migrateCodeToAlignWithSUCS is included at a completely unused state.