### PR TITLE
Fix BotForce entity list

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -443,7 +443,8 @@ public class AtBGameThread extends GameThread {
         // before we attempt to load transports.
         int entityCount = client.getGame().getEntitiesOwnedBy(client.getLocalPlayer());
         int retryCount = 0;
-        while ((entityCount != botForce.getFullEntityList(campaign).size()) &&
+        int listSize =  botForce.getFullEntityList(campaign).size();
+        while ((entityCount != listSize) &&
                 (retryCount < AtBGameThread.CLIENT_RETRY_COUNT)) {
             try {
                 Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -417,7 +417,7 @@ public class AtBGameThread extends GameThread {
 
                 String forceName = botClient.getLocalPlayer().getName() + "|1";
                 var entities = new ArrayList<Entity>();
-                for (Entity entity : botForce.getEntityList()) {
+                for (Entity entity : botForce.getFullEntityList(campaign)) {
                     if (null == entity) {
                         continue;
                     }
@@ -443,7 +443,7 @@ public class AtBGameThread extends GameThread {
         // before we attempt to load transports.
         int entityCount = client.getGame().getEntitiesOwnedBy(client.getLocalPlayer());
         int retryCount = 0;
-        while ((entityCount != botForce.getEntityList().size()) &&
+        while ((entityCount != botForce.getFixedEntityList().size()) &&
                 (retryCount < AtBGameThread.CLIENT_RETRY_COUNT)) {
             try {
                 Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -443,7 +443,7 @@ public class AtBGameThread extends GameThread {
         // before we attempt to load transports.
         int entityCount = client.getGame().getEntitiesOwnedBy(client.getLocalPlayer());
         int retryCount = 0;
-        while ((entityCount != botForce.getFixedEntityList().size()) &&
+        while ((entityCount != botForce.getFullEntityList(campaign).size()) &&
                 (retryCount < AtBGameThread.CLIENT_RETRY_COUNT)) {
             try {
                 Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -265,25 +265,9 @@ class GameThread extends Thread implements CloseClientListener {
 
                 String forceName = botClient.getLocalPlayer().getName() + "|1";
                 var entities = new ArrayList<Entity>();
-                for (Entity entity : botForce.getEntityList()) {
-                    if (null == entity) {
-                        continue;
-                    }
-                    entity.setOwner(botClient.getLocalPlayer());
-                    entity.setForceString(forceName);
-                    entities.add(entity);
-                }
-                // now check for traitor entities from the player's own forces
-                for (Entity entity : botForce.getTraitorEntities(campaign)) {
-                    if (null == entity) {
-                        continue;
-                    }
-                    entity.setOwner(botClient.getLocalPlayer());
-                    entity.setForceString(forceName);
-                    entities.add(entity);
-                }
-                // now randomly generate additional entities if needed
-                for (Entity entity : botForce.generateAdditionalForces(units)) {
+                // generate any random units
+                botForce.generateRandomForces(units, campaign);
+                for (Entity entity : botForce.getFullEntityList(campaign)) {
                     if (null == entity) {
                         continue;
                     }

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -1276,7 +1276,7 @@ public class ResolveScenarioTracker {
             for (int x = 0; x < atbScenario.getNumBots(); x++) {
                 BotForce botForce = atbScenario.getBotForce(x);
 
-                for (Entity e : botForce.getEntityList()) {
+                for (Entity e : botForce.getFullEntityList(campaign)) {
                     entities.put(UUID.fromString(e.getExternalIdAsString()), e);
                 }
             }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -208,13 +208,13 @@ public class AtBDynamicScenario extends AtBScenario {
     /**
      * Adds a bot force to this scenario.
      */
-    public void addBotForce(BotForce botForce, ScenarioForceTemplate forceTemplate) {
+    public void addBotForce(BotForce botForce, ScenarioForceTemplate forceTemplate, Campaign c) {
         botForce.setTemplateName(forceTemplate.getForceName());
-        super.addBotForce(botForce);
+        super.addBotForce(botForce, c);
         botForceTemplates.put(botForce, forceTemplate);
 
         // put all bot units into the external ID lookup.
-        for (Entity entity : botForce.getEntityList()) {
+        for (Entity entity : botForce.getFullEntityList(c)) {
             getExternalIDLookup().put(entity.getExternalIdAsString(), entity);
         }
     }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -192,13 +192,13 @@ public class AtBDynamicScenarioFactory {
 
         setScenarioRerolls(scenario, campaign);
 
-        setDeploymentTurns(scenario);
+        setDeploymentTurns(scenario, campaign);
         translatePlayerNPCsToAttached(scenario, campaign);
         translateTemplateObjectives(scenario, campaign);
         scaleObjectiveTimeLimits(scenario, campaign);
 
         if (campaign.getCampaignOptions().useAbilities()) {
-            upgradeBotCrews(scenario);
+            upgradeBotCrews(scenario, campaign);
         }
 
         scenario.setFinalized(true);
@@ -1933,12 +1933,13 @@ public class AtBDynamicScenarioFactory {
     /**
      * Sets up the deployment turns for all bot units within the specified scenario
      * @param scenario The scenario to process
+     * @param campaign A pointer to the campaign
      */
-    private static void setDeploymentTurns(AtBDynamicScenario scenario) {
+    private static void setDeploymentTurns(AtBDynamicScenario scenario, Campaign campaign) {
         for (int x = 0; x < scenario.getNumBots(); x++) {
             BotForce currentBotForce = scenario.getBotForce(x);
             ScenarioForceTemplate forceTemplate = scenario.getBotForceTemplates().get(currentBotForce);
-            setDeploymentTurns(currentBotForce, forceTemplate, scenario);
+            setDeploymentTurns(currentBotForce, forceTemplate, scenario, campaign);
         }
     }
 
@@ -1950,9 +1951,9 @@ public class AtBDynamicScenarioFactory {
      * ARRIVAL_TURN_STAGGERED is processed just prior to scenario start instead (?)
      */
     public static void setDeploymentTurns(BotForce botForce, ScenarioForceTemplate forceTemplate,
-            AtBDynamicScenario scenario) {
+            AtBDynamicScenario scenario, Campaign campaign) {
         // deployment turns don't matter for transported entities
-        List<Entity> untransportedEntities = scenario.filterUntransportedUnits(botForce.getFixedEntityList());
+        List<Entity> untransportedEntities = scenario.filterUntransportedUnits(botForce.getFullEntityList(campaign));
 
         if (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_STAGGERED_BY_LANCE) {
             setDeploymentTurnsStaggeredByLance(untransportedEntities);
@@ -2477,12 +2478,13 @@ public class AtBDynamicScenarioFactory {
      * Runs all the bot-controlled entities in the scenario through a skill upgrader,
      * potentially giving the SPAs.
      * @param scenario The scenario to process.
+     * @param campaign A pointer to the campaign
      */
-    public static void upgradeBotCrews(AtBScenario scenario) {
+    public static void upgradeBotCrews(AtBScenario scenario, Campaign campaign) {
         CrewSkillUpgrader csu = new CrewSkillUpgrader();
 
         for (int forceIndex = 0; forceIndex < scenario.getNumBots(); forceIndex++) {
-            for (Entity entity : scenario.getBotForce(forceIndex).getFixedEntityList()) {
+            for (Entity entity : scenario.getBotForce(forceIndex).getFullEntityList(campaign)) {
                 csu.upgradeCrew(entity);
             }
         }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -451,9 +451,9 @@ public class AtBDynamicScenarioFactory {
         generatedEntities.addAll(transportedEntities);
 
         BotForce generatedForce = new BotForce();
-        generatedForce.setEntityList(generatedEntities);
+        generatedForce.setFixedEntityList(generatedEntities);
         setBotForceParameters(generatedForce, forceTemplate, forceAlignment, contract);
-        scenario.addBotForce(generatedForce, forceTemplate);
+        scenario.addBotForce(generatedForce, forceTemplate, campaign);
 
         return generatedLanceCount;
     }
@@ -501,7 +501,7 @@ public class AtBDynamicScenarioFactory {
 
             if ((forceTemplate != null) && forceTemplate.isAlliedPlayerForce()) {
                 final Camouflage camouflage = scenario.getContract(campaign).getAllyCamouflage();
-                for (Entity en : botForce.getEntityList()) {
+                for (Entity en : botForce.getFullEntityList(campaign)) {
                     scenario.getAlliesPlayer().add(en);
                     scenario.getBotUnitTemplates().put(UUID.fromString(en.getExternalIdAsString()), forceTemplate);
 
@@ -636,7 +636,7 @@ public class AtBDynamicScenarioFactory {
 
         for (BotForce botForce : scenario.getBotForceTemplates().keySet()) {
             if (scenario.getBotForceTemplates().get(botForce).getContributesToUnitCount()) {
-                primaryUnitCount += botForce.getEntityList().size();
+                primaryUnitCount += botForce.getFullEntityList(campaign).size();
             }
         }
 
@@ -1642,7 +1642,7 @@ public class AtBDynamicScenarioFactory {
             BotForce botForce = scenario.getBotForce(index);
             ScenarioForceTemplate forceTemplate = scenario.getBotForceTemplates().get(botForce);
             if (forceTemplate != null && forceTemplate.getContributesToUnitCount()) {
-                unitCount += botForce.getEntityList().size();
+                unitCount += botForce.getFullEntityList(campaign).size();
             }
         }
 
@@ -1901,7 +1901,7 @@ public class AtBDynamicScenarioFactory {
 
         for (int x = 0; x < scenario.getNumBots(); x++) {
             BotForce currentBotForce = scenario.getBotForce(x);
-            for (Entity entity : currentBotForce.getEntityList()) {
+            for (Entity entity : currentBotForce.getFullEntityList(campaign)) {
                 if (entity.getDeployRound() == ScenarioForceTemplate.ARRIVAL_TURN_STAGGERED) {
                     staggeredEntities.add(entity);
                 }
@@ -1952,7 +1952,7 @@ public class AtBDynamicScenarioFactory {
     public static void setDeploymentTurns(BotForce botForce, ScenarioForceTemplate forceTemplate,
             AtBDynamicScenario scenario) {
         // deployment turns don't matter for transported entities
-        List<Entity> untransportedEntities = scenario.filterUntransportedUnits(botForce.getEntityList());
+        List<Entity> untransportedEntities = scenario.filterUntransportedUnits(botForce.getFixedEntityList());
 
         if (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_STAGGERED_BY_LANCE) {
             setDeploymentTurnsStaggeredByLance(untransportedEntities);
@@ -2482,7 +2482,7 @@ public class AtBDynamicScenarioFactory {
         CrewSkillUpgrader csu = new CrewSkillUpgrader();
 
         for (int forceIndex = 0; forceIndex < scenario.getNumBots(); forceIndex++) {
-            for (Entity entity : scenario.getBotForce(forceIndex).getEntityList()) {
+            for (Entity entity : scenario.getBotForce(forceIndex).getFixedEntityList()) {
                 csu.upgradeCrew(entity);
             }
         }
@@ -2568,8 +2568,8 @@ public class AtBDynamicScenarioFactory {
                 }
             }
 
-            if ((botForce != null) && !botForce.getEntityList().isEmpty()) {
-                Entity swapTarget = botForce.getEntityList().get(0);
+            if ((botForce != null) && !botForce.getFixedEntityList().isEmpty()) {
+                Entity swapTarget = botForce.getFixedEntityList().get(0);
                 BenchedEntityData benchedEntity = new BenchedEntityData();
                 benchedEntity.entity = swapTarget;
                 benchedEntity.templateName = destinationTemplate.getForceName();

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -591,7 +591,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
             if ((specMissionEnemies != null) && (getBotForces().get(0) != null)
                     && (specMissionEnemies.get(weight) != null)) {
-                getBotForces().get(0).setEntityList(specMissionEnemies.get(weight));
+                getBotForces().get(0).setFixedEntityList(specMissionEnemies.get(weight));
             }
             setObjectives(campaign, getContract(campaign));
         }
@@ -733,7 +733,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
             BotForce bf = getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, reinforcements);
             bf.setName(bf.getName() + " (Reinforcements)");
-            addBotForce(bf);
+            addBotForce(bf, campaign);
         }
 
         if (campaign.getCampaignOptions().getUseDropShips()) {
@@ -808,11 +808,11 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         enemyHome = enemyStart;
 
         if (allyEntities.size() > 0) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities));
+            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, enemyEntities), campaign);
     }
 
     @Override
@@ -1326,7 +1326,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
             BotForce bf = getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, aircraft);
             bf.setName(bf.getName() + " (Air Support)");
-            addBotForce(bf);
+            addBotForce(bf, campaign);
         }
     }
 
@@ -1410,7 +1410,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             });
             BotForce bf = getEnemyBotForce(getContract(campaign), Board.START_CENTER, enemyHome, scrubs);
             bf.setName(bf.getName() + " (Local Forces)");
-            addBotForce(bf);
+            addBotForce(bf, campaign);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -513,8 +513,7 @@ public class Scenario implements Serializable {
     }
 
     public BotForceStub generateBotStub(BotForce bf, Campaign c) {
-        List<String> stubs = generateEntityStub(bf.getEntityList());
-        stubs.addAll(generateEntityStub(bf.getTraitorEntities(c)));
+        List<String> stubs = generateEntityStub(bf.getFullEntityList(c));
         return new BotForceStub("<html>" +
                 bf.getName() + " <i>" +
                 ((bf.getTeam() == 1) ? "Allied" : "Enemy") + "</i>" +
@@ -553,11 +552,11 @@ public class Scenario implements Serializable {
         return botForces;
     }
 
-    public void addBotForce(BotForce botForce) {
+    public void addBotForce(BotForce botForce, Campaign c) {
         botForces.add(botForce);
 
         // put all bot units into the external ID lookup.
-        for (Entity entity : botForce.getEntityList()) {
+        for (Entity entity : botForce.getFullEntityList(c)) {
             getExternalIDLookup().put(entity.getExternalIdAsString(), entity);
         }
     }
@@ -955,7 +954,7 @@ public class Scenario implements Serializable {
                     }
 
                     if (bf != null) {
-                        retVal.addBotForce(bf);
+                        retVal.addBotForce(bf, c);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("scenarioDeploymentLimit")) {
                     retVal.deploymentLimit =  ScenarioDeploymentLimit.generateInstanceFromXML(wn2, c, version);

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
@@ -100,7 +100,7 @@ public class ScenarioObjectiveProcessor {
                 BotForce botForce = tracker.getScenario().getBotForce(botIndex);
 
                 if (forceName.equals(botForce.getName())) {
-                    for (Entity entity : botForce.getEntityList()) {
+                    for (Entity entity : botForce.getFullEntityList(tracker.getCampaign())) {
                         objectiveUnitIDs.add(entity.getExternalIdAsString());
                     }
                     break;

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -114,8 +114,8 @@ public class AtBScenarioModifierApplicator {
             // only remove units from a bot force if it's on the affected team
             // AND if it has any units to remove
             if ((bf.getTeam() == ScenarioForceTemplate.TEAM_IDS.get(eventRecipient.ordinal()))
-                    && !bf.getEntityList().isEmpty()) {
-                int unitIndexToRemove = Compute.randomInt(bf.getEntityList().size());
+                    && !bf.getFullEntityList(campaign).isEmpty()) {
+                int unitIndexToRemove = Compute.randomInt(bf.getFullEntityList(campaign).size());
                 bf.removeEntity(unitIndexToRemove);
             }
         }
@@ -132,7 +132,7 @@ public class AtBScenarioModifierApplicator {
         for (int botIndex = 0; botIndex < scenario.getNumBots(); botIndex++) {
             BotForce bf = scenario.getBotForce(botIndex);
             if (bf.getTeam() == ScenarioForceTemplate.TEAM_IDS.get(eventRecipient.ordinal())) {
-                for (Entity en : bf.getEntityList()) {
+                for (Entity en : bf.getFullEntityList(campaign)) {
                     int numClusters = Compute.randomInt(battleDamageIntensity);
 
                     for (int clusterCount = 0; clusterCount < numClusters; clusterCount++) {
@@ -156,7 +156,7 @@ public class AtBScenarioModifierApplicator {
         for (int botIndex = 0; botIndex < scenario.getNumBots(); botIndex++) {
             BotForce bf = scenario.getBotForce(botIndex);
             if (bf.getTeam() == ScenarioForceTemplate.TEAM_IDS.get(eventRecipient.ordinal())) {
-                for (Entity en : bf.getEntityList()) {
+                for (Entity en : bf.getFullEntityList(campaign)) {
                     for (Mounted ammoBin : en.getAmmo()) {
                         int remainingShots = Math.max(0, ammoBin.getUsableShotsLeft() - Compute.randomInt(ammoExpenditureIntensity));
                         ammoBin.setShotsLeft(remainingShots);
@@ -188,7 +188,7 @@ public class AtBScenarioModifierApplicator {
         for (int x = 0; x < scenario.getNumBots(); x++) {
             BotForce bf = scenario.getBotForce(x);
             if (bf.getTeam() == ScenarioForceTemplate.TEAM_IDS.get(eventRecipient.ordinal())) {
-                for (Entity en : bf.getEntityList()) {
+                for (Entity en : bf.getFullEntityList(campaign)) {
                     int[] skills = abstractSkillGenerator.generateRandomSkills(en);
                     en.getCrew().setGunnery(skills[0]);
                     en.getCrew().setPiloting(skills[1]);
@@ -271,10 +271,10 @@ public class AtBScenarioModifierApplicator {
                         continue;
                     }
 
-                    int maxHiddenUnits = currentBotForce.getEntityList().size() / 2;
+                    int maxHiddenUnits = currentBotForce.getFullEntityList(campaign).size() / 2;
                     int numHiddenUnits = 0;
 
-                    for (Entity entity : currentBotForce.getEntityList()) {
+                    for (Entity entity : currentBotForce.getFullEntityList(campaign)) {
                         if (numHiddenUnits >= maxHiddenUnits) {
                             break;
                         }

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
@@ -121,7 +121,7 @@ public class AceDuelBuiltInScenario extends AtBScenario {
             getSpecMissionEnemies().add(enemyEntities);
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AlliedTraitorsBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AlliedTraitorsBuiltInScenario.java
@@ -75,7 +75,7 @@ public class AlliedTraitorsBuiltInScenario extends AtBScenario {
         }
 
         addBotForce(
-                new BotForce(getContract(campaign).getAllyBotName(), 2, enemyStart, getSpecMissionEnemies().get(0)));
+                new BotForce(getContract(campaign).getAllyBotName(), 2, enemyStart, getSpecMissionEnemies().get(0)), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AllyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AllyRescueBuiltInScenario.java
@@ -117,7 +117,7 @@ public class AllyRescueBuiltInScenario extends AtBScenario {
                     contract.getAllyQuality(), UnitType.MEK, weightClass, campaign));
         }
 
-        addBotForce(new BotForce(contract.getAllyBotName(), 1, Board.START_CENTER, otherForce));
+        addBotForce(new BotForce(contract.getAllyBotName(), 1, Board.START_CENTER, otherForce), campaign);
 
         for (int i = 0; i < 12; i++) {
             int weightClass;
@@ -128,7 +128,7 @@ public class AllyRescueBuiltInScenario extends AtBScenario {
                     contract.getEnemyQuality(), UnitType.MEK, weightClass, campaign));
         }
 
-        addBotForce(getEnemyBotForce(contract, Board.START_N, enemyEntities));
+        addBotForce(getEnemyBotForce(contract, Board.START_N, enemyEntities), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AmbushBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AmbushBuiltInScenario.java
@@ -87,7 +87,7 @@ public class AmbushBuiltInScenario extends AtBScenario {
             getSpecMissionEnemies().add(enemyEntities);
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -121,7 +121,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
         // direction as the player (in case of the player being the defender)
         // or where it came from (in case of the player being the attacker
         addBotForce(getAllyBotForce(getContract(campaign), isAttacker() ? secondAttackerForceStart : getStart(),
-                isAttacker() ? secondAttackerForceStart : defenderHome, allyEntities));
+                isAttacker() ? secondAttackerForceStart : defenderHome, allyEntities), campaign);
 
         // "base" force gets 8 civilian units and six turrets
         // set the civilians to "cowardly" behavior by default so they don't run
@@ -131,7 +131,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
         BotForce civilianForce = new BotForce(BASE_CIVILIAN_FORCE_ID, isAttacker() ? 2 : 1, defenderStart, defenderHome,
                 otherForce);
         civilianForce.setBehaviorSettings(BehaviorSettingsFactory.getInstance().COWARDLY_BEHAVIOR);
-        addBotForce(civilianForce);
+        addBotForce(civilianForce, campaign);
 
         ArrayList<Entity> turretForce = new ArrayList<>();
 
@@ -143,11 +143,11 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
                     campaign, getContract(campaign).getEmployerFaction());
         }
 
-        addBotForce(new BotForce(BASE_TURRET_FORCE_ID, isAttacker() ? 2 : 1, defenderStart, defenderHome, turretForce));
+        addBotForce(new BotForce(BASE_TURRET_FORCE_ID, isAttacker() ? 2 : 1, defenderStart, defenderHome, turretForce), campaign);
 
         /* Roll 2x on bot lances roll */
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);
 
         // the "second" enemy force will either flee in the same direction as
         // the first enemy force in case of the player being the attacker
@@ -158,7 +158,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
                 isAttacker() ? enemyStart : secondAttackerForceStart,
                 isAttacker() ? getEnemyHome() : secondAttackerForceStart, secondBotEntities);
         secondBotForce.setName(String.format("%s%s", secondBotForce.getName(), SECOND_ENEMY_FORCE_SUFFIX));
-        addBotForce(secondBotForce);
+        addBotForce(secondBotForce, campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
@@ -91,7 +91,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
 
         if (allyEntities.size() > 0) {
             allyEntitiesForce = getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities);
-            addBotForce(allyEntitiesForce);
+            addBotForce(allyEntitiesForce, campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
@@ -112,7 +112,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
             LogManager.getLogger().error("", e);
         }
 
-        addBotForce(botForce);
+        addBotForce(botForce, campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -78,7 +78,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
 
         if (allyEntities.size() > 0) {
             allyEntitiesForce = getAllyBotForce(getContract(campaign), getStart(), destinationEdge, allyEntities);
-            addBotForce(allyEntitiesForce);
+            addBotForce(allyEntitiesForce, campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT, 0,
@@ -104,7 +104,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
             LogManager.getLogger().error("", e);
         }
 
-        addBotForce(botForce);
+        addBotForce(botForce, campaign);
 
         /* All forces deploy in 12 - WP turns */
         setDeploymentDelay(12);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianHelpBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianHelpBuiltInScenario.java
@@ -87,7 +87,7 @@ public class CivilianHelpBuiltInScenario extends AtBScenario {
             getSpecMissionEnemies().add(enemyEntities);
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)), campaign);
 
         List<Entity> otherForce = new ArrayList<>();
         addCivilianUnits(otherForce, 4, campaign);
@@ -96,7 +96,7 @@ public class CivilianHelpBuiltInScenario extends AtBScenario {
             getSurvivalBonusIds().add(UUID.fromString(e.getExternalIdAsString()));
         }
 
-        addBotForce(new BotForce(CIVILIAN_FORCE_ID, 1, getStart(), otherForce));
+        addBotForce(new BotForce(CIVILIAN_FORCE_ID, 1, getStart(), otherForce), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianRiotBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianRiotBuiltInScenario.java
@@ -123,11 +123,11 @@ public class CivilianRiotBuiltInScenario extends AtBScenario {
             getSurvivalBonusIds().add(UUID.fromString(e.getExternalIdAsString()));
         }
 
-        addBotForce(new BotForce(LOYALIST_FORCE_ID, 1, Board.START_CENTER, otherForce));
+        addBotForce(new BotForce(LOYALIST_FORCE_ID, 1, Board.START_CENTER, otherForce), campaign);
 
         otherForce = new ArrayList<Entity>();
         addCivilianUnits(otherForce, 12, campaign);
-        addBotForce(new BotForce(RIOTER_FORCE_ID, 2, Board.START_CENTER, otherForce));
+        addBotForce(new BotForce(RIOTER_FORCE_ID, 2, Board.START_CENTER, otherForce), campaign);
 
         for (int i = 0; i < 3; i++) {
             // 3 mech rebel lance, use employer RAT, enemy skill
@@ -137,7 +137,7 @@ public class CivilianRiotBuiltInScenario extends AtBScenario {
         }
 
         addBotForce(
-                new BotForce(REBEL_FORCE_ID, 2, AtBDynamicScenarioFactory.getOppositeEdge(boardEdge), enemyEntities));
+                new BotForce(REBEL_FORCE_ID, 2, AtBDynamicScenarioFactory.getOppositeEdge(boardEdge), enemyEntities), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyAttackBuiltInScenario.java
@@ -100,7 +100,7 @@ public class ConvoyAttackBuiltInScenario extends AtBScenario {
 
         List<Entity> otherForce = new ArrayList<>();
         addCivilianUnits(otherForce, 12, campaign);
-        addBotForce(new BotForce(CONVOY_FORCE_ID, 2, Board.START_CENTER, otherForce));
+        addBotForce(new BotForce(CONVOY_FORCE_ID, 2, Board.START_CENTER, otherForce), campaign);
 
         for (int i = 0; i < 8; i++) {
             enemyEntities.add(getEntity(getContract(campaign).getEnemyCode(), getContract(campaign).getEnemySkill(),
@@ -109,7 +109,7 @@ public class ConvoyAttackBuiltInScenario extends AtBScenario {
                     campaign));
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), Board.START_CENTER, enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), Board.START_CENTER, enemyEntities), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
@@ -108,7 +108,7 @@ public class ConvoyRescueBuiltInScenario extends AtBScenario {
             getSurvivalBonusIds().add(UUID.fromString(e.getExternalIdAsString()));
         }
 
-        addBotForce(new BotForce(CONVOY_FORCE_ID, 1, Board.START_CENTER, otherForce));
+        addBotForce(new BotForce(CONVOY_FORCE_ID, 1, Board.START_CENTER, otherForce), campaign);
 
         for (int i = 0; i < 12; i++) {
             enemyEntities.add(getEntity(getContract(campaign).getEnemyCode(), getContract(campaign).getEnemySkill(),
@@ -117,7 +117,7 @@ public class ConvoyRescueBuiltInScenario extends AtBScenario {
                     campaign));
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), Board.START_S, enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), Board.START_S, enemyEntities), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
@@ -96,11 +96,11 @@ public class ExtractionBuiltInScenario extends AtBScenario {
         }
 
         if (allyEntities.size() > 0) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities));
+            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);
 
         ArrayList<Entity> otherForce = new ArrayList<Entity>();
         addCivilianUnits(otherForce, 4, campaign);
@@ -111,7 +111,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
                 bf.setBehaviorSettings(BehaviorSettingsFactory.getInstance().ESCAPE_BEHAVIOR.getCopy());
                 bf.setDestinationEdge(otherHome);
 
-                addBotForce(bf);
+                addBotForce(bf, campaign);
 
                 for (Entity en : otherForce) {
                     getSurvivalBonusIds().add(UUID.fromString(en.getExternalIdAsString()));
@@ -121,7 +121,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
                 bf.setBehaviorSettings(BehaviorSettingsFactory.getInstance().ESCAPE_BEHAVIOR.getCopy());
                 bf.setDestinationEdge(otherHome);
 
-                addBotForce(bf);
+                addBotForce(bf, campaign);
             }
         } catch (PrincessException e) {
             LogManager.getLogger().error("", e);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/HideAndSeekBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/HideAndSeekBuiltInScenario.java
@@ -97,7 +97,7 @@ public class HideAndSeekBuiltInScenario extends AtBScenario {
         }
 
         if (allyEntities.size() > 0) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities));
+            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
         }
 
         if (isAttacker()) {
@@ -108,7 +108,7 @@ public class HideAndSeekBuiltInScenario extends AtBScenario {
                     EntityWeightClass.WEIGHT_HEAVY, 0, 0, campaign);
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/HoldTheLineBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/HoldTheLineBuiltInScenario.java
@@ -78,13 +78,13 @@ public class HoldTheLineBuiltInScenario extends AtBScenario {
         }
 
         if (allyEntities.size() > 0) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities));
+            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT,
                 isAttacker() ? 0 : 4, 0, campaign);
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDualBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDualBuiltInScenario.java
@@ -120,7 +120,7 @@ public class OfficerDualBuiltInScenario extends AtBScenario {
             getSpecMissionEnemies().add(enemyEntities);
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/PirateFreeForAllBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/PirateFreeForAllBuiltInScenario.java
@@ -102,7 +102,7 @@ public class PirateFreeForAllBuiltInScenario extends AtBScenario {
                     campaign));
         }
 
-        addBotForce(getEnemyBotForce(contract, Board.START_N, enemyEntities));
+        addBotForce(getEnemyBotForce(contract, Board.START_N, enemyEntities), campaign);
 
         final List<Entity> otherForce = new ArrayList<>();
         final Faction faction = Factions.getInstance().getFaction("PIR");
@@ -112,7 +112,7 @@ public class PirateFreeForAllBuiltInScenario extends AtBScenario {
                     AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, faction), campaign));
         }
 
-        addBotForce(new BotForce(PIRATE_FORCE_ID, 3, Board.START_S, otherForce));
+        addBotForce(new BotForce(PIRATE_FORCE_ID, 3, Board.START_S, otherForce), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/PrisonBreakBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/PrisonBreakBuiltInScenario.java
@@ -101,7 +101,7 @@ public class PrisonBreakBuiltInScenario extends AtBScenario {
             getSpecMissionEnemies().add(enemyEntities);
         }
 
-        addBotForce(new BotForce(GUARD_FORCE_ID, 2, enemyStart, getSpecMissionEnemies().get(0)));
+        addBotForce(new BotForce(GUARD_FORCE_ID, 2, enemyStart, getSpecMissionEnemies().get(0)), campaign);
 
         ArrayList<Entity> otherForce = new ArrayList<>();
 
@@ -111,7 +111,7 @@ public class PrisonBreakBuiltInScenario extends AtBScenario {
             getSurvivalBonusIds().add(UUID.fromString(e.getExternalIdAsString()));
         }
 
-        addBotForce(new BotForce(PRISONER_FORCE_ID, 1, getStart(), otherForce));
+        addBotForce(new BotForce(PRISONER_FORCE_ID, 1, getStart(), otherForce), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ProbeBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ProbeBuiltInScenario.java
@@ -72,13 +72,13 @@ public class ProbeBuiltInScenario extends AtBScenario {
         setEnemyHome(enemyStart);
 
         if (allyEntities.size() > 0) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities));
+            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_MEDIUM, 0, 0,
                 campaign);
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ReconRaidBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ReconRaidBuiltInScenario.java
@@ -85,13 +85,13 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
         }
 
         if (allyEntities.size() > 0) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities));
+            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign),
                 isAttacker() ? EntityWeightClass.WEIGHT_ASSAULT : EntityWeightClass.WEIGHT_MEDIUM, 0, 0, campaign);
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);
     }
 
     @Override
@@ -142,7 +142,7 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
             getScenarioObjectives().add(destroyHostiles);
         }
     }
-    
+
     @Override
     public String getBattlefieldControlDescription() {
         return getResourceBundle().getString("battleDetails.common.defenderControlsBattlefield");

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StandUpBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StandUpBuiltInScenario.java
@@ -64,11 +64,11 @@ public class StandUpBuiltInScenario extends AtBScenario {
         setEnemyHome(enemyStart);
 
         if (allyEntities.size() > 0) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities));
+            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
-        addBotForce(getEnemyBotForce(getContract(campaign), getEnemyHome(), getEnemyHome(), enemyEntities));
+        addBotForce(getEnemyBotForce(getContract(campaign), getEnemyHome(), getEnemyHome(), enemyEntities), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
@@ -116,7 +116,7 @@ public class StarLeagueCache1BuiltInScenario extends AtBScenario {
             getSpecMissionEnemies().add(enemyEntities);
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)), campaign);
 
         List<Entity> otherForce = new ArrayList<>();
         MechSummary ms = null;
@@ -144,7 +144,7 @@ public class StarLeagueCache1BuiltInScenario extends AtBScenario {
         loot.setName(defaultResourceBundle.getString("battleDetails.starLeagueCache.Mek"));
         loot.addUnit(en);
         getLoot().add(loot);
-        addBotForce(new BotForce(TECH_FORCE_ID, 1, getStart(), otherForce));
+        addBotForce(new BotForce(TECH_FORCE_ID, 1, getStart(), otherForce), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache2BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache2BuiltInScenario.java
@@ -75,7 +75,7 @@ public class StarLeagueCache2BuiltInScenario extends StarLeagueCache1BuiltInScen
             getSpecMissionEnemies().add(enemyEntities);
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)));
+        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -197,7 +197,7 @@ public class StratconRulesManager {
                 // or the units embedded in bot forces
                 for (var tuple : scenario.getBackingScenario().getBotForceTemplates().entrySet()) {
                     if (tuple.getValue().getForceName().equals(sft.getForceName())) {
-                        unitCount += tuple.getKey().getEntityList().size();
+                        unitCount += tuple.getKey().getFullEntityList(campaign).size();
                     }
                 }
 

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -529,12 +529,14 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         if (scenario instanceof AtBScenario) {
-            // Also print off allied sheets and all bot force sheets
+            // Also print off allied sheets
             chosen.addAll(((AtBScenario) scenario).getAlliesPlayer());
-            chosen.addAll(((AtBScenario) scenario).getBotForces().stream()
-                    .flatMap(botForce -> botForce.getEntityList().stream())
-                    .collect(Collectors.toList()));
         }
+
+        // add bot forces
+        chosen.addAll(scenario.getBotForces().stream()
+                .flatMap(botForce -> botForce.getFullEntityList(getCampaign()).stream())
+                .collect(Collectors.toList()));
 
         if (!chosen.isEmpty()) {
             UnitPrintManager.printAllUnits(chosen, true);

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -885,7 +885,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                     // row 0 is root node
                     int i = tree.getSelectionRows()[0] - 1;
                     UnitEditorDialog med = new UnitEditorDialog(frame,
-                            scenario.getBotForce(index).getEntityList().get(i));
+                            scenario.getBotForce(index).getFullEntityList(campaign).get(i));
                     med.setVisible(true);
                 }
             }


### PR DESCRIPTION
This PR is related to PR #3024 and #3091 which added the ability to include randomly generated forces and traitor units in the `BotForce` class that is attached to a scenario. Previously, units had to specified as a fixed `entityList`. This fixed list is created dynamically from scenario templates for AtB and by reading in basically MUL files for Story Arcs.  With the new additions, a Bot Force can be a mix of fixed units from a list, ones generated through a `BotForceRandomizer`, and a traitor units drawn from the player's own forces. Future extensions might also be possible.

There is one shortcoming with my prior PRs though. The method `getEntityList` in `BotForce` still only returns the fixed portion of this bot force which can lead to a variety of potential issues elsewhere in the code. Most importantly for immediate purposes, other types of units in BotForces (randomly generated ones and traitors) will not be recognized by the ScenarioObjectiveProcessor when trying to determine things like how many enemy forces were destroyed. 

This PR corrects that issue. I do this by creating two separate methods `getFixedEntityList` and `getFullEntityList` which will return respectively just the fixed entities and all of the entities. The random entities are not generated until the game thread is started but that will still allow them to be picked up by things like the ScenarioObjectiveProcessor.

This PR touches quite a few files because the original method was called a lot, particularly in AtB code. Because AtB currently only uses the fixed portion, `getFixedEntityList` and `getFullEntityList` should return the same result and AtB should be unaffected by the change. However, in case this feature might be useful to AtB I have switched everything to getFullEntityList where possible. The only complication is that `getFullEntityList` requires a campaign pointer (to get traitor entities) and there was one place where I was unable to easily add it given the complexity of the AtB code. I will mark that area here. 