### PR TITLE
Check for force named "Player" when processing objectives

### DIFF
--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -27,6 +27,7 @@ public final class MHQConstants extends SuiteConstants {
     //region General Constants
     public static final int ASTECH_TEAM_SIZE = 6;
     public static final int PREGNANCY_STANDARD_DURATION = 280; //standard duration of a pregnancy in days (40 weeks)
+    public static final String EGO_OBJECTIVE_NAME = "Player";
     // endregion General Constants
 
     //region GUI Constants
@@ -137,7 +138,6 @@ public final class MHQConstants extends SuiteConstants {
     //region Miscellaneous Options
     public static final String MISCELLANEOUS_NODE = "mekhq/prefs/miscellaneous";
     public static final String START_GAME_DELAY = "startGameDelay";
-    public static final String EGO_OBJECTIVE_NAME = "Player";
     //endregion Miscellaneous Options
     //endregion MHQOptions
 

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -137,6 +137,7 @@ public final class MHQConstants extends SuiteConstants {
     //region Miscellaneous Options
     public static final String MISCELLANEOUS_NODE = "mekhq/prefs/miscellaneous";
     public static final String START_GAME_DELAY = "startGameDelay";
+    public static final String EGO_OBJECTIVE_NAME = "Player";
     //endregion Miscellaneous Options
     //endregion MHQOptions
 

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 
 import megamek.common.Entity;
 import megamek.common.OffBoardDirection;
+import mekhq.MHQConstants;
 import mekhq.campaign.ResolveScenarioTracker;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.ObjectiveEffect.EffectScalingType;
@@ -80,6 +81,14 @@ public class ScenarioObjectiveProcessor {
         // "expand" the player forces involved in the objective
         for (String forceName : objective.getAssociatedForceNames()) {
             boolean forceFound = false;
+
+            if (MHQConstants.EGO_OBJECTIVE_NAME.equals(forceName)) {
+                // get the units from the player's forces assigned to the scenario
+                for (UUID unitID : tracker.getScenario().getForces(tracker.getCampaign()).getUnits()) {
+                    objectiveUnitIDs.add(tracker.getCampaign().getUnit(unitID).getEntity().getExternalIdAsString());
+                }
+                continue;
+            }
 
             for (Force force : tracker.getCampaign().getAllForces()) {
                 if (force.getName().equals(forceName)) {


### PR DESCRIPTION
Currently the `ScenarioObjectiveProcessor` has the following code to check whether the associated force name belongs to the player:

```java
            for (Force force : tracker.getCampaign().getAllForces()) {
                if (force.getName().equals(forceName)) {
                    for (UUID unitID : force.getUnits()) {
                        objectiveUnitIDs.add(tracker.getCampaign().getUnit(unitID).getEntity().getExternalIdAsString());
                    }
                    forceFound = true;
                    break;
                }
            }
```

This only works when using a scenario template because when the template is created, the associated force names are mapped to the player's forces. However, this will not work in cases where the scenario was not created through a template (as will be generally be the case for story arcs and other imaginable future enhancements) and there is no systematic way at present to tell the processor that this force should be the player's force deployed in the scenario. The result is that it is impossible to process objectives related to the player's own force (e.g. 50% of your force must survive). 

To resolve this, I added the following check directly above this code:

```java
            if (MHQConstants.EGO_OBJECTIVE_NAME.equals(forceName)) {
                // get the units from the player's forces assigned to the scenario
                for (UUID unitID : tracker.getScenario().getForces(tracker.getCampaign()).getUnits()) {
                    objectiveUnitIDs.add(tracker.getCampaign().getUnit(unitID).getEntity().getExternalIdAsString());
                }
                continue;
            }
```

This just checks whether the `forceName` is equal to a constant value ("Player") stored in `MHQConstants` and if so, it adds the player's units that are assigned to the scenario. I went through MHQConstants because I didn't like the idea of directly hardwiring a specific string into the code here and because this will make it easier to assign this value when I get around to adding all of the new features to the scenario editor.