### PR TITLE
Fix bug with missing Player units in ScenarioObjectiveProcessor

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
@@ -84,7 +84,7 @@ public class ScenarioObjectiveProcessor {
 
             if (MHQConstants.EGO_OBJECTIVE_NAME.equals(forceName)) {
                 // get the units from the player's forces assigned to the scenario
-                for (UUID unitID : tracker.getScenario().getForces(tracker.getCampaign()).getUnits()) {
+                for (UUID unitID : tracker.getScenario().getForces(tracker.getCampaign()).getAllUnits(true)) {
                     objectiveUnitIDs.add(tracker.getCampaign().getUnit(unitID).getEntity().getExternalIdAsString());
                 }
                 continue;


### PR DESCRIPTION
This fixes a bug in PR #3094. I used the getUnits method in Scenario to get units assigned to the scenario. However, that is apparently the wrong method that only gets units unaffiliated with larger forces which meant that the secenarioObjectiveProcessor would just ignore units that were part of a larger force. To get all units, I need to use the getAllUnits method. Duh, right? Anyway, this very small PR fixes that.