### PR TITLE
Remove bad logic from check on preventing breakthrough

### DIFF
--- a/MekHQ/data/scenariotemplates/Harass.xml
+++ b/MekHQ/data/scenariotemplates/Harass.xml
@@ -128,12 +128,11 @@
                     <howMuch>1</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails>
-                <additionalDetail>Crippled units do not count towards this objective.</additionalDetail>
-            </additionalDetails>
-            <description>Prevent 50% of the following force(s) and unit(s) form reaching the opposite map edge:</description>
+            <additionalDetails/>
+            <description>Destroy 50% of the following force(s) and unit(s) before they can reach the destination
+                edge:</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>PreventReachMapEdge</objectiveCriterion>
+            <objectiveCriterion>Destroy</objectiveCriterion>
             <percentage>50</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>

--- a/MekHQ/data/scenariotemplates/Prevent Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Prevent Breakthrough.xml
@@ -129,12 +129,11 @@
                     <howMuch>1</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails>
-                <additionalDetail>Crippled units do not count for this objective.</additionalDetail>
-            </additionalDetails>
-            <description>Prevent 50% of the following force(s) and unit(s) from reaching the destination edge:</description>
+            <additionalDetails/>
+            <description>Destroy 50% of the following force(s) and unit(s) before they can reach the destination
+                edge:</description>
             <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>PreventReachMapEdge</objectiveCriterion>
+            <objectiveCriterion>Destroy</objectiveCriterion>
             <percentage>50</percentage>
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
@@ -174,7 +174,7 @@ public class ScenarioObjectiveProcessor {
                         break;
                     case PreventReachMapEdge:
                         entityMeetsObjective = forceEntityDestruction ||
-                                !entityHasReachedDestinationEdge(entity, objective, opponentHasBattlefieldControl);
+                                !entityHasReachedDestinationEdge(entity, objective);
                         break;
                     case Preserve:
                         entityMeetsObjective = forceEntityEscape ||
@@ -182,7 +182,7 @@ public class ScenarioObjectiveProcessor {
                         break;
                     case ReachMapEdge:
                         entityMeetsObjective = forceEntityEscape ||
-                            !forceEntityDestruction && entityHasReachedDestinationEdge(entity, objective, opponentHasBattlefieldControl);
+                            !forceEntityDestruction && entityHasReachedDestinationEdge(entity, objective);
                         break;
                     // criteria that we have no way of tracking will not be doing any updates
                     default:
@@ -215,11 +215,11 @@ public class ScenarioObjectiveProcessor {
                 case Capture:
                     return entityIsCaptured(entity, !opponentHasBattlefieldControl);
                 case PreventReachMapEdge:
-                    return !entityHasReachedDestinationEdge(entity, objective, opponentHasBattlefieldControl);
+                    return !entityHasReachedDestinationEdge(entity, objective);
                 case Preserve:
                     return !entityIsDestroyed(entity, opponentHasBattlefieldControl);
                 case ReachMapEdge:
-                    return entityHasReachedDestinationEdge(entity, objective, !opponentHasBattlefieldControl);
+                    return entityHasReachedDestinationEdge(entity, objective);
                 default:
                     return false;
             }
@@ -259,7 +259,7 @@ public class ScenarioObjectiveProcessor {
     /**
      * Check whether or not the entity can be considered as having reached the destination edge in the given objective
      */
-    private boolean entityHasReachedDestinationEdge(Entity entity, ScenarioObjective objective, boolean opponentHasBattlefieldControl) {
+    private boolean entityHasReachedDestinationEdge(Entity entity, ScenarioObjective objective) {
                 // we've reached the destination edge if we've reached an edge and it's the right one
         return ((entity.getRetreatedDirection() != OffBoardDirection.NONE) && (entity.getRetreatedDirection() == objective.getDestinationEdge()));
     }

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
@@ -174,7 +174,7 @@ public class ScenarioObjectiveProcessor {
                         break;
                     case PreventReachMapEdge:
                         entityMeetsObjective = forceEntityDestruction ||
-                            !forceEntityEscape && !entityHasReachedDestinationEdge(entity, objective, opponentHasBattlefieldControl);
+                                !entityHasReachedDestinationEdge(entity, objective, opponentHasBattlefieldControl);
                         break;
                     case Preserve:
                         entityMeetsObjective = forceEntityEscape ||
@@ -261,9 +261,7 @@ public class ScenarioObjectiveProcessor {
      */
     private boolean entityHasReachedDestinationEdge(Entity entity, ScenarioObjective objective, boolean opponentHasBattlefieldControl) {
                 // we've reached the destination edge if we've reached an edge and it's the right one
-        return ((entity.getRetreatedDirection() != OffBoardDirection.NONE) && (entity.getRetreatedDirection() == objective.getDestinationEdge())) ||
-                // or the opponent has been routed and the entity hasn't been shot to hell
-                (!entity.isCrippled() && !entity.isDestroyed() && !opponentHasBattlefieldControl);
+        return ((entity.getRetreatedDirection() != OffBoardDirection.NONE) && (entity.getRetreatedDirection() == objective.getDestinationEdge()));
     }
 
     /**


### PR DESCRIPTION
Ok, this is a very small PR intended to change the logic of the ScenarioObjectiveProcessor with regard to the preventing breakthrough objective. I am fairly certain that the existing logic makes no sense.

This came about because I was building a prevent breakthrough scenario for the demo story arc in PR #2997 and noticed that it was not assigning units correctly based on the outcome. Basically, the objectives was to prevent the breakthrough of 70% of the enemy forces (who were arriving in waves) for 12 turns before retreating. After running through the scenario and seemingly accomplishing the mission, the only enemy units that were shown as correct for the scenario objective were those units that I destroyed, even though I had prevented the breakthrough of most units. 

I tracked the issue back to two lines of code. The first problem is in `ScenarioObjectiveProcessor#UpdateObjectiveEntityState` which is called after the user makes changes to the status of a unit in the scenario resolution tracker. Specifically:

```java
case PreventReachMapEdge:
                        entityMeetsObjective = forceEntityDestruction ||
                            !forceEntityEscape && !entityHasReachedDestinationEdge(entity, objective, opponentHasBattlefieldControl);
```

The problem there is the `!forceEntityEscape` logic. By default any entity that is not destroyed or crippled is treated as escaping. The logic here assumes that if an entity is listed as escaping then it should be considered as having broken through despite the fact that it may have literally failed to breakthrough. This is bonkers. It effectively means that the only way to prevent an entity from breaking through is to destroy it and if that is the logic then this scenario objective is effectively no different than a forced withdrawal scenario objective.

The second problem regards who has control of the battlefield. In `ScenarioObjectiveProcessor#entityHasReachedDestinationEdge` we have:

```java
return ((entity.getRetreatedDirection() != OffBoardDirection.NONE) && (entity.getRetreatedDirection() == objective.getDestinationEdge())) ||
                // or the opponent has been routed and the entity hasn't been shot to hell
                (!entity.isCrippled() && !entity.isDestroyed() && !opponentHasBattlefieldControl);
```

The second part of the or statement is the problem. It assumes that if the other side did not have control of the battlefield and you weren't crippled and destroyed that you will eventually get there. But that is why assumptions are often problematic. It completely makes impossible the scenario I described above in which the goal is to hold off the enemy unit for a certain amount of time before pulling back. Battlefield control at the end of the scenario has nothing to do with it. 

In short, if the goal of the scenario is to prevent a breakthrough or to accomplish one, then what should matter is actually breaking through in the scenario.