### PR TITLE
Fix incorrect tag on xml output

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Skill.java
@@ -180,7 +180,7 @@ public class Skill {
         MekHqXmlUtil.writeSimpleXMLOpenTag(pw, indent++, "skill");
         MekHqXmlUtil.writeSimpleXMLTag(pw, indent, "type", type.getName());
         MekHqXmlUtil.writeSimpleXMLTag(pw, indent, "level", level);
-        MekHqXmlUtil.writeSimpleXMLTag(pw, indent, "type", bonus);
+        MekHqXmlUtil.writeSimpleXMLTag(pw, indent, "bonus", bonus);
         MekHqXmlUtil.writeSimpleXMLCloseTag(pw, --indent, "skill");
     }
 


### PR DESCRIPTION
This corrects issue #3108. The issue looks like a residual copy and paste artifact where an XML tag was not changed. 