### PR TITLE
Adding the Legendary SkillLevel

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -24,6 +24,7 @@ import megamek.client.generator.skillGenerators.TaharqaSkillGenerator;
 import megamek.common.*;
 import megamek.common.enums.SkillLevel;
 import megamek.common.options.OptionsConstants;
+import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.*;
@@ -172,9 +173,9 @@ public class AtBScenarioModifierApplicator {
     public static void adjustSkill(AtBDynamicScenario scenario, Campaign campaign,
             ForceAlignment eventRecipient, int skillAdjustment) {
         // We want a non-none Skill Level
-        final SkillLevel adjustedSkill = SkillLevel.values()[Math.min(SkillLevel.HEROIC.ordinal(),
-                Math.max(SkillLevel.ULTRA_GREEN.ordinal(), scenario.getEffectiveOpforSkill().ordinal() + skillAdjustment))];
-
+        final SkillLevel adjustedSkill = SkillLevel.values()[Utilities.clamp(
+                scenario.getEffectiveOpforSkill().ordinal() + skillAdjustment,
+                SkillLevel.ULTRA_GREEN.ordinal(), SkillLevel.LEGENDARY.ordinal())];
         // fire up a skill generator set to the appropriate skill model
         final AbstractSkillGenerator abstractSkillGenerator = new TaharqaSkillGenerator();
         abstractSkillGenerator.setLevel(adjustedSkill);


### PR DESCRIPTION
This is the first part of handling #3111. MekHQ has only been partially swapped to use SkillLevel, as it previously used two setups. This is thus the only place that needs to change for now.

Requires https://github.com/MegaMek/megamek/pull/3446