### PR TITLE
3132: Adding Entity Generation Null Protection for Officer Duel Scenario

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -913,10 +913,10 @@ public class AtBDynamicScenarioFactory {
     /**
      * Determines the most appropriate RAT and uses it to generate a random Entity
      *
-     * @param faction     The faction code to use for locating the correct RAT and assigning a crew name
-     * @param skill       The RandomSkillGenerator constant that represents the skill level of the overall force.
-     * @param quality     The equipment rating of the force.
-     * @param unitType    The UnitTableData constant for the type of unit to generate.
+     * @param faction The faction code to use for locating the correct RAT and assigning a crew name
+     * @param skill The {@link SkillLevel} that represents the skill level of the overall force.
+     * @param quality The equipment rating of the force.
+     * @param unitType The UnitTableData constant for the type of unit to generate.
      * @param weightClass The weight class of the unit to generate
      * @param campaign
      * @return A new Entity with crew.
@@ -929,18 +929,19 @@ public class AtBDynamicScenarioFactory {
     /**
      * Determines the most appropriate RAT and uses it to generate a random Entity
      *
-     * @param faction     The faction code to use for locating the correct RAT and assigning a crew name
-     * @param skill       The {@link SkillLevel} that represents the skill level of the overall force.
-     * @param quality     The equipment rating of the force.
-     * @param unitType    The UnitTableData constant for the type of unit to generate.
+     * @param faction The faction code to use for locating the correct RAT and assigning a crew name
+     * @param skill The {@link SkillLevel} that represents the skill level of the overall force.
+     * @param quality The equipment rating of the force.
+     * @param unitType The UnitTableData constant for the type of unit to generate.
      * @param weightClass The weight class of the unit to generate
-     * @param artillery   Whether the unit should be artillery or not. Use with caution, as some unit types simply do not have
-     *                    support artillery.
-     * @param campaign
+     * @param artillery Whether the unit should be artillery or not. Use with caution, as some unit
+     *                  types simply do not have support artillery.
+     * @param campaign The current campaign
      * @return A new Entity with crew.
      */
-    public static Entity getEntity(String faction, SkillLevel skill, int quality, int unitType,
-                                   int weightClass, boolean artillery, Campaign campaign) {
+    public static @Nullable Entity getEntity(String faction, SkillLevel skill, int quality,
+                                             int unitType, int weightClass, boolean artillery,
+                                             Campaign campaign) {
         MechSummary ms;
 
         UnitGeneratorParameters params = new UnitGeneratorParameters();

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -23,6 +23,7 @@ package mekhq.campaign.mission;
 
 import megamek.Version;
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
 import megamek.common.options.OptionsConstants;
@@ -892,10 +893,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     /**
      * Generates an enemy lance of a given weight class.
      *
-     * @param list            Generated enemy entities are added to this list.
-     * @param weight        Weight class of the enemy lance.
-     * @param maxWeight        Maximum weight of enemy entities.
-     * @param campaign
+     * @param list Generated enemy entities are added to this list.
+     * @param weight Weight class of the enemy lance.
+     * @param maxWeight Maximum weight of enemy entities.
+     * @param campaign  The current campaign
      */
     private void addEnemyLance(List<Entity> list, int weight, int maxWeight, Campaign campaign) {
         if (weight < EntityWeightClass.WEIGHT_LIGHT) {
@@ -913,15 +914,16 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     /**
      * Determines the most appropriate RAT and uses it to generate a random Entity
      *
-     * @param faction        The faction code to use for locating the correct RAT and assigning a crew name
-     * @param skill          The {@link SkillLevel} that represents the skill level of the overall force.
-     * @param quality        The equipment rating of the force.
-     * @param unitType       The UnitTableData constant for the type of unit to generate.
-     * @param weightClass    The weight class of the unit to generate
-     * @param campaign
-     * @return               A new Entity with crew.
+     * @param faction The faction code to use for locating the correct RAT and assigning a crew name
+     * @param skill The {@link SkillLevel} that represents the skill level of the overall force.
+     * @param quality The equipment rating of the force.
+     * @param unitType The UnitTableData constant for the type of unit to generate.
+     * @param weightClass The weight class of the unit to generate
+     * @param campaign The current campaign
+     * @return A new Entity with crew.
      */
-    protected Entity getEntity(String faction, SkillLevel skill, int quality, int unitType, int weightClass, Campaign campaign) {
+    protected @Nullable Entity getEntity(String faction, SkillLevel skill, int quality,
+                                         int unitType, int weightClass, Campaign campaign) {
         return AtBDynamicScenarioFactory.getEntity(faction, skill, quality, unitType, weightClass, false, campaign);
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -47,7 +47,7 @@ public class AtBScenarioFactory {
         registerScenario(new ExtractionBuiltInScenario());
         registerScenario(new HideAndSeekBuiltInScenario());
         registerScenario(new HoldTheLineBuiltInScenario());
-        registerScenario(new OfficerDualBuiltInScenario());
+        registerScenario(new OfficerDuelBuiltInScenario());
         registerScenario(new PirateFreeForAllBuiltInScenario());
         registerScenario(new PrisonBreakBuiltInScenario());
         registerScenario(new ProbeBuiltInScenario());

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDualBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDualBuiltInScenario.java
@@ -32,6 +32,7 @@ import mekhq.campaign.mission.CommonObjectiveFactory;
 import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
 import mekhq.campaign.unit.Unit;
+import org.apache.logging.log4j.LogManager;
 
 @AtBScenarioEnabled
 public class OfficerDualBuiltInScenario extends AtBScenario {
@@ -111,6 +112,11 @@ public class OfficerDualBuiltInScenario extends AtBScenario {
                     contract.getEnemyQuality(), UnitType.MEK,
                     Math.min(weight + 1, EntityWeightClass.WEIGHT_ASSAULT), campaign);
 
+            if (en == null) {
+                LogManager.getLogger().warn("Failed to generate a mek for " + contract.getEnemyCode());
+                continue;
+            }
+
             if (weight == EntityWeightClass.WEIGHT_ASSAULT) {
                 en.getCrew().setGunnery(en.getCrew().getGunnery() - 1);
                 en.getCrew().setPiloting(en.getCrew().getPiloting() - 1);
@@ -120,7 +126,7 @@ public class OfficerDualBuiltInScenario extends AtBScenario {
             getSpecMissionEnemies().add(enemyEntities);
         }
 
-        addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getSpecMissionEnemies().get(0)), campaign);
+        addBotForce(getEnemyBotForce(contract, enemyStart, getSpecMissionEnemies().get(0)), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDualBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDualBuiltInScenario.java
@@ -95,7 +95,7 @@ public class OfficerDualBuiltInScenario extends AtBScenario {
 
     @Override
     public void setExtraMissionForces(Campaign campaign, ArrayList<Entity> allyEntities,
-            ArrayList<Entity> enemyEntities) {
+                                      ArrayList<Entity> enemyEntities) {
         setStart(startPos[Compute.randomInt(4)]);
         int enemyStart = getStart() + 4;
 
@@ -103,11 +103,14 @@ public class OfficerDualBuiltInScenario extends AtBScenario {
             enemyStart -= 8;
         }
 
+        final AtBContract contract = getContract(campaign);
+
         for (int weight = EntityWeightClass.WEIGHT_LIGHT; weight <= EntityWeightClass.WEIGHT_ASSAULT; weight++) {
-            enemyEntities = new ArrayList<Entity>();
-            Entity en = getEntity(getContract(campaign).getEnemyCode(), getContract(campaign).getEnemySkill(),
-                    getContract(campaign).getEnemyQuality(), UnitType.MEK,
+            enemyEntities = new ArrayList<>();
+            final Entity en = getEntity(contract.getEnemyCode(), contract.getEnemySkill(),
+                    contract.getEnemyQuality(), UnitType.MEK,
                     Math.min(weight + 1, EntityWeightClass.WEIGHT_ASSAULT), campaign);
+
             if (weight == EntityWeightClass.WEIGHT_ASSAULT) {
                 en.getCrew().setGunnery(en.getCrew().getGunnery() - 1);
                 en.getCrew().setPiloting(en.getCrew().getPiloting() - 1);
@@ -125,8 +128,8 @@ public class OfficerDualBuiltInScenario extends AtBScenario {
         super.setObjectives(campaign, contract);
 
         ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 100);
-        ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                100, false);
+        ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign,
+                contract, this, 100, false);
 
         getScenarioObjectives().add(destroyHostiles);
         getScenarioObjectives().add(keepFriendliesAlive);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
@@ -35,7 +35,7 @@ import mekhq.campaign.unit.Unit;
 import org.apache.logging.log4j.LogManager;
 
 @AtBScenarioEnabled
-public class OfficerDualBuiltInScenario extends AtBScenario {
+public class OfficerDuelBuiltInScenario extends AtBScenario {
     @Override
     public boolean isSpecialMission() {
         return true;


### PR DESCRIPTION
This fixes #3132.

Commit 1 cleans up some related code and improves the performance, Commit 2 adds the null protection, and Commit 3 fixes the class name.