### PR TITLE
Displayscaling

### DIFF
--- a/MekHQ/src/mekhq/IconPackage.java
+++ b/MekHQ/src/mekhq/IconPackage.java
@@ -52,6 +52,14 @@ public class IconPackage {
         loadingScreenImages.put(1921, "data/images/misc/MekHQ Load_spooky_uhd.png");
     }
 
+    public TreeMap<Integer, String> getLoadingScreenImages() {
+        return loadingScreenImages;
+    }
+
+    public TreeMap<Integer, String> getStartupScreenImagesScreenImages() {
+        return startupScreenImages;
+    }
+
     public IconPackage() {
 
     }
@@ -60,21 +68,4 @@ public class IconPackage {
         return guiElements.get(key);
     }
 
-    /**
-     * Gets the name of the startup screen image appropriate for the given horizontal resolution.
-     * @param resolutionWidth Screen width
-     * @return Path to the appropriate startup screen image.
-     */
-    public String getStartupScreenImage(int resolutionWidth) {
-        return startupScreenImages.floorEntry(resolutionWidth).getValue();
-    }
-
-    /**
-     * Gets the name of the loading screen image appropriate for the given horizontal resolution.
-     * @param resolutionWidth Screen width
-     * @return Path to the appropriate loading screen image.
-     */
-    public String getLoadingScreenImage(int resolutionWidth) {
-        return loadingScreenImages.floorEntry(resolutionWidth).getValue();
-    }
 }

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -523,25 +523,6 @@ public class MekHQ implements GameListener {
         return iconPackage;
     }
 
-    /**
-     * Helper function that calculates the maximum screen width available locally.
-     *
-     * @return Maximum screen width.
-     */
-    public double calculateMaxScreenWidth() {
-        GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-        GraphicsDevice[] gs = ge.getScreenDevices();
-        double maxWidth = 0;
-        for (GraphicsDevice g : gs) {
-            Rectangle b = g.getDefaultConfiguration().getBounds();
-            if (b.getWidth() > maxWidth) { // Update the max size found on this monitor
-                maxWidth = b.getWidth();
-            }
-        }
-
-        return maxWidth;
-    }
-
     /*
      * Access methods for event bus.
      */

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -28,7 +28,7 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.swing.GameOptionsDialog;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
-import megamek.codeUtilities.DisplayUtilities;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.Subscribe;
@@ -327,7 +327,7 @@ public class CampaignGUI extends JPanel {
 
         frame.setName("mainWindow");
         preferences.manage(new JWindowPreference(frame));
-        DisplayUtilities.keepOnScreen(frame);
+        UIUtil.keepOnScreen(frame);
     }
 
     public CampaignGuiTab getTab(GuiTabType tabType) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -28,6 +28,7 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.swing.GameOptionsDialog;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
+import megamek.codeUtilities.DisplayUtilities;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.Subscribe;
@@ -326,6 +327,7 @@ public class CampaignGUI extends JPanel {
 
         frame.setName("mainWindow");
         preferences.manage(new JWindowPreference(frame));
+        DisplayUtilities.keepOnScreen(frame);
     }
 
     public CampaignGuiTab getTab(GuiTabType tabType) {

--- a/MekHQ/src/mekhq/gui/dialog/CampaignPresetSelectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignPresetSelectionDialog.java
@@ -35,6 +35,7 @@ public class CampaignPresetSelectionDialog extends AbstractMHQButtonDialog {
     public CampaignPresetSelectionDialog(final JFrame parent) {
         super(parent, "CampaignPresetSelectionDialog", "CampaignPresetSelectionDialog.title");
         initialize();
+        setLocationRelativeTo(parent);
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -44,6 +44,7 @@ import mekhq.campaign.universe.RATManager;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.eras.Eras;
 import org.apache.logging.log4j.LogManager;
+import org.jfree.data.gantt.Task;
 
 import javax.swing.*;
 import java.awt.*;
@@ -83,12 +84,7 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
         DisplayMode currentMonitor = frame.getGraphicsConfiguration().getDevice().getDisplayMode();
         int scaledMonitorW = DisplayUtilities.getScaledScreenWidth(currentMonitor);
         int scaledMonitorH = DisplayUtilities.getScaledScreenHeight(currentMonitor);
-//        Image imgSplash = DisplayUtilities.constrainImageSize(
-//                getToolkit().getImage(app.getIconPackage().getLoadingScreenImage(scaledMonitorW)),
-//                (int)(scaledMonitorW*0.75));
-        Image imgSplash =
-                getToolkit().getImage(app.getIconPackage().getLoadingScreenImage(scaledMonitorW));
-
+        Image imgSplash = getToolkit().getImage(app.getIconPackage().getLoadingScreenImage(scaledMonitorW));
 
         // wait for loading image to load completely
         MediaTracker tracker = new MediaTracker(frame);
@@ -97,6 +93,10 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
             tracker.waitForID(0);
         } catch (InterruptedException ignored) {
             // really should never come here
+        }
+
+        if (imgSplash != null) {
+            imgSplash = DisplayUtilities.constrainImageSize(imgSplash, frame, scaledMonitorW, scaledMonitorH);
         }
 
         int splashW = imgSplash == null ? (int) (scaledMonitorW * 0.75) : imgSplash.getWidth(frame);

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -80,38 +80,43 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
         progressBar.setVisible(true);
         progressBar.setString(resourceMap.getString("loadPlanet.text"));
 
-        // initialize loading image
-        DisplayMode currentMonitor = frame.getGraphicsConfiguration().getDevice().getDisplayMode();
-        int scaledMonitorW = DisplayUtilities.getScaledScreenWidth(currentMonitor);
-        int scaledMonitorH = DisplayUtilities.getScaledScreenHeight(currentMonitor);
-        Image imgSplash = getToolkit().getImage(app.getIconPackage().getLoadingScreenImage(scaledMonitorW));
 
-        // wait for loading image to load completely
-        MediaTracker tracker = new MediaTracker(frame);
-        tracker.addImage(imgSplash, 0);
-        try {
-            tracker.waitForID(0);
-        } catch (InterruptedException ignored) {
-            // really should never come here
-        }
+        Dimension scaledMonitorSize = DisplayUtilities.getScaledScreenSize(frame);
+        JLabel splash = DisplayUtilities.createSplashComponent(app.getIconPackage().getLoadingScreenImages(), frame);
 
-        if (imgSplash != null) {
-            imgSplash = DisplayUtilities.constrainImageSize(imgSplash, frame, scaledMonitorW, scaledMonitorH);
-        }
+//        // initialize loading image
+//        DisplayMode currentMonitor = frame.getGraphicsConfiguration().getDevice().getDisplayMode();
+//        int scaledMonitorW = DisplayUtilities.getScaledScreenWidth(currentMonitor);
+//        int scaledMonitorH = DisplayUtilities.getScaledScreenHeight(currentMonitor);
+//        Image imgSplash = getToolkit().getImage(app.getIconPackage().getLoadingScreenImage(scaledMonitorW));
+//
+//        // wait for loading image to load completely
+//        MediaTracker tracker = new MediaTracker(frame);
+//        tracker.addImage(imgSplash, 0);
+//        try {
+//            tracker.waitForID(0);
+//        } catch (InterruptedException ignored) {
+//            // really should never come here
+//        }
+//
+//        if (imgSplash != null) {
+//            imgSplash = DisplayUtilities.constrainImageSize(imgSplash, frame, scaledMonitorW, scaledMonitorH);
+//        }
+//
+//        int splashW = imgSplash == null ? (int) (scaledMonitorW * 0.75) : imgSplash.getWidth(frame);
+//        int splashH = imgSplash == null ? (int) (scaledMonitorH * 0.75) : imgSplash.getHeight(frame);
+//        Dimension splashDim =  new Dimension((int) splashW, (int) splashH);
+//
+//        // make splash image panel
+//        ImageIcon icon = new ImageIcon(imgSplash);
+//        JLabel splash = new JLabel(icon);
 
-        int splashW = imgSplash == null ? (int) (scaledMonitorW * 0.75) : imgSplash.getWidth(frame);
-        int splashH = imgSplash == null ? (int) (scaledMonitorH * 0.75) : imgSplash.getHeight(frame);
-        Dimension splashDim =  new Dimension((int) splashW, (int) splashH);
-
-        // make splash image panel
-        ImageIcon icon = new ImageIcon(imgSplash);
-        JLabel splash = new JLabel(icon);
         getContentPane().setLayout(new BorderLayout());
         getContentPane().add(splash, BorderLayout.CENTER);
         getContentPane().add(progressBar, BorderLayout.PAGE_END);
 
-        setPreferredSize(splashDim);
-        setSize(splashDim);
+        setPreferredSize(splash.getPreferredSize());
+        setSize(splash.getPreferredSize());
 
         this.pack();
         this.setLocationRelativeTo(frame);

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -23,7 +23,7 @@ import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.codeUtilities.DisplayUtilities;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.MechSummaryCache;
 import megamek.common.QuirksHandler;
 import megamek.common.options.OptionsConstants;
@@ -81,35 +81,8 @@ public class DataLoadingDialog extends JDialog implements PropertyChangeListener
         progressBar.setString(resourceMap.getString("loadPlanet.text"));
 
 
-        Dimension scaledMonitorSize = DisplayUtilities.getScaledScreenSize(frame);
-        JLabel splash = DisplayUtilities.createSplashComponent(app.getIconPackage().getLoadingScreenImages(), frame);
-
-//        // initialize loading image
-//        DisplayMode currentMonitor = frame.getGraphicsConfiguration().getDevice().getDisplayMode();
-//        int scaledMonitorW = DisplayUtilities.getScaledScreenWidth(currentMonitor);
-//        int scaledMonitorH = DisplayUtilities.getScaledScreenHeight(currentMonitor);
-//        Image imgSplash = getToolkit().getImage(app.getIconPackage().getLoadingScreenImage(scaledMonitorW));
-//
-//        // wait for loading image to load completely
-//        MediaTracker tracker = new MediaTracker(frame);
-//        tracker.addImage(imgSplash, 0);
-//        try {
-//            tracker.waitForID(0);
-//        } catch (InterruptedException ignored) {
-//            // really should never come here
-//        }
-//
-//        if (imgSplash != null) {
-//            imgSplash = DisplayUtilities.constrainImageSize(imgSplash, frame, scaledMonitorW, scaledMonitorH);
-//        }
-//
-//        int splashW = imgSplash == null ? (int) (scaledMonitorW * 0.75) : imgSplash.getWidth(frame);
-//        int splashH = imgSplash == null ? (int) (scaledMonitorH * 0.75) : imgSplash.getHeight(frame);
-//        Dimension splashDim =  new Dimension((int) splashW, (int) splashH);
-//
-//        // make splash image panel
-//        ImageIcon icon = new ImageIcon(imgSplash);
-//        JLabel splash = new JLabel(icon);
+        Dimension scaledMonitorSize = UIUtil.getScaledScreenSize(frame);
+        JLabel splash = UIUtil.createSplashComponent(app.getIconPackage().getLoadingScreenImages(), frame);
 
         getContentPane().setLayout(new BorderLayout());
         getContentPane().add(splash, BorderLayout.CENTER);

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -70,34 +70,10 @@ public class StartupScreenPanel extends AbstractMHQPanel {
 
         setBackground(UIManager.getColor("controlHighlight"));
 
-        // Use the current monitor so we don't "overflow" computers whose primary
-        // displays aren't as large as their secondary displays.
-        DisplayMode currentMonitor = getFrame().getGraphicsConfiguration().getDevice().getDisplayMode();
-        int scaledMonitorW = DisplayUtilities.getScaledScreenWidth(currentMonitor);
-        int scaledMonitorH = DisplayUtilities.getScaledScreenHeight(currentMonitor);
-        Image imgSplash = getToolkit().getImage(app.getIconPackage().getStartupScreenImage(scaledMonitorW));
-
-        // wait for splash image to load completely
-        MediaTracker tracker = new MediaTracker(getFrame());
-        tracker.addImage(imgSplash, 0);
-        try {
-            tracker.waitForID(0);
-        } catch (InterruptedException ignored) {
-            // really should never come here
-        }
-
-        if (imgSplash != null) {
-            imgSplash = DisplayUtilities.constrainImageSize(imgSplash, getFrame(), scaledMonitorW, scaledMonitorH);
-        }
-
-        int splashW = imgSplash == null ? (int) (scaledMonitorW * 0.75) : imgSplash.getWidth(getFrame());
-        int splashH = imgSplash == null ? (int) (scaledMonitorH * 0.75) : imgSplash.getHeight(getFrame());
-        Dimension splashDim =  new Dimension((int) splashW, (int) splashH);
-
-        // make splash image panel
-        ImageIcon icon = new ImageIcon(imgSplash);
-        JLabel panTitle = new JLabel(icon);
-        add(panTitle, BorderLayout.CENTER);
+        Dimension scaledMonitorSize = DisplayUtilities.getScaledScreenSize(getFrame());
+        JLabel splash = DisplayUtilities.createSplashComponent(app.getIconPackage().getStartupScreenImagesScreenImages(), getFrame());
+        add(splash, BorderLayout.CENTER);
+        
         if (skinSpec.hasBackgrounds()) {
             if (skinSpec.backgrounds.size() > 1) {
                 File file = new MegaMekFile(Configuration.widgetsDir(),
@@ -148,7 +124,7 @@ public class StartupScreenPanel extends AbstractMHQPanel {
 
         // Strive for no more than ~90% of the screen and use golden ratio to make
         // the button width "look" reasonable.
-        int maximumWidth = (int) (0.9 * scaledMonitorW) - splashW;
+        int maximumWidth = (int) (0.9 * scaledMonitorSize.width) - splash.getPreferredSize().width;
 
         Dimension minButtonDim = new Dimension((int) (maximumWidth / 1.618), 25);
         if (textDim.getWidth() > minButtonDim.getWidth()) {
@@ -176,7 +152,7 @@ public class StartupScreenPanel extends AbstractMHQPanel {
         c.weightx = 0.0; c.weighty = 0.0;
         c.gridwidth = 1;
         c.gridheight = 12;
-        add(panTitle, c);
+        add(splash, c);
         // Right Column
         c.insets = new Insets(2, 2, 2, 10);
         c.fill = GridBagConstraints.BOTH;

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -18,11 +18,11 @@
  */
 package mekhq.gui.panels;
 
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.client.ui.swing.widget.SkinSpecification;
 import megamek.client.ui.swing.widget.SkinSpecification.UIComponents;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
-import megamek.codeUtilities.DisplayUtilities;
 import megamek.common.Configuration;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.ImageUtil;
@@ -70,10 +70,10 @@ public class StartupScreenPanel extends AbstractMHQPanel {
 
         setBackground(UIManager.getColor("controlHighlight"));
 
-        Dimension scaledMonitorSize = DisplayUtilities.getScaledScreenSize(getFrame());
-        JLabel splash = DisplayUtilities.createSplashComponent(app.getIconPackage().getStartupScreenImagesScreenImages(), getFrame());
+        Dimension scaledMonitorSize = UIUtil.getScaledScreenSize(getFrame());
+        JLabel splash = UIUtil.createSplashComponent(app.getIconPackage().getStartupScreenImagesScreenImages(), getFrame());
         add(splash, BorderLayout.CENTER);
-        
+
         if (skinSpec.hasBackgrounds()) {
             if (skinSpec.backgrounds.size() > 1) {
                 File file = new MegaMekFile(Configuration.widgetsDir(),

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -22,6 +22,7 @@ import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.client.ui.swing.widget.SkinSpecification;
 import megamek.client.ui.swing.widget.SkinSpecification.UIComponents;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
+import megamek.codeUtilities.DisplayUtilities;
 import megamek.common.Configuration;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.ImageUtil;
@@ -42,6 +43,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 
 public class StartupScreenPanel extends AbstractMHQPanel {
+
     //region Variable Declarations
     private MekHQ app;
     private File lastSaveFile;
@@ -68,8 +70,13 @@ public class StartupScreenPanel extends AbstractMHQPanel {
 
         setBackground(UIManager.getColor("controlHighlight"));
 
+        // Use the current monitor so we don't "overflow" computers whose primary
+        // displays aren't as large as their secondary displays.
+        DisplayMode currentMonitor = getFrame().getGraphicsConfiguration().getDevice().getDisplayMode();
+        int scaledMonitorW = DisplayUtilities.getScaledScreenWidth(currentMonitor);
+
         final Image imgSplash = getToolkit().getImage(app.getIconPackage()
-                .getStartupScreenImage((int) app.calculateMaxScreenWidth()));
+                .getStartupScreenImage(scaledMonitorW));
 
         // wait for splash image to load completely
         MediaTracker tracker = new MediaTracker(getFrame());
@@ -105,26 +112,6 @@ public class StartupScreenPanel extends AbstractMHQPanel {
             lblVersion.setForeground(skinSpec.fontColors.get(0));
         }
 
-        /*
-        final MMButton btnNewCampaign = new MMButton("btnNewCampaign", resources,
-                "btnNewCampaign.text", null, evt -> startCampaign(null));
-
-        final MMButton btnLoadCampaign = new MMButton("btnLoadCampaign", resources,
-                "btnLoadCampaign.text", null, evt -> {
-            final File file = selectCampaignFile();
-            if (file != null) {
-                startCampaign(file);
-            }
-        });
-
-        final MMButton btnLoadLastCampaign = new MMButton("btnLoadLastCampaign", resources,
-                "btnLoadLastCampaign.text", null, evt -> startCampaign(lastSaveFile));
-        btnLoadLastCampaign.setEnabled(lastSaveFile != null);
-
-        final MMButton btnQuit = new MMButton("btnQuit", resources, "Quit.text",
-                null, evt -> System.exit(0));
-         */
-
         MegamekButton btnNewCampaign = new MegamekButton(resources.getString("btnNewCampaign.text"),
                 UIComponents.MainMenuButton.getComp(), true);
         btnNewCampaign.addActionListener(evt -> startCampaign(null));
@@ -147,9 +134,6 @@ public class StartupScreenPanel extends AbstractMHQPanel {
                 UIComponents.MainMenuButton.getComp(), true);
         btnQuit.addActionListener(evt -> System.exit(0));
 
-        // Use the current monitor, so we don't "overflow" computers whose primary
-        // displays aren't as large as their secondary displays.
-        DisplayMode currentMonitor = getFrame().getGraphicsConfiguration().getDevice().getDisplayMode();
         FontMetrics metrics = btnNewCampaign.getFontMetrics(btnNewCampaign.getFont());
         int width = metrics.stringWidth(btnNewCampaign.getText());
         int height = metrics.getHeight();
@@ -160,7 +144,7 @@ public class StartupScreenPanel extends AbstractMHQPanel {
         int imageWidth = imgSplash.getWidth(getFrame());
 
         // But keep the maximum to no more than 50% of image width
-        int maximumWidth = (int) Math.min((0.9 * currentMonitor.getWidth()) - imageWidth, 0.5 * imageWidth);
+        int maximumWidth = (int) Math.min((0.9 * scaledMonitorW) - imageWidth, 0.5 * imageWidth);
 
         Dimension minButtonDim = new Dimension((int) (maximumWidth / 1.618), 25);
         if (textDim.getWidth() > minButtonDim.getWidth()) {
@@ -218,13 +202,8 @@ public class StartupScreenPanel extends AbstractMHQPanel {
         });
         getFrame().validate();
         getFrame().pack();
-
-        // Determine the location of the window
-        int w = getFrame().getSize().width;
-        int h = getFrame().getSize().height;
-        int x = (currentMonitor.getWidth() - w) / 2;
-        int y = (currentMonitor.getHeight() - h) / 2;
-        getFrame().setLocation(x, y);
+        // center window in screen
+        getFrame().setLocationRelativeTo(null);
     }
     //endregion Initialization
 

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -74,9 +74,8 @@ public class StartupScreenPanel extends AbstractMHQPanel {
         // displays aren't as large as their secondary displays.
         DisplayMode currentMonitor = getFrame().getGraphicsConfiguration().getDevice().getDisplayMode();
         int scaledMonitorW = DisplayUtilities.getScaledScreenWidth(currentMonitor);
-
-        final Image imgSplash = getToolkit().getImage(app.getIconPackage()
-                .getStartupScreenImage(scaledMonitorW));
+        int scaledMonitorH = DisplayUtilities.getScaledScreenHeight(currentMonitor);
+        Image imgSplash = getToolkit().getImage(app.getIconPackage().getStartupScreenImage(scaledMonitorW));
 
         // wait for splash image to load completely
         MediaTracker tracker = new MediaTracker(getFrame());
@@ -86,6 +85,14 @@ public class StartupScreenPanel extends AbstractMHQPanel {
         } catch (InterruptedException ignored) {
             // really should never come here
         }
+
+        if (imgSplash != null) {
+            imgSplash = DisplayUtilities.constrainImageSize(imgSplash, getFrame(), scaledMonitorW, scaledMonitorH);
+        }
+
+        int splashW = imgSplash == null ? (int) (scaledMonitorW * 0.75) : imgSplash.getWidth(getFrame());
+        int splashH = imgSplash == null ? (int) (scaledMonitorH * 0.75) : imgSplash.getHeight(getFrame());
+        Dimension splashDim =  new Dimension((int) splashW, (int) splashH);
 
         // make splash image panel
         ImageIcon icon = new ImageIcon(imgSplash);
@@ -141,10 +148,7 @@ public class StartupScreenPanel extends AbstractMHQPanel {
 
         // Strive for no more than ~90% of the screen and use golden ratio to make
         // the button width "look" reasonable.
-        int imageWidth = imgSplash.getWidth(getFrame());
-
-        // But keep the maximum to no more than 50% of image width
-        int maximumWidth = (int) Math.min((0.9 * scaledMonitorW) - imageWidth, 0.5 * imageWidth);
+        int maximumWidth = (int) (0.9 * scaledMonitorW) - splashW;
 
         Dimension minButtonDim = new Dimension((int) (maximumWidth / 1.618), 25);
         if (textDim.getWidth() > minButtonDim.getWidth()) {


### PR DESCRIPTION
DRAFT
Use shared methods across MM, MHQ and MML for display scaling and splash screens.  Also cleans up some startup screen code so new campaign dialogs appear in the center of the screen.

Depends on: https://github.com/MegaMek/megamek/pull/3473
Resolves https://github.com/MegaMek/mekhq/issues/3143