### PR TITLE
Properly refresh logistics target when handling the person update

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2490,11 +2490,7 @@ public class CampaignGUI extends JPanel {
 
     @Subscribe
     public void handlePersonUpdate(PersonEvent ev) {
-        // only bother recalculating AtB parts availability if a logistics admin has been changed
-        // refreshPartsAvailability cuts out early with a "use AtB" check so it's not necessary here
-        if (ev.getPerson().hasRole(PersonnelRole.ADMINISTRATOR_LOGISTICS)) {
-            refreshPartsAvailability();
-        }
+        refreshPartsAvailability();
     }
 
     @Subscribe


### PR DESCRIPTION
This bug was found by misclick... I kid you not.