### PR TITLE
GUI Menu Bar: Adding Accelerators to Menu Items

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -67,6 +67,7 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.campaign.universe.RandomFactionGenerator;
 import mekhq.gui.dialog.*;
+import mekhq.gui.dialog.CampaignExportWizard.CampaignExportWizardState;
 import mekhq.gui.dialog.nagDialogs.*;
 import mekhq.gui.dialog.reportDialogs.*;
 import mekhq.gui.model.PartsTableModel;
@@ -81,10 +82,7 @@ import javax.swing.*;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.xml.parsers.DocumentBuilder;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.event.*;
 import java.io.*;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -312,7 +310,7 @@ public class CampaignGUI extends JPanel {
         frame.setVisible(true);
         frame.addWindowListener(new WindowAdapter() {
             @Override
-            public void windowClosing(WindowEvent e) {
+            public void windowClosing(WindowEvent evt) {
                 getApplication().exit();
             }
         });
@@ -564,28 +562,31 @@ public class CampaignGUI extends JPanel {
         menuBar.getAccessibleContext().setAccessibleName("Main Menu");
 
         //region File Menu
-        // The File menu uses the following Mnemonic keys as of 05-APR-2021:
+        // The File menu uses the following Mnemonic keys as of 25-MAR-2022:
         // C, E, H, I, L, M, N, R, S, T, U, X
         JMenu menuFile = new JMenu(resourceMap.getString("fileMenu.text"));
         menuFile.setMnemonic(KeyEvent.VK_F);
 
         JMenuItem menuLoad = new JMenuItem(resourceMap.getString("menuLoad.text"));
         menuLoad.setMnemonic(KeyEvent.VK_L);
+        menuLoad.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_L, InputEvent.ALT_DOWN_MASK));
         menuLoad.addActionListener(this::menuLoadXmlActionPerformed);
         menuFile.add(menuLoad);
 
         JMenuItem menuSave = new JMenuItem(resourceMap.getString("menuSave.text"));
         menuSave.setMnemonic(KeyEvent.VK_S);
+        menuSave.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK));
         menuSave.addActionListener(this::saveCampaign);
         menuFile.add(menuSave);
 
         JMenuItem menuNew = new JMenuItem(resourceMap.getString("menuNew.text"));
         menuNew.setMnemonic(KeyEvent.VK_N);
+        menuNew.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.ALT_DOWN_MASK));
         menuNew.addActionListener(this::menuNewCampaignActionPerformed);
         menuFile.add(menuNew);
 
         //region menuImport
-        // The Import menu uses the following Mnemonic keys as of 12-APR-2021:
+        // The Import menu uses the following Mnemonic keys as of 25-MAR-2022:
         // A, C, F, I, P
         JMenu menuImport = new JMenu(resourceMap.getString("menuImport.text"));
         menuImport.setMnemonic(KeyEvent.VK_I);
@@ -594,6 +595,7 @@ public class CampaignGUI extends JPanel {
         miImportCampaignPreset.setToolTipText(resourceMap.getString("miImportCampaignPreset.toolTipText"));
         miImportCampaignPreset.setName("miImportCampaignPreset");
         miImportCampaignPreset.setMnemonic(KeyEvent.VK_C);
+        miImportCampaignPreset.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_DOWN_MASK));
         miImportCampaignPreset.addActionListener(evt -> {
             final CampaignPresetSelectionDialog campaignPresetSelectionDialog = new CampaignPresetSelectionDialog(getFrame());
             if (!campaignPresetSelectionDialog.showDialog().isConfirmed()) {
@@ -609,6 +611,7 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miImportPerson = new JMenuItem(resourceMap.getString("miImportPerson.text"));
         miImportPerson.setMnemonic(KeyEvent.VK_P);
+        miImportPerson.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.ALT_DOWN_MASK));
         miImportPerson.addActionListener(this::miImportPersonActionPerformed);
         menuImport.add(miImportPerson);
 
@@ -616,17 +619,20 @@ public class CampaignGUI extends JPanel {
         miImportIndividualRankSystem.setToolTipText(resourceMap.getString("miImportIndividualRankSystem.toolTipText"));
         miImportIndividualRankSystem.setName("miImportIndividualRankSystem");
         miImportIndividualRankSystem.setMnemonic(KeyEvent.VK_I);
+        miImportIndividualRankSystem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.ALT_DOWN_MASK));
         miImportIndividualRankSystem.addActionListener(evt -> getCampaign().setRankSystem(RankSystem
                 .generateIndividualInstanceFromXML(FileDialogs.openIndividualRankSystem(getFrame()).orElse(null))));
         menuImport.add(miImportIndividualRankSystem);
 
         JMenuItem miImportParts = new JMenuItem(resourceMap.getString("miImportParts.text"));
         miImportParts.setMnemonic(KeyEvent.VK_A);
+        miImportParts.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.ALT_DOWN_MASK));
         miImportParts.addActionListener(this::miImportPartsActionPerformed);
         menuImport.add(miImportParts);
 
         JMenuItem miLoadForces = new JMenuItem(resourceMap.getString("miLoadForces.text"));
         miLoadForces.setMnemonic(KeyEvent.VK_F);
+        miLoadForces.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F, InputEvent.ALT_DOWN_MASK));
         miLoadForces.addActionListener(this::miLoadForcesActionPerformed);
         menuImport.add(miLoadForces);
 
@@ -634,29 +640,32 @@ public class CampaignGUI extends JPanel {
         //endregion menuImport
 
         //region menuExport
-        // The Export menu uses the following Mnemonic keys as of 12-APR-2021:
+        // The Export menu uses the following Mnemonic keys as of 25-MAR-2022:
         // C, X, S
         JMenu menuExport = new JMenu(resourceMap.getString("menuExport.text"));
         menuExport.setMnemonic(KeyEvent.VK_X);
 
         //region CSV Export
-        // The CSV menu uses the following Mnemonic keys as of 12-APR-2021:
+        // The CSV menu uses the following Mnemonic keys as of 25-MAR-2022:
         // F, P, U
         JMenu miExportCSVFile = new JMenu(resourceMap.getString("menuExportCSV.text"));
         miExportCSVFile.setMnemonic(KeyEvent.VK_C);
 
         JMenuItem miExportPersonCSV = new JMenuItem(resourceMap.getString("miExportPersonnel.text"));
         miExportPersonCSV.setMnemonic(KeyEvent.VK_P);
+        miExportPersonCSV.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.ALT_DOWN_MASK));
         miExportPersonCSV.addActionListener(this::miExportPersonnelCSVActionPerformed);
         miExportCSVFile.add(miExportPersonCSV);
 
         JMenuItem miExportUnitCSV = new JMenuItem(resourceMap.getString("miExportUnit.text"));
         miExportUnitCSV.setMnemonic(KeyEvent.VK_U);
+        miExportUnitCSV.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U, InputEvent.ALT_DOWN_MASK));
         miExportUnitCSV.addActionListener(this::miExportUnitCSVActionPerformed);
         miExportCSVFile.add(miExportUnitCSV);
 
         JMenuItem miExportFinancesCSV = new JMenuItem(resourceMap.getString("miExportFinances.text"));
         miExportFinancesCSV.setMnemonic(KeyEvent.VK_F);
+        miExportFinancesCSV.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F, InputEvent.ALT_DOWN_MASK));
         miExportFinancesCSV.addActionListener(this::miExportFinancesCSVActionPerformed);
         miExportCSVFile.add(miExportFinancesCSV);
 
@@ -664,7 +673,7 @@ public class CampaignGUI extends JPanel {
         //endregion CSV Export
 
         //region XML Export
-        // The XML menu uses the following Mnemonic keys as of 12-APR-2021:
+        // The XML menu uses the following Mnemonic keys as of 25-MAR-2022:
         // C, I, P, R
         JMenu miExportXMLFile = new JMenu(resourceMap.getString("menuExportXML.text"));
         miExportXMLFile.setMnemonic(KeyEvent.VK_X);
@@ -672,6 +681,7 @@ public class CampaignGUI extends JPanel {
         final JMenuItem miExportCampaignPreset = new JMenuItem(resourceMap.getString("miExportCampaignPreset.text"));
         miExportCampaignPreset.setName("miExportCampaignPreset");
         miExportCampaignPreset.setMnemonic(KeyEvent.VK_C);
+        miExportCampaignPreset.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_DOWN_MASK));
         miExportCampaignPreset.addActionListener(evt -> {
             final CreateCampaignPresetDialog createCampaignPresetDialog
                     = new CreateCampaignPresetDialog(getFrame(), getCampaign(), null);
@@ -690,19 +700,22 @@ public class CampaignGUI extends JPanel {
         JMenuItem miExportRankSystems = new JMenuItem(resourceMap.getString("miExportRankSystems.text"));
         miExportRankSystems.setName("miExportRankSystems");
         miExportRankSystems.setMnemonic(KeyEvent.VK_R);
+        miExportRankSystems.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK));
         miExportRankSystems.addActionListener(evt -> Ranks.exportRankSystemsToFile(FileDialogs
-                        .saveRankSystems(getFrame()).orElse(null), getCampaign().getRankSystem()));
+                .saveRankSystems(getFrame()).orElse(null), getCampaign().getRankSystem()));
         miExportXMLFile.add(miExportRankSystems);
 
         JMenuItem miExportIndividualRankSystem = new JMenuItem(resourceMap.getString("miExportIndividualRankSystem.text"));
         miExportIndividualRankSystem.setName("miExportIndividualRankSystem");
         miExportIndividualRankSystem.setMnemonic(KeyEvent.VK_I);
+        miExportIndividualRankSystem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.ALT_DOWN_MASK));
         miExportIndividualRankSystem.addActionListener(evt -> getCampaign().getRankSystem()
                 .writeToFile(FileDialogs.saveIndividualRankSystem(getFrame()).orElse(null)));
         miExportXMLFile.add(miExportIndividualRankSystem);
 
         JMenuItem miExportPlanetsXML = new JMenuItem(resourceMap.getString("miExportPlanets.text"));
         miExportPlanetsXML.setMnemonic(KeyEvent.VK_P);
+        miExportPlanetsXML.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.ALT_DOWN_MASK));
         miExportPlanetsXML.addActionListener(this::miExportPlanetsXMLActionPerformed);
         miExportXMLFile.add(miExportPlanetsXML);
 
@@ -711,9 +724,10 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miExportCampaignSubset = new JMenuItem(resourceMap.getString("miExportCampaignSubset.text"));
         miExportCampaignSubset.setMnemonic(KeyEvent.VK_S);
+        miExportCampaignSubset.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK));
         miExportCampaignSubset.addActionListener(evt -> {
             CampaignExportWizard cew = new CampaignExportWizard(getCampaign());
-            cew.display(CampaignExportWizard.CampaignExportWizardState.ForceSelection);
+            cew.display(CampaignExportWizardState.ForceSelection);
         });
         menuExport.add(miExportCampaignSubset);
 
@@ -729,12 +743,14 @@ public class CampaignGUI extends JPanel {
         JMenuItem miRefreshUnitCache = new JMenuItem(resourceMap.getString("miRefreshUnitCache.text"));
         miRefreshUnitCache.setName("miRefreshUnitCache");
         miRefreshUnitCache.setMnemonic(KeyEvent.VK_U);
+        miRefreshUnitCache.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U, InputEvent.ALT_DOWN_MASK));
         miRefreshUnitCache.addActionListener(evt -> MechSummaryCache.refreshUnitData(false));
         menuRefresh.add(miRefreshUnitCache);
 
         JMenuItem miRefreshCamouflage = new JMenuItem(resourceMap.getString("miRefreshCamouflage.text"));
         miRefreshCamouflage.setName("miRefreshCamouflage");
         miRefreshCamouflage.setMnemonic(KeyEvent.VK_C);
+        miRefreshCamouflage.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_DOWN_MASK));
         miRefreshCamouflage.addActionListener(evt -> {
             MHQStaticDirectoryManager.refreshCamouflageDirectory();
             refreshAllTabs();
@@ -744,6 +760,7 @@ public class CampaignGUI extends JPanel {
         JMenuItem miRefreshPortraits = new JMenuItem(resourceMap.getString("miRefreshPortraits.text"));
         miRefreshPortraits.setName("miRefreshPortraits");
         miRefreshPortraits.setMnemonic(KeyEvent.VK_P);
+        miRefreshPortraits.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.ALT_DOWN_MASK));
         miRefreshPortraits.addActionListener(evt -> {
             MHQStaticDirectoryManager.refreshPortraitDirectory();
             refreshAllTabs();
@@ -753,6 +770,7 @@ public class CampaignGUI extends JPanel {
         JMenuItem miRefreshForceIcons = new JMenuItem(resourceMap.getString("miRefreshForceIcons.text"));
         miRefreshForceIcons.setName("miRefreshForceIcons");
         miRefreshForceIcons.setMnemonic(KeyEvent.VK_F);
+        miRefreshForceIcons.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F, InputEvent.ALT_DOWN_MASK));
         miRefreshForceIcons.addActionListener(evt -> {
             MHQStaticDirectoryManager.refreshForceIcons();
             refreshAllTabs();
@@ -762,6 +780,7 @@ public class CampaignGUI extends JPanel {
         JMenuItem miRefreshAwards = new JMenuItem(resourceMap.getString("miRefreshAwards.text"));
         miRefreshAwards.setName("miRefreshAwards");
         miRefreshAwards.setMnemonic(KeyEvent.VK_A);
+        miRefreshAwards.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.ALT_DOWN_MASK));
         miRefreshAwards.addActionListener(evt -> {
             MHQStaticDirectoryManager.refreshAwardIcons();
             refreshAllTabs();
@@ -771,6 +790,7 @@ public class CampaignGUI extends JPanel {
         JMenuItem miRefreshRanks = new JMenuItem(resourceMap.getString("miRefreshRanks.text"));
         miRefreshRanks.setName("miRefreshRanks");
         miRefreshRanks.setMnemonic(KeyEvent.VK_R);
+        miRefreshRanks.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK));
         miRefreshRanks.addActionListener(evt -> Ranks.reinitializeRankSystems(getCampaign()));
         menuRefresh.add(miRefreshRanks);
 
@@ -779,21 +799,25 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miMercRoster = new JMenuItem(resourceMap.getString("miMercRoster.text"));
         miMercRoster.setMnemonic(KeyEvent.VK_U);
+        miMercRoster.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U, InputEvent.ALT_DOWN_MASK));
         miMercRoster.addActionListener(evt -> showMercRosterDialog());
         menuFile.add(miMercRoster);
 
         JMenuItem menuOptions = new JMenuItem(resourceMap.getString("menuOptions.text"));
         menuOptions.setMnemonic(KeyEvent.VK_C);
+        menuOptions.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_DOWN_MASK));
         menuOptions.addActionListener(this::menuOptionsActionPerformed);
         menuFile.add(menuOptions);
 
         JMenuItem menuOptionsMM = new JMenuItem(resourceMap.getString("menuOptionsMM.text"));
         menuOptionsMM.setMnemonic(KeyEvent.VK_M);
+        menuOptionsMM.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.ALT_DOWN_MASK));
         menuOptionsMM.addActionListener(this::menuOptionsMMActionPerformed);
         menuFile.add(menuOptionsMM);
 
         JMenuItem menuMekHqOptions = new JMenuItem(resourceMap.getString("menuMekHqOptions.text"));
         menuMekHqOptions.setMnemonic(KeyEvent.VK_H);
+        menuMekHqOptions.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.ALT_DOWN_MASK));
         menuMekHqOptions.addActionListener(evt -> new MekHqOptionsDialog(getFrame()).setVisible(true));
         menuFile.add(menuMekHqOptions);
 
@@ -804,6 +828,7 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem menuExitItem = new JMenuItem(resourceMap.getString("menuExit.text"));
         menuExitItem.setMnemonic(KeyEvent.VK_E);
+        menuExitItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.ALT_DOWN_MASK));
         menuExitItem.addActionListener(evt -> getApplication().exit());
         menuFile.add(menuExitItem);
 
@@ -818,39 +843,46 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miPersonnelMarket = new JMenuItem(resourceMap.getString("miPersonnelMarket.text"));
         miPersonnelMarket.setMnemonic(KeyEvent.VK_P);
+        miPersonnelMarket.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.ALT_DOWN_MASK));
         miPersonnelMarket.addActionListener(evt -> hirePersonMarket());
         menuMarket.add(miPersonnelMarket);
 
         miContractMarket = new JMenuItem(resourceMap.getString("miContractMarket.text"));
         miContractMarket.setMnemonic(KeyEvent.VK_C);
+        miContractMarket.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_DOWN_MASK));
         miContractMarket.addActionListener(evt -> showContractMarket());
         miContractMarket.setVisible(getCampaign().getCampaignOptions().getUseAtB());
         menuMarket.add(miContractMarket);
 
         miUnitMarket = new JMenuItem(resourceMap.getString("miUnitMarket.text"));
         miUnitMarket.setMnemonic(KeyEvent.VK_U);
+        miUnitMarket.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U, InputEvent.ALT_DOWN_MASK));
         miUnitMarket.addActionListener(evt -> showUnitMarket());
         miUnitMarket.setVisible(!getCampaign().getUnitMarket().getMethod().isNone());
         menuMarket.add(miUnitMarket);
 
         miShipSearch = new JMenuItem(resourceMap.getString("miShipSearch.text"));
         miShipSearch.setMnemonic(KeyEvent.VK_S);
+        miShipSearch.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK));
         miShipSearch.addActionListener(ev -> showShipSearch());
         miShipSearch.setVisible(getCampaign().getCampaignOptions().getUseAtB());
         menuMarket.add(miShipSearch);
 
         JMenuItem miPurchaseUnit = new JMenuItem(resourceMap.getString("miPurchaseUnit.text"));
         miPurchaseUnit.setMnemonic(KeyEvent.VK_N);
+        miPurchaseUnit.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.ALT_DOWN_MASK));
         miPurchaseUnit.addActionListener(this::miPurchaseUnitActionPerformed);
         menuMarket.add(miPurchaseUnit);
 
         JMenuItem miBuyParts = new JMenuItem(resourceMap.getString("miBuyParts.text"));
         miBuyParts.setMnemonic(KeyEvent.VK_R);
+        miBuyParts.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK));
         miBuyParts.addActionListener(evt -> buyParts());
         menuMarket.add(miBuyParts);
 
         JMenuItem miHireBulk = new JMenuItem(resourceMap.getString("miHireBulk.text"));
         miHireBulk.setMnemonic(KeyEvent.VK_B);
+        miHireBulk.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_B, InputEvent.ALT_DOWN_MASK));
         miHireBulk.addActionListener(evt -> hireBulkPersonnel());
         menuMarket.add(miHireBulk);
 
@@ -860,6 +892,7 @@ public class CampaignGUI extends JPanel {
             JMenuItem miHire = new JMenuItem(role.getName(getCampaign().getFaction().isClan()));
             if (role.getMnemonic() != KeyEvent.VK_UNDEFINED) {
                 miHire.setMnemonic(role.getMnemonic());
+                miHire.setAccelerator(KeyStroke.getKeyStroke(role.getMnemonic(), InputEvent.ALT_DOWN_MASK));
             }
             miHire.setActionCommand(role.name());
             miHire.addActionListener(this::hirePerson);
@@ -875,6 +908,7 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miHireAstechs = new JMenuItem(resourceMap.getString("miHireAstechs.text"));
         miHireAstechs.setMnemonic(KeyEvent.VK_H);
+        miHireAstechs.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.ALT_DOWN_MASK));
         miHireAstechs.addActionListener(evt -> {
             PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(
                     getFrame(), true, resourceMap.getString("popupHireAstechsNum.text"),
@@ -888,6 +922,7 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miFireAstechs = new JMenuItem(resourceMap.getString("miFireAstechs.text"));
         miFireAstechs.setMnemonic(KeyEvent.VK_E);
+        miFireAstechs.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.ALT_DOWN_MASK));
         miFireAstechs.addActionListener(evt -> {
             PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(
                     getFrame(), true, resourceMap.getString("popupFireAstechsNum.text"),
@@ -901,11 +936,13 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miFullStrengthAstechs = new JMenuItem(resourceMap.getString("miFullStrengthAstechs.text"));
         miFullStrengthAstechs.setMnemonic(KeyEvent.VK_B);
+        miFullStrengthAstechs.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_B, InputEvent.ALT_DOWN_MASK));
         miFullStrengthAstechs.addActionListener(evt -> getCampaign().fillAstechPool());
         menuAstechPool.add(miFullStrengthAstechs);
 
         JMenuItem miFireAllAstechs = new JMenuItem(resourceMap.getString("miFireAllAstechs.text"));
         miFireAllAstechs.setMnemonic(KeyEvent.VK_R);
+        miFireAllAstechs.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK));
         miFireAllAstechs.addActionListener(evt -> getCampaign().decreaseAstechPool(getCampaign().getAstechPool()));
         menuAstechPool.add(miFireAllAstechs);
         menuMarket.add(menuAstechPool);
@@ -919,6 +956,7 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miHireMedics = new JMenuItem(resourceMap.getString("miHireMedics.text"));
         miHireMedics.setMnemonic(KeyEvent.VK_H);
+        miHireMedics.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.ALT_DOWN_MASK));
         miHireMedics.addActionListener(evt -> {
             PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(
                     getFrame(), true, resourceMap.getString("popupHireMedicsNum.text"),
@@ -932,6 +970,7 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miFireMedics = new JMenuItem(resourceMap.getString("miFireMedics.text"));
         miFireMedics.setMnemonic(KeyEvent.VK_E);
+        miFireMedics.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.ALT_DOWN_MASK));
         miFireMedics.addActionListener(evt -> {
             PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(
                     getFrame(), true, resourceMap.getString("popupFireMedicsNum.text"),
@@ -945,11 +984,13 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miFullStrengthMedics = new JMenuItem(resourceMap.getString("miFullStrengthMedics.text"));
         miFullStrengthMedics.setMnemonic(KeyEvent.VK_B);
+        miFullStrengthMedics.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_B, InputEvent.ALT_DOWN_MASK));
         miFullStrengthMedics.addActionListener(evt -> getCampaign().fillMedicPool());
         menuMedicPool.add(miFullStrengthMedics);
 
         JMenuItem miFireAllMedics = new JMenuItem(resourceMap.getString("miFireAllMedics.text"));
         miFireAllMedics.setMnemonic(KeyEvent.VK_R);
+        miFireAllMedics.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK));
         miFireAllMedics.addActionListener(evt -> getCampaign().decreaseMedicPool(getCampaign().getMedicPool()));
         menuMedicPool.add(miFireAllMedics);
         menuMarket.add(menuMedicPool);
@@ -966,30 +1007,35 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miDragoonsRating = new JMenuItem(resourceMap.getString("miDragoonsRating.text"));
         miDragoonsRating.setMnemonic(KeyEvent.VK_U);
+        miDragoonsRating.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U, InputEvent.ALT_DOWN_MASK));
         miDragoonsRating.addActionListener(evt ->
                 new UnitRatingReportDialog(getFrame(), getCampaign()).setVisible(true));
         menuReports.add(miDragoonsRating);
 
         JMenuItem miPersonnelReport = new JMenuItem(resourceMap.getString("miPersonnelReport.text"));
         miPersonnelReport.setMnemonic(KeyEvent.VK_P);
+        miPersonnelReport.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.ALT_DOWN_MASK));
         miPersonnelReport.addActionListener(evt ->
                 new PersonnelReportDialog(getFrame(), new PersonnelReport(getCampaign())).setVisible(true));
         menuReports.add(miPersonnelReport);
 
         JMenuItem miHangarBreakdown = new JMenuItem(resourceMap.getString("miHangarBreakdown.text"));
         miHangarBreakdown.setMnemonic(KeyEvent.VK_H);
+        miHangarBreakdown.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.ALT_DOWN_MASK));
         miHangarBreakdown.addActionListener(evt ->
                 new HangarReportDialog(getFrame(), new HangarReport(getCampaign())).setVisible(true));
         menuReports.add(miHangarBreakdown);
 
         JMenuItem miTransportReport = new JMenuItem(resourceMap.getString("miTransportReport.text"));
         miTransportReport.setMnemonic(KeyEvent.VK_T);
+        miTransportReport.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_T, InputEvent.ALT_DOWN_MASK));
         miTransportReport.addActionListener(evt ->
                 new TransportReportDialog(getFrame(), new TransportReport(getCampaign())).setVisible(true));
         menuReports.add(miTransportReport);
 
         JMenuItem miCargoReport = new JMenuItem(resourceMap.getString("miCargoReport.text"));
         miCargoReport.setMnemonic(KeyEvent.VK_C);
+        miCargoReport.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_DOWN_MASK));
         miCargoReport.addActionListener(evt ->
                 new CargoReportDialog(getFrame(), new CargoReport(getCampaign())).setVisible(true));
         menuReports.add(miCargoReport);
@@ -1005,11 +1051,13 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miHistoricalDailyReportDialog = new JMenuItem(resourceMap.getString("miShowHistoricalReportLog.text"));
         miHistoricalDailyReportDialog.setMnemonic(KeyEvent.VK_H);
+        miHistoricalDailyReportDialog.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, InputEvent.ALT_DOWN_MASK));
         miHistoricalDailyReportDialog.addActionListener(evt -> showHistoricalDailyReportDialog());
         menuView.add(miHistoricalDailyReportDialog);
 
         miRetirementDefectionDialog = new JMenuItem(resourceMap.getString("miRetirementDefectionDialog.text"));
         miRetirementDefectionDialog.setMnemonic(KeyEvent.VK_R);
+        miRetirementDefectionDialog.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK));
         miRetirementDefectionDialog.setVisible(!getCampaign().getCampaignOptions().getRandomRetirementMethod().isNone());
         miRetirementDefectionDialog.addActionListener(evt -> showRetirementDefectionDialog());
         menuView.add(miRetirementDefectionDialog);
@@ -1026,27 +1074,32 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem miGMToolsDialog = new JMenuItem(resourceMap.getString("miGMToolsDialog.text"));
         miGMToolsDialog.setMnemonic(KeyEvent.VK_G);
+        miGMToolsDialog.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_G, InputEvent.ALT_DOWN_MASK));
         miGMToolsDialog.addActionListener(evt -> showGMToolsDialog());
         menuManage.add(miGMToolsDialog);
 
         miAdvanceMultipleDays = new JMenuItem(resourceMap.getString("miAdvanceMultipleDays.text"));
         miAdvanceMultipleDays.setMnemonic(KeyEvent.VK_A);
+        miAdvanceMultipleDays.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.ALT_DOWN_MASK));
         miAdvanceMultipleDays.addActionListener(evt -> showAdvanceDaysDialog());
         miAdvanceMultipleDays.setVisible(getCampaignController().isHost());
         menuManage.add(miAdvanceMultipleDays);
 
         JMenuItem miBloodnames = new JMenuItem(resourceMap.getString("miRandomBloodnames.text"));
         miBloodnames.setMnemonic(KeyEvent.VK_B);
+        miBloodnames.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_B, InputEvent.ALT_DOWN_MASK));
         miBloodnames.addActionListener(evt -> randomizeAllBloodnames());
         menuManage.add(miBloodnames);
 
         JMenuItem miBatchXP = new JMenuItem(resourceMap.getString("miBatchXP.text"));
         miBatchXP.setMnemonic(KeyEvent.VK_M);
+        miBatchXP.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.ALT_DOWN_MASK));
         miBatchXP.addActionListener(evt -> spendBatchXP());
         menuManage.add(miBatchXP);
 
         JMenuItem miScenarioEditor = new JMenuItem(resourceMap.getString("miScenarioEditor.text"));
         miScenarioEditor.setMnemonic(KeyEvent.VK_S);
+        miScenarioEditor.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK));
         miScenarioEditor.addActionListener(evt -> {
             ScenarioTemplateEditorDialog sted = new ScenarioTemplateEditorDialog(getFrame());
             sted.setVisible(true);
@@ -1055,6 +1108,7 @@ public class CampaignGUI extends JPanel {
 
         miCompanyGenerator = new JMenuItem(resourceMap.getString("miCompanyGenerator.text"));
         miCompanyGenerator.setMnemonic(KeyEvent.VK_C);
+        miCompanyGenerator.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.ALT_DOWN_MASK));
         miCompanyGenerator.setVisible(MekHQ.getMHQOptions().getShowCompanyGenerator());
         miCompanyGenerator.addActionListener(evt ->
                 new CompanyGenerationDialog(getFrame(), getCampaign()).setVisible(true));
@@ -1072,6 +1126,7 @@ public class CampaignGUI extends JPanel {
 
         JMenuItem menuAboutItem = new JMenuItem(resourceMap.getString("menuAbout.text"));
         menuAboutItem.setMnemonic(KeyEvent.VK_A);
+        menuAboutItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.ALT_DOWN_MASK));
         menuAboutItem.setName("aboutMenuItem");
         menuAboutItem.addActionListener(evt -> showAboutBox());
         menuHelp.add(menuAboutItem);

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2,7 +2,7 @@
  * CampaignGUI.java
  *
  * Copyright (c) 2009 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
- * Copyright (c) 2020-2021 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2020-2022 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -132,14 +132,11 @@ public class CampaignGUI extends JPanel {
     private JLabel lblTempAstechs;
     private JLabel lblTempMedics;
     private JLabel lblPartsAvailabilityRating;
-    @SuppressWarnings(value = "unused")
-    private JLabel lblCargo; // FIXME: Re-add this in an optionized form
 
     /* for the top button panel */
     private JPanel btnPanel;
     private JToggleButton btnGMMode;
     private JToggleButton btnOvertime;
-    private JButton btnAdvanceDay;
 
     ReportHyperlinkListener reportHLL;
 
@@ -243,8 +240,8 @@ public class CampaignGUI extends JPanel {
 
         tabMain = new JTabbedPane();
         tabMain.setToolTipText(resourceMap.getString("tabMain.toolTipText"));
-        tabMain.setMinimumSize(new java.awt.Dimension(600, 200));
-        tabMain.setPreferredSize(new java.awt.Dimension(900, 300));
+        tabMain.setMinimumSize(new Dimension(600, 200));
+        tabMain.setPreferredSize(new Dimension(900, 300));
 
         addStandardTab(GuiTabType.COMMAND);
         addStandardTab(GuiTabType.TOE);
@@ -261,9 +258,9 @@ public class CampaignGUI extends JPanel {
         addStandardTab(GuiTabType.MEKLAB);
         addStandardTab(GuiTabType.FINANCES);
 
-        //check to see if we just selected the command center tab
-        //and if so change its color to standard
-        tabMain.addChangeListener(e -> {
+        // check to see if we just selected the command center tab
+        // and if so change its color to standard
+        tabMain.addChangeListener(evt -> {
             if (tabMain.getSelectedIndex() == 0) {
                 tabMain.setBackgroundAt(0, null);
                 logNagActive = false;
@@ -324,53 +321,52 @@ public class CampaignGUI extends JPanel {
 
     private void setUserPreferences() {
         PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(CampaignGUI.class);
-
         frame.setName("mainWindow");
         preferences.manage(new JWindowPreference(frame));
         UIUtil.keepOnScreen(frame);
     }
 
-    public CampaignGuiTab getTab(GuiTabType tabType) {
+    public @Nullable CampaignGuiTab getTab(GuiTabType tabType) {
         return standardTabs.get(tabType);
     }
 
-    public CommandCenterTab getCommandCenterTab() {
+    public @Nullable CommandCenterTab getCommandCenterTab() {
         return (CommandCenterTab) getTab(GuiTabType.COMMAND);
     }
 
-    public TOETab getTOETab() {
+    public @Nullable TOETab getTOETab() {
         return (TOETab) getTab(GuiTabType.TOE);
     }
 
-    public BriefingTab getBriefingTab() {
+    public @Nullable BriefingTab getBriefingTab() {
         return (BriefingTab) getTab(GuiTabType.BRIEFING);
     }
 
-    public MapTab getMapTab() {
+    public @Nullable MapTab getMapTab() {
         return (MapTab) getTab(GuiTabType.MAP);
     }
 
-    public PersonnelTab getPersonnelTab() {
+    public @Nullable PersonnelTab getPersonnelTab() {
         return (PersonnelTab) getTab(GuiTabType.PERSONNEL);
     }
 
-    public HangarTab getHangarTab() {
+    public @Nullable HangarTab getHangarTab() {
         return (HangarTab) getTab(GuiTabType.HANGAR);
     }
 
-    public WarehouseTab getWarehouseTab() {
+    public @Nullable WarehouseTab getWarehouseTab() {
         return (WarehouseTab) getTab(GuiTabType.WAREHOUSE);
     }
 
-    public RepairTab getRepairTab() {
+    public @Nullable RepairTab getRepairTab() {
         return (RepairTab) getTab(GuiTabType.REPAIR);
     }
 
-    public MekLabTab getMekLabTab() {
+    public @Nullable MekLabTab getMekLabTab() {
         return (MekLabTab) getTab(GuiTabType.MEKLAB);
     }
 
-    public InfirmaryTab getInfirmaryTab() {
+    public @Nullable InfirmaryTab getInfirmaryTab() {
         return (InfirmaryTab) getTab(GuiTabType.INFIRMARY);
     }
 
@@ -562,7 +558,7 @@ public class CampaignGUI extends JPanel {
      * Note 2: the A mnemonic is used for the Advance Day button
      */
     private void initMenu() {
-        // TODO: Implement "Export All" versions for Personnel and Parts
+        // TODO : Implement "Export All" versions for Personnel and Parts
         // See the JavaDoc comment for used mnemonic keys
         menuBar = new JMenuBar();
         menuBar.getAccessibleContext().setAccessibleName("Main Menu");
@@ -1100,22 +1096,20 @@ public class CampaignGUI extends JPanel {
     }
 
     private void initTopButtons() {
-        GridBagConstraints gridBagConstraints;
-
         lblLocation = new JLabel(getCampaign().getLocation().getReport(getCampaign().getLocalDate()));
 
         btnPanel = new JPanel(new GridBagLayout());
         btnPanel.getAccessibleContext().setAccessibleName("Campaign Actions");
 
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.weightx = 0.0;
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.gridheight = 2;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
-        gridBagConstraints.insets = new java.awt.Insets(3, 10, 3, 3);
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(3, 10, 3, 3);
         btnPanel.add(lblLocation, gridBagConstraints);
 
         btnGMMode = new JToggleButton(resourceMap.getString("btnGMMode.text"));
@@ -1125,14 +1119,14 @@ public class CampaignGUI extends JPanel {
         btnGMMode.setMinimumSize(new Dimension(150, 25));
         btnGMMode.setPreferredSize(new Dimension(150, 25));
         btnGMMode.setMaximumSize(new Dimension(150, 25));
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
-        gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
+        gridBagConstraints.anchor = GridBagConstraints.EAST;
+        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
         btnPanel.add(btnGMMode, gridBagConstraints);
 
         btnOvertime = new JToggleButton(resourceMap.getString("btnOvertime.text"));
@@ -1141,31 +1135,31 @@ public class CampaignGUI extends JPanel {
         btnOvertime.setMinimumSize(new Dimension(150, 25));
         btnOvertime.setPreferredSize(new Dimension(150, 25));
         btnOvertime.setMaximumSize(new Dimension(150, 25));
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 1;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.NONE;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
-        gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
+        gridBagConstraints.anchor = GridBagConstraints.EAST;
+        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
         btnPanel.add(btnOvertime, gridBagConstraints);
 
         // This button uses a mnemonic that is unique and listed in the initMenu JavaDoc
-        btnAdvanceDay = new JButton(resourceMap.getString("btnAdvanceDay.text"));
+        JButton btnAdvanceDay = new JButton(resourceMap.getString("btnAdvanceDay.text"));
         btnAdvanceDay.setToolTipText(resourceMap.getString("btnAdvanceDay.toolTipText"));
         btnAdvanceDay.addActionListener(evt -> getCampaignController().advanceDay());
         btnAdvanceDay.setMnemonic(KeyEvent.VK_A);
         btnAdvanceDay.setPreferredSize(new Dimension(250, 50));
-        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.VERTICAL;
+        gridBagConstraints.fill = GridBagConstraints.VERTICAL;
         gridBagConstraints.weightx = 0.0;
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.gridheight = 2;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 15);
+        gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
+        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
         btnPanel.add(btnAdvanceDay, gridBagConstraints);
     }
 
@@ -1203,13 +1197,6 @@ public class CampaignGUI extends JPanel {
             menuThemes.add(miPlaf);
             miPlaf.setActionCommand(laf.getClassName());
             miPlaf.addActionListener(this::changeTheme);
-        }
-    }
-
-    //TODO: trigger from event
-    public void filterTasks() {
-        if (getTab(GuiTabType.REPAIR) != null) {
-            ((RepairTab) getTab(GuiTabType.REPAIR)).filterTasks();
         }
     }
 
@@ -1377,7 +1364,7 @@ public class CampaignGUI extends JPanel {
         boolean hadAtB = getCampaign().getCampaignOptions().getUseAtB();
         DataLoadingDialog dataLoadingDialog = new DataLoadingDialog(
                 getApplication(), getFrame(), f);
-        // TODO: does this effectively deal with memory management issues?
+        // TODO : does this effectively deal with memory management issues?
         dataLoadingDialog.setVisible(true);
         if (hadAtB && !getCampaign().getCampaignOptions().getUseAtB()) {
             RandomFactionGenerator.getInstance().dispose();


### PR DESCRIPTION
This adds accelerators to menu items, and thus displays the mnemonics in the options themselves. We want to use both accelerators and mnemonics to prevent issues with layered menus, as just using an accelerator can cause different submenus to be selected instead of the proper menu item.

e.g. When selecting the Marketplace / Hire / MechWarrior dialog through mnemonics, with just an accelerator it would swap to the Marketplace / Medic Pool submenu instead of launching the correct dialog. It works properly using both.
![Selection Menu](https://user-images.githubusercontent.com/39067288/160287285-f3f9ad50-e96c-4e07-a803-49bb4bf79048.png)

For Review: Commit 1 is a general code cleanup, Commit 2 is the actual change.
