### PR TITLE
Increasing Maximum Bulk Part and Personnel Purchase Quantity to 10k

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -99,7 +99,7 @@ public class CampaignGUI extends JPanel {
     public static final int MAX_START_WIDTH = 1400;
     public static final int MAX_START_HEIGHT = 900;
     // the max quantity when mass purchasing parts, hiring, etc. using the JSpinner
-    public static final int MAX_QUANTITY_SPINNER = 1000;
+    public static final int MAX_QUANTITY_SPINNER = 100000;
 
     private JFrame frame;
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -99,7 +99,7 @@ public class CampaignGUI extends JPanel {
     public static final int MAX_START_WIDTH = 1400;
     public static final int MAX_START_HEIGHT = 900;
     // the max quantity when mass purchasing parts, hiring, etc. using the JSpinner
-    public static final int MAX_QUANTITY_SPINNER = 100000;
+    public static final int MAX_QUANTITY_SPINNER = 10000;
 
     private JFrame frame;
 


### PR DESCRIPTION
This is for dev testing and large campaigns, and has been repeatedly annoying for testing various personnel changes.