### PR TITLE
Personnel Modules: Death

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractDefinition.java
@@ -25,6 +25,7 @@ import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import megamek.common.annotations.Nullable;
 import mekhq.MHQConstants;
 import mekhq.MekHqXmlUtil;
 import mekhq.campaign.mission.enums.AtBContractType;
@@ -69,7 +70,7 @@ public class StratconContractDefinition {
     /**
      * Returns the StratCon contract definition for the given {@link AtBContractType}
      */
-    public static StratconContractDefinition getContractDefinition(final AtBContractType atbContractType) {
+    public static @Nullable StratconContractDefinition getContractDefinition(final AtBContractType atbContractType) {
         if (!loadedDefinitions.containsKey(atbContractType)) {
             String filePath = Paths.get(MHQConstants.STRATCON_CONTRACT_PATH,
                     getContractDefinitionManifest().definitionFileNames.get(atbContractType)).toString();
@@ -355,22 +356,20 @@ public class StratconContractDefinition {
      * @param inputFile The source file
      * @return Possibly an instance of a ScenarioTemplate
      */
-    public static StratconContractDefinition Deserialize(File inputFile) {
-        StratconContractDefinition resultingDefinition = null;
-
+    public static @Nullable StratconContractDefinition Deserialize(File inputFile) {
         try {
             JAXBContext context = JAXBContext.newInstance(StratconContractDefinition.class);
             Unmarshaller um = context.createUnmarshaller();
             try (FileInputStream fileStream = new FileInputStream(inputFile)) {
                 Source inputSource = MekHqXmlUtil.createSafeXmlSource(fileStream);
                 JAXBElement<StratconContractDefinition> definitionElement = um.unmarshal(inputSource, StratconContractDefinition.class);
-                resultingDefinition = definitionElement.getValue();
+                return definitionElement.getValue();
             }
-        } catch (Exception e) {
-            LogManager.getLogger().error("Error deserializing contract definition " + inputFile.getPath(), e);
+        } catch (Exception ex) {
+            LogManager.getLogger().error("Error deserializing contract definition " + inputFile.getPath(), ex);
         }
 
-        return resultingDefinition;
+        return null;
     }
 
     /**
@@ -387,7 +386,7 @@ public class StratconContractDefinition {
          * Attempt to deserialize an instance of an contract definition manifest from the passed-in file path
          * @return Possibly an instance of a contract definition Manifest
          */
-        public static ContractDefinitionManifest Deserialize(String fileName) {
+        public static @Nullable ContractDefinitionManifest Deserialize(String fileName) {
             ContractDefinitionManifest resultingManifest = null;
             File inputFile = new File(fileName);
             if (!inputFile.exists()) {
@@ -411,4 +410,3 @@ public class StratconContractDefinition {
         }
     }
 }
-

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -19,6 +19,7 @@
 package mekhq.campaign.stratcon;
 
 import megamek.common.Compute;
+import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.*;
@@ -40,8 +41,14 @@ public class StratconContractInitializer {
 
     /**
      * Initializes the campaign state given a contract, campaign and contract definition
+     * @return true if the contract initializes successfully
      */
-    public static void initializeCampaignState(AtBContract contract, Campaign campaign, StratconContractDefinition contractDefinition) {
+    public static boolean initializeCampaignState(AtBContract contract, Campaign campaign,
+                                                  @Nullable StratconContractDefinition contractDefinition) {
+        if (contractDefinition == null) {
+            LogManager.getLogger().error("Cannot attempt to initialize a StratCon contract with a null contract definition");
+            return false;
+        }
         StratconCampaignState campaignState = new StratconCampaignState(contract);
         campaignState.setBriefingText(contractDefinition.getBriefing() + "<br/>" + contract.getCommandRights().getStratConText());
         campaignState.setAllowEarlyVictory(contractDefinition.isAllowEarlyVictory());
@@ -167,7 +174,8 @@ public class StratconContractInitializer {
                     false, Collections.emptyList());
         }
 
-        // now we're done
+        // now we're done, so return true
+        return true;
     }
 
     /**


### PR DESCRIPTION
This follows https://github.com/MegaMek/mekhq/pull/2493, https://github.com/MegaMek/mekhq/pull/2851, and https://github.com/MegaMek/mekhq/pull/2908 by creating the Death Module, which uses the same design to ensure the same level of functionality and customization as the three previous modules.

This PR does the following:
- [x] Abstract Random Death Baseline
- [x] Disabled Random Death Method Implementation
- [x] Percentage Random Death Method Implementation
- [x] Exponential Random Death Method Implementation
- [x] Age Range Random Death Method Implementation
- [x] Age Group Enum (Baby, Toddler, Child, Pre-Teen, Teen, Adult, Elder)
- [x] Ten Year Age Range Enum
- [x] Data-based Random Death Cause Generator
- [x] Random Death Cause Generator UserData Support
- [x] Random Death Cause Generator Data Refresh Menu Item