### PR TITLE
3252: Fixing Retirement Table Column Pay Bonus Sorters and Default Return Values

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.dialog;
 
+import megamek.client.ui.models.XTableColumnModel;
 import megamek.client.ui.preferences.JComboBoxPreference;
 import megamek.client.ui.preferences.JIntNumberSpinnerPreference;
 import megamek.client.ui.preferences.JWindowPreference;
@@ -39,8 +40,6 @@ import mekhq.gui.CampaignGUI;
 import mekhq.gui.enums.PersonnelFilter;
 import mekhq.gui.model.RetirementTableModel;
 import mekhq.gui.model.UnitAssignmentTableModel;
-import megamek.client.ui.models.XTableColumnModel;
-import mekhq.gui.sorter.BonusSorter;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.PersonRankStringSorter;
 import mekhq.gui.sorter.WeightClassSorter;
@@ -203,8 +202,7 @@ public class RetirementDefectionDialog extends JDialog {
             personnelSorter = new TableRowSorter<>(model);
             personnelSorter.setComparator(RetirementTableModel.COL_PERSON, new PersonRankStringSorter(hqView.getCampaign()));
             personnelSorter.setComparator(RetirementTableModel.COL_PAYOUT, new FormattedNumberSorter());
-            personnelSorter.setComparator(RetirementTableModel.COL_BONUS_COST, new BonusSorter());
-            personnelSorter.setComparator(RetirementTableModel.COL_PAY_BONUS, new BonusSorter());
+            personnelSorter.setComparator(RetirementTableModel.COL_BONUS_COST, new FormattedNumberSorter());
             personnelTable.setRowSorter(personnelSorter);
             ArrayList<RowSorter.SortKey> sortKeys = new ArrayList<>();
             sortKeys.add(new RowSorter.SortKey(RetirementTableModel.COL_PERSON, SortOrder.DESCENDING));

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -226,15 +226,9 @@ public class RetirementTableModel extends AbstractTableModel {
             case COL_BONUS_COST:
                 return RetirementDefectionTracker.getBonusCost(campaign, p).toAmountAndSymbolString();
             case COL_PAY_BONUS:
-                if (null == payBonus.get(p.getId())) {
-                    return false;
-                }
-                return payBonus.get(p.getId());
+                return payBonus.getOrDefault(p.getId(), false);
             case COL_MISC_MOD:
-                if (null == miscMods.get(p.getId())) {
-                    return false;
-                }
-                return miscMods.get(p.getId());
+                return miscMods.getOrDefault(p.getId(), 0);
             case COL_SHARES:
                 return p.getNumShares(campaign, campaign.getCampaignOptions().getSharesForAll());
             case COL_PAYOUT:


### PR DESCRIPTION
This fixes #3252 and another pair of bugs I found in the misc mod column.