### PR TITLE
3270: Preventing RandomFactionGenerator Rebel Faction Target NPE from Null Faction Borders

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
+++ b/MekHQ/src/mekhq/campaign/universe/FactionBorderTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2018-2022 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -37,7 +37,7 @@ import java.util.concurrent.Executors;
  * rather than a circle, with the radius being the distance from the center to each vertex.
  *
  * Recalculates in the background whenever the date or the bound of the region to examine change. By
- * default queries made while the background thread is working will block until it finishes, but thresholds
+ * default, queries made while the background thread is working will block until it finishes, but thresholds
  * can be set for a number of days or a distance, any query made while a change falls under that threshold
  * will use the partially updated data.
  *
@@ -206,12 +206,11 @@ public class FactionBorderTracker {
      * @see #setDayThreshold(int)
      * @see #setDistanceThreshold(double)
      */
-
-    @Nullable public synchronized FactionBorders getBorders(Faction f) {
+    public synchronized @Nullable FactionBorders getBorders(Faction f) {
         while (invalid) {
             try {
                 wait();
-            } catch (InterruptedException ex) {
+            } catch (Exception ignored) {
                 Thread.currentThread().interrupt();
             }
         }
@@ -234,7 +233,7 @@ public class FactionBorderTracker {
      * @see #setDayThreshold(int)
      * @see #setDistanceThreshold(double)
      */
-    @Nullable public synchronized FactionBorders getBorders(String fKey) {
+    public synchronized @Nullable FactionBorders getBorders(String fKey) {
         while (invalid) {
             try {
                 wait();
@@ -243,10 +242,7 @@ public class FactionBorderTracker {
             }
         }
         Faction f = Factions.getInstance().getFaction(fKey);
-        if (null != f) {
-            return borders.get(f);
-        }
-        return null;
+        return (f == null) ? null : borders.get(f);
     }
 
     /**
@@ -272,15 +268,13 @@ public class FactionBorderTracker {
         while (invalid) {
             try {
                 wait();
-            } catch (InterruptedException ex) {
+            } catch (Exception ignored) {
                 Thread.currentThread().interrupt();
             }
         }
-        if (borderSystems.containsKey(self)
-                && borderSystems.get(self).containsKey(other)) {
-            return borderSystems.get(self).get(other);
-        }
-        return Collections.emptyList();
+
+        return (borderSystems.containsKey(self) && borderSystems.get(self).containsKey(other))
+                ? borderSystems.get(self).get(other) : Collections.emptyList();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -527,33 +527,34 @@ public class RandomFactionGenerator {
         // If the attacker or defender are not in the set of factions that control planets,
         // and they are not rebels or pirates, they will be a faction contained within another
         // (e.g. Nova Cat in the Draconis Combine, or Wolf-in-Exile in Lyran space
-        if (!borderTracker.getFactionsInRegion().contains(attacker)
-                && !attacker.is(Faction.Tag.PIRATE)) {
+        if (!borderTracker.getFactionsInRegion().contains(attacker) && !attacker.isPirate()) {
             attacker = factionHints.getContainedFactionHost(attacker, getCurrentDate());
         }
-        if (!borderTracker.getFactionsInRegion().contains(defender)
-                && !defender.is(Faction.Tag.PIRATE)
-                && !defender.is(Faction.Tag.REBEL)) {
+
+        if (!borderTracker.getFactionsInRegion().contains(defender) && !defender.isRebelOrPirate()) {
             defender = factionHints.getContainedFactionHost(defender, getCurrentDate());
         }
+
         if ((null == attacker) || (null == defender)) {
             return Collections.emptyList();
         }
+
         // Locate rebels on any of the attacker's planet
-        if (defender.is(Faction.Tag.REBEL)) {
+        if (defender.isRebel()) {
             return new ArrayList<>(borderTracker.getBorders(attacker).getSystems());
         }
 
         Set<PlanetarySystem> planetSet = new HashSet<>(borderTracker.getBorderSystems(attacker, defender));
         // If mission is against generic pirates (those that don't control any systems),
         // add all border systems as possible locations
-        if ((attacker.is(Faction.Tag.PIRATE) && !borderTracker.getFactionsInRegion().contains(attacker))
-                || (defender.is(Faction.Tag.PIRATE) && !borderTracker.getFactionsInRegion().contains(defender))) {
+        if ((attacker.isPirate() && !borderTracker.getFactionsInRegion().contains(attacker))
+                || (defender.isPirate() && !borderTracker.getFactionsInRegion().contains(defender))) {
             for (Faction f : borderTracker.getFactionsInRegion()) {
                 planetSet.addAll(borderTracker.getBorderSystems(f, attacker));
                 planetSet.addAll(borderTracker.getBorderSystems(attacker, f));
             }
         }
+
         /* No border with defender found among systems controlled by
          * attacker; check for presence of attacker and defender
          * in systems controlled by other factions.

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -541,7 +541,9 @@ public class RandomFactionGenerator {
 
         // Locate rebels on any of the attacker's planet
         if (defender.isRebel()) {
-            return new ArrayList<>(borderTracker.getBorders(attacker).getSystems());
+            final FactionBorders factionBorders = borderTracker.getBorders(attacker);
+            return (factionBorders == null) ? new ArrayList<>()
+                    : new ArrayList<>(factionBorders.getSystems());
         }
 
         Set<PlanetarySystem> planetSet = new HashSet<>(borderTracker.getBorderSystems(attacker, defender));


### PR DESCRIPTION
This fixes #3270.

To Review:
Commits 1-2 are cleanups to simplify the code, Commit 3 is the bugfix.