### PR TITLE
AbstractDeath: Fixing Cause Generation Typo

### DIFF
--- a/MekHQ/data/universe/randomDeathCauses.xml
+++ b/MekHQ/data/universe/randomDeathCauses.xml
@@ -17,7 +17,7 @@ I took the baseline ones and expanded from that to fill the data out.
 
 Any numbers not handled there are based on further data originating from the CDC.
 -->
-<randomDeathCauses version="0.49.0">
+<randomDeathCauses version="0.49.8">
     <MALE>
         <UNDER_ONE>
             <HOMICIDE>7.5</HOMICIDE> <!-- 178 deaths -->

--- a/MekHQ/src/mekhq/campaign/personnel/death/AbstractDeath.java
+++ b/MekHQ/src/mekhq/campaign/personnel/death/AbstractDeath.java
@@ -64,7 +64,9 @@ public abstract class AbstractDeath {
         setUseRandomPrisonerDeath(options.isUseRandomPrisonerDeath());
         this.enableRandomDeathSuicideCause = options.isUseRandomDeathSuicideCause();
         this.causes = new HashMap<>();
-        initializeCauses();
+        if (!method.isNone()) {
+            initializeCauses();
+        }
     }
     //endregion Constructors
 
@@ -252,11 +254,12 @@ public abstract class AbstractDeath {
             if (!wn.hasChildNodes()) {
                 continue;
             }
+
             try {
                 final Gender gender = Gender.valueOf(wn.getNodeName());
                 getCauses().putIfAbsent(gender, new HashMap<>());
                 final NodeList nl2 = wn.getChildNodes();
-                for (int j = 0; j < nl.getLength(); j++) {
+                for (int j = 0; j < nl2.getLength(); j++) {
                     final Node wn2 = nl2.item(j);
                     if (!wn2.hasChildNodes()) {
                         continue;
@@ -268,6 +271,10 @@ public abstract class AbstractDeath {
                         final NodeList nl3 = wn2.getChildNodes();
                         for (int k = 0; k < nl3.getLength(); k++) {
                             final Node wn3 = nl3.item(k);
+                            if (wn3.getNodeType() != Node.ELEMENT_NODE) {
+                                continue;
+                            }
+
                             try {
                                 final PersonnelStatus status = PersonnelStatus.valueOf(wn3.getNodeName());
                                 if (status.isSuicide() && !isEnableRandomDeathSuicideCause()) {


### PR DESCRIPTION
This fixes the cause generation and doesn't load causes when random death isn't enabled (no need to waste the memory)