### PR TITLE
prevent stratcon scenario generation during rout morale

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -100,7 +100,7 @@ public class StratconRulesManager {
 
             // if we haven't already used all the player forces and are required to randomly
             // generate a scenario
-            if (!availableForceIDs.isEmpty() && (Compute.randomInt(100) <= targetNum)) {
+            if (!availableForceIDs.isEmpty() && (Compute.randomInt(100) < targetNum)) {
                 // pick random coordinates and force to drive the scenario
                 int x = Compute.randomInt(track.getWidth());
                 int y = Compute.randomInt(track.getHeight());


### PR DESCRIPTION
Due to a misunderstanding of how compute.randomInt behaves, situations where the odds of a random scenario are 0 (e.g. rout) can still (with 1% odds) generate random scenarios. Fixed the logic and misunderstanding.