### PR TITLE
3294: Unit Is Properly Removed after Black Market Swindle

### DIFF
--- a/MekHQ/src/mekhq/gui/panes/UnitMarketPane.java
+++ b/MekHQ/src/mekhq/gui/panes/UnitMarketPane.java
@@ -411,6 +411,7 @@ public class UnitMarketPane extends AbstractMHQSplitPane {
             final Entity entity = offer.getEntity();
             if (entity == null) {
                 LogManager.getLogger().error("Cannot purchase a null entity");
+                getCampaign().getUnitMarket().getOffers().remove(offer);
                 offersIterator.remove();
                 continue;
             }
@@ -429,6 +430,7 @@ public class UnitMarketPane extends AbstractMHQSplitPane {
                         price.dividedBy(roll), String.format(resources.getString("UnitMarketPane.PurchasedUnitBlackMarketSwindled.finances"),
                                 entity.getShortName()));
                 getCampaign().addReport(resources.getString("UnitMarketPane.BlackMarketSwindled.report"));
+                getCampaign().getUnitMarket().getOffers().remove(offer);
                 offersIterator.remove();
                 continue;
             }


### PR DESCRIPTION
This fixes #3294. It was also missing for the entity null check error.