### PR TITLE
added do-not-remove flag to force templates

### DIFF
--- a/MekHQ/data/scenariotemplates/Assassinate.xml
+++ b/MekHQ/data/scenariotemplates/Assassinate.xml
@@ -107,6 +107,7 @@
                 <minWeightClass>1</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
+		<subjectToRandomRemoval>false</subjectToRandomRemoval>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Capture.xml
+++ b/MekHQ/data/scenariotemplates/Capture.xml
@@ -107,6 +107,7 @@
                 <minWeightClass>1</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
+		<subjectToRandomRemoval>false</subjectToRandomRemoval>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Convoy Attack.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Attack.xml
@@ -100,6 +100,7 @@
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
+		<subjectToRandomRemoval>false</subjectToRandomRemoval>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Destroy Grounded Dropship.xml
+++ b/MekHQ/data/scenariotemplates/Destroy Grounded Dropship.xml
@@ -113,6 +113,7 @@
                 <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
+		<subjectToRandomRemoval>false</subjectToRandomRemoval>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>

--- a/MekHQ/data/scenariotemplates/Low Atmo - Destroy Dropship.xml
+++ b/MekHQ/data/scenariotemplates/Low Atmo - Destroy Dropship.xml
@@ -73,6 +73,7 @@
                 <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>5</startingAltitude>
+		<subjectToRandomRemoval>false</subjectToRandomRemoval>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Space - Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space - Blockade Run.xml
@@ -134,6 +134,7 @@
                 <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
+		<subjectToRandomRemoval>false</subjectToRandomRemoval>
                 <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
@@ -344,6 +344,12 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
      */
     private List<String> objectiveLinkedForces;
 
+    /**
+     * Whether or not this force is subject to modifiers that cause random unit removal
+     * e.g. "Good Intel".
+     */
+    private boolean subjectToRandomRemoval = true;
+    
     @Override
     public ScenarioForceTemplate clone() {
         return new ScenarioForceTemplate(this);
@@ -606,6 +612,14 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
 
     public void setDeployOffboard(boolean deployOffBoard) {
         this.deployOffBoard = deployOffBoard;
+    }
+    
+    public boolean isSubjectToRandomRemoval() {
+        return subjectToRandomRemoval;
+    }
+
+    public void setSubjectToRandomRemoval(boolean subjectToRandomRemoval) {
+        this.subjectToRandomRemoval = subjectToRandomRemoval;
     }
 
     @XmlElementWrapper(name = "objectiveLinkedForces")

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -111,11 +111,13 @@ public class AtBScenarioModifierApplicator {
         for (int x = 0; x < actualUnitsToRemove; x++) {
             int botForceIndex = Compute.randomInt(scenario.getNumBots());
             BotForce bf = scenario.getBotForce(botForceIndex);
+            ScenarioForceTemplate template = scenario.getBotForceTemplates().get(bf);
+            boolean subjectToRemoval = (template != null) && template.isSubjectToRandomRemoval();
 
             // only remove units from a bot force if it's on the affected team
             // AND if it has any units to remove
             if ((bf.getTeam() == ScenarioForceTemplate.TEAM_IDS.get(eventRecipient.ordinal()))
-                    && !bf.getFullEntityList(campaign).isEmpty()) {
+                    && !bf.getFullEntityList(campaign).isEmpty() && subjectToRemoval) {
                 int unitIndexToRemove = Compute.randomInt(bf.getFullEntityList(campaign).size());
                 bf.removeEntity(unitIndexToRemove);
             }


### PR DESCRIPTION
Adds a flag to scenario force templates to make them not subject to random unit removal modifiers (at the moment, just "Good Intel").

Fixes #3160