### PR TITLE
configure SPA upgrade intensity

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -647,3 +647,5 @@ chkAssignPortraitOnRoleChange.text=Automatically assign portrait on role change
 chkAssignPortraitOnRoleChange.toolTipText=With this enabled, a person without a portrait will automatically gain a random portrait when their primary role is switched to one of those selected below
 lblFixedMapChance.text=Fixed Map Chance
 lblFixedMapChance.toolTipText=The likelihood, in percent, that a fixed user-made map will be used in place of a generated map.
+lblSPAUpgradeIntensity.text=SPA Upgrade Intensity
+lblSPAUpgradeIntensity.toolTipText=How likely it is that regular+ opfor pilots will receive SPAs. -1 indicates never, 3 indicates always.

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -447,6 +447,7 @@ public class CampaignOptions {
     private boolean useLightConditions;
     private boolean usePlanetaryConditions;
     private int fixedMapChance;
+    private int spaUpgradeIntensity;
     //endregion Against the Bot Tab
     //endregion Variable Declarations
 
@@ -937,6 +938,7 @@ public class CampaignOptions {
         allowOpforLocalUnits = false;
         opforLocalUnitChance = 5;
         setFixedMapChance(25);
+        setSpaUpgradeIntensity(0);
         adjustPlayerVehicles = false;
         regionalMechVariations = false;
         attachedPlayerCamouflage = true;
@@ -3519,6 +3521,14 @@ public class CampaignOptions {
         this.fixedMapChance = fixedMapChance;
     }
 
+    public int getSpaUpgradeIntensity() {
+        return spaUpgradeIntensity;
+    }
+
+    public void setSpaUpgradeIntensity(int spaUpgradeIntensity) {
+        this.spaUpgradeIntensity = spaUpgradeIntensity;
+    }
+
     public void writeToXml(PrintWriter pw1, int indent) {
         pw1.println(MekHqXmlUtil.indentStr(indent) + "<campaignOptions>");
         //region General Tab
@@ -3879,6 +3889,7 @@ public class CampaignOptions {
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "opforAeroChance", opforAeroChance);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "opforLocalUnitChance", opforLocalUnitChance);
         MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "fixedMapChance", fixedMapChance);
+        MekHqXmlUtil.writeSimpleXmlTag(pw1, indent + 1, "spaUpgradeIntensity", spaUpgradeIntensity);        
 
         //Mass Repair/Salvage Options
         MekHqXmlUtil.writeSimpleXmlTag(pw1, ++indent, "massRepairUseRepair", massRepairUseRepair());
@@ -4680,6 +4691,8 @@ public class CampaignOptions {
                     retVal.opforLocalUnitChance = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("fixedMapChance")) {
                     retVal.fixedMapChance = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("spaUpgradeIntensity")) {
+                    retVal.setSpaUpgradeIntensity(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("massRepairUseRepair")) {
                     retVal.setMassRepairUseRepair(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("massRepairUseSalvage")) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2499,7 +2499,7 @@ public class AtBDynamicScenarioFactory {
      * @param campaign A pointer to the campaign
      */
     public static void upgradeBotCrews(AtBScenario scenario, Campaign campaign) {
-        CrewSkillUpgrader csu = new CrewSkillUpgrader();
+        CrewSkillUpgrader csu = new CrewSkillUpgrader(campaign.getCampaignOptions().getSpaUpgradeIntensity());
 
         for (int forceIndex = 0; forceIndex < scenario.getNumBots(); forceIndex++) {
             for (Entity entity : scenario.getBotForce(forceIndex).getFullEntityList(campaign)) {

--- a/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
+++ b/MekHQ/src/mekhq/campaign/mission/CrewSkillUpgrader.java
@@ -39,12 +39,15 @@ public class CrewSkillUpgrader {
     private double twoThirdsXPCost;
     private double oneThirdXPCost;
     private double minAbilityCost = Double.MAX_VALUE;
-
+    private int upgradeIntensity;
 
     /**
      * Constructor. Initializes updated SPA list, broken down by unit type.
+     * @param upgradeIntensity how likely a pilot is to receive consideration for an SPA (<0 means none, 3+ means every time)
      */
-    public CrewSkillUpgrader() {
+    public CrewSkillUpgrader(int upgradeIntensity) {
+        this.upgradeIntensity = upgradeIntensity;
+        
         specialAbilitiesByUnitType = new HashMap<>();
 
         for (SpecialAbility spa : SpecialAbility.getWeightedSpecialAbilities()) {
@@ -74,19 +77,20 @@ public class CrewSkillUpgrader {
      * @param entity The entity to potentially upgrade.
      */
     public void upgradeCrew(Entity entity) {
-        // roll 1d4, and get SPAs with 25% odds (as recommended by CamOps)
+        // roll 1d4, and get SPAs with configurable odds
         // determine veterancy level
         // this sets the weight limit and how many SPAs we can assign
+        // complete scrubs don't get SPAs.
         // this is described in some detail in CamOps page 70 (Special Pilot Abilities)
         int upgradeRoll = Compute.randomInt(4);
-        if (upgradeRoll != 3) {
+        if (upgradeRoll > upgradeIntensity) {
             return;
         }
 
         double skillAvg = (entity.getCrew().getGunnery() + entity.getCrew().getPiloting()) / 2.0;
         double xpCap = 0;
         int spaCap = 0;
-
+        
         // elite
         if (skillAvg < 3) {
             xpCap = maxAbilityXPCost;

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -507,6 +507,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private JSpinner spnOpforAeroChance;
     private JCheckBox chkOpforUsesLocalForces;
     private JSpinner spnOpforLocalForceChance;
+    private JSpinner spnSPAUpgradeIntensity;
     private JSpinner spnFixedMapChance;
     private JCheckBox chkAdjustPlayerVehicles;
     private JCheckBox chkRegionalMechVariations;
@@ -3029,6 +3030,20 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.insets = new Insets(0, 5, 5, 5);
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         panSubAtBScenario.add(panFixedMapChance, gridBagConstraints);
+        
+        JPanel panSPAUpgradeIntensity = new JPanel();
+        JLabel lblSPAUpgradeIntensity = new JLabel(resources.getString("lblSPAUpgradeIntensity.text"));
+        lblSPAUpgradeIntensity.setToolTipText(resources.getString("lblSPAUpgradeIntensity.toolTipText"));
+        spnSPAUpgradeIntensity = new JSpinner(new SpinnerNumberModel(0, -1, 3, 1));
+        panSPAUpgradeIntensity.add(lblSPAUpgradeIntensity);
+        panSPAUpgradeIntensity.add(spnSPAUpgradeIntensity);
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = yTablePosition++;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.insets = new Insets(0, 5, 5, 5);
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        panSubAtBScenario.add(panSPAUpgradeIntensity, gridBagConstraints);
 
         JScrollPane scrAtB = new JScrollPane(panAtB);
         scrAtB.setPreferredSize(new Dimension(500, 410));
@@ -6421,6 +6436,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnOpforLocalForceChance.setValue(options.getOpforLocalUnitChance());
         chkAdjustPlayerVehicles.setSelected(options.getAdjustPlayerVehicles());
         spnFixedMapChance.setValue(options.getFixedMapChance());
+        spnSPAUpgradeIntensity.setValue(options.getSpaUpgradeIntensity());
         chkRegionalMechVariations.setSelected(options.getRegionalMechVariations());
         chkAttachedPlayerCamouflage.setSelected(options.getAttachedPlayerCamouflage());
         chkPlayerControlsAttachedUnits.setSelected(options.getPlayerControlsAttachedUnits());
@@ -6828,6 +6844,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             options.setOpforAeroChance((Integer) spnOpforAeroChance.getValue());
             options.setOpforLocalUnitChance((Integer) spnOpforLocalForceChance.getValue());
             options.setFixedMapChance((Integer) spnFixedMapChance.getValue());
+            options.setSpaUpgradeIntensity((Integer) spnSPAUpgradeIntensity.getValue());
             options.setUseDropShips(chkUseDropShips.isSelected());
 
             options.setSearchRadius((Integer) spnSearchRadius.getValue());


### PR DESCRIPTION
Pretty straightforward - addresses #3289 

The SPA upgrade code for opfors was already present - I hate to add more configurable settings, but it seems like it wasn't generating enough SPAs for people to notice? So now they can crank the odds of getting SPAs up to the max and let every regular+ opponent get SPAs.