### PR TITLE
Revert "2766: Preventing an exception whereby the processing entity has a -1 external id"

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -182,10 +182,6 @@ public class ResolveScenarioTracker {
             if (!e.getSubEntities().isEmpty()) {
                 // Sub-entities have their own entry in the VictoryEvent data
                 continue;
-            } else if ("-1".equals(e.getExternalIdAsString())) {
-                LogManager.getLogger().error("Entity " + e.getDisplayName()
-                        + " has an illegal External Id of -1. Cannot process the unit.");
-                continue;
             }
 
             entities.put(UUID.fromString(e.getExternalIdAsString()), e);


### PR DESCRIPTION
As part of adding the history note I noticed that the opener has been banned from our socials for many issues including ignoring repeated dev advice while asking them for advice on the same topic (with reverse compatibility being a constantly ignored topic). I'm pretty much certain this is just user error because of the opener's history and complete lack of other raises.

I had no idea how this could have happened originally, and this path shows why. I'm sorry for wasting your time with #2831 @NickAragua and @rjhancock.