### PR TITLE
add remove stratcon scenario option

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3668,13 +3668,11 @@ public class Campaign implements ITechManager {
         if (mission != null) {
             mission.getScenarios().remove(scenario);
 
-            // if we GM-remove the scenario and it's attached to a StratCon scenario
-            // then pretend like we let the StratCon scenario expire
+            // run through the stratcon campaign state where applicable and remove the "parent" scenario as well
             if ((mission instanceof AtBContract) &&
                     (((AtBContract) mission).getStratconCampaignState() != null) &&
                     (scenario instanceof AtBDynamicScenario)) {
-                StratconRulesManager.processIgnoredScenario(
-                        (AtBDynamicScenario) scenario, ((AtBContract) mission).getStratconCampaignState());
+                ((AtBContract) mission).getStratconCampaignState().removeStratconScenario(scenario.getId());
             }
         }
         scenarios.remove(scenario.getId());

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
@@ -34,6 +34,7 @@ import javax.xml.namespace.QName;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
+import mekhq.campaign.mission.Scenario;
 
 /**
  * Contract-level state object for a StratCon campaign.
@@ -168,6 +169,17 @@ public class StratconCampaignState {
         }
 
         return false;
+    }
+    
+    /**
+     * Removes the scenario with the given campaign scenario ID from any tracks where it's present
+     */
+    public StratconScenario removeStratconScenario(int scenarioID) {
+        for (StratconTrackState trackState : tracks) {
+            trackState.removeScenario(scenarioID);
+        }
+        
+        return null;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
@@ -174,12 +174,10 @@ public class StratconCampaignState {
     /**
      * Removes the scenario with the given campaign scenario ID from any tracks where it's present
      */
-    public StratconScenario removeStratconScenario(int scenarioID) {
+    public void removeStratconScenario(int scenarioID) {
         for (StratconTrackState trackState : tracks) {
             trackState.removeScenario(scenarioID);
         }
-        
-        return null;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -25,6 +25,7 @@ import jakarta.xml.bind.annotation.XmlTransient;
 import megamek.common.annotations.Nullable;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
+import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -148,12 +149,28 @@ public class StratconTrackState {
         }
     }
 
+    public void removeScenario(int campaignScenarioID) {
+        if (getBackingScenariosMap().containsKey(campaignScenarioID)) {
+            removeScenario(getBackingScenariosMap().get(campaignScenarioID));
+        }
+    }
+    
     /**
      * Removes a StratconScenario from this track.
      */
     public void removeScenario(StratconScenario scenario) {
         scenarios.remove(scenario.getCoords());
         getBackingScenariosMap().remove(scenario.getBackingScenarioID());
+        Map<StratconCoords, StratconStrategicObjective> objectives = getObjectivesByCoords();
+        if (objectives.containsKey(scenario.getCoords())) {
+            StrategicObjectiveType objectiveType = objectives.get(scenario.getCoords()).getObjectiveType();
+            
+            switch (objectiveType) {
+                case RequiredScenarioVictory:
+                case SpecificScenarioVictory:
+                    objectives.remove(scenario.getCoords());
+            }
+        }
 
         // any assigned forces get cleared out here as well.
         for (int forceID : scenario.getAssignedForces()) {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -169,6 +169,9 @@ public class StratconTrackState {
                 case RequiredScenarioVictory:
                 case SpecificScenarioVictory:
                     objectives.remove(scenario.getCoords());
+                    break;
+                default:
+                    break;
             }
         }
 

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -72,6 +72,7 @@ public class StratconPanel extends JPanel implements ActionListener {
     private static final String RCLICK_COMMAND_REMOVE_FACILITY = "RemoveFacility";
     private static final String RCLICK_COMMAND_CAPTURE_FACILITY = "CaptureFacility";
     private static final String RCLICK_COMMAND_ADD_FACILITY = "AddFacility";
+    private static final String RCLICK_COMMAND_REMOVE_SCENARIO = "RemoveScenario";
 
     /**
      * What to do when drawing a hex
@@ -243,6 +244,14 @@ public class StratconPanel extends JPanel implements ActionListener {
                 }
 
                 rightClickMenu.add(menuItemAddFacility);
+            }
+            
+            if (scenario != null) {
+                JMenuItem removeScenarioItem = new JMenuItem();
+                removeScenarioItem.setText("Remove Scenario");
+                removeScenarioItem.setActionCommand(RCLICK_COMMAND_REMOVE_SCENARIO);
+                removeScenarioItem.addActionListener(this);
+                rightClickMenu.add(removeScenarioItem);
             }
         }
     }
@@ -767,6 +776,13 @@ public class StratconPanel extends JPanel implements ActionListener {
                 StratconFacility newFacility = facility.clone();
                 newFacility.setVisible(currentTrack.getRevealedCoords().contains(selectedCoords));
                 currentTrack.addFacility(selectedCoords, newFacility);
+                break;
+            case RCLICK_COMMAND_REMOVE_SCENARIO:
+                StratconScenario scenario = getSelectedScenario();
+                
+                if (scenario != null) {
+                    campaign.removeScenario(scenario.getBackingScenario());
+                }
                 break;
         }
 


### PR DESCRIPTION
Adds a gm-remove scenario option to the stratcon track panel; updates the 'remove scenario' option in the briefing tab to perform the same sequence of actions, resolving #2791 and the root cause of #3225.