### PR TITLE
update aero functionality logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -463,7 +463,12 @@ public class Unit implements ITechnology {
             }
         }
         if (en instanceof Aero) {
-            if (en.getWalkMP() <= 0 && !(en instanceof Jumpship)) {
+            // aerospace units are considered non-functional if their walk MP is 0
+            // unless they are grounded spheroid dropships or jumpships
+            boolean hasNoWalkMP = en.getWalkMP() <= 0;
+            boolean isJumpship = en instanceof Jumpship;
+            boolean isGroundedSpheroid = (en instanceof Dropship) && ((Dropship) en).isSpheroid() && en.getAltitude() == 0;
+            if (hasNoWalkMP && !isJumpship && !isGroundedSpheroid) {
                 return false;
             }
             return ((Aero) en).getSI() > 0;


### PR DESCRIPTION
Updates the "isfunctional" method of Unit class to prevent "grounded" spheroid dropships from being classified as non-functional. They're perfectly fine, in fact. Fixes #3408 and also the sporadic inability to deploy spheroid dropships to multiple sequential scenarios without a MekHQ restart.