### PR TITLE
Disabling Randomization-based Tests

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1224,7 +1224,7 @@ public class Campaign implements ITechManager {
         return getHangar().getUnits();
     }
 
-    public ArrayList<Entity> getEntities() {
+    public List<Entity> getEntities() {
         return getUnits().stream()
                 .map(Unit::getEntity)
                 .collect(Collectors.toCollection(ArrayList::new));
@@ -2028,7 +2028,7 @@ public class Campaign implements ITechManager {
         TargetRoll target = getTargetFor(medWork, doctor);
         int roll = Compute.d6(2);
         report = report + ",  needs " + target.getValueAsString()
-                + " and rolls " + roll + ":";
+                + " and rolls " + roll + ':';
         int xpGained = 0;
         //If we get a natural 2 that isn't an automatic success, reroll if Edge is available and in use.
         if (getCampaignOptions().useSupportEdge()
@@ -2036,8 +2036,8 @@ public class Campaign implements ITechManager {
             if ((roll == 2) && (doctor.getCurrentEdge() > 0) && (target.getValue() != TargetRoll.AUTOMATIC_SUCCESS)) {
                 doctor.changeCurrentEdge(-1);
                 roll = Compute.d6(2);
-                report += medWork.fail() + "\n" + doctor.getHyperlinkedFullTitle() + " uses Edge to reroll:"
-                        + " rolls " + roll + ":";
+                report += medWork.fail() + '\n' + doctor.getHyperlinkedFullTitle() + " uses Edge to reroll:"
+                        + " rolls " + roll + ':';
             }
         }
         if (roll >= target.getValue()) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1227,7 +1227,7 @@ public class Campaign implements ITechManager {
     public List<Entity> getEntities() {
         return getUnits().stream()
                 .map(Unit::getEntity)
-                .collect(Collectors.toCollection(ArrayList::new));
+                .collect(Collectors.toList());
     }
 
     public Unit getUnit(UUID id) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1114,9 +1114,7 @@ public class Campaign implements ITechManager {
      * @param tu
      */
     public void addTestUnit(TestUnit tu) {
-        // we really just want the entity and the parts so let's just wrap that around a
-        // new
-        // unit.
+        // we really just want the entity and the parts so let's just wrap that around a new unit.
         Unit unit = new Unit(tu.getEntity(), this);
         getHangar().addUnit(unit);
 
@@ -1162,12 +1160,12 @@ public class Campaign implements ITechManager {
         en.setExternalIdAsString(unit.getId().toString());
 
         unit.initializeBaySpace();
-        removeUnitFromForce(unit); // Added to avoid the 'default force bug'
-        // when calculating cargo
+        // Added to avoid the 'default force bug' when calculating cargo
+        removeUnitFromForce(unit);
 
         // If this is a ship, add it to the list of potential transports
         // JumpShips and space stations are intentionally ignored at present, because this
-        // functionality is being used to auto-load ground units into bays, and doing this for large
+        // functionality is being used to autoload ground units into bays, and doing this for large
         // craft that can't transit is pointless.
         if ((unit.getEntity() instanceof Dropship) || (unit.getEntity() instanceof Warship)) {
             addTransportShip(unit);
@@ -1181,8 +1179,10 @@ public class Campaign implements ITechManager {
         unit.setDaysToArrival(days);
 
         if (allowNewPilots) {
-            Map<CrewType, Collection<Person>> newCrew = Utilities.genRandomCrewWithCombinedSkill(this, unit, getFactionCode());
-            newCrew.forEach((type, personnel) -> personnel.forEach(p -> type.getAddMethod().accept(unit, p)));
+            Map<CrewType, Collection<Person>> newCrew = Utilities
+                    .genRandomCrewWithCombinedSkill(this, unit, getFactionCode());
+            newCrew.forEach((type, personnel) ->
+                    personnel.forEach(p -> type.getAddMethod().accept(unit, p)));
         }
         unit.resetPilotAndEntity();
 
@@ -1225,11 +1225,9 @@ public class Campaign implements ITechManager {
     }
 
     public ArrayList<Entity> getEntities() {
-        ArrayList<Entity> entities = new ArrayList<>();
-        for (Unit unit : getUnits()) {
-            entities.add(unit.getEntity());
-        }
-        return entities;
+        return getUnits().stream()
+                .map(Unit::getEntity)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     public Unit getUnit(UUID id) {

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
@@ -39,6 +39,7 @@ import mekhq.campaign.universe.Systems;
 import org.apache.logging.log4j.LogManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.security.SecureRandom;
@@ -80,6 +81,7 @@ public class ContractMarketIntegrationTest {
         fillHangar(campaign);
     }
 
+    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void addAtBContractMercsTest() {
         ContractMarket market = new ContractMarket();
@@ -92,6 +94,7 @@ public class ContractMarketIntegrationTest {
         assertFalse(market.getContracts().isEmpty());
     }
 
+    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void generateContractOffersMercsTest() {
         ContractMarket market = new ContractMarket();
@@ -108,6 +111,7 @@ public class ContractMarketIntegrationTest {
         assertTrue(foundContract);
     }
 
+    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void addAtBContractMercRetainerTest() {
         campaign.setRetainerEmployerCode("LA");
@@ -122,6 +126,7 @@ public class ContractMarketIntegrationTest {
         assertFalse(market.getContracts().isEmpty());
     }
 
+    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void generateContractOffersMercRetainerTest() {
         campaign.setRetainerEmployerCode("CS");
@@ -140,6 +145,7 @@ public class ContractMarketIntegrationTest {
         assertTrue(foundContract);
     }
 
+    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void generateContractOffersMercSubcontractTest() {
         AtBContract existing = mock(AtBContract.class);
@@ -199,6 +205,7 @@ public class ContractMarketIntegrationTest {
         }
     }
 
+    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void addAtBContractHouseTest() {
         campaign.setFactionCode("DC");
@@ -213,6 +220,7 @@ public class ContractMarketIntegrationTest {
         assertFalse(market.getContracts().isEmpty());
     }
 
+    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void generateContractOffersHouseTest() {
         campaign.setFactionCode("FS");

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketIntegrationTest.java
@@ -51,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
+@Disabled // All tests under this class rely on randomness, and thus doesn't work properly.
 public class ContractMarketIntegrationTest {
     private static final int REASONABLE_GENERATION_ATTEMPTS = 3;
 
@@ -81,7 +82,6 @@ public class ContractMarketIntegrationTest {
         fillHangar(campaign);
     }
 
-    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void addAtBContractMercsTest() {
         ContractMarket market = new ContractMarket();
@@ -94,7 +94,6 @@ public class ContractMarketIntegrationTest {
         assertFalse(market.getContracts().isEmpty());
     }
 
-    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void generateContractOffersMercsTest() {
         ContractMarket market = new ContractMarket();
@@ -111,7 +110,6 @@ public class ContractMarketIntegrationTest {
         assertTrue(foundContract);
     }
 
-    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void addAtBContractMercRetainerTest() {
         campaign.setRetainerEmployerCode("LA");
@@ -126,7 +124,6 @@ public class ContractMarketIntegrationTest {
         assertFalse(market.getContracts().isEmpty());
     }
 
-    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void generateContractOffersMercRetainerTest() {
         campaign.setRetainerEmployerCode("CS");
@@ -145,7 +142,6 @@ public class ContractMarketIntegrationTest {
         assertTrue(foundContract);
     }
 
-    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void generateContractOffersMercSubcontractTest() {
         AtBContract existing = mock(AtBContract.class);
@@ -205,7 +201,6 @@ public class ContractMarketIntegrationTest {
         }
     }
 
-    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void addAtBContractHouseTest() {
         campaign.setFactionCode("DC");
@@ -220,7 +215,6 @@ public class ContractMarketIntegrationTest {
         assertFalse(market.getContracts().isEmpty());
     }
 
-    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void generateContractOffersHouseTest() {
         campaign.setFactionCode("FS");

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -45,7 +45,7 @@ public class AtBContractTest {
         // Ensure the parent is not set
         assertNull(child.getParentContract());
     }
-    
+
     @Test
     public void atbContractRestoresRefs() {
         Campaign mockCampaign = mock(Campaign.class);

--- a/MekHQ/unittests/mekhq/campaign/mission/DynamicScenarioFactoryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/DynamicScenarioFactoryTest.java
@@ -20,6 +20,7 @@ package mekhq.campaign.mission;
 
 import megamek.common.Board;
 import megamek.common.UnitType;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,6 +58,7 @@ public class DynamicScenarioFactoryTest {
         assertEquals(Board.START_SE, AtBDynamicScenarioFactory.getOppositeEdge(startingEdge));
     }
 
+    @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void testAeroLanceSize() {
         assertEquals(2, AtBDynamicScenarioFactory.getAeroLanceSize(UnitType.AERO, true, "FC"));


### PR DESCRIPTION
This PR is disables random testing in MekHQ, as they do not properly test functionality. Testing based on static mocking is the proper way to test these, and they will need to be rewritten to do that.