### PR TITLE
Adding Faction Data Validation to Campaign Options Pane

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -418,6 +418,8 @@ btnLoadPreset.toolTipText=Load a Campaign Preset and apply it to the current dia
 
 ## Option Validation Warnings
 CampaignOptionsPane.EmptyCampaignName.text=You cannot have an empty campaign name.
+CampaignOptionsPane.NullFactionSelected.text=You cannot have an empty campaign name.
+CampaignOptionsPane.FactionWithoutFactionCodeSelected.text=You cannot select a faction named %s, as it is missing its faction code.
 
 ## Unsorted Properties
 lblName.text=Name:

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -25,6 +25,7 @@ import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.dialogs.CamoChooserDialog;
 import megamek.client.ui.enums.ValidationState;
 import megamek.client.ui.swing.util.PlayerColour;
+import megamek.codeUtilities.StringUtility;
 import megamek.common.EquipmentType;
 import megamek.common.ITechnology;
 import megamek.common.annotations.Nullable;
@@ -6439,6 +6440,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             campaign.setLocalDate(date);
             // Ensure that the MegaMek year GameOption matches the campaign year
             campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());
+            // Null state handled during validation
             campaign.setFactionCode(comboFaction.getSelectedItem().getFaction().getShortName());
             RandomNameGenerator.getInstance().setChosenFaction(comboFactionNames.getSelectedItem());
             RandomGenderGenerator.setPercentFemale(sldGender.getValue());
@@ -6871,6 +6873,27 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             if (display) {
                 JOptionPane.showMessageDialog(getFrame(),
                         resources.getString("CampaignOptionsPane.EmptyCampaignName.text"),
+                        resources.getString("InvalidOptions.title"),
+                        JOptionPane.ERROR_MESSAGE);
+            }
+            return ValidationState.FAILURE;
+        }
+
+        // Faction Validation
+        final FactionDisplay factionDisplay = comboFaction.getSelectedItem();
+        if (factionDisplay == null) {
+            if (display) {
+                JOptionPane.showMessageDialog(getFrame(),
+                        resources.getString("CampaignOptionsPane.NullFactionSelected.text"),
+                        resources.getString("InvalidOptions.title"),
+                        JOptionPane.ERROR_MESSAGE);
+            }
+            return ValidationState.FAILURE;
+        } else if (StringUtility.isNullOrBlank(factionDisplay.getFaction().getShortName())) {
+            if (display) {
+                JOptionPane.showMessageDialog(getFrame(),
+                        String.format(resources.getString("CampaignOptionsPane.FactionWithoutFactionCodeSelected.text"),
+                                factionDisplay),
                         resources.getString("InvalidOptions.title"),
                         JOptionPane.ERROR_MESSAGE);
             }


### PR DESCRIPTION
I have no ability to test this, but have known the first was technically possible. The second one is just a safety check, as that will cause problems in future if it is set to blank.