### PR TITLE
Fixes issue where training ammo was affected by the parts cost multiplier

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -5274,7 +5274,7 @@ public class Unit implements ITechnology {
 
         for (Part p : getParts()) {
             if (p instanceof EquipmentPart && ((EquipmentPart) p).getType() instanceof AmmoType) {
-                ammoCost = ammoCost.plus(p.getActualValue());
+                ammoCost = ammoCost.plus(p.getStickerPrice());
             }
         }
 


### PR DESCRIPTION
This bug was caused by the PR adding code for Joda Money. I did find another bug when calculating the cost of SRM 6 ammo but I do not know the cause or reason. It uses getStickerPrice() as does other parts of the HQ code, but only in this instance (and when using the replaced function) SRM6 ammo costs 28,929 instead of the typical 27,000. It does not affect other SRM ammo and those show up correctly.