### PR TITLE
Fixes issue with missing pay for transport check

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -588,7 +588,7 @@ public class Contract extends Mission {
         }
 
         // calculate transportation costs
-        if (null != getSystem()) {
+        if (null != getSystem() && c.getCampaignOptions().payForTransport()) {
             JumpPath jumpPath = getJumpPath(c);
 
             // FM:Mercs transport payments take into account owned transports and do not use CampaignOps DropShip costs.


### PR DESCRIPTION
This appears to be a really old bug that has largely gone unnoticed.

Basically players were getting additional income when **not** using the Pay for Transportation option. This corrects that issue. Now if pay for transport is false both income and expenses are correctly zeroed out.