### PR TITLE
3473: Load Default AtB Config When Custom Config Cannot Be Parsed

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBConfigDefaults.properties
+++ b/MekHQ/resources/mekhq/resources/AtBConfigDefaults.properties
@@ -9,8 +9,8 @@ botLance.IS=3:LLLL,2:LLLM,1:LLMM|1:LLMM,2:LMMM,2:MMMM,1:MMMH|1:MMHH,2:MHHH,2:HHH
 botLance.CLAN=1:LLLLL,1:LLLLM,1:LLLMM|1:LLMMM,1:LMMMM,2:MMMMM,1:MMMMH,1:MMMHH|1:MMHHH,2:MHHHH,2:HHHHH,1:HHHHA|1:MHHAA,2:HHAAA,2:HHAAA,1:AAAAA
 botLance.CS=1:LLLLLL,2:LLLLLM,2:LLLLMM,1:LLLMMM|1:LLLMMM,1:LLMMMM,1:LMMMMM,1:MMMMMM,1:MMMMMH,1:MMMMHH|1:MMMHHH,1:MMHHHH,1:MHHHHH,1:HHHHHH,1:HHHHHA,1:HHHHAA|2:HHHAAA,1:HHAAAA,2:HAAAAA,1:AAAAAA
 
-#The following are not required for AtB to function and are only used if atbconfig.xml is missing.
-hiringHalls=3031-01-01,3067-10-15,Outreach|2700-01-01,,Solaris|3057-01-01",,Arc-Royal|3058-01-01,3081-03-15,Fletcher|2650-01-01,,Galatea|3000-01-01,,Westerhand|3057-01-01,3081-03-15,Northwind|3020-01-01,,Herotitus
+#The following are not required for AtB to function and are only used if atbconfig.xml is missing or broken
+hiringHalls=3031-01-01,3067-10-15,Outreach|2700-01-01,,Solaris|3057-01-01,,Arc-Royal|3058-01-01,3081-03-15,Fletcher|2650-01-01,,Galatea|3000-01-01,,Westerhand|3057-01-01,3081-03-15,Northwind|3020-01-01,,Herotitus
 
 shipSearchCost=100000
 shipSearchLengthWeeks=4

--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
@@ -394,7 +394,8 @@ public class AtBConfiguration {
             retVal.setAllValuesToDefaults();
             return retVal;
         } catch (Exception ex) {
-            LogManager.getLogger().error("", ex);
+            LogManager.getLogger().error("Error parsing file data/universe/atbconfig.xml. Loading defaults.", ex);
+            retVal.setAllValuesToDefaults();
             return retVal;
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -902,9 +902,15 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      */
     protected void addEnemyForce(List<Entity> list, int weightClass, int maxWeight, int rollMod,
                                  int weightMod, Campaign campaign) {
-        String org = AtBConfiguration.getParentFactionType(getContract(campaign).getEnemyCode());
+        String org = AtBConfiguration.getParentFactionType(getContract(campaign).getEnemy());
 
         String lances = campaign.getAtBConfig().selectBotLances(org, weightClass, rollMod / 20f);
+        if (lances == null) {
+            LogManager.getLogger().error(String.format(
+                    "Cannot add enemy force: failed to generate lances for faction %s at weight class %s",
+                    org, weightClass));
+            return;
+        }
         int maxLances = Math.min(lances.length(), campaign.getCampaignOptions().getSkillLevel() + 1);
 
         for (int i = 0; i < maxLances; i++) {
@@ -1036,14 +1042,18 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         if (Factions.getInstance().getFaction(faction).isClan()) {
             addStar(list, faction, skill, quality, weightClass, maxWeight, campaign, arrivalTurn);
             return;
-        }
-        if (faction.equals("CS") || faction.equals("WOB")) {
+        } else if (faction.equals("CS") || faction.equals("WOB")) {
             addLevelII(list, faction, skill, quality, weightClass, maxWeight, campaign, arrivalTurn);
             return;
         }
 
-        String weights = adjustForMaxWeight(campaign.getAtBConfig()
-                .selectBotUnitWeights(AtBConfiguration.ORG_IS, weightClass), maxWeight);
+        String weights = campaign.getAtBConfig().selectBotUnitWeights(AtBConfiguration.ORG_IS, weightClass);
+        if (weights == null) {
+            // we can't generate a weight, so cancel adding the lance
+            LogManager.getLogger().error("Cannot add lance: failed to generate weights for faction IS with weight class " + weightClass);
+            return;
+        }
+        weights = adjustForMaxWeight(weights, maxWeight);
 
         int forceType = FORCE_MEK;
         if (campaign.getCampaignOptions().getUseVehicles()) {
@@ -1138,8 +1148,13 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             forceType = FORCE_VEHICLE;
         }
 
-        String weights = adjustForMaxWeight(campaign.getAtBConfig()
-                .selectBotUnitWeights(AtBConfiguration.ORG_CLAN, weightClass), maxWeight);
+        String weights = campaign.getAtBConfig().selectBotUnitWeights(AtBConfiguration.ORG_CLAN, weightClass);
+        if (weights == null) {
+            // we can't generate a weight, so cancel adding the star
+            LogManager.getLogger().error("Cannot add star: failed to generate weights for faction CLAN with weight class " + weightClass);
+            return;
+        }
+        weights = adjustForMaxWeight(weights, maxWeight);
 
         int unitType = (forceType == FORCE_VEHICLE) ? UnitType.TANK : UnitType.MEK;
 
@@ -1213,8 +1228,13 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      */
     private void addLevelII(List<Entity> list, String faction, SkillLevel skill, int quality,
                             int weightClass, int maxWeight, Campaign campaign, int arrivalTurn) {
-        String weights = adjustForMaxWeight(campaign.getAtBConfig()
-                .selectBotUnitWeights(AtBConfiguration.ORG_CS, weightClass), maxWeight);
+        String weights = campaign.getAtBConfig().selectBotUnitWeights(AtBConfiguration.ORG_CS, weightClass);
+        if (weights == null) {
+            // we can't generate a weight, so cancel adding the Level II
+            LogManager.getLogger().error("Cannot add Level II: failed to generate weights for faction CS with weight class " + weightClass);
+            return;
+        }
+        weights = adjustForMaxWeight(weights, maxWeight);
 
         int forceType = FORCE_MEK;
         int roll = Compute.d6();


### PR DESCRIPTION
The first commit fixes #3473, the second fixes a large number of null issues arising from missing nullable annotations, and the third fixes an erroneous " in a date in the AtB config defaults.

I also cleaned up some unused code along the way, including removing a useless null check.