### PR TITLE
3492: Removing Cached ToolTip Portraits between MM Launches

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -62,6 +62,7 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * The main class of the application.
@@ -478,10 +479,15 @@ public class MekHQ implements GameListener {
                 RandomUnitGenerator.getInstance();
                 RandomNameGenerator.getInstance();
             }
+            // MegaMek creates some temporary files that MHQ needs to remove between runs
+            final File tempImageDirectory = new File("data/images/temp");
+            if (tempImageDirectory.isDirectory()) {
+                // This can't be null because of the above
+                Stream.of(tempImageDirectory.listFiles()).filter(file -> file.getName().endsWith(".png")).forEach(File::delete);
+            }
             MekHQ.triggerEvent(new ScenarioResolvedEvent(currentScenario));
-
-        } catch (Exception e) {
-            LogManager.getLogger().error("", e);
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
         }
     }
 


### PR DESCRIPTION
This fixes #3492 