### PR TITLE
Tearing out EncodeControl

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -28,7 +28,6 @@ import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.finances.Money;
@@ -57,7 +56,7 @@ import java.util.function.Consumer;
 
 public class Utilities {
     private static final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.Utilities",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     // A couple of arrays for use in the getLevelName() method
     private static final int[] arabicNumbers = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -36,7 +36,6 @@ import megamek.common.loaders.BLKFile;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.options.*;
 import megamek.common.util.BuildingBlock;
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.Utilities;
@@ -233,7 +232,7 @@ public class Campaign implements ITechManager {
     private final Quartermaster quartermaster;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     /** This is used to determine if the player has an active AtB Contract, and is recalculated on load */
     private transient boolean hasActiveContract;

--- a/MekHQ/src/mekhq/campaign/CampaignPreset.java
+++ b/MekHQ/src/mekhq/campaign/CampaignPreset.java
@@ -21,7 +21,6 @@ package mekhq.campaign;
 import megamek.Version;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.GameOptions;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.utilities.xml.MMXMLUtility;
 import mekhq.MekHQ;
@@ -315,7 +314,7 @@ public class CampaignPreset {
         } catch (Exception ex) {
             LogManager.getLogger().error("", ex);
             final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
-                    MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                    MekHQ.getMHQOptions().getLocale());
             JOptionPane.showMessageDialog(frame, resources.getString("CampaignPresetSaveFailure.text"),
                     resources.getString("CampaignPresetSaveFailure.title"), JOptionPane.ERROR_MESSAGE);
         }

--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
@@ -23,7 +23,6 @@ package mekhq.campaign.againstTheBot;
 
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.Campaign;
@@ -33,7 +32,6 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
 import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -86,7 +84,7 @@ public class AtBConfiguration {
     private WeightedTable<String> jsTable;
 
     private final transient ResourceBundle defaultProperties = ResourceBundle.getBundle("mekhq.resources.AtBConfigDefaults",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     private AtBConfiguration() {
         hiringHalls = new ArrayList<>();

--- a/MekHQ/src/mekhq/campaign/enums/PlanetaryAcquisitionFactionLimit.java
+++ b/MekHQ/src/mekhq/campaign/enums/PlanetaryAcquisitionFactionLimit.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -39,7 +38,7 @@ public enum PlanetaryAcquisitionFactionLimit {
     //region Constructors
     PlanetaryAcquisitionFactionLimit(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/finances/Asset.java
+++ b/MekHQ/src/mekhq/campaign/finances/Asset.java
@@ -21,7 +21,6 @@
  */
 package mekhq.campaign.finances;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.enums.FinancialTerm;
@@ -50,7 +49,7 @@ public class Asset {
     private Money income;
 
     private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Finances",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -20,7 +20,6 @@
 package mekhq.campaign.finances;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.LoanDefaultedEvent;
@@ -57,7 +56,7 @@ import java.util.stream.IntStream;
  */
 public class Finances {
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.Finances",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     private List<Transaction> transactions;
     private List<Loan> loans;

--- a/MekHQ/src/mekhq/campaign/finances/enums/FinancialTerm.java
+++ b/MekHQ/src/mekhq/campaign/finances/enums/FinancialTerm.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.finances.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -46,7 +45,7 @@ public enum FinancialTerm {
     //region Constructors
     FinancialTerm(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Finances",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/finances/enums/FinancialYearDuration.java
+++ b/MekHQ/src/mekhq/campaign/finances/enums/FinancialYearDuration.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.finances.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -46,7 +45,7 @@ public enum FinancialYearDuration {
     //region Constructors
     FinancialYearDuration(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Finances",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/finances/enums/TransactionType.java
+++ b/MekHQ/src/mekhq/campaign/finances/enums/TransactionType.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.finances.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -62,7 +61,7 @@ public enum TransactionType {
     //region Constructors
     TransactionType(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Finances",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/icons/enums/LayeredForceIconLayer.java
+++ b/MekHQ/src/mekhq/campaign/icons/enums/LayeredForceIconLayer.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.icons.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.MHQConstants;
 
@@ -62,7 +61,7 @@ public enum LayeredForceIconLayer {
     LayeredForceIconLayer(final String name, final String toolTipText, final String layerPath,
                           final String tableName, final int listSelectionMode) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.layerPath = layerPath;

--- a/MekHQ/src/mekhq/campaign/log/AwardLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/AwardLogger.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.log;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Award;
 import mekhq.campaign.personnel.Person;
@@ -36,7 +35,7 @@ import java.util.regex.Pattern;
  */
 public class AwardLogger {
     private static final transient ResourceBundle logEntriesResourceMap = ResourceBundle.getBundle("mekhq.resources.LogEntries",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public static void award(Person person, LocalDate date, Award award) {
         String message = logEntriesResourceMap.getString("awarded.text");

--- a/MekHQ/src/mekhq/campaign/log/MedicalLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/MedicalLogger.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.log;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.Person;
@@ -35,7 +34,7 @@ import java.util.ResourceBundle;
  */
 public class MedicalLogger {
     private static final transient ResourceBundle logEntriesResourceMap = ResourceBundle.getBundle("mekhq.resources.LogEntries",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public static MedicalLogEntry severedSpine(Person person, LocalDate date) {
         String message = logEntriesResourceMap.getString("severedSpine.text");

--- a/MekHQ/src/mekhq/campaign/log/PersonalLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/PersonalLogger.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.log;
 
 import megamek.codeUtilities.StringUtility;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -35,7 +34,7 @@ import java.util.ResourceBundle;
  */
 public class PersonalLogger {
     private static final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.LogEntries",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public static void spouseKia(Person spouse, Person person, LocalDate date) {
         String message = resources.getString("spouseKia.text");

--- a/MekHQ/src/mekhq/campaign/log/ServiceLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/ServiceLogger.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.log;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -38,7 +37,7 @@ import java.util.ResourceBundle;
  */
 public class ServiceLogger {
     private static final transient ResourceBundle logEntriesResourceMap = ResourceBundle.getBundle("mekhq.resources.LogEntries",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public static void retireDueToWounds(Person person, LocalDate date) {
         String message = logEntriesResourceMap.getString("retiredDueToWounds.text");

--- a/MekHQ/src/mekhq/campaign/market/enums/ContractMarketMethod.java
+++ b/MekHQ/src/mekhq/campaign/market/enums/ContractMarketMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.market.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -37,7 +36,7 @@ public enum ContractMarketMethod {
     //region Constructors
     ContractMarketMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Market",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/market/enums/UnitMarketMethod.java
+++ b/MekHQ/src/mekhq/campaign/market/enums/UnitMarketMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.market.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.market.unitMarket.AbstractUnitMarket;
 import mekhq.campaign.market.unitMarket.AtBMonthlyUnitMarket;
@@ -40,7 +39,7 @@ public enum UnitMarketMethod {
     //region Constructors
     UnitMarketMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Market",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/market/enums/UnitMarketType.java
+++ b/MekHQ/src/mekhq/campaign/market/enums/UnitMarketType.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.market.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -40,7 +39,7 @@ public enum UnitMarketType {
     //region Constructors
     UnitMarketType(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Market",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AbstractUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AbstractUnitMarket.java
@@ -24,7 +24,6 @@ import megamek.common.Compute;
 import megamek.common.EntityMovementMode;
 import megamek.common.MechSummary;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.Campaign;
@@ -47,7 +46,7 @@ public abstract class AbstractUnitMarket {
     private List<UnitMarketOffer> offers;
 
     protected final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Market",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -28,7 +28,6 @@ import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.utilities.MHQXMLUtility;
@@ -175,7 +174,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     private Map<Integer, Integer> numPlayerMinefields;
 
     protected final transient ResourceBundle defaultResourceBundle = ResourceBundle.getBundle("mekhq.resources.AtBScenarioBuiltIn",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     public AtBScenario () {

--- a/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.OffBoardDirection;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.ObjectiveEffect.EffectScalingType;
@@ -39,7 +38,7 @@ import mekhq.campaign.mission.ScenarioObjective.ObjectiveCriterion;
  */
 public class CommonObjectiveFactory {
     private static final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AtBScenarioBuiltIn",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     /**
      * Generates a "keep the attached units alive" objective that applies to

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.mission.enums;
 
 import megamek.common.Compute;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
@@ -56,7 +55,7 @@ public enum AtBContractType {
     AtBContractType(final String name, final String toolTipText, final int constantLength,
                     final double paymentMultiplier) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Mission",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.constantLength = constantLength;

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBLanceRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBLanceRole.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.mission.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -41,7 +40,7 @@ public enum AtBLanceRole {
     //region Constructors
     AtBLanceRole(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Mission",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBMoraleLevel.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBMoraleLevel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.mission.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -42,7 +41,7 @@ public enum AtBMoraleLevel {
     //region Constructors
     AtBMoraleLevel(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Mission",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/ContractCommandRights.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ContractCommandRights.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.mission.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -41,7 +40,7 @@ public enum ContractCommandRights {
     //region Constructors
     ContractCommandRights(final String name, final String toolTipText, final String stratConText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Mission",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.stratConText = resources.getString(stratConText);

--- a/MekHQ/src/mekhq/campaign/mission/enums/MissionStatus.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/MissionStatus.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.mission.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -41,7 +40,7 @@ public enum MissionStatus {
     //region Constructors
     MissionStatus(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Mission",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.mission.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -45,7 +44,7 @@ public enum ScenarioStatus {
     //region Constructors
     ScenarioStatus(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Mission",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -25,7 +25,6 @@ import megamek.Version;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.Campaign;
@@ -154,7 +153,7 @@ public abstract class Part implements IPartWork, ITechnology {
     private Part replacementPart;
 
     protected final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Parts",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public Part() {
         this(0, false, null);

--- a/MekHQ/src/mekhq/campaign/parts/enums/PartRepairType.java
+++ b/MekHQ/src/mekhq/campaign/parts/enums/PartRepairType.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.parts.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -53,7 +52,7 @@ public enum PartRepairType {
     //region Constructors
     PartRepairType(final String name, final boolean validForMRMS) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Parts",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.validForMRMS = validForMRMS;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/BodyLocation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/BodyLocation.java
@@ -20,7 +20,6 @@ package mekhq.campaign.personnel;
 
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.BodyLocation.XMLAdapter;
 
@@ -93,7 +92,7 @@ public enum BodyLocation {
 
     BodyLocation(int id, String localizationString, boolean limb, BodyLocation parent) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.id = id;
         this.locationName = resources.getString(localizationString);
         this.limb = limb;

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -29,7 +29,6 @@ import megamek.common.icons.Portrait;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.Utilities;
@@ -203,7 +202,7 @@ public class Person {
     private ExtraData extraData;
 
     private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     // initializes the AtB ransom values
     static {

--- a/MekHQ/src/mekhq/campaign/personnel/death/AbstractDeath.java
+++ b/MekHQ/src/mekhq/campaign/personnel/death/AbstractDeath.java
@@ -21,7 +21,6 @@ package mekhq.campaign.personnel.death;
 import megamek.Version;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.weightedMaps.WeightedDoubleMap;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
@@ -53,7 +52,7 @@ public abstract class AbstractDeath {
     private final Map<Gender, Map<TenYearAgeRange, WeightedDoubleMap<PersonnelStatus>>> causes;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/divorce/AbstractDivorce.java
+++ b/MekHQ/src/mekhq/campaign/personnel/divorce/AbstractDivorce.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.personnel.divorce;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
@@ -52,7 +51,7 @@ public abstract class AbstractDivorce {
     private boolean useRandomPrisonerDivorce;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/AgeGroup.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/AgeGroup.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -44,7 +43,7 @@ public enum AgeGroup {
     //region Constructors
     AgeGroup(final String name, final String toolTipText, final int groupLowerBound) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.groupLowerBound = groupLowerBound;

--- a/MekHQ/src/mekhq/campaign/personnel/enums/BabySurnameStyle.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/BabySurnameStyle.java
@@ -20,7 +20,6 @@ package mekhq.campaign.personnel.enums;
 
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 import org.apache.logging.log4j.LogManager;
@@ -51,7 +50,7 @@ public enum BabySurnameStyle {
     //region Constructors
     BabySurnameStyle(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/FamilialConnectionType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/FamilialConnectionType.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -41,7 +40,7 @@ public enum FamilialConnectionType {
     //region Constructors
     FamilialConnectionType(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/FamilialRelationshipDisplayLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/FamilialRelationshipDisplayLevel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -39,7 +38,7 @@ public enum FamilialRelationshipDisplayLevel {
     //region Constructors
     FamilialRelationshipDisplayLevel(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/FamilialRelationshipType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/FamilialRelationshipType.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -96,7 +95,7 @@ public enum FamilialRelationshipType {
     private final String other; // Genderless form of the relationship type, like Parent for Parent
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/FormerSpouseReason.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/FormerSpouseReason.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -37,7 +36,7 @@ public enum FormerSpouseReason {
     //region Constructors
     FormerSpouseReason(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/GenderDescriptors.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/GenderDescriptors.java
@@ -20,7 +20,6 @@ package mekhq.campaign.personnel.enums;
 
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -69,7 +68,7 @@ public enum GenderDescriptors {
 
     GenderDescriptors(final String masculine, final String feminine, final @Nullable String neutral) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.masculine = resources.getString(masculine);
         this.feminine = resources.getString(feminine);
         this.neutral = (neutral == null) ? "" : resources.getString(neutral);

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ManeiDominiClass.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ManeiDominiClass.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -43,7 +42,7 @@ public enum ManeiDominiClass {
     //region Constructors
     ManeiDominiClass(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ManeiDominiRank.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ManeiDominiRank.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -43,7 +42,7 @@ public enum ManeiDominiRank {
     //region Constructors
     ManeiDominiRank(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/MergingSurnameStyle.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/MergingSurnameStyle.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.codeUtilities.StringUtility;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.weightedMaps.WeightedIntMap;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -61,7 +60,7 @@ public enum MergingSurnameStyle {
     //region Constructors
     MergingSurnameStyle(final String name, final String toolTipText, final String dropDownText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.dropDownText = resources.getString(dropDownText);

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -74,7 +73,7 @@ public enum PersonnelRole {
 
     PersonnelRole(final String name, final String clanName, final int mnemonic) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.clanName = (clanName == null) ? this.name : resources.getString(clanName);
         this.mnemonic = mnemonic;

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -63,7 +62,7 @@ public enum PersonnelStatus {
     PersonnelStatus(final String name, final String toolTipText, final String reportText,
                     final String logText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.reportText = resources.getString(reportText);

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -58,7 +57,7 @@ public enum Phenotype {
     Phenotype(final String name, final String shortName, final String groupingName,
               final String toolTipText, final boolean external) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.shortName = resources.getString(shortName);
         this.groupingName = resources.getString(groupingName);

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PrisonerCaptureStyle.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PrisonerCaptureStyle.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -38,7 +37,7 @@ public enum PrisonerCaptureStyle {
     //region Constructors
     PrisonerCaptureStyle(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PrisonerStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PrisonerStatus.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -52,7 +51,7 @@ public enum PrisonerStatus {
     //region Constructors
     PrisonerStatus(final String name, final String titleExtension) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.titleExtension = resources.getString(titleExtension);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Profession.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Profession.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
@@ -48,7 +47,7 @@ public enum Profession {
     //region Constructors
     Profession(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ROMDesignation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ROMDesignation.java
@@ -21,7 +21,6 @@ package mekhq.campaign.personnel.enums;
 import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.Jumpship;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
@@ -55,7 +54,7 @@ public enum ROMDesignation {
     //region Constructors
     ROMDesignation(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RandomDeathMethod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RandomDeathMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.death.*;
@@ -41,7 +40,7 @@ public enum RandomDeathMethod {
     //region Constructors
     RandomDeathMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RandomDependentMethod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RandomDependentMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -37,7 +36,7 @@ public enum RandomDependentMethod {
     //region Constructors
     RandomDependentMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RandomDivorceMethod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RandomDivorceMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.divorce.AbstractDivorce;
@@ -41,7 +40,7 @@ public enum RandomDivorceMethod {
     //region Constructors
     RandomDivorceMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RandomMarriageMethod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RandomMarriageMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.marriage.AbstractMarriage;
@@ -41,7 +40,7 @@ public enum RandomMarriageMethod {
     //region Constructors
     RandomMarriageMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RandomProcreationMethod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RandomProcreationMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
@@ -41,7 +40,7 @@ public enum RandomProcreationMethod {
     //region Constructors
     RandomProcreationMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RandomRetirementMethod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RandomRetirementMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -37,7 +36,7 @@ public enum RandomRetirementMethod {
     //region Constructors
     RandomRetirementMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RankSystemType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RankSystemType.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.MHQConstants;
 import org.apache.logging.log4j.LogManager;
@@ -40,7 +39,7 @@ public enum RankSystemType {
     //region Constructors
     RankSystemType(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/enums/SplittingSurnameStyle.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/SplittingSurnameStyle.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import megamek.common.util.weightedMaps.WeightedIntMap;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -46,7 +45,7 @@ public enum SplittingSurnameStyle {
     //region Constructors
     SplittingSurnameStyle(final String name, final String toolTipText, final String dropDownText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.dropDownText = resources.getString(dropDownText);

--- a/MekHQ/src/mekhq/campaign/personnel/enums/TenYearAgeRange.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/TenYearAgeRange.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -45,7 +44,7 @@ public enum TenYearAgeRange {
     //region Constructors
     TenYearAgeRange(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/enums/TimeInDisplayFormat.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/TimeInDisplayFormat.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.time.LocalDate;
@@ -46,7 +45,7 @@ public enum TimeInDisplayFormat {
     //region Constructors
     TimeInDisplayFormat(final String name, final String displayFormat) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.displayFormat = resources.getString(displayFormat);
     }

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -21,7 +21,6 @@ package mekhq.campaign.personnel.marriage;
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
@@ -51,7 +50,7 @@ public abstract class AbstractMarriage {
     private boolean useRandomPrisonerMarriages;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -21,7 +21,6 @@ package mekhq.campaign.personnel.procreation;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -56,7 +55,7 @@ public abstract class AbstractProcreation {
     public static final StringKey PREGNANCY_FATHER_DATA = new StringKey("procreation:father");
 
     private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
+++ b/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
@@ -20,7 +20,6 @@
  */
 package mekhq.campaign.rating;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -43,7 +42,7 @@ public enum UnitRatingMethod {
     //region Constructors
     UnitRatingMethod(String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Rating",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/campaign/report/AbstractReport.java
+++ b/MekHQ/src/mekhq/campaign/report/AbstractReport.java
@@ -21,7 +21,6 @@
  */
 package mekhq.campaign.report;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 
@@ -35,7 +34,7 @@ public abstract class AbstractReport {
     private final Campaign campaign;
 
     protected final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Reports",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/campaign/unit/enums/CrewAssignmentState.java
+++ b/MekHQ/src/mekhq/campaign/unit/enums/CrewAssignmentState.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.unit.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.campaign.unit.Unit;
 
 import java.util.ResourceBundle;
@@ -50,7 +49,7 @@ public enum CrewAssignmentState {
 
     //region Constructors
     CrewAssignmentState(final String name, final String toolTipText) {
-        final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Unit", new EncodeControl());
+        final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Unit");
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/enums/Alphabet.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/Alphabet.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -66,7 +65,7 @@ public enum Alphabet {
     //region Constructors
     Alphabet(final String ccb1943, final String icao1956, final String english, final String greek) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.ccb1943 = resources.getString(ccb1943);
         this.icao1956 = resources.getString(icao1956);
         this.english = resources.getString(english);

--- a/MekHQ/src/mekhq/campaign/universe/enums/BattleMechFactionGenerationMethod.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/BattleMechFactionGenerationMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -44,7 +43,7 @@ public enum BattleMechFactionGenerationMethod {
     //region Constructors
     BattleMechFactionGenerationMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/enums/BattleMechQualityGenerationMethod.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/BattleMechQualityGenerationMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.universe.generators.battleMechQualityGenerators.*;
 
@@ -47,7 +46,7 @@ public enum BattleMechQualityGenerationMethod {
     //region Constructors
     BattleMechQualityGenerationMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/enums/BattleMechWeightClassGenerationMethod.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/BattleMechWeightClassGenerationMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.universe.generators.battleMechWeightClassGenerators.*;
 
@@ -49,7 +48,7 @@ public enum BattleMechWeightClassGenerationMethod {
     //region Constructors
     BattleMechWeightClassGenerationMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/enums/CompanyGenerationMethod.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/CompanyGenerationMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.companyGeneration.CompanyGenerationOptions;
@@ -43,7 +42,7 @@ public enum CompanyGenerationMethod {
     //region Constructors
     CompanyGenerationMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/enums/CompanyGenerationPersonType.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/CompanyGenerationPersonType.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -44,7 +43,7 @@ public enum CompanyGenerationPersonType {
     //region Constructors
     CompanyGenerationPersonType(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/enums/ForceNamingMethod.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/ForceNamingMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -42,7 +41,7 @@ public enum ForceNamingMethod {
     //region Constructors
     ForceNamingMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/enums/MysteryBoxType.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/MysteryBoxType.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -46,7 +45,7 @@ public enum MysteryBoxType {
     //region Constructors
     MysteryBoxType(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/enums/PartGenerationMethod.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/PartGenerationMethod.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.universe.generators.partGenerators.AbstractPartGenerator;
 import mekhq.campaign.universe.generators.partGenerators.MishraPartGenerator;
@@ -49,7 +48,7 @@ public enum PartGenerationMethod {
     //region Constructors
     PartGenerationMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
@@ -22,7 +22,6 @@ import megamek.client.generator.RandomCallsignGenerator;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
@@ -129,7 +128,7 @@ public abstract class AbstractCompanyGenerator {
     private final AbstractBattleMechQualityGenerator battleMechQualityGenerator;
 
     private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -24,7 +24,6 @@ import megamek.common.EntityListFile;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.Subscribe;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import megameklab.util.UnitPrintManager;
 import mekhq.MekHQ;
@@ -113,7 +112,7 @@ public final class BriefingTab extends CampaignGuiTab {
     @Override
     public void initTab() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         GridBagConstraints gridBagConstraints;
 
         panMission = new JPanel(new GridBagLayout());

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -32,7 +32,6 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.Subscribe;
 import megamek.common.loaders.EntityLoadingException;
-import megamek.common.util.EncodeControl;
 import mekhq.*;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignController;
@@ -107,7 +106,7 @@ public class CampaignGUI extends JPanel {
     private MekHQ app;
 
     private ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     /* for the main panel */
     private JTabbedPane tabMain;

--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -22,7 +22,6 @@ import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
 import megamek.common.MechSummaryCache;
 import megamek.common.event.Subscribe;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.MHQOptionsChangedEvent;
 import mekhq.campaign.event.*;
@@ -91,7 +90,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
     private JLabel lblIcon;
 
     private static final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     /**
      * @param gui a {@link CampaignGUI} object that this tab is a component of

--- a/MekHQ/src/mekhq/gui/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/FinancesTab.java
@@ -19,7 +19,6 @@
 package mekhq.gui;
 
 import megamek.common.event.Subscribe;
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.event.*;
@@ -75,7 +74,7 @@ public final class FinancesTab extends CampaignGuiTab {
     private LoanTableModel loanModel;
 
     private static final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.FinancesTab",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     //region Constructors
     public FinancesTab(CampaignGUI gui, String name) {

--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -25,7 +25,6 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.Entity;
 import megamek.common.UnitType;
 import megamek.common.event.Subscribe;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
 import mekhq.campaign.event.*;
@@ -71,7 +70,7 @@ public final class HangarTab extends CampaignGuiTab {
     private TableRowSorter<UnitTableModel> unitSorter;
 
     private static final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     //region Constructors
     public HangarTab(CampaignGUI gui, String name) {

--- a/MekHQ/src/mekhq/gui/InfirmaryTab.java
+++ b/MekHQ/src/mekhq/gui/InfirmaryTab.java
@@ -38,7 +38,6 @@ import javax.swing.JTable;
 
 import megamek.common.TargetRoll;
 import megamek.common.event.Subscribe;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.event.MedicPoolChangedEvent;
 import mekhq.campaign.event.PersonEvent;
@@ -81,7 +80,7 @@ public final class InfirmaryTab extends CampaignGuiTab {
     @Override
     public void initTab() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         GridBagConstraints gridBagConstraints;
 
         setLayout(new GridBagLayout());

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -34,7 +34,6 @@ import javax.swing.JViewport;
 import javax.swing.ScrollPaneConstants;
 
 import megamek.common.event.Subscribe;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.event.NewDayEvent;
@@ -78,7 +77,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
     @Override
     public void initTab() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         panMapView = new JPanel(new BorderLayout());
 

--- a/MekHQ/src/mekhq/gui/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/PersonnelTab.java
@@ -25,7 +25,6 @@ import megamek.client.ui.preferences.JTablePreference;
 import megamek.client.ui.preferences.JToggleButtonPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.event.Subscribe;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.MHQOptionsChangedEvent;
 import mekhq.campaign.event.*;
@@ -85,7 +84,7 @@ public final class PersonnelTab extends CampaignGuiTab {
     @Override
     public void initTab() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         GridBagConstraints gridBagConstraints;
 
         setLayout(new GridBagLayout());

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -24,7 +24,6 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.MechView;
 import megamek.common.TargetRoll;
 import megamek.common.event.Subscribe;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.event.*;
 import mekhq.campaign.parts.Part;
@@ -118,7 +117,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     @Override
     public void initTab() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         GridBagConstraints gridBagConstraints;
 
         setLayout(new GridLayout());

--- a/MekHQ/src/mekhq/gui/SpecialAbilityPanel.java
+++ b/MekHQ/src/mekhq/gui/SpecialAbilityPanel.java
@@ -1,6 +1,5 @@
 package mekhq.gui;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.gui.dialog.EditSpecialAbilityDialog;
@@ -39,7 +38,7 @@ public class SpecialAbilityPanel extends JPanel {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.SpecialAbilityPanel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         GridBagConstraints c = new GridBagConstraints();
 

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -25,7 +25,6 @@ import megamek.common.MiscType;
 import megamek.common.TargetRoll;
 import megamek.common.WeaponType;
 import megamek.common.event.Subscribe;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.event.*;
 import mekhq.campaign.parts.*;
@@ -116,7 +115,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     @Override
     public void initTab() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         GridBagConstraints gridBagConstraints;
 
         panSupplies = new JPanel(new GridBagLayout());

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -25,7 +25,6 @@ import megamek.common.Crew;
 import megamek.common.Mounted;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
 import mekhq.Utilities;
@@ -157,7 +156,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private final PersonnelTableModel personnelModel;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     protected PersonnelTableMouseAdapter(CampaignGUI gui, JTable personnelTable,

--- a/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ProcurementTableMouseAdapter.java
@@ -19,7 +19,6 @@
 package mekhq.gui.adapter;
 
 import megamek.common.Entity;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.event.ProcurementEvent;
 import mekhq.campaign.parts.Part;
@@ -42,7 +41,7 @@ public class ProcurementTableMouseAdapter extends JPopupMenuAdapter {
     private final ProcurementTableModel model;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -26,7 +26,6 @@ import megamek.common.annotations.Nullable;
 import megamek.common.icons.Camouflage;
 import megamek.common.loaders.BLKFile;
 import megamek.common.loaders.EntityLoadingException;
-import megamek.common.util.EncodeControl;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import mekhq.MekHQ;
 import mekhq.MHQConstants;
@@ -126,7 +125,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
     //endregion Commands
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     protected UnitTableMouseAdapter(CampaignGUI gui, JTable unitTable, UnitTableModel unitModel) {

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQButtonDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQButtonDialog.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.baseComponents.AbstractButtonDialog;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -55,7 +54,7 @@ public abstract class AbstractMHQButtonDialog extends AbstractButtonDialog {
     protected AbstractMHQButtonDialog(final JFrame frame, final boolean modal, final String name,
                                       final String title) {
         this(frame, modal, ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl()), name, title);
+                MekHQ.getMHQOptions().getLocale()), name, title);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQDialog.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.baseComponents.AbstractDialog;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -47,7 +46,7 @@ public abstract class AbstractMHQDialog extends AbstractDialog {
      */
     protected AbstractMHQDialog(final JFrame frame, final boolean modal, final String name, final String title) {
         this(frame, modal, ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl()), name, title);
+                MekHQ.getMHQOptions().getLocale()), name, title);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQPanel.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQPanel.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.baseComponents.AbstractPanel;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -46,7 +45,7 @@ public abstract class AbstractMHQPanel extends AbstractPanel {
      */
     protected AbstractMHQPanel(final JFrame frame, final String name, final boolean isDoubleBuffered) {
         this(frame, ResourceBundle.getBundle("mekhq.resources.GUI",
-                        MekHQ.getMHQOptions().getLocale(), new EncodeControl()),
+                        MekHQ.getMHQOptions().getLocale()),
                 name, new FlowLayout(), isDoubleBuffered);
     }
 
@@ -66,7 +65,7 @@ public abstract class AbstractMHQPanel extends AbstractPanel {
     protected AbstractMHQPanel(final JFrame frame, final String name,
                                final LayoutManager layoutManager, final boolean isDoubleBuffered) {
         this(frame, ResourceBundle.getBundle("mekhq.resources.GUI",
-                        MekHQ.getMHQOptions().getLocale(), new EncodeControl()),
+                        MekHQ.getMHQOptions().getLocale()),
                 name, layoutManager, isDoubleBuffered);
     }
 

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQScrollPane.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQScrollPane.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.baseComponents.AbstractScrollPane;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -47,7 +46,7 @@ public abstract class AbstractMHQScrollPane extends AbstractScrollPane {
     protected AbstractMHQScrollPane(final JFrame frame, final String name,
                                     final int verticalScrollBarPolicy, final int horizontalScrollBarPolicy) {
         this(frame, ResourceBundle.getBundle("mekhq.resources.GUI",
-                        MekHQ.getMHQOptions().getLocale(), new EncodeControl()),
+                        MekHQ.getMHQOptions().getLocale()),
                 name, verticalScrollBarPolicy, horizontalScrollBarPolicy);
     }
 

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQScrollablePanel.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQScrollablePanel.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.baseComponents.AbstractScrollablePanel;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -48,7 +47,7 @@ public abstract class AbstractMHQScrollablePanel extends AbstractScrollablePanel
     protected AbstractMHQScrollablePanel(final JFrame frame, final String name,
                                          final boolean isDoubleBuffered) {
         this(frame, ResourceBundle.getBundle("mekhq.resources.GUI",
-                        MekHQ.getMHQOptions().getLocale(), new EncodeControl()),
+                        MekHQ.getMHQOptions().getLocale()),
                 name, new FlowLayout(), isDoubleBuffered);
     }
 
@@ -69,7 +68,7 @@ public abstract class AbstractMHQScrollablePanel extends AbstractScrollablePanel
                                          final LayoutManager layoutManager,
                                          final boolean isDoubleBuffered) {
         this(frame, ResourceBundle.getBundle("mekhq.resources.GUI",
-                        MekHQ.getMHQOptions().getLocale(), new EncodeControl()),
+                        MekHQ.getMHQOptions().getLocale()),
                 name, layoutManager, isDoubleBuffered);
     }
 

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQSplitPane.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQSplitPane.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.baseComponents.AbstractSplitPane;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -39,7 +38,7 @@ public abstract class AbstractMHQSplitPane extends AbstractSplitPane {
      */
     protected AbstractMHQSplitPane(final JFrame frame, final String name) {
         this(frame, ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl()), name);
+                MekHQ.getMHQOptions().getLocale()), name);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQTabbedPane.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQTabbedPane.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.baseComponents.AbstractTabbedPane;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -38,7 +37,7 @@ public abstract class AbstractMHQTabbedPane extends AbstractTabbedPane {
      */
     protected AbstractMHQTabbedPane(final JFrame frame, final String name) {
         this(frame, ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl()), name);
+                MekHQ.getMHQOptions().getLocale()), name);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQValidationButtonDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQValidationButtonDialog.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.baseComponents.AbstractValidationButtonDialog;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -61,7 +60,7 @@ public abstract class AbstractMHQValidationButtonDialog extends AbstractValidati
     protected AbstractMHQValidationButtonDialog(final JFrame frame, final boolean modal,
                                                 final String name, final String title) {
         this(frame, modal, ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl()), name, title);
+                MekHQ.getMHQOptions().getLocale()), name, title);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/JScrollableMenu.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/JScrollableMenu.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.swing.util.MenuScroller;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.MHQConstants;
 
@@ -38,7 +37,7 @@ import java.util.ResourceBundle;
 public class JScrollableMenu extends JMenu {
     //region Variable Declarations
     protected final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/baseComponents/JScrollablePopupMenu.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/JScrollablePopupMenu.java
@@ -19,7 +19,6 @@
 package mekhq.gui.baseComponents;
 
 import megamek.client.ui.swing.util.MenuScroller;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.MHQConstants;
 
@@ -39,7 +38,7 @@ import java.util.ResourceBundle;
 public class JScrollablePopupMenu extends JPopupMenu {
     //region Variable Declarations
     protected final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/control/EditKillLogControl.java
+++ b/MekHQ/src/mekhq/gui/control/EditKillLogControl.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.control;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Kill;
@@ -55,7 +54,7 @@ public class EditKillLogControl extends JPanel {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditKillLogControl",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setName(resourceMap.getString("control.name"));
         this.setLayout(new java.awt.BorderLayout());

--- a/MekHQ/src/mekhq/gui/control/EditPersonnelLogControl.java
+++ b/MekHQ/src/mekhq/gui/control/EditPersonnelLogControl.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.control;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.log.LogEntry;
@@ -55,7 +54,7 @@ public class EditPersonnelLogControl extends JPanel {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditPersonnelLogControl",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setName(resourceMap.getString("control.name"));
         this.setLayout(new java.awt.BorderLayout());

--- a/MekHQ/src/mekhq/gui/control/EditScenarioLogControl.java
+++ b/MekHQ/src/mekhq/gui/control/EditScenarioLogControl.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.control;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.log.LogEntry;
@@ -55,7 +54,7 @@ public class EditScenarioLogControl extends JPanel {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditScenarioLogControl",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setName(resourceMap.getString("control.name"));
         this.setLayout(new java.awt.BorderLayout());

--- a/MekHQ/src/mekhq/gui/dialog/AbstractMHQIconChooserDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AbstractMHQIconChooserDialog.java
@@ -19,7 +19,6 @@
 package mekhq.gui.dialog;
 
 import megamek.client.ui.dialogs.AbstractIconChooserDialog;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.gui.panels.AbstractMHQIconChooser;
 
@@ -36,7 +35,7 @@ public abstract class AbstractMHQIconChooserDialog extends AbstractIconChooserDi
     protected AbstractMHQIconChooserDialog(final JFrame frame, final String name, final String title,
                                            final AbstractMHQIconChooser chooser) {
         super(frame, true, ResourceBundle.getBundle("mekhq.resources.GUI",
-                        MekHQ.getMHQOptions().getLocale(), new EncodeControl()),
+                        MekHQ.getMHQOptions().getLocale()),
                 name, title, chooser, false);
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/gui/dialog/AddFundsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AddFundsDialog.java
@@ -3,7 +3,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
@@ -25,7 +24,7 @@ public class AddFundsDialog extends JDialog implements FocusListener {
     private MMComboBox<TransactionType> categoryCombo;
     private int closedType = JOptionPane.CLOSED_OPTION;
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AddFundsDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     /** Creates new form AlertPopup */
     public AddFundsDialog(Frame parent, boolean modal) {

--- a/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
@@ -23,7 +23,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Kill;
 import org.apache.logging.log4j.LogManager;
@@ -93,7 +92,7 @@ public class AddOrEditKillEntryDialog extends JDialog {
         btnDate = new JButton();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AddOrEditKillEntryDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         if (this.operationType == ADD_OPERATION) {

--- a/MekHQ/src/mekhq/gui/dialog/AddOrEditScenarioEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AddOrEditScenarioEntryDialog.java
@@ -20,7 +20,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.log.LogEntry;
 import mekhq.campaign.log.ServiceLogEntry;
@@ -86,7 +85,7 @@ public class AddOrEditScenarioEntryDialog extends JDialog {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AddOrEditScenarioEntryDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         GridBagConstraints gridBagConstraints;
 
         panMain = new JPanel();

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -21,7 +21,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.models.XTableColumnModel;
 import megamek.client.ui.preferences.*;
 import megamek.codeUtilities.MathUtility;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.log.PersonalLogger;
@@ -74,7 +73,7 @@ public final class BatchXPDialog extends JDialog {
 
     private transient String choiceNoSkill;
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.BatchXPDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public BatchXPDialog(JFrame parent, Campaign campaign) {
         super(parent, "", true);

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -20,7 +20,6 @@ package mekhq.gui.dialog;
 
 import megamek.common.AmmoType;
 import megamek.common.UnitType;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.NullEntityException;
 import mekhq.campaign.Campaign;
@@ -78,7 +77,7 @@ public class CampaignExportWizard extends JDialog {
 
     private Optional<File> destinationCampaignFile;
     private ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignExportWizard",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public enum CampaignExportWizardState {
         ForceSelection,

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -22,7 +22,6 @@ import megamek.client.ui.baseComponents.MMButton;
 import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.enums.ValidationState;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignPreset;
@@ -48,7 +47,7 @@ public class CampaignOptionsDialog extends AbstractMHQValidationButtonDialog {
     //region Constructors
     public CampaignOptionsDialog(final JFrame frame, final Campaign campaign, final boolean startup) {
         super(frame, true, ResourceBundle.getBundle("mekhq.resources.CampaignOptionsDialog",
-                        MekHQ.getMHQOptions().getLocale(), new EncodeControl()),
+                        MekHQ.getMHQOptions().getLocale()),
                 "CampaignOptionsDialog", "CampaignOptionsDialog.title");
         this.campaign = campaign;
         this.startup = startup;

--- a/MekHQ/src/mekhq/gui/dialog/ChooseFactionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseFactionsDialog.java
@@ -20,7 +20,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
@@ -41,7 +40,7 @@ public class ChooseFactionsDialog extends JDialog {
     private boolean changed;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ChooseFactionsDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public ChooseFactionsDialog(Frame parent, LocalDate date, List<String> defaults) {
         this(parent, date, defaults, true);

--- a/MekHQ/src/mekhq/gui/dialog/ChooseMulFilesDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseMulFilesDialog.java
@@ -22,7 +22,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.ResolveScenarioTracker;
 import org.apache.logging.log4j.LogManager;
@@ -59,7 +58,7 @@ public class ChooseMulFilesDialog extends JDialog {
         GridBagConstraints gridBagConstraints;
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ChooseMulFilesDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
         // Adding Escape Mnemonic

--- a/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
@@ -24,7 +24,6 @@ import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -85,7 +84,7 @@ public class ChooseRefitDialog extends JDialog {
     private void initComponents() {
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ChooseRefitDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setTitle(resourceMap.getString("title.text") + " " + unit.getName());
 

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -21,7 +21,6 @@
 package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -186,7 +185,7 @@ public class ContractMarketDialog extends JDialog {
         btnStartRetainer = new JButton();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ContractMarketDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setTitle(resourceMap.getString("Form.title"));
         setName("Form");

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -27,7 +27,6 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.swing.util.PlayerColour;
 import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
@@ -109,7 +108,7 @@ public class CustomizeAtBContractDialog extends JDialog {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.NewContractDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         setTitle(resourceMap.getString("Form.title"));

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeMissionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeMissionDialog.java
@@ -20,7 +20,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Mission;
@@ -85,7 +84,7 @@ public class CustomizeMissionDialog extends JDialog {
         lblPlanetName = new JLabel();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CustomizeMissionDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         setTitle(resourceMap.getString("title"));

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -31,7 +31,6 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.Option;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.*;
@@ -112,7 +111,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     private Campaign campaign;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CustomizePersonDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable declarations
 
     /** Creates new form CustomizePilotDialog */

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -22,7 +22,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.*;
@@ -39,9 +38,7 @@ import javax.swing.table.TableColumn;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.File;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 
@@ -120,7 +117,7 @@ public class CustomizeScenarioDialog extends JDialog {
         choiceStatus = new javax.swing.JComboBox<>();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CustomizeScenarioDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         setTitle(resourceMap.getString("title.new"));

--- a/MekHQ/src/mekhq/gui/dialog/EditAssetDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditAssetDialog.java
@@ -23,7 +23,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.finances.Asset;
 import mekhq.campaign.finances.enums.FinancialTerm;
@@ -50,7 +49,7 @@ public class EditAssetDialog extends JDialog {
     boolean cancelled;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditAssetDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public EditAssetDialog(Frame parent, Asset a) {
         super(parent, true);

--- a/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditInjuryEntryDialog.java
@@ -23,7 +23,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Injury;
 import mekhq.campaign.personnel.InjuryType;
@@ -119,7 +118,7 @@ public class EditInjuryEntryDialog extends JDialog {
         panMain = new JPanel();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditInjuryEntryDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         setTitle(resourceMap.getString("Form.title"));

--- a/MekHQ/src/mekhq/gui/dialog/EditKillLogDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditKillLogDialog.java
@@ -22,7 +22,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -61,7 +60,7 @@ public class EditKillLogDialog extends JDialog {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditKillLogDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName(resourceMap.getString("dialog.name"));

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelHitsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelHitsDialog.java
@@ -20,7 +20,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 import org.apache.logging.log4j.LogManager;
@@ -55,7 +54,7 @@ public class EditPersonnelHitsDialog extends JDialog {
         btnOK = new JButton();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditPersonnelHitsDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         setTitle(resourceMap.getString("Form.title") + ' ' + person.getFullName());

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelInjuriesDialog.java
@@ -21,7 +21,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Injury;
@@ -70,7 +69,7 @@ public class EditPersonnelInjuriesDialog extends JDialog {
         btnDelete = new JButton();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditPersonnelInjuriesDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         setTitle(resourceMap.getString("Form.title") + " " + person.getFullName());

--- a/MekHQ/src/mekhq/gui/dialog/EditPersonnelLogDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditPersonnelLogDialog.java
@@ -22,7 +22,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -62,7 +61,7 @@ public class EditPersonnelLogDialog extends JDialog {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditPersonnelLogDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName(resourceMap.getString("dialog.name"));

--- a/MekHQ/src/mekhq/gui/dialog/EditScenarioLogDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditScenarioLogDialog.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.dialog;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -57,7 +56,7 @@ public class EditScenarioLogDialog extends JDialog {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditScenarioLogDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName(resourceMap.getString("dialog.name"));

--- a/MekHQ/src/mekhq/gui/dialog/EditTransactionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditTransactionDialog.java
@@ -21,7 +21,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.finances.Transaction;
 import mekhq.campaign.finances.enums.TransactionType;
@@ -47,7 +46,7 @@ public class EditTransactionDialog extends JDialog implements ActionListener, Fo
     private JButton cancelButton;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.EditTransactionDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public EditTransactionDialog(JFrame parent, Transaction transaction, boolean modal) {
         super(parent, modal);

--- a/MekHQ/src/mekhq/gui/dialog/ForceTemplateAssignmentDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ForceTemplateAssignmentDialog.java
@@ -19,7 +19,6 @@
  */
 package mekhq.gui.dialog;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.event.DeploymentChangedEvent;
 import mekhq.campaign.force.Force;
@@ -58,7 +57,7 @@ public class ForceTemplateAssignmentDialog extends JDialog {
     private static final String DEPLOY_TRANSPORTED_DIALOG_TITLE = "Also deploy transported units?";
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ForceTemplateAssignmentDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public ForceTemplateAssignmentDialog(CampaignGUI gui, Vector<Force> assignedForces, Vector<Unit> assignedUnits, AtBDynamicScenario scenario) {
         currentForceVector = assignedForces;

--- a/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
@@ -22,7 +22,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.Compute;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -68,7 +67,7 @@ public class HireBulkPersonnelDialog extends JDialog {
     private int maxAgeVal = 99;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.HireBulkPersonnelDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public HireBulkPersonnelDialog(Frame parent, boolean modal, Campaign c) {
         super(parent, modal);

--- a/MekHQ/src/mekhq/gui/dialog/HistoricalDailyReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/HistoricalDailyReportDialog.java
@@ -22,7 +22,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.log.LogEntry;
@@ -48,7 +47,7 @@ public class HistoricalDailyReportDialog extends JDialog {
     private JLabel cacheInfoLabel;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.HistoricalDailyReportDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     /**
      * HistoricalDailyReportDialog - opens a dialog that shows a history of the daily log

--- a/MekHQ/src/mekhq/gui/dialog/ManageAssetsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ManageAssetsDialog.java
@@ -22,7 +22,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.AssetChangedEvent;
@@ -55,7 +54,7 @@ public class ManageAssetsDialog extends JDialog {
     private JScrollPane scrollAssetTable;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ManageAssetsDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     /** Creates new form EditPersonnelLogDialog */
     public ManageAssetsDialog(JFrame parent, Campaign c) {

--- a/MekHQ/src/mekhq/gui/dialog/MarkdownEditorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MarkdownEditorDialog.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.dialog;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 
@@ -67,7 +66,7 @@ public class MarkdownEditorDialog extends JDialog {
         btnCancel = new JButton();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.TextAreaDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setLayout(new java.awt.GridBagLayout());
 

--- a/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassRepairSalvageDialog.java
@@ -21,7 +21,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.models.XTableColumnModel;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.event.OptionsChangedEvent;
@@ -96,7 +95,7 @@ public class MassRepairSalvageDialog extends JDialog {
     private List<Part> filteredPartsList = null;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MassRepair",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MedicalViewDialog.java
@@ -20,7 +20,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -77,7 +76,7 @@ public class MedicalViewDialog extends JDialog {
     private transient Color labelColor;
     private transient ImageIcon healImageIcon;
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MedicalViewDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public MedicalViewDialog(Window parent, Campaign c, Person p) {
         super();
@@ -540,7 +539,7 @@ public class MedicalViewDialog extends JDialog {
         private final Injury injury;
         private ImageIcon healImageIcon;
         private ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MedicalViewDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         public InjuryLabelMouseAdapter(JLabel label, Person person, Injury injury) {
             this.label = label;

--- a/MekHQ/src/mekhq/gui/dialog/MekHQAboutBox.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQAboutBox.java
@@ -23,7 +23,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
@@ -57,9 +56,9 @@ public class MekHQAboutBox extends JDialog {
         javax.swing.JLabel appDescLabel = new javax.swing.JLabel();
 
         final ResourceBundle mekhqProperties = ResourceBundle.getBundle("mekhq.resources.MekHQ",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MekHQAboutBox",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setTitle("MekHQ");

--- a/MekHQ/src/mekhq/gui/dialog/MekViewDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekViewDialog.java
@@ -3,7 +3,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.MechView;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -33,7 +32,7 @@ public class MekViewDialog extends JDialog {
         btnOkay = new JButton();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MekViewDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName("Unit View");
 

--- a/MekHQ/src/mekhq/gui/dialog/MercRosterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MercRosterDialog.java
@@ -2,7 +2,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.MercRosterAccess;
@@ -45,7 +44,7 @@ public class MercRosterDialog extends JDialog implements PropertyChangeListener 
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MercRosterDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         txtAddress = new JTextField("localhost");
         txtPort = new JTextField("3306");

--- a/MekHQ/src/mekhq/gui/dialog/MissionTypeDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MissionTypeDialog.java
@@ -20,7 +20,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.apache.logging.log4j.LogManager;
 
@@ -45,7 +44,7 @@ public class MissionTypeDialog extends JDialog {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.MissionTypeDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");

--- a/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
@@ -23,7 +23,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.enums.TransactionType;
@@ -98,7 +97,7 @@ public class NewContractDialog extends JDialog {
         GridBagConstraints gridBagConstraints;
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.NewContractDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         setTitle(resourceMap.getString("Form.title"));

--- a/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
@@ -23,7 +23,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Loan;
@@ -93,7 +92,7 @@ public class NewLoanDialog extends javax.swing.JDialog implements ActionListener
     private JLabel lblTotalPayment;
     private JLabel lblCollateralAmount;
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.NewLoanDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     /**
      * Creates new form NewLoanDialog

--- a/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewPlanetaryEventDialog.java
@@ -22,7 +22,6 @@ import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.EquipmentType;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.adapter.SocioIndustrialDataAdapter;
 import mekhq.campaign.Campaign;
@@ -89,7 +88,7 @@ public class NewPlanetaryEventDialog extends JDialog {
     private JLabel hpgCombined;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.NewPlanetaryEventDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public NewPlanetaryEventDialog(Frame parent, Campaign campaign, Planet planet) {
         this(parent, campaign, planet, true);

--- a/MekHQ/src/mekhq/gui/dialog/NewRecruitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewRecruitDialog.java
@@ -23,7 +23,6 @@ import megamek.client.ui.dialogs.PortraitChooserDialog;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.Profession;
@@ -72,7 +71,7 @@ public class NewRecruitDialog extends JDialog {
         choiceRanks = new JComboBox<>();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.NewRecruitDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
         setTitle(resourceMap.getString("Form.title"));

--- a/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
@@ -29,7 +29,6 @@ import megamek.common.MiscType;
 import megamek.common.TargetRoll;
 import megamek.common.WeaponType;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -91,7 +90,7 @@ public class PartsStoreDialog extends JDialog {
     private JButton btnUseBonusPart;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PartsStoreDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     /** Creates new form PartsStoreDialog */

--- a/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PayCollateralDialog.java
@@ -22,7 +22,6 @@ package mekhq.gui.dialog;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Asset;
@@ -73,7 +72,7 @@ public class PayCollateralDialog extends JDialog {
 
     private void initComponents() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PayCollateralDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         java.awt.GridBagConstraints gridBagConstraints;
 
         JTabbedPane panMain = new JTabbedPane();

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -24,7 +24,6 @@ import megamek.client.ui.swing.MechViewPanel;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.Compute;
 import megamek.common.Entity;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -89,7 +88,7 @@ public class PersonnelMarketDialog extends JDialog {
     );
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonnelMarketDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     /** Creates new form PersonnelMarketDialog */

--- a/MekHQ/src/mekhq/gui/dialog/PopupValueChoiceDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PopupValueChoiceDialog.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.dialog;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import javax.swing.*;
@@ -77,7 +76,7 @@ public class PopupValueChoiceDialog extends JDialog implements WindowListener {
         df.setCommitsOnValidEdit(true);
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PopupValueChoiceDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
 

--- a/MekHQ/src/mekhq/gui/dialog/RefitNameDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RefitNameDialog.java
@@ -23,7 +23,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.MechSummaryCache;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.parts.Refit;
 import org.apache.logging.log4j.LogManager;
@@ -70,7 +69,7 @@ public class RefitNameDialog extends JDialog {
         btnCancel = new JButton();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.RefitNameDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setName("Form");
         setTitle(resourceMap.getString("Form.title"));

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -27,7 +27,6 @@ import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.swing.UnitEditorDialog;
 import megamek.common.GunEmplacement;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.ResolveScenarioTracker;
@@ -176,7 +175,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
     //endregion Preview Panel components
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ResolveScenarioWizardDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     public ResolveScenarioWizardDialog(JFrame parent, boolean modal, ResolveScenarioTracker t) {

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -27,7 +27,6 @@ import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.TargetRoll;
 import megamek.common.UnitType;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
@@ -105,7 +104,7 @@ public class RetirementDefectionDialog extends JDialog {
     private boolean aborted = true;
 
     private final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.RetirementDefectionDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public RetirementDefectionDialog (CampaignGUI gui, AtBContract contract, boolean doRetirement) {
         super(gui.getFrame(), true);

--- a/MekHQ/src/mekhq/gui/dialog/ShipSearchDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ShipSearchDialog.java
@@ -27,7 +27,6 @@ import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
 import megamek.common.TargetRoll;
 import megamek.common.UnitType;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.finances.Money;
 import mekhq.gui.CampaignGUI;
@@ -63,7 +62,7 @@ public class ShipSearchDialog extends JDialog {
 
     private void init() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ShipSearchDialog",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         setTitle(resourceMap.getString("title.text"));
 
         Container contentPane = getContentPane();

--- a/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
@@ -21,7 +21,6 @@ package mekhq.gui.dialog;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.AmmoType;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.equipment.InfantryAmmoBin;
@@ -42,7 +41,7 @@ public class SmallSVAmmoSwapDialog extends JDialog {
     private final List<WeaponRow> rows = new ArrayList<>();
     private boolean canceled = true;
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.SmallSVAmmoSwapDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public SmallSVAmmoSwapDialog(Frame frame, Unit unit) {
         super(frame, true);

--- a/MekHQ/src/mekhq/gui/enums/ForceIconOperationalStatusStyle.java
+++ b/MekHQ/src/mekhq/gui/enums/ForceIconOperationalStatusStyle.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.MHQConstants;
 
@@ -44,7 +43,7 @@ public enum ForceIconOperationalStatusStyle {
     ForceIconOperationalStatusStyle(final String name, final String toolTipText,
                                     final String path) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.path = path;

--- a/MekHQ/src/mekhq/gui/enums/MHQTabType.java
+++ b/MekHQ/src/mekhq/gui/enums/MHQTabType.java
@@ -19,7 +19,6 @@
 package mekhq.gui.enums;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.gui.*;
 
@@ -56,7 +55,7 @@ public enum MHQTabType {
     //region Constructors
     MHQTabType(final String name, final int mnemonic) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(),  new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.mnemonic = mnemonic;
     }

--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
@@ -105,7 +104,7 @@ public enum PersonnelFilter {
     PersonnelFilter(final String name, final String toolTipText, final boolean baseline,
                     final boolean standard, final boolean individualRole) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
         this.baseline = baseline;

--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilterStyle.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilterStyle.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.List;
@@ -39,7 +38,7 @@ public enum PersonnelFilterStyle {
     //region Constructors
     PersonnelFilterStyle(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTabView.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTabView.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 
 import java.util.ResourceBundle;
@@ -46,7 +45,7 @@ public enum PersonnelTabView {
     //region Constructors
     PersonnelTabView(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -24,7 +24,6 @@ import megamek.common.Jumpship;
 import megamek.common.SmallCraft;
 import megamek.common.Tank;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -107,7 +106,7 @@ public enum PersonnelTableModelColumn {
     private final String name;
 
     private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -22,7 +22,6 @@ import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.parts.PartInUse;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
@@ -46,7 +45,7 @@ public class PartsInUseTableModel extends DataTableModel {
     public final static int COL_BUTTON_GMADD_BULK  = 9;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PartsInUseTableModel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public PartsInUseTableModel () {
         data = new ArrayList<PartInUse>();

--- a/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelEventLogModel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.model;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.log.LogEntry;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
@@ -41,7 +40,7 @@ public class PersonnelEventLogModel extends DataTableModel {
     private final int dateTextWidth;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonnelEventLogModel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public PersonnelEventLogModel() {
         data = new ArrayList<LogEntry>();

--- a/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelKillLogModel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.model;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Kill;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
@@ -39,7 +38,7 @@ public class PersonnelKillLogModel extends DataTableModel {
     public final static int COL_TEXT = 1;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonnelKillLogModel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     private final int dateTextWidth;
 
     public PersonnelKillLogModel() {

--- a/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
@@ -28,7 +28,6 @@ import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
 
 import megamek.common.TargetRoll;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.Part;
@@ -53,7 +52,7 @@ public class ProcurementTableModel extends DataTableModel {
     public final static int N_COL          = 7;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/model/RankTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RankTableModel.java
@@ -19,7 +19,6 @@
 package mekhq.gui.model;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.enums.Profession;
 import mekhq.campaign.personnel.ranks.Rank;
@@ -55,7 +54,7 @@ public class RankTableModel extends DefaultTableModel {
     public final static int COL_NUM = 12;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.model;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Scenario;
@@ -44,7 +43,7 @@ public class ScenarioTableModel extends DataTableModel {
     public final static int N_COL          = 4;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.ScenarioTableModel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/model/UnitMarketTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitMarketTableModel.java
@@ -31,7 +31,6 @@ import javax.swing.table.TableCellRenderer;
 
 import megamek.common.EntityWeightClass;
 import megamek.common.UnitType;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.market.unitMarket.UnitMarketOffer;
 
@@ -54,7 +53,7 @@ public class UnitMarketTableModel extends DataTableModel {
     public static final int COL_NUM = 7;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -34,7 +34,6 @@ import megamek.common.icons.Camouflage;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -522,7 +521,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     //region Constructors
     public CampaignOptionsPane(final JFrame frame, final Campaign campaign, final boolean startup) {
         super(frame, ResourceBundle.getBundle("mekhq.resources.CampaignOptionsDialog",
-                        MekHQ.getMHQOptions().getLocale(), new EncodeControl()),
+                        MekHQ.getMHQOptions().getLocale()),
                 "CampaignOptionsPane");
         this.campaign = campaign;
         this.startup = startup;

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -19,7 +19,6 @@
 package mekhq.gui.stratcon;
 
 import megamek.common.Minefield;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -51,7 +50,7 @@ public class StratconScenarioWizard extends JDialog {
     private StratconTrackState currentTrackState;
     private StratconCampaignState currentCampaignState;
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AtBStratCon",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     private Map<String, JList<Force>> availableForceLists = new HashMap<>();
     private Map<String, JList<Unit>> availableUnitLists = new HashMap<>();

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -26,7 +26,6 @@ import megamek.client.ui.swing.UnitEditorDialog;
 import megamek.common.IStartingPositions;
 import megamek.common.PlanetaryConditions;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.ForceStub;
@@ -176,7 +175,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
     private void fillStats() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AtBScenarioViewPanel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
         lblStatus = new JLabel();
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/ContractPaymentBreakdown.java
+++ b/MekHQ/src/mekhq/gui/view/ContractPaymentBreakdown.java
@@ -20,7 +20,6 @@
  */
 package mekhq.gui.view;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Contract;
@@ -40,7 +39,7 @@ public class ContractPaymentBreakdown {
     private Contract contract;
 
     private ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ContractPaymentBreakdown",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     private static final String indentation = "    ";
     private JLabel lblBaseAmount2;

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -21,7 +21,6 @@
  */
 package mekhq.gui.view;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
@@ -63,7 +62,7 @@ public class ContractSummaryPanel extends JPanel {
     private JLabel txtBattleLossComp;
 
     private ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ContractMarketDialog",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     private ContractPaymentBreakdown contractPaymentBreakdown;
 
     // These three are used locally to ensure consistent formatting

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -21,7 +21,6 @@ package mekhq.gui.view;
 import megamek.client.ui.Messages;
 import megamek.common.Entity;
 import megamek.common.UnitType;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -143,7 +142,7 @@ public class ForceViewPanel extends JScrollablePanel {
 
     private void fillStats() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ForceViewPanel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         lblType = new javax.swing.JLabel();
         lblAssign1 = new javax.swing.JLabel();

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -23,7 +23,6 @@ import java.util.ResourceBundle;
 
 import javax.swing.BorderFactory;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
@@ -124,7 +123,7 @@ public class JumpPathViewPanel extends JScrollablePanel {
 
     private void fillStats() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.JumpPathViewPanel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         lblJumps = new javax.swing.JLabel();
         txtJumps = new javax.swing.JLabel();

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.view;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
@@ -92,7 +91,7 @@ public class MissionViewPanel extends JScrollablePanel {
     protected JTable scenarioTable;
 
     private final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ContractViewPanel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public MissionViewPanel(Mission m, JTable scenarioTable, CampaignGUI gui) {
         super();

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -19,7 +19,6 @@
 package mekhq.gui.view;
 
 import megamek.common.options.IOption;
-import megamek.common.util.EncodeControl;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
 import mekhq.Utilities;
@@ -68,7 +67,7 @@ public class PersonViewPanel extends JScrollablePanel {
     private final Campaign campaign;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PersonViewPanel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public PersonViewPanel(Person p, Campaign c, CampaignGUI gui) {
         super();

--- a/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
@@ -39,7 +39,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextPane;
 import javax.swing.text.DefaultCaret;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.Planet;
@@ -63,7 +62,7 @@ public class PlanetViewPanel extends JScrollablePanel {
     private Image planetIcon = null;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PlanetViewPanel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public PlanetViewPanel(PlanetarySystem s, Campaign c) {
         this(s, c, 0);

--- a/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
@@ -21,7 +21,6 @@
 package mekhq.gui.view;
 
 import megamek.common.PlanetaryConditions;
-import megamek.common.util.EncodeControl;
 import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -67,7 +66,7 @@ public class ScenarioViewPanel extends JScrollablePanel {
     private StubTreeModel forceModel;
 
     private ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ScenarioViewPanel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     public ScenarioViewPanel(JFrame f, Campaign c, Scenario s) {
         super();

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -23,7 +23,6 @@ import megamek.common.Entity;
 import megamek.common.MechView;
 import megamek.common.TechConstants;
 import megamek.common.UnitType;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
@@ -76,7 +75,7 @@ public class UnitViewPanel extends JScrollablePanel {
         pnlStats = new JPanel();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.UnitViewPanel",
-                MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+                MekHQ.getMHQOptions().getLocale());
 
         setLayout(new GridBagLayout());
 

--- a/MekHQ/src/mekhq/service/MassRepairService.java
+++ b/MekHQ/src/mekhq/service/MassRepairService.java
@@ -19,7 +19,6 @@
 package mekhq.service;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -40,7 +39,7 @@ import java.util.*;
 
 public class MassRepairService {
     private static final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.MassRepair",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
 
     private MassRepairService() {
 

--- a/MekHQ/unittests/mekhq/campaign/finances/enums/FinancialTermTest.java
+++ b/MekHQ/unittests/mekhq/campaign/finances/enums/FinancialTermTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.finances.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class FinancialTermTest {
     private static final FinancialTerm[] terms = FinancialTerm.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Finances",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/finances/enums/FinancialYearDurationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/finances/enums/FinancialYearDurationTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.finances.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class FinancialYearDurationTest {
     private static final FinancialYearDuration[] durations = FinancialYearDuration.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Finances",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/finances/enums/TransactionTypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/finances/enums/TransactionTypeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.finances.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class TransactionTypeTest {
     private static final TransactionType[] types = TransactionType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Finances",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/market/enums/ContractMarketMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/enums/ContractMarketMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.market.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class ContractMarketMethodTest {
     private static final ContractMarketMethod[] methods = ContractMarketMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Market",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/market/enums/UnitMarketMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/enums/UnitMarketMethodTest.java
@@ -18,11 +18,9 @@
  */
 package mekhq.campaign.market.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.market.unitMarket.AtBMonthlyUnitMarket;
 import mekhq.campaign.market.unitMarket.DisabledUnitMarket;
-import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import org.junit.jupiter.api.Test;
 
 import java.util.ResourceBundle;
@@ -37,7 +35,7 @@ public class UnitMarketMethodTest {
     private static final UnitMarketMethod[] methods = UnitMarketMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Market",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/market/enums/UnitMarketTypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/market/enums/UnitMarketTypeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.market.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class UnitMarketTypeTest {
     private static final UnitMarketType[] types = UnitMarketType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Market",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/parts/enums/PartRepairTypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/enums/PartRepairTypeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.parts.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class PartRepairTypeTest {
     private static final PartRepairType[] types = PartRepairType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Parts",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/AgeGroupTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/AgeGroupTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class AgeGroupTest {
     private static final AgeGroup[] ageGroups = AgeGroup.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/BabySurnameStyleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/BabySurnameStyleTest.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ public class BabySurnameStyleTest {
     private static final BabySurnameStyle[] styles = BabySurnameStyle.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/FamilialConnectionTypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/FamilialConnectionTypeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class FamilialConnectionTypeTest {
     private static final FamilialConnectionType[] types = FamilialConnectionType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/FamilialRelationshipDisplayLevelTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/FamilialRelationshipDisplayLevelTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class FamilialRelationshipDisplayLevelTest {
     private static final FamilialRelationshipDisplayLevel[] levels = FamilialRelationshipDisplayLevel.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/FamilialRelationshipTypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/FamilialRelationshipTypeTest.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class FamilialRelationshipTypeTest {
     private static final FamilialRelationshipType[] types = FamilialRelationshipType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/FormerSpouseReasonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/FormerSpouseReasonTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class FormerSpouseReasonTest {
     private static final FormerSpouseReason[] reasons = FormerSpouseReason.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/GenderDescriptorsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/GenderDescriptorsTest.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class GenderDescriptorsTest {
     private static final GenderDescriptors[] genderDescriptors = GenderDescriptors.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/ManeiDominiClassTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/ManeiDominiClassTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class ManeiDominiClassTest {
     private static final ManeiDominiClass[] classes = ManeiDominiClass.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/ManeiDominiRankTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/ManeiDominiRankTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class ManeiDominiRankTest {
     private static final ManeiDominiRank[] maneiDominiRanks = ManeiDominiRank.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/MergingSurnameStyleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/MergingSurnameStyleTest.java
@@ -20,7 +20,6 @@ package mekhq.campaign.personnel.enums;
 
 import megamek.client.generator.RandomNameGenerator;
 import megamek.common.enums.Gender;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.weightedMaps.WeightedIntMap;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -58,7 +57,7 @@ public class MergingSurnameStyleTest {
     private CampaignOptions mockCampaignOptions;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     @BeforeEach

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class PersonnelRoleTest {
     private static final PersonnelRole[] roles = PersonnelRole.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelStatusTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelStatusTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class PersonnelStatusTest {
     private static final PersonnelStatus[] statuses = PersonnelStatus.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PhenotypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PhenotypeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,7 @@ public class PhenotypeTest {
     private static final Phenotype[] phenotypes = Phenotype.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PrisonerCaptureStyleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PrisonerCaptureStyleTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class PrisonerCaptureStyleTest {
     private static final PrisonerCaptureStyle[] styles = PrisonerCaptureStyle.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PrisonerStatusTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PrisonerStatusTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class PrisonerStatusTest {
     private static final PrisonerStatus[] statuses = PrisonerStatus.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/ProfessionTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/ProfessionTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
@@ -42,7 +41,7 @@ public class ProfessionTest {
     private static final Profession[] professions = Profession.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/ROMDesignationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/ROMDesignationTest.java
@@ -21,7 +21,6 @@ package mekhq.campaign.personnel.enums;
 import megamek.common.BipedMech;
 import megamek.common.Dropship;
 import megamek.common.Jumpship;
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
@@ -40,7 +39,7 @@ public class ROMDesignationTest {
     private static final ROMDesignation[] designations = ROMDesignation.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomDeathMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomDeathMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.death.AgeRangeRandomDeath;
@@ -43,7 +42,7 @@ public class RandomDeathMethodTest {
     private static final RandomDeathMethod[] methods = RandomDeathMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomDependentMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomDependentMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class RandomDependentMethodTest {
     private static final RandomDependentMethod[] methods = RandomDependentMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomDivorceMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomDivorceMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.divorce.DisabledRandomDivorce;
@@ -39,7 +38,7 @@ public class RandomDivorceMethodTest {
     private static final RandomDivorceMethod[] methods = RandomDivorceMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomMarriageMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomMarriageMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.marriage.DisabledRandomMarriage;
@@ -39,7 +38,7 @@ public class RandomMarriageMethodTest {
     private static final RandomMarriageMethod[] methods = RandomMarriageMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomProcreationMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomProcreationMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.procreation.DisabledRandomProcreation;
@@ -39,7 +38,7 @@ public class RandomProcreationMethodTest {
     private static final RandomProcreationMethod[] methods = RandomProcreationMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomRetirementMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomRetirementMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class RandomRetirementMethodTest {
     private static final RandomRetirementMethod[] methods = RandomRetirementMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RankSystemTypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RankSystemTypeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ public class RankSystemTypeTest {
     private static final RankSystemType[] types = RankSystemType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/SplittingSurnameStyleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/SplittingSurnameStyleTest.java
@@ -19,7 +19,6 @@
 package mekhq.campaign.personnel.enums;
 
 import megamek.client.generator.RandomNameGenerator;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.weightedMaps.WeightedIntMap;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -56,7 +55,7 @@ public class SplittingSurnameStyleTest {
     private CampaignOptions mockCampaignOptions;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     @BeforeEach

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/TenYearAgeRangeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/TenYearAgeRangeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class TenYearAgeRangeTest {
     private static final TenYearAgeRange[] ranges = TenYearAgeRange.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/TimeInDisplayFormatTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/TimeInDisplayFormatTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class TimeInDisplayFormatTest {
     private static final TimeInDisplayFormat[] formats = TimeInDisplayFormat.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/AlphabetTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/AlphabetTest.java
@@ -18,13 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.personnel.enums.FamilialRelationshipType;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AlphabetTest {
@@ -32,7 +25,7 @@ public class AlphabetTest {
     private static final FamilialRelationshipType[] reasons = FamilialRelationshipType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/BattleMechFactionGenerationMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/BattleMechFactionGenerationMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -38,7 +37,7 @@ public class BattleMechFactionGenerationMethodTest {
     private static final BattleMechFactionGenerationMethod[] methods = BattleMechFactionGenerationMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/BattleMechQualityGenerationMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/BattleMechQualityGenerationMethodTest.java
@@ -18,13 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.personnel.enums.FamilialRelationshipType;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BattleMechQualityGenerationMethodTest {
@@ -33,7 +26,7 @@ public class BattleMechQualityGenerationMethodTest {
     private static final FamilialRelationshipType[] reasons = FamilialRelationshipType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/BattleMechWeightClassGenerationMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/BattleMechWeightClassGenerationMethodTest.java
@@ -18,13 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.personnel.enums.FamilialRelationshipType;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BattleMechWeightClassGenerationMethodTest {
@@ -33,7 +26,7 @@ public class BattleMechWeightClassGenerationMethodTest {
     private static final FamilialRelationshipType[] reasons = FamilialRelationshipType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/CompanyGenerationMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/CompanyGenerationMethodTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.RandomOriginOptions;
@@ -43,7 +42,7 @@ public class CompanyGenerationMethodTest {
     private static final CompanyGenerationMethod[] methods = CompanyGenerationMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/CompanyGenerationPersonTypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/CompanyGenerationPersonTypeTest.java
@@ -18,13 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.personnel.enums.FamilialRelationshipType;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CompanyGenerationPersonTypeTest {/*
@@ -32,7 +25,7 @@ public class CompanyGenerationPersonTypeTest {/*
     private static final FamilialRelationshipType[] reasons = FamilialRelationshipType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/EraFlagTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/EraFlagTest.java
@@ -18,13 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.personnel.enums.FamilialRelationshipType;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EraFlagTest {/*
@@ -32,7 +25,7 @@ public class EraFlagTest {/*
     private static final FamilialRelationshipType[] reasons = FamilialRelationshipType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/ForceNamingMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/ForceNamingMethodTest.java
@@ -18,13 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.personnel.enums.FamilialRelationshipType;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ForceNamingMethodTest {
@@ -33,7 +26,7 @@ public class ForceNamingMethodTest {
     private static final FamilialRelationshipType[] reasons = FamilialRelationshipType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/MysteryBoxTypeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/MysteryBoxTypeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class MysteryBoxTypeTest {
     private static final MysteryBoxType[] types = MysteryBoxType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/campaign/universe/enums/PartGenerationMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/enums/PartGenerationMethodTest.java
@@ -18,13 +18,6 @@
  */
 package mekhq.campaign.universe.enums;
 
-import megamek.common.util.EncodeControl;
-import mekhq.MekHQ;
-import mekhq.campaign.personnel.enums.FamilialRelationshipType;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartGenerationMethodTest {
@@ -33,7 +26,7 @@ public class PartGenerationMethodTest {
     private static final FamilialRelationshipType[] reasons = FamilialRelationshipType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Universe",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/gui/enums/ForceIconOperationalStatusStyleTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/ForceIconOperationalStatusStyleTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ public class ForceIconOperationalStatusStyleTest {
     private static final ForceIconOperationalStatusStyle[] styles = ForceIconOperationalStatusStyle.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/gui/enums/MHQTabTypeTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/MHQTabTypeTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import mekhq.gui.*;
 import org.junit.jupiter.api.Disabled;
@@ -35,7 +34,7 @@ public class MHQTabTypeTest {
     private static final MHQTabType[] types = MHQTabType.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelFilterStyleTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelFilterStyleTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -37,7 +36,7 @@ public class PersonnelFilterStyleTest {
     private static final PersonnelFilterStyle[] styles = PersonnelFilterStyle.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelFilterTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelFilterTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ public class PersonnelFilterTest {
     private static final PersonnelFilter[] filters = PersonnelFilter.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTabViewTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTabViewTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import mekhq.MekHQ;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class PersonnelTabViewTest {
     private static final PersonnelTabView[] views = PersonnelTabView.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.enums;
 
-import megamek.common.util.EncodeControl;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -37,7 +36,7 @@ public class PersonnelTableModelColumnTest {
     private static final PersonnelTableModelColumn[] columns = PersonnelTableModelColumn.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale(), new EncodeControl());
+            MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Boolean Comparison Methods


### PR DESCRIPTION
ResourceBundles default to UTF-8 as of Java 9 instead of ISO-8859-1, so we no longer need the workaround.