### PR TITLE
AtBStaticWeightGenerator: Separating Out Code From Unit Market

### DIFF
--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBStaticWeightGenerator.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBStaticWeightGenerator.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.againstTheBot;
+
+import megamek.common.Compute;
+import megamek.common.EntityWeightClass;
+import megamek.common.UnitType;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.universe.Faction;
+
+public class AtBStaticWeightGenerator {
+    /**
+     * @param campaign the campaign to generate the unit weight based on
+     * @param unitType the unit type to determine the format of weight to generate
+     * @param faction the faction to generate the weight for
+     * @return the generated weight
+     */
+    public static int getRandomWeight(final Campaign campaign, final int unitType,
+                                      final Faction faction) {
+        return getRandomWeight(unitType, faction, campaign.getCampaignOptions().getRegionalMechVariations());
+    }
+
+    /**
+     * @param unitType the unit type to determine the format of weight to generate
+     * @param faction the faction to generate the weight for
+     * @param regionVariations whether to generate 'Mech weights based on hardcoded regional variations
+     * @return the generated weight
+     */
+    private static int getRandomWeight(final int unitType, final Faction faction,
+                                       final boolean regionVariations) {
+        if (unitType == UnitType.AERO) {
+            return getRandomAerospaceWeight();
+        } else if ((unitType == UnitType.MEK) && regionVariations) {
+            return getRegionalMechWeight(faction);
+        } else {
+            return getRandomMechWeight();
+        }
+    }
+
+    /**
+     * @return the generated weight for a BattleMech
+     */
+    private static int getRandomMechWeight() {
+        final int roll = Compute.randomInt(10);
+        if (roll < 3) {
+            return EntityWeightClass.WEIGHT_LIGHT;
+        } else if (roll < 7) {
+            return EntityWeightClass.WEIGHT_MEDIUM;
+        } else if (roll < 9) {
+            return EntityWeightClass.WEIGHT_HEAVY;
+        } else {
+            return EntityWeightClass.WEIGHT_ASSAULT;
+        }
+    }
+
+    /**
+     * @param faction the faction to determine the regional BattleMech weight for
+     * @return the generated weight for a BattleMech
+     */
+    private static int getRegionalMechWeight(final Faction faction) {
+        final int roll = Compute.randomInt(100);
+        switch (faction.getShortName()) {
+            case "DC":
+                if (roll < 40) {
+                    return EntityWeightClass.WEIGHT_LIGHT;
+                } else if (roll < 60) {
+                    return EntityWeightClass.WEIGHT_MEDIUM;
+                } else if (roll < 90) {
+                    return EntityWeightClass.WEIGHT_HEAVY;
+                } else {
+                    return EntityWeightClass.WEIGHT_ASSAULT;
+                }
+            case "LA":
+                if (roll < 20) {
+                    return EntityWeightClass.WEIGHT_LIGHT;
+                } else if (roll < 50) {
+                    return EntityWeightClass.WEIGHT_MEDIUM;
+                } else if (roll < 85) {
+                    return EntityWeightClass.WEIGHT_HEAVY;
+                } else {
+                    return EntityWeightClass.WEIGHT_ASSAULT;
+                }
+            case "FWL":
+                if (roll < 30) {
+                    return EntityWeightClass.WEIGHT_LIGHT;
+                } else if (roll < 70) {
+                    return EntityWeightClass.WEIGHT_MEDIUM;
+                } else if (roll < 92) {
+                    return EntityWeightClass.WEIGHT_HEAVY;
+                } else {
+                    return EntityWeightClass.WEIGHT_ASSAULT;
+                }
+            default:
+                if (roll < 30) {
+                    return EntityWeightClass.WEIGHT_LIGHT;
+                } else if (roll < 70) {
+                    return EntityWeightClass.WEIGHT_MEDIUM;
+                } else if (roll < 90) {
+                    return EntityWeightClass.WEIGHT_HEAVY;
+                } else {
+                    return EntityWeightClass.WEIGHT_ASSAULT;
+                }
+        }
+    }
+
+    /**
+     * @return the generated random weight for an Aerospace Fighter
+     */
+    private static int getRandomAerospaceWeight() {
+        final int roll = Compute.randomInt(8);
+        if (roll < 3) {
+            return EntityWeightClass.WEIGHT_LIGHT;
+        } else if (roll < 7) {
+            return EntityWeightClass.WEIGHT_MEDIUM;
+        } else {
+            return EntityWeightClass.WEIGHT_HEAVY;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -22,10 +22,10 @@ import megamek.client.ratgenerator.MissionRole;
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.Compute;
 import megamek.common.EntityMovementMode;
-import megamek.common.EntityWeightClass;
 import megamek.common.UnitType;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
 import mekhq.campaign.market.enums.UnitMarketMethod;
 import mekhq.campaign.market.enums.UnitMarketType;
 import mekhq.campaign.mission.AtBContract;
@@ -157,7 +157,6 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
         }
     }
 
-    //region Random Weight
     /**
      * This generates a random weight using the static weight generation methods in this market
      * @param campaign the campaign to generate the unit weight based on
@@ -167,118 +166,8 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
      */
     @Override
     protected int generateWeight(final Campaign campaign, final int unitType, final Faction faction) {
-        return getRandomWeight(unitType, faction, campaign.getCampaignOptions().useUnitMarketRegionalMechVariations());
+        return AtBStaticWeightGenerator.getRandomWeight(campaign, unitType, faction);
     }
-
-    /**
-     * This is a simplification method that is used for regional 'Mech variations not part of the
-     * Unit Market while sharing the same code
-     * @param campaign the campaign to generate the unit weight based on
-     * @param unitType the unit type to determine the format of weight to generate
-     * @param faction the faction to generate the weight for
-     * @return the generated weight
-     */
-    public static int getRandomWeight(final Campaign campaign, final int unitType, final Faction faction) {
-        return getRandomWeight(unitType, faction, campaign.getCampaignOptions().getRegionalMechVariations());
-    }
-
-
-    /**
-     * @param unitType the unit type to determine the format of weight to generate
-     * @param faction the faction to generate the weight for
-     * @param regionVariations whether to generate 'Mech weights based on hardcoded regional variations
-     * @return the generated weight
-     */
-    private static int getRandomWeight(final int unitType, final Faction faction, final boolean regionVariations) {
-        if (unitType == UnitType.AERO) {
-            return getRandomAerospaceWeight();
-        } else if ((unitType == UnitType.MEK) && regionVariations) {
-            return getRegionalMechWeight(faction);
-        } else {
-            return getRandomMechWeight();
-        }
-    }
-
-    /**
-     * @return the generated weight for a BattleMech
-     */
-    private static int getRandomMechWeight() {
-        final int roll = Compute.randomInt(10);
-        if (roll < 3) {
-            return EntityWeightClass.WEIGHT_LIGHT;
-        } else if (roll < 7) {
-            return EntityWeightClass.WEIGHT_MEDIUM;
-        } else if (roll < 9) {
-            return EntityWeightClass.WEIGHT_HEAVY;
-        } else {
-            return EntityWeightClass.WEIGHT_ASSAULT;
-        }
-    }
-
-    /**
-     * @param faction the faction to determine the regional BattleMech weight for
-     * @return the generated weight for a BattleMech
-     */
-    private static int getRegionalMechWeight(final Faction faction) {
-        final int roll = Compute.randomInt(100);
-        switch (faction.getShortName()) {
-            case "DC":
-                if (roll < 40) {
-                    return EntityWeightClass.WEIGHT_LIGHT;
-                } else if (roll < 60) {
-                    return EntityWeightClass.WEIGHT_MEDIUM;
-                } else if (roll < 90) {
-                    return EntityWeightClass.WEIGHT_HEAVY;
-                } else {
-                    return EntityWeightClass.WEIGHT_ASSAULT;
-                }
-            case "LA":
-                if (roll < 20) {
-                    return EntityWeightClass.WEIGHT_LIGHT;
-                } else if (roll < 50) {
-                    return EntityWeightClass.WEIGHT_MEDIUM;
-                } else if (roll < 85) {
-                    return EntityWeightClass.WEIGHT_HEAVY;
-                } else {
-                    return EntityWeightClass.WEIGHT_ASSAULT;
-                }
-            case "FWL":
-                if (roll < 30) {
-                    return EntityWeightClass.WEIGHT_LIGHT;
-                } else if (roll < 70) {
-                    return EntityWeightClass.WEIGHT_MEDIUM;
-                } else if (roll < 92) {
-                    return EntityWeightClass.WEIGHT_HEAVY;
-                } else {
-                    return EntityWeightClass.WEIGHT_ASSAULT;
-                }
-            default:
-                if (roll < 30) {
-                    return EntityWeightClass.WEIGHT_LIGHT;
-                } else if (roll < 70) {
-                    return EntityWeightClass.WEIGHT_MEDIUM;
-                } else if (roll < 90) {
-                    return EntityWeightClass.WEIGHT_HEAVY;
-                } else {
-                    return EntityWeightClass.WEIGHT_ASSAULT;
-                }
-        }
-    }
-
-    /**
-     * @return the generated random weight for an Aerospace Fighter
-     */
-    private static int getRandomAerospaceWeight() {
-        final int roll = Compute.randomInt(8);
-        if (roll < 3) {
-            return EntityWeightClass.WEIGHT_LIGHT;
-        } else if (roll < 7) {
-            return EntityWeightClass.WEIGHT_MEDIUM;
-        } else {
-            return EntityWeightClass.WEIGHT_HEAVY;
-        }
-    }
-    //endregion Random Weight
     //endregion Offer Generation
 
     //region Offer Removal

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -31,6 +31,7 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.util.EncodeControl;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
+import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
@@ -781,7 +782,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 for (int i = 0; i < Compute.d6() - 3; i++) {
                     addLance(enemyEntities, getContract(campaign).getEnemyCode(),
                             getContract(campaign).getEnemySkill(), getContract(campaign).getEnemyQuality(),
-                            AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, getContract(campaign).getEnemy()),
+                            AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, getContract(campaign).getEnemy()),
                             EntityWeightClass.WEIGHT_ASSAULT, campaign);
                 }
             } else if (getLanceRole().isScouting()) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AllyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AllyRescueBuiltInScenario.java
@@ -23,7 +23,7 @@ import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import megamek.common.UnitType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.market.unitMarket.AtBMonthlyUnitMarket;
+import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
 import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ObjectiveEffect.ObjectiveEffectType;
 import mekhq.campaign.mission.ScenarioObjective.ObjectiveCriterion;
@@ -92,7 +92,7 @@ public class AllyRescueBuiltInScenario extends AtBScenario {
         for (int i = 0; i < 4; i++) {
             getAlliesPlayer().add(getEntity(contract.getEmployerCode(), contract.getAllySkill(),
                     contract.getAllyQuality(), UnitType.MEK,
-                    AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, contract.getEmployerFaction()),
+                    AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, contract.getEmployerFaction()),
                     campaign));
         }
 
@@ -101,7 +101,7 @@ public class AllyRescueBuiltInScenario extends AtBScenario {
         for (int i = 0; i < 8; i++) {
             int weightClass;
             do {
-                weightClass = AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, contract.getEmployerFaction());
+                weightClass = AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, contract.getEmployerFaction());
             } while (weightClass >= EntityWeightClass.WEIGHT_ASSAULT);
             otherForce.add(getEntity(contract.getEmployerCode(), contract.getAllySkill(),
                     contract.getAllyQuality(), UnitType.MEK, weightClass, campaign));
@@ -112,7 +112,7 @@ public class AllyRescueBuiltInScenario extends AtBScenario {
         for (int i = 0; i < 12; i++) {
             int weightClass;
             do {
-                weightClass = AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, contract.getEnemy());
+                weightClass = AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, contract.getEnemy());
             } while (weightClass <= EntityWeightClass.WEIGHT_LIGHT);
             enemyEntities.add(getEntity(contract.getEnemyCode(), contract.getEnemySkill(),
                     contract.getEnemyQuality(), UnitType.MEK, weightClass, campaign));

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyAttackBuiltInScenario.java
@@ -19,21 +19,17 @@
 
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import megamek.common.Board;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import megamek.common.UnitType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.market.unitMarket.AtBMonthlyUnitMarket;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @AtBScenarioEnabled
 public class ConvoyAttackBuiltInScenario extends AtBScenario {
@@ -103,7 +99,7 @@ public class ConvoyAttackBuiltInScenario extends AtBScenario {
         for (int i = 0; i < 8; i++) {
             enemyEntities.add(getEntity(getContract(campaign).getEnemyCode(), getContract(campaign).getEnemySkill(),
                     getContract(campaign).getEnemyQuality(), UnitType.MEK,
-                    AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, getContract(campaign).getEnemy()),
+                    AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, getContract(campaign).getEnemy()),
                     campaign));
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
@@ -18,24 +18,19 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-import java.util.UUID;
-
 import megamek.common.Board;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import megamek.common.UnitType;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.market.unitMarket.AtBMonthlyUnitMarket;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ObjectiveEffect;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ObjectiveEffect.EffectScalingType;
 import mekhq.campaign.mission.ObjectiveEffect.ObjectiveEffectType;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+
+import java.util.ArrayList;
+import java.util.UUID;
 
 @AtBScenarioEnabled
 public class ConvoyRescueBuiltInScenario extends AtBScenario {
@@ -111,7 +106,7 @@ public class ConvoyRescueBuiltInScenario extends AtBScenario {
         for (int i = 0; i < 12; i++) {
             enemyEntities.add(getEntity(getContract(campaign).getEnemyCode(), getContract(campaign).getEnemySkill(),
                     getContract(campaign).getEnemyQuality(), UnitType.MEK,
-                    AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, getContract(campaign).getEnemy()),
+                    AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, getContract(campaign).getEnemy()),
                     campaign));
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/PirateFreeForAllBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/PirateFreeForAllBuiltInScenario.java
@@ -18,25 +18,21 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import megamek.common.Board;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import megamek.common.UnitType;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.market.unitMarket.AtBMonthlyUnitMarket;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @AtBScenarioEnabled
 public class PirateFreeForAllBuiltInScenario extends AtBScenario {
@@ -87,7 +83,7 @@ public class PirateFreeForAllBuiltInScenario extends AtBScenario {
         for (int i = 0; i < 4; i++) {
             int weightClass;
             do {
-                weightClass = AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, contract.getEmployerFaction());
+                weightClass = AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, contract.getEmployerFaction());
             } while (weightClass >= EntityWeightClass.WEIGHT_ASSAULT);
             getAlliesPlayer().add(getEntity(contract.getEmployerCode(), contract.getAllySkill(),
                     contract.getAllyQuality(), UnitType.MEK, weightClass, campaign));
@@ -96,7 +92,7 @@ public class PirateFreeForAllBuiltInScenario extends AtBScenario {
         for (int i = 0; i < 12; i++) {
             enemyEntities.add(getEntity(contract.getEnemyCode(), contract.getEnemySkill(),
                     contract.getEnemyQuality(), UnitType.MEK,
-                    AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, contract.getEnemy()),
+                    AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, contract.getEnemy()),
                     campaign));
         }
 
@@ -107,7 +103,7 @@ public class PirateFreeForAllBuiltInScenario extends AtBScenario {
         for (int i = 0; i < 12; i++) {
             otherForce.add(getEntity(faction.getShortName(), SkillLevel.REGULAR,
                     IUnitRating.DRAGOON_C, UnitType.MEK,
-                    AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, faction), campaign));
+                    AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, faction), campaign));
         }
 
         addBotForce(new BotForce(PIRATE_FORCE_ID, 3, Board.START_S, otherForce), campaign);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
@@ -19,22 +19,11 @@
 package mekhq.campaign.mission.atb.scenario;
 
 import megamek.client.generator.RandomUnitGenerator;
-import megamek.common.Board;
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.EntityWeightClass;
-import megamek.common.MechSummary;
-import megamek.common.UnitType;
+import megamek.common.*;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.market.unitMarket.AtBMonthlyUnitMarket;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.Loot;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.universe.Faction;
@@ -129,7 +118,7 @@ public class StarLeagueCache1BuiltInScenario extends AtBScenario {
             // TODO : AtB Star League RAT Roll Year Option
             final Faction faction = Factions.getInstance().getFaction("SL");
             ms = campaign.getUnitGenerator().generate(faction.getShortName(), UnitType.MEK,
-                    AtBMonthlyUnitMarket.getRandomWeight(campaign, UnitType.MEK, faction), 2750,
+                    AtBStaticWeightGenerator.getRandomWeight(campaign, UnitType.MEK, faction), 2750,
                     (roll == 6) ? IUnitRating.DRAGOON_A : IUnitRating.DRAGOON_D);
         }
         Entity en = (ms == null) ? null


### PR DESCRIPTION
This moves weight generation code for AtB out of the unit market and into its own class, as it is called from multiple places not just the unit market.