### PR TITLE
3373: Company Generator: Parts No Longer Go Missing After Unit Removal Before Reload

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
@@ -1719,7 +1719,6 @@ public abstract class AbstractCompanyGenerator {
         return mothballedUnits;
     }
 
-
     /**
      * Phase Three: Finalizing Contract and Finances
      *

--- a/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/AbstractPartGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/partGenerators/AbstractPartGenerator.java
@@ -75,8 +75,11 @@ public abstract class AbstractPartGenerator {
      * @return the list of generated parts
      */
     public List<Part> generate(final List<Part> inputParts) {
-        return generateWarehouse(inputParts).getParts().stream()
-                .filter(part -> part.getQuantity() > 0).collect(Collectors.toList());
+        final List<Part> parts = generateWarehouse(inputParts).getParts().stream()
+                .filter(part -> part.getQuantity() > 0)
+                .collect(Collectors.toList());
+        parts.forEach(part -> part.setId(0));
+        return parts;
     }
 
     /**


### PR DESCRIPTION
This fixes #3373, which I found to be a severe transient issue.