### PR TITLE
3558: RATs Are Used Outside of AtB

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6687,7 +6687,6 @@ public class Campaign implements ITechManager {
      */
     public void shutdownAtB() {
         RandomFactionGenerator.getInstance().dispose();
-        RandomUnitGenerator.getInstance().dispose();
         atbEventProcessor.shutdown();
     }
 


### PR DESCRIPTION
This fixes #3558. RATs are used outside of AtB now, so this clearing breaks stuff