### PR TITLE
3569: Company Generation Dialog: Fixing Warning Option Names

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1067,9 +1067,9 @@ chkGenerateMysteryBoxes.toolTipText=Allow the generation of enabled mystery box 
 ### Option Validation Warnings
 CompanyGenerationOptionsPanel.InvalidGenerationSize.text=You must select at least one company or independent lance to generate
 CompanyGenerationOptionsPanel.OverMaximumSupportPersonnel.title=Over Maximum Support Personnel
-CompanyGenerationOptionsPanel.OverMaximumSupportPersonnel.text=The specified number of support personnel to generate is over the recommended maximum number of support personnel. Select "Ok" to continue, or "Cancel" to make changes to these Company Generation Options.
+CompanyGenerationOptionsPanel.OverMaximumSupportPersonnel.text=The specified number of support personnel to generate is over the recommended maximum number of support personnel. Select "Yes" to continue, or "No" to make changes to these Company Generation Options.
 CompanyGenerationOptionsPanel.UnderHalfMaximumSupportPersonnel.title=Under Half Maximum Support Personnel
-CompanyGenerationOptionsPanel.UnderHalfMaximumSupportPersonnel.text=The specified number of support personnel to generate is under half the recommended maximum number of support personnel. Select "Ok" to continue, or "Cancel" to make changes to these Company Generation Options.
+CompanyGenerationOptionsPanel.UnderHalfMaximumSupportPersonnel.text=The specified number of support personnel to generate is under half the recommended maximum number of support personnel. Select "Yes" to continue, or "No" to make changes to these Company Generation Options.
 
 #### LayeredForceIconCreationPanel Class
 lblIcon.accessibleName=The current layered force icon


### PR DESCRIPTION
This fixes #3569 