### PR TITLE
Campaign Preset: Prevent Preset From Loading in Older Versions

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignPreset.java
+++ b/MekHQ/src/mekhq/campaign/CampaignPreset.java
@@ -422,6 +422,13 @@ public class CampaignPreset {
     }
 
     public static @Nullable CampaignPreset parseFromXML(final NodeList nl, final Version version) {
+        if (MHQConstants.VERSION.isLowerThan(version)) {
+            LogManager.getLogger().error(String.format(
+                    "Cannot parse Campaign Preset from %s in older version %s.",
+                    version.toString(), MHQConstants.VERSION));
+            return null;
+        }
+
         final CampaignPreset preset = new CampaignPreset();
         try {
             for (int x = 0; x < nl.getLength(); x++) {


### PR DESCRIPTION
This fixes a bug whereby you can open a preset in an older version, which has and will almost certainly cause issues.