### PR TITLE
Campaign Ops Unit Rating: Properly Calculate Admin Personnel Numbers

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1604,13 +1604,9 @@ public class Campaign implements ITechManager {
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getActivePersonnel() {
-        List<Person> activePersonnel = new ArrayList<>();
-        for (Person p : getPersonnel()) {
-            if (p.getStatus().isActive()) {
-                activePersonnel.add(p);
-            }
-        }
-        return activePersonnel;
+        return getPersonnel().stream()
+                .filter(p -> p.getStatus().isActive())
+                .collect(Collectors.toList());
     }
     //endregion Other Personnel Methods
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5369,13 +5369,11 @@ public class Campaign implements ITechManager {
      * @return the number of medics in the campaign including any in the temporary medic pool
      */
     public int getNumberMedics() {
-        int medics = getMedicPool(); // this uses a getter for unit testing
-        for (Person p : getActivePersonnel()) {
-            if ((p.getPrimaryRole().isMedic() || p.getSecondaryRole().isMedic()) && !p.isDeployed()) {
-                medics++;
-            }
-        }
-        return medics;
+        return getMedicPool()
+                + Math.toIntExact(getActivePersonnel().stream()
+                        .filter(p -> (p.getPrimaryRole().isMedic() || p.getSecondaryRole().isMedic())
+                                && !p.isDeployed())
+                        .count());
     }
 
     public boolean requiresAdditionalMedics() {

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -321,16 +321,19 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         technicians = 0;
 
         for (Person p : getCampaign().getActivePersonnel()) {
-            if (p.isAdministrator() || p.isDoctor()) {
+            if (p.isAdministrator() || p.isDoctor() || p.getPrimaryRole().isDependent()
+                    || !p.getPrisonerStatus().isFree()) {
                 continue;
             }
+
             if (p.isTech()) {
                 technicians++;
             }
+
             setNonAdminPersonnelCount(getNonAdminPersonnelCount() + 1);
         }
-        setNonAdminPersonnelCount(getNonAdminPersonnelCount() +
-                                  getCampaign().getAstechPool());
+        setNonAdminPersonnelCount(getNonAdminPersonnelCount() + getCampaign().getAstechPool()
+                + getCampaign().getMedicPool());
     }
 
     private void calcNeededAdmins() {

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -313,9 +313,9 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         setNonAdminPersonnelCount(0);
         technicians = 0;
 
-        // We could all active personnel in the force provided they are not:
+        // We count all active personnel in the force provided they are not:
         // 1) A Dependent
-        // 2) Administrative Personnel: Cannot be an administrator, doctor, or medic
+        // 2) Administrative Personnel: Administrator, doctor, or medic (as per CO (3rd Printing) pg. 21)
         // 3) A Prisoner
         for (Person p : getCampaign().getActivePersonnel()) {
             if (p.getPrimaryRole().isDependent() || p.isAdministrator() || p.isDoctor()

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -20,25 +20,18 @@
  */
 package mekhq.campaign.rating;
 
+import megamek.common.*;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.unit.Unit;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import megamek.common.Crew;
-import megamek.common.Entity;
-import megamek.common.FixedWingSupport;
-import megamek.common.Infantry;
-import megamek.common.Jumpship;
-import megamek.common.SmallCraft;
-import megamek.common.UnitType;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.SkillType;
-import mekhq.campaign.unit.Unit;
-import mekhq.campaign.universe.Faction.Tag;
 
 /**
  * @author Deric Page (deric (dot) page (at) usa.net)
@@ -320,8 +313,13 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         setNonAdminPersonnelCount(0);
         technicians = 0;
 
+        // We could all active personnel in the force provided they are not:
+        // 1) A Dependent
+        // 2) Administrative Personnel: Cannot be an administrator, doctor, or medic
+        // 3) A Prisoner
         for (Person p : getCampaign().getActivePersonnel()) {
-            if (p.isAdministrator() || p.isDoctor() || p.getPrimaryRole().isDependent()
+            if (p.getPrimaryRole().isDependent() || p.isAdministrator() || p.isDoctor()
+                    || p.getPrimaryRole().isMedic() || p.getSecondaryRole().isMedic()
                     || !p.getPrisonerStatus().isFree()) {
                 continue;
             }
@@ -332,19 +330,18 @@ public class CampaignOpsReputation extends AbstractUnitRating {
 
             setNonAdminPersonnelCount(getNonAdminPersonnelCount() + 1);
         }
-        setNonAdminPersonnelCount(getNonAdminPersonnelCount() + getCampaign().getAstechPool()
-                + getCampaign().getMedicPool());
+        setNonAdminPersonnelCount(getNonAdminPersonnelCount() + getCampaign().getAstechPool());
     }
 
     private void calcNeededAdmins() {
         int calculatedAdmin = BigDecimal.valueOf(getNonAdminPersonnelCount())
-                .divide(BigDecimal.TEN, 0,
-                RoundingMode.UP).intValue();
+                .divide(BigDecimal.TEN, 0, RoundingMode.UP)
+                .intValue();
 
-        if (getCampaign().getFaction().is(Tag.MERC) || getCampaign().getFaction().is(Tag.PIRATE)) {
+        if (getCampaign().getFaction().isMercenary() || getCampaign().getFaction().isPirate()) {
             setAdminsNeeded(calculatedAdmin);
         } else {
-            setAdminsNeeded((int) Math.ceil((double) calculatedAdmin / 2));
+            setAdminsNeeded((int) Math.ceil(calculatedAdmin / 2d));
         }
     }
 
@@ -655,14 +652,8 @@ public class CampaignOpsReputation extends AbstractUnitRating {
         return totalValue;
     }
 
-    // Campaign Ops counts both Doctors and Admins as admins.
     private int calcAdminSupportValue() {
-        int admins = getCampaign().getAdmins().size();
-        int docs = getCampaign().getDoctors().size();
-        if (getAdminsNeeded() > (admins + docs)) {
-            return -5;
-        }
-        return 0;
+        return (getAdminsNeeded() > getTotalAdmins()) ? -5 : 0;
     }
 
     private int calcLargeCraftSupportValue() {
@@ -854,8 +845,10 @@ public class CampaignOpsReputation extends AbstractUnitRating {
     }
 
     private int getTotalAdmins() {
-        return getCampaign().getAdmins().size() + getCampaign().getDoctors()
-                                                               .size();
+        // Admins, Doctors, and Medics all fall under the Administrators based on my read of
+        // CO (3rd Printing) pg. 21
+        return getCampaign().getAdmins().size() + getCampaign().getDoctors().size()
+                + getCampaign().getNumberMedics();
     }
 
     @Override


### PR DESCRIPTION
This fixes a few minor issues around calculating the admin personnel requirements for Campaign Operations Unit Rating.