### PR TITLE
Campaign Options: Properly Disable Retirement and Dependent Options On Preset Load

### DIFF
--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -3715,7 +3715,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             if (method == null) {
                 return;
             }
-            final boolean enabled = comboRandomDependentMethod.isEnabled() && !method.isNone();
+            final boolean enabled = !method.isNone();
             chkUseRandomDependentAddition.setEnabled(enabled);
             chkUseRandomDependentRemoval.setEnabled(enabled);
         });
@@ -3727,6 +3727,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkUseRandomDependentRemoval = new JCheckBox(resources.getString("chkUseRandomDependentRemoval.text"));
         chkUseRandomDependentRemoval.setToolTipText(resources.getString("chkUseRandomDependentRemoval.toolTipText"));
         chkUseRandomDependentRemoval.setName("chkUseRandomDependentRemoval");
+
+        // Programmatically Assign Accessibility Labels
+        lblRandomDependentMethod.setLabelFor(comboRandomDependentMethod);
 
         // Layout the Panel
         randomDependentPanel = new JDisableablePanel("randomDependentPanel");
@@ -4855,7 +4858,10 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             }
         });
         comboRandomDeathMethod.addActionListener(evt -> {
-            final RandomDeathMethod method = Objects.requireNonNull(comboRandomDeathMethod.getSelectedItem());
+            final RandomDeathMethod method = comboRandomDeathMethod.getSelectedItem();
+            if (method == null) {
+                return;
+            }
             final boolean enabled = !method.isNone();
             enabledRandomDeathAgeGroupsPanel.setEnabled(enabled);
             chkUseRandomClanPersonnelDeath.setEnabled(enabled);
@@ -4885,6 +4891,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         createExponentialRandomDeathPanel(exponentialRandomDeathPanel);
 
         createAgeRangeRandomDeathPanel(ageRangeRandomDeathPanel);
+
+        // Programmatically Assign Accessibility Labels
+        lblRandomDeathMethod.setLabelFor(comboRandomDeathMethod);
 
         // Layout the Panel
         final JPanel panel = new JPanel();
@@ -5542,7 +5551,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             }
         });
         comboUnitMarketMethod.addActionListener(evt -> {
-            final boolean enabled = !Objects.requireNonNull(comboUnitMarketMethod.getSelectedItem()).isNone();
+            final UnitMarketMethod method = comboUnitMarketMethod.getSelectedItem();
+            if (method == null) {
+                return;
+            }
+            final boolean enabled = !method.isNone();
             chkUnitMarketRegionalMechVariations.setEnabled(enabled);
             chkInstantUnitMarketDelivery.setEnabled(enabled);
             chkUnitMarketReportRefresh.setEnabled(enabled);

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -2585,7 +2585,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             final boolean enabled = chkUseAtB.isSelected();
             enableAtBComponents(panAtB, enabled);
 
-            // This is necessary to prevent issues where disabled options become visibile
+            // This is necessary to prevent issues where disabled options become visible
             if (randomRetirementPanel.isEnabled() != enabled) {
                 randomRetirementPanel.setEnabled(enabled);
                 if (enabled) {

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -3553,7 +3553,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             if (method == null) {
                 return;
             }
-            final boolean enabled = comboRandomRetirementMethod.isEnabled() && !method.isNone();
+            final boolean enabled = !method.isNone();
             chkUseYearEndRandomRetirement.setEnabled(enabled);
             chkUseContractCompletionRandomRetirement.setEnabled(enabled);
             chkUseCustomRetirementModifiers.setEnabled(enabled);
@@ -3580,6 +3580,12 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkTrackUnitFatigue = new JCheckBox(resources.getString("chkTrackUnitFatigue.text"));
         chkTrackUnitFatigue.setToolTipText(resources.getString("chkTrackUnitFatigue.toolTipText"));
         chkTrackUnitFatigue.setName("chkTrackUnitFatigue");
+
+        // Programmatically Assign Accessibility Labels
+        lblRandomRetirementMethod.setLabelFor(comboRandomRetirementMethod);
+
+        // Disable Panel Portions by Default
+//        comboRandomRetirementMethod.setSelectedItem(RandomRetirementMethod.NONE);
 
         // Layout the Panel
         randomRetirementPanel = new JDisableablePanel("randomRetirementPanel");

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -2584,8 +2584,21 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkUseAtB.addActionListener(evt -> {
             final boolean enabled = chkUseAtB.isSelected();
             enableAtBComponents(panAtB, enabled);
-            randomRetirementPanel.setEnabled(enabled);
-            randomDependentPanel.setEnabled(enabled);
+
+            // This is necessary to prevent issues where disabled options become visibile
+            if (randomRetirementPanel.isEnabled() != enabled) {
+                randomRetirementPanel.setEnabled(enabled);
+                if (enabled) {
+                    comboRandomRetirementMethod.setSelectedItem(comboRandomRetirementMethod.getSelectedItem());
+                }
+            }
+
+            if (randomDependentPanel.isEnabled() != enabled) {
+                randomDependentPanel.setEnabled(enabled);
+                if (enabled) {
+                    comboRandomDependentMethod.setSelectedItem(comboRandomDependentMethod.getSelectedItem());
+                }
+            }
         });
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -3553,7 +3566,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             if (method == null) {
                 return;
             }
-            final boolean enabled = !method.isNone();
+            final boolean enabled = randomRetirementPanel.isEnabled() && !method.isNone();
             chkUseYearEndRandomRetirement.setEnabled(enabled);
             chkUseContractCompletionRandomRetirement.setEnabled(enabled);
             chkUseCustomRetirementModifiers.setEnabled(enabled);
@@ -3583,9 +3596,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         // Programmatically Assign Accessibility Labels
         lblRandomRetirementMethod.setLabelFor(comboRandomRetirementMethod);
-
-        // Disable Panel Portions by Default
-//        comboRandomRetirementMethod.setSelectedItem(RandomRetirementMethod.NONE);
 
         // Layout the Panel
         randomRetirementPanel = new JDisableablePanel("randomRetirementPanel");
@@ -3715,7 +3725,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             if (method == null) {
                 return;
             }
-            final boolean enabled = !method.isNone();
+            final boolean enabled = randomDependentPanel.isEnabled() && !method.isNone();
             chkUseRandomDependentAddition.setEnabled(enabled);
             chkUseRandomDependentRemoval.setEnabled(enabled);
         });


### PR DESCRIPTION
While working on this I found a few missing accessibility labels and updated some old hard fail action listeners to the silent fail method.