### PR TITLE
Adds two new "v2" Princess presets for new Aggression value

### DIFF
--- a/MekHQ/mmconf/princessBehaviors.xml
+++ b/MekHQ/mmconf/princessBehaviors.xml
@@ -27,6 +27,19 @@
     <strategicTargets/>
   </behavior>
   <behavior>
+    <name>BERSERK v2 ANGRY HORDE</name>
+    <homeEdge>0</homeEdge>
+    <forcedWithdrawal>false</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>2</fallShameIndex>
+    <hyperAggressionIndex>10</hyperAggressionIndex>
+    <selfPreservationIndex>2</selfPreservationIndex>
+    <herdMentalityIndex>8</herdMentalityIndex>
+    <braveryIndex>9</braveryIndex>
+    <strategicTargets/>
+  </behavior>
+  <behavior>
     <name>ESCAPE</name>
     <homeEdge>0</homeEdge>
     <forcedWithdrawal>true</forcedWithdrawal>
@@ -50,6 +63,19 @@
     <selfPreservationIndex>5</selfPreservationIndex>
     <herdMentalityIndex>5</herdMentalityIndex>
     <braveryIndex>5</braveryIndex>
+    <strategicTargets/>
+  </behavior>
+  <behavior>
+    <name>DEFAULT v2 BRAVER</name>
+    <homeEdge>0</homeEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>5</hyperAggressionIndex>
+    <selfPreservationIndex>2</selfPreservationIndex>
+    <herdMentalityIndex>5</herdMentalityIndex>
+    <braveryIndex>9</braveryIndex>
     <strategicTargets/>
   </behavior>
 </princessBehaviors>


### PR DESCRIPTION
These new presets should take advantage of the change to the highest new Aggression value.  I have tested them in about 50+ bot v bot games and 2 me v bot games and they work.  These are additional presets.  They do not replace or change existing presets.

Because of the increased aggression on Berserker - the default BERSERK setting is foaming at the mouth damn the torpedos aggressive.  This is desireable in some situations.  But they will charge in depending on speed alone and faster mechs sometimes get meat-grindered.

BERSERK v2 ANGRY HORDE - adds Herding 8 to Berserker.  Just as aggressive as above, but will at least attempt to maintain a formation and stay together.  In tests this is the most dangerous bot setting I have found.  It beats all other presets I have tested.  It is still beatable by the player, but she will get in range and cause more damage.  In most situations, I would reccomend this over the default Berserk setting, now.  If the community decides this setting is just flat better than default Berserk, we might just replace normal Berserk with this, and remove the v2 option, just to avoid confusion.

DEFAULT v2 BRAVER - keeps default aggression, but makes Princess slightly less cautious.  She will attempt to attack and kill solo and injured mechs a bit more, and wont get run over as much as regular DEFAULT.  

I have attached a screen summarizing the testing leading to these two new presets.  

![Screenshot 2023-03-29 232355](https://user-images.githubusercontent.com/23645569/228729150-387b6cba-3afd-4c8d-92f2-cf73083b8e4a.png)

