### PR TITLE
Enable weather restrictions/temperature passing to megamek

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -158,6 +158,7 @@ public class AtBGameThread extends GameThread {
                 planetaryConditions.setFog(scenario.getFog());
                 planetaryConditions.setAtmosphere(scenario.getAtmosphere());
                 planetaryConditions.setGravity(scenario.getGravity());
+                planetaryConditions.setTemperature(scenario.getTemperature());
                 client.sendPlanetaryConditions(planetaryConditions);
                 Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -123,13 +123,13 @@ public class AtBDynamicScenarioFactory {
             setLightConditions(scenario);
         }
 
+        if (campaign.getCampaignOptions().isUsePlanetaryConditions() && planetsideScenario) {
+            setPlanetaryConditions(scenario, contract, campaign);
+        }
+
         // set weather conditions if the user wants to play with them and is on a ground map
         if (campaign.getCampaignOptions().isUseWeatherConditions() && planetsideScenario) {
             setWeather(scenario);
-        }
-
-        if (campaign.getCampaignOptions().isUsePlanetaryConditions() && planetsideScenario) {
-            setPlanetaryConditions(scenario, contract, campaign);
         }
 
         setTerrain(scenario);
@@ -790,9 +790,17 @@ public class AtBDynamicScenarioFactory {
             }
         }
 
-        scenario.setWeather(weather);
-        scenario.setWind(wind);
-        scenario.setFog(fog);
+        if (!WeatherRestriction.IsWeatherRestricted(weather, scenario.getAtmosphere(), scenario.getTemperature())) {
+            scenario.setWeather(weather);
+        }
+
+        if (!WeatherRestriction.IsWindRestricted(wind, scenario.getAtmosphere(), scenario.getTemperature())) {
+            scenario.setWind(wind);
+        }
+
+        if (!WeatherRestriction.IsFogRestricted(fog, scenario.getAtmosphere(), scenario.getTemperature())) {
+            scenario.setFog(fog);
+        }
     }
 
     /**
@@ -845,9 +853,11 @@ public class AtBDynamicScenarioFactory {
             if (null != p) {
                 int atmosphere = ObjectUtility.nonNull(p.getPressure(campaign.getLocalDate()), scenario.getAtmosphere());
                 float gravity = ObjectUtility.nonNull(p.getGravity(), scenario.getGravity()).floatValue();
+                int temperature = ObjectUtility.nonNull(p.getTemperature(campaign.getLocalDate()), scenario.getTemperature());
 
                 scenario.setAtmosphere(atmosphere);
                 scenario.setGravity(gravity);
+                scenario.setTemperature(temperature);
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -79,6 +79,10 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
     private JLabel lblWindDesc = new JLabel();
     private JLabel lblFog = new JLabel();
     private JLabel lblFogDesc = new JLabel();
+
+    private JLabel lblTemp = new JLabel();
+
+    private JLabel lblTempDesc = new JLabel();
     private JLabel lblAtmosphere = new JLabel();
     private JLabel lblAtmosphereDesc = new JLabel();
     private JLabel lblGravity = new JLabel();
@@ -174,7 +178,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
     }
 
     private void fillStats() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AtBScenarioViewPanel",
+        ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ScenarioViewPanel",
                 MekHQ.getMHQOptions().getLocale());
         lblStatus = new JLabel();
 
@@ -591,6 +595,19 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
         panStats.add(lblFogDesc, gridBagConstraints);
         lblFog.setVisible(campaign.getCampaignOptions().isUseWeatherConditions());
         lblFogDesc.setVisible(campaign.getCampaignOptions().isUseWeatherConditions());
+
+        lblTemp.setText(resourceMap.getString("lblTemperature.text"));
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.gridwidth = 1;
+        panStats.add(lblTemp, gridBagConstraints);
+
+        lblTempDesc.setText(PlanetaryConditions.getTemperatureDisplayableName(scenario.getTemperature()));
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = y++;
+        panStats.add(lblTempDesc, gridBagConstraints);
+        lblTemp.setVisible(campaign.getCampaignOptions().isUsePlanetaryConditions());
+        lblTempDesc.setVisible(campaign.getCampaignOptions().isUsePlanetaryConditions());
 
         lblGravity.setText(resourceMap.getString("lblGravity.text"));
         gridBagConstraints.gridx = 0;


### PR DESCRIPTION
Addresses #2455 by using the companion MegaMek pull request's weather restriction mechanism to filter out invalid weather/atmo/temperature combinations.

Also displays and passes the scenario temperature (currently pegged to the planetary temperature) to megamek when planetary conditions are enabled.