### PR TITLE
FedCom Civil War - Flashpoints and Wave One Planetary Control + Possible Fix to Faction Hints

### DIFF
--- a/MekHQ/data/universe/factionhints.xml
+++ b/MekHQ/data/universe/factionhints.xml
@@ -456,6 +456,7 @@ they shouldn't be fighting DC and Stone's Coalition, so I make them neutral for 
 		<parties>CJF,CSV</parties>
 	</war>
 	<war name="FedCom Civil War" start="3062-12-08" end="3067-04-20">
+		<parties>LA,FC</parties>
 		<parties>LA,FS</parties>
 		<parties>FS,DC</parties>
 	</war>

--- a/MekHQ/data/universe/factionhints.xml
+++ b/MekHQ/data/universe/factionhints.xml
@@ -455,7 +455,7 @@ they shouldn't be fighting DC and Stone's Coalition, so I make them neutral for 
 	<war name="Falcon-Viper War" start="3061-04-01" end="3061-07-04">
 		<parties>CJF,CSV</parties>
 	</war>
-	<war name="FedCom Civil War" start="3062-12-08" end="3067-04-20">
+	<war name="FedCom Civil War" start="3062-11-16" end="3067-04-20">
 		<parties>LA,FC</parties>
 		<parties>LA,FS</parties>
 		<parties>FS,DC</parties>


### PR DESCRIPTION
This PR is to introduce and get early peer review on my suggestions for FedCom Civil War planetary control tracking, for the period from 16th November 3062 to August 3063.

All data has been drawn from the old Classic Battletech sourcebook on the FCCW. I've tested that planets flip manually by clicking through dates in MekHQ.

I have changed the start date of the civil war to 16th November 3062 to line up with the flashpoint on Kathil.

The fix to add FC to the factionhints.xml file for the war is a _possible_ fix for MHQ not generating contracts between the Lyrans and FedCom after the war starts. Much more testing and experimentation is needed with this. 

The next thing I want to do, apart from Wave Two of the FCCW, is to look into where the LA and FC are defined as friends. I can't see any reference to them being allies in the factionhints file. 