### PR TITLE
Campaign Options Cleanup

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -12,18 +12,111 @@ CampaignOptionsDialog.title=Campaign Options
 
 ## General Tab
 generalPanel.title=General
+unitRatingMethodLabel.text=Unit Rating Method:
+manualUnitRatingModifierLabel.text=Manual Unit Rating Modifier
+lblName.text=Name:
+lblDate.text=Date:
+lblFaction.text=Faction:
+lblFactionNames.text=Faction:
+lblGender.text=Percent Female:
+lblCamo.text=Camo:
+lblIcon.text=Unit Icon:
 ##end General Tab
 
 ## Repair and Maintenance Tab
 repairAndMaintenancePanel.title=Repair and Maintenance
+lblSubRepair.text=Repair
+lblSubMaintenance.text=Maintenance
+checkMaintenance.text=Make maintenance checks
+checkMaintenance.toolTipText=If checked, each unit will make a parts-specific maintenance check at the end of each maintenance cycle
+lblMaintenanceDays.text=Maintenance cycle length in days
+lblMaintenanceBonus.text=Maintenance modifier
+spnMaintenanceBonus.toolTipText=When checking by parts, Strat Ops applies a -1 bonus to the maintenance check target - you can change this modifier with this value
+useQualityMaintenance.text=Use quality modifiers in maintenance checks
+useQualityMaintenance.toolTipText=If checked, quality modifiers will be added to maintenance checks (WARNING: this will lead to unstable quality ratings over time)
+reverseQualityNames.text=Reverse quality names
+reverseQualityNames.toolTipText=If checked, quality name reporting will be reversed so that A is the best and F is the worst
+useUnofficialMaintenance.text=Only damage parts that are already at worst quality (Unofficial)
+useUnofficialMaintenance.toolTipText=<html>When this option is checked and you are using quality maintenance, <br>the margin of failure rolls for damaging parts only happen for parts that are already rated at the lowest level.</html>
+logMaintenance.text=Log maintenance rolls in log file
+logMaintenance.toolTipText=If checked, details of each maintenance check will be added to mekhq.log
+useEraModsCheckBox.text=Use era mods for repair rolls
+useEraModsCheckBox.toolTipText=Use faction-specific era mods for repair rolls
+assignedTechFirstCheckBox.text=Place tech assigned to unit at the top of the list for repairs
+assignedTechFirstCheckBox.toolTipText=In the repair bay, if the unit has an assigned technician, that technician is placed at the top of the list of available technicians.
+resetToFirstTechCheckBox.text=After repair reset to the technician at the top of the list
+resetToFirstTechCheckBox.toolTipText=<html>After any repair/salvage task, always selects the technician at the top of the list <br>(Can be combined with option to place tech assigned to unit at top of list)</html>
+useDamageMargin.text=Damage/destroy parts by margin of failure
+useDamageMargin.toolTipText=Instead of destroying/damaging parts only by elite techs, parts are damaged/destroyed when the tech roll fails by a given margin.
+lblDamageMargin.text=Margin:
+useAeroSystemHits.text=(Proposed Errata) Damage/destroy Aero system parts by number of hits taken
+useAeroSystemHits.toolTipText=Changes repair/replacement time and difficulty of Aero large and small craft systems (Avionics, FCS, etc)
+useQuirksBox.text=Use Quirk
+useQuirksBox.toolTipText=Allow units to have StratOps quirks
+lblDestroyPartTarget.text=Equipment hit in combat survives on a roll of
+lblDestroyPartTargetSuffix.text=or better
 ##end Repair and Maintenance Tab
 
 ## Supplies and Acquisition Tab
 suppliesAndAcquisitionsPanel.title=Supplies and Acquisition
+lblSubAcquire.text=Acquisition
+lblSubDelivery.text=Delivery
+lblSubPlanetAcquire.text=Planetary Acquisition
+lblAcquireSkill.text=Acquisition Skill:
+lblSupportStaffOnly.text=Only support personnel can make acquisition checks
+lblWaitingPeriod.text=Waiting period (in days) between acquisition rolls
+spnMaxAcquisitions.toolTipText=This number is the maximum number of acquisitions an administrator can attempt each day. Setting this to 0 makes it unlimited.
+lblMaxAcquisitions.text=Max Daily Acquisitions Per Admin (0 for unlimited)
+lblAcquireClanPenalty.text=Penalty for Clan equipment
+lblAcquireIsPenalty.text=Penalty for Inner Sphere equipment
+lblTransitTime.text=Delivery Time:
+lblMinTransit.text=Minimum Transit Time:
+lblMosBonus.text=Reduce delivery time by
+lblMosBonusSuffix.text=per margin of success
+usePlanetaryAcquisitions.text=Use Planet-based Acquisition System (overrides default delivery times)
+usePlanetaryAcquisitions.toolTipText=<html>Supplies will be searched for on specific planets up to a certain jump radius away, starting on current planet. <br>To find a given part, an availability roll must first succeed to identify a contact and then parts may be rolled for until a failure. <br> Planetary socio-industrial ratings can affect the target roll. <br> All delivery times are based on the number of recharges necessary (7 days), the in-system transit time at both points, and 1d6 extra days per jump.</html>
+usePlanetaryAcquisitionsVerbose.text=Verbose Planetary Acquisitions Reporting
+usePlanetaryAcquisitionsVerbose.toolTipText=<html>This shows all the details of the planetary searches in the daily log. <br>This is usually TMI, but is good for testing and for understanding how it works. <br>Warning: This option can lead to a huge daily report, which may create a saved campaign file that requires more than the default amount of RAM assigned to MHQ to load, or just takes a significant amount of time to do so.</html>
+lblMaxJumpPlanetaryAcquisitions.text=Maximum number of jumps away to search for supplies
+lblPlanetaryAcquisitionsFactionLimits.text=Faction supply limitations
+disallowPlanetaryAcquisitionClanCrossover.text=No Clan/Inner Sphere supply sharing
+disallowPlanetaryAcquisitionClanCrossover.toolTipText=If checked, Inner Sphere factions will not be able to find supplies on Clan-controlled worlds, and vice versa.
+disallowClanPartsFromIS.text=Disallow acquiring clan parts from non-Clan factions
+disallowClanPartsFromIS.toolTipText=If checked, you will not be able to purchase clan parts from non-Clan factions. The modifier below will be ignored.
+spnPenaltyClanPartsFromIS.text=Penalty for acquiring clan parts from non-Clan factions
+spnPenaltyClanPartsFromIS.toolTipText=<html>The penalty for acquiring clan parts from non-Clan factions when not disallowed entirely. <br>This penalty is cumulative with the general penalty for clan parts.</html>
+lblTechBonus.text=<html><b>Tech<b></html>
+lblIndustryBonus.text=<html><b>Industry<b></html>
+lblOutputBonus.text=<html><b>Output<b></html>
+lblSocioIndustrialBonusPanel.text=Planet socio-industrial modifiers 
 ##end Supplies and Acquisition Tab
 
 ## Tech Limits Tab
 techLimitsPanel.title=Tech Limits
+limitByYearBox.text=Limit Units and Parts by Year
+limitByYearBox.toolTipText=Units and parts will be limited by the current year of the campaign
+disallowExtinctStuffBox.text=Disallow extinct units and parts
+disallowExtinctStuffBox.toolTipText=Normally extinct parts can still be found with a penalty. This option will disallow them completely.
+allowClanPurchasesBox.text=Allow the purchasing of Clan units and parts
+allowClanPurchasesBox.toolTipText=If unchecked, clan units and parts will not be available for purchase
+allowISPurchasesBox.text=Allow the purchasing of Inner Sphere units and parts
+allowISPurchasesBox.toolTipText=If unchecked, inner sphere units and parts will not be available for purchase
+allowCanonOnlyBox.text=Only allow canon units for purchase
+allowCanonOnlyBox.toolTipText=Just what it says
+allowCanonRefitOnlyBox.text=Only allow canon variants as refits
+allowCanonRefitOnlyBox.toolTipText=Just what it says
+variableTechLevelBox.text=Variable tech level
+variableTechLevelBox.toolTipText=<html>If checked, the tech level for a part or unit will change depending on whether it is in <br>prototype stage (experimental), production (advanced), or common (standard).</html>
+factionIntroDateBox.text=Use faction intro dates
+factionIntroDateBox.toolTipText=<html>If checked, the campaign faction will be used to determine a part's intro date in cases where it differs. <br>If using variable tech levels, the faction is also used to determine the tech level of a part or unit.</html>
+useAmmoByTypeBox.text=Use ammo by type (Unofficial)
+useAmmoByTypeBox.toolTipText=LRM, SRM, MRM, and MML launchers can mix ammo among sizes. For example, an LRM-10 can use LRM-20 ammo.
+lblSkillTarget.text=Target Number:
+lblSkillGreen.text=Green Level:
+lblSkillRegular.text=Regular Level:
+lblSkillVeteran.text=Veteran Level:
+lblSkillElite.text=Elite Level:
+lblTechLevel.text=Maximum Tech Level:
 ##end Tech Limits Tab
 
 ## Personnel Tab
@@ -288,6 +381,42 @@ lblAgeRange.text=Age Range
 
 ## Finances Tab
 financesPanel.title=Finances
+payForPartsBox.text=Pay For Parts
+payForPartsBox.toolTipText=Pay the C-Bill cost of any replacement parts
+payForRepairsBox.text=Pay For Repairs
+payForRepairsBox.toolTipText=<html>CamOps p46: Repairs cost 20% of a parts list price. This is for equipment repairs only and does not count armor repairs. <br>This is reimbursed by Battle Loss Compensation.</html>
+payForUnitsBox.text=Pay For New Units
+payForUnitsBox.toolTipText=Pay the C-Bill cost for any new units (Meks, vees, etc.)
+payForSalariesBox.text=Pay for personnel salaries
+payForSalariesBox.toolTipText=Pay the monthly salaries of all personnel
+payForRecruitmentBox.text=Pay for personnel recruitment
+payForRecruitmentBox.toolTipText=Pay two months salary to recruit personnel (FMMr)
+useLoanLimitsBox.text=Limit loan parameters by unit rating
+useLoanLimitsBox.toolTipText=Put limits on interest, collateral, and length as per IntOps Beta
+payForOverheadBox.text=Pay for overhead expenses
+payForOverheadBox.toolTipText=Pay overhead expenses as per FM: Mercs Revised (5% of monthly personnel salaries)
+payForMaintainBox.text=Pay for unit maintenance
+payForMaintainBox.toolTipText=Pay weekly unit maintenance costs as per FM: Mercs Revised
+payForTransportBox.text=Pay for Transportation
+payForTransportBox.toolTipText=Pay for excess transportation needs (costs are a total hack at the moment, FYI)
+usePeacetimeCostBox.text=Use Campaign Operations Peacetime Operating Costs
+usePeacetimeCostBox.toolTipText=Includes salaries, spare parts, fuel, and peacetime ammo consumption. 75% added to base contract amount when using CamOps rating.
+useExtendedPartsModifierBox.text=Use the expanded spare parts modifiers (CO pg. 14).
+showPeacetimeCostBox.text=Breakdown peacetime costs to core costs.
+showPeacetimeCostBox.toolTipText=Displays a breakdown of peacetime costs in the daily log.
+financialYearDuration.text=Financial Year Duration
+financialYearDuration.toolTipText=This changes the Financial Year, which is when the finances table resets. Any settings longer than biennially are not recommended.
+newFinancialYearFinancesToCSVExportBox.text=Finance Table CSV Export on New Financial Year
+newFinancialYearFinancesToCSVExportBox.toolTipText=This writes the finances table to a CSV file on the first day of a new financial year, right before the table is carried over to the next year.
+sellUnitsBox.text=Allow selling of units
+sellUnitsBox.toolTipText=Units can be sold for C-bills
+sellPartsBox.text=Allow selling of parts
+sellPartsBox.toolTipText=Parts can be sold for C-bills
+usePercentageMaintBox.text=Use percentage based maintenance costs (Unofficial)
+usePercentageMaintBox.toolTipText=Maintenance costs based upon value of the unit instead of the type of unit. This actually makes maintenance costs important.
+infantryDontCount.text=Infantry Don't Count for Contract Pay
+infantryDontCount.toolTipText=When this option is ticked, infantry will not count for contract pay
+
 
 # Price Multipliers
 priceMultipliersPanel.title=Price Multipliers
@@ -315,6 +444,32 @@ lblCancelledOrderRefundMultiplier.toolTipText=The decimal percentage of the orig
 
 ## Mercenary Tab
 mercenaryPanel.title=Mercenary
+lblEquipPercent.text=Combat Percent:
+chkEquipContractSaleValue.text=Base on equipment sale value
+lblDropShipPercent.text=DropShip Percent:
+lblJumpShipPercent.text=JumpShip Percent:
+lblWarShipPercent.text=WarShip Percent:
+panMercenary.IntOpsPayment.title=Base contract payment on percentage of TO&E unit value (Campaign Operations)
+panMercenary.IntOpsPayment.tooltip=Base contract payment on percentage of TO&E unit value (Campaign Operations)
+panMercenary.FMMRPayment.title=Base contract payment on personnel payroll (FM:Mr)
+panMercenary.FMMRPayment.tooltip=Base contract payment on personnel payroll (FM:Mr)
+lblBLCSaleValue.text=Base battle loss compensation on equipment sale value
+chkOverageRepaymentInFinalPayment.text=Repay Salvage Overages in Final Payment (Unofficial)
+chkOverageRepaymentInFinalPayment.toolTipText=This is an unofficial addition that has you repay any overages from your salvage percent as part of the final payment, which may take that into a debit.
+lblScenarioXP.text=XP for each completed scenario
+lblKillXP.text=XP for every
+lblXPForEvery.text=XP for every
+lblKills.text=kills
+lblTasks.text=successful tasks
+lblSuccessXP.text=XP for each 12 rolled on a successful task
+lblMistakeXP.text=XP for each 2 rolled on an unsuccessful task
+lblTargetIdleXP.text=active month(s) on a 2d6 roll of greater than or equal to
+lblContractNegotiationXP.text=XP awarded to the selected negotiator for a new contract
+lblAdminWeeklyXP.text=XP awarded to each administrator every Monday for the work of the previous
+lblAdminWeeklyXPPeriod.text=week(s)
+lblEdgeCost.text=XP Cost for 1 Edge Point
+txtInstructionsXP.title=Customizing Skill Costs
+txtInstructionsXP.text=You can adjust the numbers in the table below to customize the XP costs for each skill at each level. \nThe given level listed on the row is the level being purchased, so the numbers in the +2 column are the costs of moving from level 1 to level 2. \nTo determine the BattleTech target number for each skill level, subtract the given level from each skill's target number, given in the Skills tab. \nEnter a -1 for skill levels that should be unattainable, and zero for skill levels that should be skipped.
 ##end Mercenary Tab
 
 ## Experience Tab
@@ -331,6 +486,33 @@ specialAbilitiesPanel.title=SPAs
 
 ## Skill Randomization Tab
 skillRandomizationPanel.title=Skill Randomization
+lblOverallRecruitBonus.text=Overall Recruitment Bonus
+panTypeRecruitBonus.title=Personnel Type Recruitment Bonus
+chkExtraRandom.text=Extra Randomness
+chkExtraRandom.toolTipText=If checked, an additional 1d6 will be rolled. On a 1, the skill will be lowered, and on a 6 the skill will be raised.
+lblProbAntiMek.text=Probability of anti-mek skill for conventional infantry
+spnOverallRecruitBonus.toolTipText=Add this number to the roll for primary skill levels
+spnArtyProb.toolTipText=Probability that MechWarriors, vehicle crews, and infantry have artillery skill. Only applies if separate artillery skill is in use.
+spnSecondProb.toolTipText=Probability that person will have a randomly chosen secondary skill.
+spnTacticsGreen.toolTipText=Modifier for tactics skill for person with green primary skills. Only applies if tactics skill is in use.
+spnTacticsReg.toolTipText=Modifier for tactics skill for person with regular primary skills. Only applies if tactics skill is in use.
+spnTacticsVet.toolTipText=Modifier for tactics skill for person with veteran primary skills. Only applies if tactics skill is in use.
+spnTacticsElite.toolTipText=Modifier for tactics skill for person with elite primary skills. Only applies if tactics skill is in use.
+spnCombatSA.toolTipText=Modifier for Small Arms skill for all non-infantry combat personnel.
+spnSupportSA.toolTipText=Modifier for Small Arms skill for all support personnel.
+spnAbilGreen.toolTipText=Modifier for the number of special abilities for person with green primary skills. Only applies if special abilities in use.
+spnAbilReg.toolTipText=Modifier for the number of special abilities for person with green primary skills. Only applies if special abilities in use.
+spnAbilVet.toolTipText=Modifier for the number of special abilities for person with green primary skills. Only applies if special abilities in use.
+spnAbilElite.toolTipText=Modifier for the number of special abilities for person with green primary skills. Only applies if special abilities in use.
+lblUltraGreen.toolTipText=Ultra-Green for primary skills and no skill for other skills.
+lblPhenotypesPanel.text=Trueborn Phenotype Probabilities
+lblArtillerySkill.text=Artillery Skill
+lblSecondarySkills.text=Secondary Skills
+lblTacticsSkill.text=Tactics Skill
+lblSupportPersonnel.text=Support Personnel
+lblCombatPersonnel.text=Combat Personnel
+lblSmallArmsSkill.text=Small Arms Skill
+lblSpecialAbilities.text=Special Abilities
 ##end Skill Randomization Tab
 
 ## Rank Systems Tab
@@ -339,6 +521,14 @@ rankSystemsPanel.title=Rank Systems
 
 ## Name and Portrait Generation Tab
 nameAndPortraitGenerationPanel.title=Name and Portrait Generation
+chkUseOriginFactionForNames.text=Use origin faction for assigned names
+chkUseOriginFactionForNames.toolTipText=The random name generator uses the person's origin faction to assign their name.
+chkAssignPortraitOnRoleChange.text=Automatically assign portrait on role change
+chkAssignPortraitOnRoleChange.toolTipText=With this enabled, a person without a portrait will automatically gain a random portrait when their primary role is switched to one of those selected below
+panUsePortrait.all.text=All Roles
+panUsePortrait.no.text=No Roles
+txtPortraitInst.text=Checked personnel types will have a random portrait selected for them upon creation. \nThis setup is explained in the guide located at /docs/Windchilds Guides/Windchilds_Guide_to_MekHQ_Portrait_Generation.txt.
+panRandomPortrait.title=Portrait Generation
 ##end Name and Portrait Generation Tab
 
 ## Markets Tab
@@ -402,162 +592,9 @@ chkIgnoreRATEra.toolTipText=If none of the chosen collections has an appropriate
 
 ## Against the Bot Tab
 againstTheBotPanel.title=Against the Bot
-##end Against the Bot Tab
-
-## Button Panel
-btnOkay.text=Confirm
-btnSavePreset.text=Confirm and Save as Preset
-btnSavePreset.toolTipText=Confirm the changes in the dialog and save it as a Campaign Preset.
-btnLoadPreset.text=Load a Preset
-btnLoadPreset.toolTipText=Load a Campaign Preset and apply it to the current dialog. If it is during startup, it will apply all values outside of starting planet, contract count, and game options. Otherwise, it will only apply continuous preset values outside of game options.
-##end Button Panel
-
-## Option Validation Warnings
-CampaignOptionsPane.EmptyCampaignName.text=You cannot have an empty campaign name.
-CampaignOptionsPane.NullFactionSelected.text=You cannot have an empty campaign name.
-CampaignOptionsPane.FactionWithoutFactionCodeSelected.text=You cannot select a faction named %s, as it is missing its faction code.
-
-## Unsorted Properties
-lblName.text=Name:
-lblDate.text=Date:
-lblFaction.text=Faction:
-lblFactionNames.text=Faction:
-lblGender.text=Percent Female:
-lblCamo.text=Camo:
-lblIcon.text=Unit Icon:
-panMercenary.IntOpsPayment.title=Base contract payment on percentage of TO&E unit value (Campaign Operations)
-panMercenary.IntOpsPayment.tooltip=Base contract payment on percentage of TO&E unit value (Campaign Operations)
-panMercenary.FMMRPayment.title=Base contract payment on personnel payroll (FM:Mr)
-panMercenary.FMMRPayment.tooltip=Base contract payment on personnel payroll (FM:Mr)
-useEraModsCheckBox.text=Use era mods for repair rolls
-useEraModsCheckBox.toolTipText=Use faction-specific era mods for repair rolls
-assignedTechFirstCheckBox.text=Place tech assigned to unit at the top of the list for repairs
-assignedTechFirstCheckBox.toolTipText=In the repair bay, if the unit has an assigned technician, that technician is placed at the top of the list of available technicians.
-resetToFirstTechCheckBox.text=After repair reset to the technician at the top of the list
-resetToFirstTechCheckBox.toolTipText=<html>After any repair/salvage task, always selects the technician at the top of the list <br>(Can be combined with option to place tech assigned to unit at top of list)</html>
-useDamageMargin.text=Damage/destroy parts by margin of failure
-useDamageMargin.toolTipText=Instead of destroying/damaging parts only by elite techs, parts are damaged/destroyed when the tech roll fails by a given margin.
-useAeroSystemHits.text=(Proposed Errata) Damage/destroy Aero system parts by number of hits taken
-useAeroSystemHits.toolTipText=Changes repair/replacement time and difficulty of Aero large and small craft systems (Avionics, FCS, etc)
-checkMaintenance.text=Make maintenance checks
-checkMaintenance.toolTipText=If checked, each unit will make a parts-specific maintenance check at the end of each maintenance cycle
-useQualityMaintenance.text=Use quality modifiers in maintenance checks
-useQualityMaintenance.toolTipText=If checked, quality modifiers will be added to maintenance checks (WARNING: this will lead to unstable quality ratings over time)
-reverseQualityNames.text=Reverse quality names
-reverseQualityNames.toolTipText=If checked, quality name reporting will be reversed so that A is the best and F is the worst
-useUnofficialMaintenance.text=Only damage parts that are already at worst quality (Unofficial)
-useUnofficialMaintenance.toolTipText=<html>When this option is checked and you are using quality maintenance, <br>the MOF rolls for damaging parts only happen for parts that are already rated at the lowest level.</html>
-logMaintenance.text=Log maintenance rolls in log file
-logMaintenance.toolTipText=If checked, details of each maintenance check will be added to mekhq.log
-spnMaintenanceBonus.toolTipText=When checking by parts, Strat Ops applies a -1 bonus to the maintenance check target - you can change this modifier with this value
-lblMaxJumpPlanetaryAcquisitions.text=Maximum number of jumps away to search for supplies
-lblPlanetaryAcquisitionsFactionLimits.text=Faction supply limitations
-disallowPlanetaryAcquisitionClanCrossover.text=No Clan/Inner Sphere supply sharing
-disallowPlanetaryAcquisitionClanCrossover.toolTipText=If checked, Inner Sphere factions will not be able to find supplies on Clan-controlled worlds, and vice versa.
-unitRatingMethodLabel.text=Unit Rating Method:
-manualUnitRatingModifierLabel.text=Manual Unit Rating Modifier
-usePlanetaryAcquisitions.text=Use Planet-based Acquisition System (overrides default delivery times)
-usePlanetaryAcquisitions.toolTipText=<html>Supplies will be searched for on specific planets up to a certain jump radius away, starting on current planet. <br>To find a given part, an availability roll must first succeed to identify a contact and then parts may be rolled for until a failure. <br> Planetary socio-industrial ratings can affect the target roll. <br> All delivery times are based on the number of recharges necessary (7 days), the in-system transit time at both points, and 1d6 extra days per jump.</html>
-usePlanetaryAcquisitionsVerbose.text=Verbose Planetary Acquisitions Reporting
-usePlanetaryAcquisitionsVerbose.toolTipText=<html>This shows all the details of the planetary searches in the daily log. <br>This is usually TMI, but is good for testing and for understanding how it works. <br>Warning: This option can lead to a huge daily report, which may create a saved campaign file that requires more than the default amount of RAM assigned to MHQ to load, or just takes a significant amount of time to do so.</html>
-chkUseOriginFactionForNames.text=Use origin faction for assigned names
-chkUseOriginFactionForNames.toolTipText=The random name generator uses the person's origin faction to assign their name.
-useQuirksBox.text=Use Quirk
-useQuirksBox.toolTipText=Allow units to have StratOps quirks
-payForPartsBox.text=Pay For Parts
-payForPartsBox.toolTipText=Pay the C-Bill cost of any replacement parts
-payForRepairsBox.text=Pay For Repairs
-payForRepairsBox.toolTipText=<html>CamOps p46: Repairs cost 20% of a parts list price. This is for equipment repairs only and does not count armor repairs. <br>This is reimbursed by Battle Loss Compensation.</html>
-payForUnitsBox.text=Pay For New Units
-payForUnitsBox.toolTipText=Pay the C-Bill cost for any new units (Meks, vees, etc.)
-payForSalariesBox.text=Pay for personnel salaries
-payForSalariesBox.toolTipText=Pay the monthly salaries of all personnel
-payForRecruitmentBox.text=Pay for personnel recruitment
-payForRecruitmentBox.toolTipText=Pay two months salary to recruit personnel (FMMr)
-useLoanLimitsBox.text=Limit loan parameters by unit rating
-useLoanLimitsBox.toolTipText=Put limits on interest, collateral, and length as per IntOps Beta
-payForOverheadBox.text=Pay for overhead expenses
-payForOverheadBox.toolTipText=Pay overhead expenses as per FM: Mercs Revised (5% of monthly personnel salaries)
-payForMaintainBox.text=Pay for unit maintenance
-payForMaintainBox.toolTipText=Pay weekly unit maintenance costs as per FM: Mercs Revised
-payForTransportBox.text=Pay for Transportation
-payForTransportBox.toolTipText=Pay for excess transportation needs (costs are a total hack at the moment, FYI)
-usePeacetimeCostBox.text=Use Campaign Operations Peacetime Operating Costs
-usePeacetimeCostBox.toolTipText=Includes salaries, spare parts, fuel, and peacetime ammo consumption. 75% added to base contract amount when using CamOps rating.
-useExtendedPartsModifierBox.text=Use the expanded spare parts modifiers (CO pg. 14).
-showPeacetimeCostBox.text=Breakdown peacetime costs to core costs.
-showPeacetimeCostBox.toolTipText=Displays a breakdown of peacetime costs in the daily log.
-financialYearDuration.text=Financial Year Duration
-financialYearDuration.toolTipText=This changes the Financial Year, which is when the finances table resets. Any settings longer than biennially are not recommended.
-newFinancialYearFinancesToCSVExportBox.text=Finance Table CSV Export on New Financial Year
-newFinancialYearFinancesToCSVExportBox.toolTipText=This writes the finances table to a CSV file on the first day of a new financial year, right before the table is carried over to the next year.
-sellUnitsBox.text=Allow selling of units
-sellUnitsBox.toolTipText=Units can be sold for C-bills
-sellPartsBox.text=Allow selling of parts
-sellPartsBox.toolTipText=Parts can be sold for C-bills
-limitByYearBox.text=Limit Units and Parts by Year
-limitByYearBox.toolTipText=Units and parts will be limited by the current year of the campaign
-disallowExtinctStuffBox.text=Disallow extinct units and parts
-disallowExtinctStuffBox.toolTipText=Normally extinct parts can still be found with a penalty. This option will disallow them completely.
-allowClanPurchasesBox.text=Allow the purchasing of Clan units and parts
-allowClanPurchasesBox.toolTipText=If unchecked, clan units and parts will not be available for purchase
-allowISPurchasesBox.text=Allow the purchasing of Inner Sphere units and parts
-allowISPurchasesBox.toolTipText=If unchecked, inner sphere units and parts will not be available for purchase
-allowCanonOnlyBox.text=Only allow canon units for purchase
-allowCanonOnlyBox.toolTipText=Just what it says
-allowCanonRefitOnlyBox.text=Only allow canon variants as refits
-allowCanonRefitOnlyBox.toolTipText=Just what it says
-disallowClanPartsFromIS.text=Disallow acquiring clan parts from non-Clan factions
-disallowClanPartsFromIS.toolTipText=If checked, you will not be able to purchase clan parts from non-Clan factions. The modifier below will be ignored.
-spnPenaltyClanPartsFromIS.text=Penalty for acquiring clan parts from non-Clan factions
-spnPenaltyClanPartsFromIS.toolTipText=<html>The penalty for acquiring clan parts from non-Clan factions when not disallowed entirely. <br>This penalty is cumulative with the general penalty for clan parts.</html>
-variableTechLevelBox.text=Variable tech level
-variableTechLevelBox.toolTipText=<html>If checked, the tech level for a part or unit will change depending on whether it is in <br>prototype stage (experimental), production (advanced), or common (standard).</html>
-factionIntroDateBox.text=Use faction intro dates
-factionIntroDateBox.toolTipText=<html>If checked, the campaign faction will be used to determine a part's intro date in cases where it differs. <br>If using variable tech levels, the faction is also used to determine the tech level of a part or unit.</html>
-useAmmoByTypeBox.text=Use ammo by type (Unofficial)
-useAmmoByTypeBox.toolTipText=LRM, SRM, MRM, and MML launchers can mix ammo among sizes. For example, an LRM-10 can use LRM-20 ammo.
-txtInstructionsXP.title=Customizing Skill Costs
-txtInstructionsXP.text=You can adjust the numbers in the table below to customize the XP costs for each skill at each level. \nThe given level listed on the row is the level being purchased, so the numbers in the +2 column are the costs of moving from level 1 to level 2. \nTo determine the BattleTech target number for each skill level, subtract the given level from each skill's target number, given in the Skills tab. \nEnter a -1 for skill levels that should be unattainable, and zero for skill levels that should be skipped.
-lblScenarioXP.text=XP for each completed scenario
-lblSuccessXP.text=XP for each 12 rolled on a successful task
-lblMistakeXP.text=XP for each 2 rolled on an unsuccessful task
-lblKillXP.text=XP for every
-lblKills.text=kills
-lblTasks.text=successful tasks
-lblSkillTarget.text=Target Number:
-lblSkillGreen.text=Green Level:
-lblSkillRegular.text=Regular Level:
-lblSkillVeteran.text=Veteran Level:
-lblSkillElite.text=Elite Level:
-lblTechLevel.text=Maximum Tech Level:
-lblOverallRecruitBonus.text=Overall Recruitment Bonus
-panTypeRecruitBonus.title=Personnel Type Recruitment Bonus
-panUsePortrait.all.text=All Roles
-panUsePortrait.no.text=No Roles
-txtPortraitInst.text=Checked personnel types will have a random portrait selected for them upon creation. \nThis setup is explained in the guide located at /docs/Windchilds Guides/Windchilds_Guide_to_MekHQ_Portrait_Generation.txt.
-panRandomPortrait.title=Portrait Generation
-chkExtraRandom.text=Extra Randomness
-chkExtraRandom.toolTipText=If checked, an additional 1d6 will be rolled. On a 1, the skill will be lowered, and on a 6 the skill will be raised.
-lblProbAntiMek.text=Probability of anti-mek skill for conventional infantry
-spnOverallRecruitBonus.toolTipText=Add this number to the roll for primary skill levels
-spnArtyProb.toolTipText=Probability that MechWarriors, vehicle crews, and infantry have artillery skill. Only applies if separate artillery skill is in use.
-spnSecondProb.toolTipText=Probability that person will have a randomly chosen secondary skill.
-spnTacticsGreen.toolTipText=Modifier for tactics skill for person with green primary skills. Only applies if tactics skill is in use.
-spnTacticsReg.toolTipText=Modifier for tactics skill for person with regular primary skills. Only applies if tactics skill is in use.
-spnTacticsVet.toolTipText=Modifier for tactics skill for person with veteran primary skills. Only applies if tactics skill is in use.
-spnTacticsElite.toolTipText=Modifier for tactics skill for person with elite primary skills. Only applies if tactics skill is in use.
-spnCombatSA.toolTipText=Modifier for Small Arms skill for all non-infantry combat personnel.
-spnSupportSA.toolTipText=Modifier for Small Arms skill for all support personnel.
-spnAbilGreen.toolTipText=Modifier for the number of special abilities for person with green primary skills. Only applies if special abilities in use.
-spnAbilReg.toolTipText=Modifier for the number of special abilities for person with green primary skills. Only applies if special abilities in use.
-spnAbilVet.toolTipText=Modifier for the number of special abilities for person with green primary skills. Only applies if special abilities in use.
-spnAbilElite.toolTipText=Modifier for the number of special abilities for person with green primary skills. Only applies if special abilities in use.
-lblUltraGreen.toolTipText=Ultra-Green for primary skills and no skill for other skills.
-usePercentageMaintBox.text=Use percentage based maintenance costs (Unofficial)
-usePercentageMaintBox.toolTipText=Maintenance costs based upon value of the unit instead of the type of unit. This actually makes maintenance costs important.
-infantryDontCount.text=Infantry Don't Count for Contract Pay
-infantryDontCount.toolTipText=When this option is ticked, infantry will not count for contract pay
+lblSubAtbAdmin.text=Unit Administration
+lblSubAtBContract.text=Contract Operations
+lblSubAtBScenario.text=Scenarios
 chkUseAtB.text=Use Against the Bot campaign rules
 chkUseAtB.toolTipText=Against the Bot is a set of campaign rules developed by users of the BattleTech forums.
 chkUseStratCon.text=Use StratCon campaign rules
@@ -570,8 +607,6 @@ chkSharesExcludeLargeCraft.text=Exclude large craft from share value
 chkSharesExcludeLargeCraft.toolTipText=When calculating payout to retirees, exclude DropShips and JumpShips from net worth when calculating share value.
 chkSharesForAll.text=All personnel have shares
 chkSharesForAll.toolTipText=All combat and support personnel have shares rather than just MechWarriors
-chkOverageRepaymentInFinalPayment.text=Repay Salvage Overages in Final Payment (Unofficial)
-chkOverageRepaymentInFinalPayment.toolTipText=This is an unofficial addition that has you repay any overages from your salvage percent as part of the final payment, which may take that into a debit.
 chkTrackOriginalUnit.text=Track original unit
 chkTrackOriginalUnit.toolTipText=MechWarriors who have their own unit when recruited will take the same unit when they go, if it is still available.
 chkUseLeadership.text=Use leadership skill
@@ -636,11 +671,23 @@ chkUseLightConditions.text=Use light conditions
 chkUseLightConditions.toolTipText=Determine light conditions when generating a scenario.
 chkUsePlanetaryConditions.text=Use planetary conditions
 chkUsePlanetaryConditions.toolTipText=Set gravity and atmosphere based on the contract location.
-chkAeroRecruitsHaveUnits.text=Treat Aerospace pilots like MechWarriors
-chkAeroRecruitsHaveUnits.toolTipText=Aerospace pilot recruits can have fighters, and those that do will take a fighter with them when retiring/defecting.
-chkAssignPortraitOnRoleChange.text=Automatically assign portrait on role change
-chkAssignPortraitOnRoleChange.toolTipText=With this enabled, a person without a portrait will automatically gain a random portrait when their primary role is switched to one of those selected below
 lblFixedMapChance.text=Fixed Map Chance
 lblFixedMapChance.toolTipText=The likelihood, in percent, that a fixed user-made map will be used in place of a generated map.
 lblSPAUpgradeIntensity.text=SPA Upgrade Intensity
 lblSPAUpgradeIntensity.toolTipText=How likely it is that regular+ OpFor pilots will receive SPAs. -1 indicates never, 3 indicates always.
+chkAeroRecruitsHaveUnits.text=Treat Aerospace pilots like MechWarriors
+chkAeroRecruitsHaveUnits.toolTipText=Aerospace pilot recruits can have fighters, and those that do will take a fighter with them when retiring/defecting.
+##end Against the Bot Tab
+
+## Button Panel
+btnOkay.text=Confirm
+btnSavePreset.text=Confirm and Save as Preset
+btnSavePreset.toolTipText=Confirm the changes in the dialog and save it as a Campaign Preset.
+btnLoadPreset.text=Load a Preset
+btnLoadPreset.toolTipText=Load a Campaign Preset and apply it to the current dialog. If it is during startup, it will apply all values outside of starting planet, contract count, and game options. Otherwise, it will only apply continuous preset values outside of game options.
+##end Button Panel
+
+## Option Validation Warnings
+CampaignOptionsPane.EmptyCampaignName.text=You cannot have an empty campaign name.
+CampaignOptionsPane.NullFactionSelected.text=You cannot have an empty campaign name.
+CampaignOptionsPane.FactionWithoutFactionCodeSelected.text=You cannot select a faction named %s, as it is missing its faction code.

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -1050,10 +1050,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         spnMaxAcquisitions = new JSpinner(new SpinnerNumberModel(0, 0, 100, 1));
         spnMaxAcquisitions.setName("spnMaxAcquisitions");
+        spnMaxAcquisitions.setToolTipText("This number is the maximum number of acquisitions an administrator can attempt each day. Setting this to 0 makes it unlimited.");
 
         JPanel pnlMaxAcquisitions = new JPanel();
         pnlMaxAcquisitions.add(spnMaxAcquisitions);
-        pnlMaxAcquisitions.add(new JLabel("Maximum Acquisitions Per Day (0 for unlimited)"));
+        pnlMaxAcquisitions.add(new JLabel("Max Daily Acquisitions Per Admin (0 for unlimited)"));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -703,8 +703,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         JPanel panSubRepair = new JPanel(new GridBagLayout());
         JPanel panSubMaintenance = new JPanel(new GridBagLayout());
 
-        panSubRepair.setBorder(BorderFactory.createTitledBorder("Repair"));
-        panSubMaintenance.setBorder(BorderFactory.createTitledBorder("Maintenance"));
+        panSubRepair.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSubRepair.text")));
+        panSubMaintenance.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSubMaintenance.text")));
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -796,7 +796,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnDamageMargin = new JSpinner(new SpinnerNumberModel(1, 1, 20, 1));
         ((DefaultEditor) spnDamageMargin.getEditor()).getTextField().setEditable(false);
         JPanel pnlDamageMargin = new JPanel();
-        pnlDamageMargin.add(new JLabel("Margin:"));
+        pnlDamageMargin.add(new JLabel(resources.getString("lblDamageMargin.text")));
         pnlDamageMargin.add(spnDamageMargin);
 
         gridBagConstraints = new GridBagConstraints();
@@ -812,9 +812,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         ((DefaultEditor) spnDestroyPartTarget.getEditor()).getTextField().setEditable(false);
 
         JPanel pnlDestroyPartTarget = new JPanel();
-        pnlDestroyPartTarget.add(new JLabel("Equipment hit in combat survives on a roll of"));
+        pnlDestroyPartTarget.add(new JLabel(resources.getString("lblDestroyPartTarget.text")));
         pnlDestroyPartTarget.add(spnDestroyPartTarget);
-        pnlDestroyPartTarget.add(new JLabel("or better"));
+        pnlDestroyPartTarget.add(new JLabel(resources.getString("lblDestroyPartTargetSuffix.text")));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -858,7 +858,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         ((DefaultEditor) spnMaintenanceDays.getEditor()).getTextField().setEditable(false);
         JPanel pnlMaintenanceDays = new JPanel();
         pnlMaintenanceDays.add(spnMaintenanceDays);
-        pnlMaintenanceDays.add(new JLabel("Maintenance cycle length in days"));
+        pnlMaintenanceDays.add(new JLabel(resources.getString("lblMaintenanceDays.text")));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
@@ -874,7 +874,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         JPanel pnlMaintenanceBonus = new JPanel();
         pnlMaintenanceBonus.add(spnMaintenanceBonus);
-        pnlMaintenanceBonus.add(new JLabel("Maintenance modifier"));
+        pnlMaintenanceBonus.add(new JLabel(resources.getString("lblMaintenanceBonus.text")));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -937,9 +937,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         JPanel panSubDelivery = new JPanel(new GridBagLayout());
         JPanel panSubPlanetAcquire = new JPanel(new GridBagLayout());
 
-        panSubAcquire.setBorder(BorderFactory.createTitledBorder("Acquisition"));
-        panSubDelivery.setBorder(BorderFactory.createTitledBorder("Delivery"));
-        panSubPlanetAcquire.setBorder(BorderFactory.createTitledBorder("Planetary Acquisition"));
+        panSubAcquire.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSubAcquire.text")));
+        panSubDelivery.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSubDelivery.text")));
+        panSubPlanetAcquire.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSubPlanetAcquire.text")));
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -970,7 +970,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         JPanel pnlWaitingPeriod = new JPanel();
         pnlWaitingPeriod.add(spnAcquireWaitingPeriod);
-        pnlWaitingPeriod.add(new JLabel("Waiting period (in days) between acquisition rolls"));
+        pnlWaitingPeriod.add(new JLabel(resources.getString("lblWaitingPeriod.text")));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -987,7 +987,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
-        panSubAcquire.add(new JLabel("Acquisition Skill:"), gridBagConstraints);
+        panSubAcquire.add(new JLabel(resources.getString("lblAcquireSkill.text")), gridBagConstraints);
 
         DefaultComboBoxModel<String> acquireSkillModel = new DefaultComboBoxModel<>();
         acquireSkillModel.addElement(CampaignOptions.S_TECH);
@@ -1003,7 +1003,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         panSubAcquire.add(choiceAcquireSkill, gridBagConstraints);
 
-        chkSupportStaffOnly = new JCheckBox("Only support personnel can make acquisition checks");
+        chkSupportStaffOnly = new JCheckBox(resources.getString("lblSupportStaffOnly.text"));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 3;
@@ -1019,7 +1019,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         JPanel pnlClanPenalty = new JPanel();
         pnlClanPenalty.add(spnAcquireClanPenalty);
-        pnlClanPenalty.add(new JLabel("Penalty for Clan equipment"));
+        pnlClanPenalty.add(new JLabel(resources.getString("lblAcquireClanPenalty.text")));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -1036,7 +1036,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         JPanel pnlIsPenalty = new JPanel();
         pnlIsPenalty.add(spnAcquireIsPenalty);
-        pnlIsPenalty.add(new JLabel("Penalty for Inner Sphere equipment"));
+        pnlIsPenalty.add(new JLabel(resources.getString("lblAcquireIsPenalty.text")));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -1050,11 +1050,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         spnMaxAcquisitions = new JSpinner(new SpinnerNumberModel(0, 0, 100, 1));
         spnMaxAcquisitions.setName("spnMaxAcquisitions");
-        spnMaxAcquisitions.setToolTipText("This number is the maximum number of acquisitions an administrator can attempt each day. Setting this to 0 makes it unlimited.");
+        spnMaxAcquisitions.setToolTipText(resources.getString("spnMaxAcquisitions.toolTipText"));
 
         JPanel pnlMaxAcquisitions = new JPanel();
         pnlMaxAcquisitions.add(spnMaxAcquisitions);
-        pnlMaxAcquisitions.add(new JLabel("Max Daily Acquisitions Per Admin (0 for unlimited)"));
+        pnlMaxAcquisitions.add(new JLabel(resources.getString("lblMaxAcquisitions.text")));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -1097,7 +1097,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         choiceAcquireMinimumUnit = new MMComboBox<>("choiceAcquireMinimumUnit", transitMinUnitModel);
 
         JPanel pnlTransitTime = new JPanel();
-        pnlTransitTime.add(new JLabel("Delivery Time:"));
+        pnlTransitTime.add(new JLabel(resources.getString("lblTransitTime.text")));
         pnlTransitTime.add(spnNDiceTransitTime);
         pnlTransitTime.add(new JLabel("d6 + "));
         pnlTransitTime.add(spnConstantTransitTime);
@@ -1113,7 +1113,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         panSubDelivery.add(pnlTransitTime, gridBagConstraints);
 
         JPanel pnlMinTransit = new JPanel();
-        pnlMinTransit.add(new JLabel("Minimum Transit Time:"));
+        pnlMinTransit.add(new JLabel(resources.getString("lblMinTransit.text")));
         pnlMinTransit.add(spnAcquireMinimum);
         pnlMinTransit.add(choiceAcquireMinimumUnit);
 
@@ -1127,10 +1127,10 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         panSubDelivery.add(pnlMinTransit, gridBagConstraints);
 
         JPanel pnlMosBonus = new JPanel();
-        pnlMosBonus.add(new JLabel("Reduce delivery time by"));
+        pnlMosBonus.add(new JLabel(resources.getString("lblMosBonus.text")));
         pnlMosBonus.add(spnAcquireMosBonus);
         pnlMosBonus.add(choiceAcquireMosUnits);
-        pnlMosBonus.add(new JLabel("per MoS"));
+        pnlMosBonus.add(new JLabel(resources.getString("lblMosBonusSuffix.text")));
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -1228,7 +1228,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         JPanel panSocioIndustrialBonus = new JPanel();
         panSocioIndustrialBonus.setLayout(new BoxLayout(panSocioIndustrialBonus, BoxLayout.LINE_AXIS));
-        panSocioIndustrialBonus.setBorder(BorderFactory.createTitledBorder("Planet socio-industrial modifiers "));
+        panSocioIndustrialBonus.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSocioIndustrialBonusPanel.text")));
 
         JPanel panTechBonus = new JPanel(new GridBagLayout());
         JPanel panIndustryBonus = new JPanel(new GridBagLayout());
@@ -1242,9 +1242,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.gridy = 0;
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridwidth = 2;
-        panTechBonus.add(new JLabel("<html><b>Tech<b></html>"), gridBagConstraints);
-        panIndustryBonus.add(new JLabel("<html><b>Industry<b></html>"), gridBagConstraints);
-        panOutputBonus.add(new JLabel("<html><b>Output<b></html>"), gridBagConstraints);
+        panTechBonus.add(new JLabel(resources.getString("lblTechBonus.text")), gridBagConstraints);
+        panIndustryBonus.add(new JLabel(resources.getString("lblIndustryBonus.text")), gridBagConstraints);
+        panOutputBonus.add(new JLabel(resources.getString("lblOutputBonus.text")), gridBagConstraints);
         for (int i = EquipmentType.RATING_A; i <= EquipmentType.RATING_F; i++) {
             gridBagConstraints.gridwidth = 1;
             gridBagConstraints.gridy++;
@@ -1648,7 +1648,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.insets = new Insets(5, 30, 5, 5);
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        panMercenary.add(new JLabel("Combat Percent:"), gridBagConstraints);
+        panMercenary.add(new JLabel(resources.getString("lblEquipPercent.text")), gridBagConstraints);
 
         spnEquipPercent = new JSpinner(new SpinnerNumberModel(0.1, 0.1, CampaignOptions.MAXIMUM_COMBAT_EQUIPMENT_PERCENT, 0.1));
         spnEquipPercent.setEditor(new NumberEditor(spnEquipPercent, "0.0"));
@@ -1660,7 +1660,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         panMercenary.add(spnEquipPercent, gridBagConstraints);
 
-        chkEquipContractSaleValue = new JCheckBox("Base on equipment sale value");
+        chkEquipContractSaleValue = new JCheckBox(resources.getString("chkEquipContractSaleValue.text"));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 1;
@@ -1674,7 +1674,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.insets = new Insets(5, 30, 5, 5);
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        panMercenary.add(new JLabel("DropShip Percent:"), gridBagConstraints);
+        panMercenary.add(new JLabel(resources.getString("lblDropShipPercent.text")), gridBagConstraints);
 
         spnDropShipPercent = new JSpinner(new SpinnerNumberModel(0.1, 0.0, CampaignOptions.MAXIMUM_DROPSHIP_EQUIPMENT_PERCENT, 0.1));
         spnDropShipPercent.setEditor(new NumberEditor(spnDropShipPercent, "0.0"));
@@ -1692,7 +1692,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.insets = new Insets(5, 30, 5, 5);
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        panMercenary.add(new JLabel("JumpShip Percent:"), gridBagConstraints);
+        panMercenary.add(new JLabel(resources.getString("lblJumpShipPercent.text")), gridBagConstraints);
 
         spnJumpShipPercent = new JSpinner(new SpinnerNumberModel(0.1, 0.0, CampaignOptions.MAXIMUM_JUMPSHIP_EQUIPMENT_PERCENT, 0.1));
         spnJumpShipPercent.setEditor(new NumberEditor(spnJumpShipPercent, "0.0"));
@@ -1710,7 +1710,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.insets = new Insets(5, 30, 5, 5);
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        panMercenary.add(new JLabel("WarShip Percent:"), gridBagConstraints);
+        panMercenary.add(new JLabel(resources.getString("lblWarShipPercent.text")), gridBagConstraints);
 
         spnWarShipPercent = new JSpinner(new SpinnerNumberModel(0.1, 0.0, CampaignOptions.MAXIMUM_WARSHIP_EQUIPMENT_PERCENT, 0.1));
         spnWarShipPercent.setEditor(new NumberEditor(spnWarShipPercent, "0.0"));
@@ -1732,7 +1732,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         panMercenary.add(btnContractPersonnel, gridBagConstraints);
 
-        chkBLCSaleValue = new JCheckBox("Base battle loss compensation on equipment sale value");
+        chkBLCSaleValue = new JCheckBox(resources.getString("lblBLCSaleValue.text"));
         gridBagConstraints.gridy = 6;
         panMercenary.add(chkBLCSaleValue, gridBagConstraints);
 
@@ -1772,7 +1772,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         panXP.add(lblScenarioXP, gridBagConstraints);
 
-        JLabel lblKillXP = new JLabel(resources.getString("lblKillXP.text"));
+        JLabel lblKillXP = new JLabel(resources.getString("lblXPForEvery.text"));
         spnKillXP = new JSpinner(new SpinnerNumberModel(0, 0, 10000, 1));
         ((DefaultEditor) spnKillXP.getEditor()).getTextField().setEditable(false);
         gridBagConstraints = new GridBagConstraints();
@@ -1810,7 +1810,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         panXP.add(lblKills, gridBagConstraints);
 
-        JLabel lblTaskXP = new JLabel(resources.getString("lblKillXP.text"));
+        JLabel lblTaskXP = new JLabel(resources.getString("lblXPForEvery.text"));
         spnTaskXP = new JSpinner(new SpinnerNumberModel(0, 0, 10000, 1));
         ((DefaultEditor) spnTaskXP.getEditor()).getTextField().setEditable(false);
         gridBagConstraints = new GridBagConstraints();
@@ -1905,7 +1905,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
-        panXP.add(new JLabel("XP for every"), gridBagConstraints);
+        panXP.add(new JLabel(resources.getString("lblXPForEvery.text")), gridBagConstraints);
 
         spnMonthsIdleXP = new JSpinner(new SpinnerNumberModel(0, 0, 36, 1));
         ((DefaultEditor) spnMonthsIdleXP.getEditor()).getTextField().setEditable(false);
@@ -1922,7 +1922,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
-        panXP.add(new JLabel("active month(s) on a 2d6 roll of greater than or equal to"), gridBagConstraints);
+        panXP.add(new JLabel(resources.getString("lblTargetIdleXP.text")), gridBagConstraints);
 
         spnTargetIdleXP = new JSpinner(new SpinnerNumberModel(2, 2, 13, 1));
         ((DefaultEditor) spnTargetIdleXP.getEditor()).getTextField().setEditable(false);
@@ -1949,7 +1949,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
-        panXP.add(new JLabel("XP awarded to the selected negotiator for a new contract"), gridBagConstraints);
+        panXP.add(new JLabel(resources.getString("lblContractNegotiationXP.text")), gridBagConstraints);
 
         spnAdminWeeklyXP = new JSpinner(new SpinnerNumberModel(0, 0, 10000, 1));
         ((DefaultEditor) spnAdminWeeklyXP.getEditor()).getTextField().setEditable(false);
@@ -1966,7 +1966,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
-        panXP.add(new JLabel("XP awarded to each administrator every Monday for the work of the previous"), gridBagConstraints);
+        panXP.add(new JLabel(resources.getString("lblAdminWeeklyXP.text")), gridBagConstraints);
 
         spnAdminWeeklyXPPeriod = new JSpinner(new SpinnerNumberModel(1, 1, 100, 1));
         ((DefaultEditor) spnAdminWeeklyXPPeriod.getEditor()).getTextField().setEditable(false);
@@ -1983,7 +1983,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
-        panXP.add(new JLabel("week(s)"), gridBagConstraints);
+        panXP.add(new JLabel(resources.getString("lblAdminWeeklyXPPeriod.text")), gridBagConstraints);
 
         spnEdgeCost = new JSpinner(new SpinnerNumberModel(0, 0, 10000, 1));
         ((DefaultEditor) spnEdgeCost.getEditor()).getTextField().setEditable(false);
@@ -2000,7 +2000,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
-        panXP.add(new JLabel("XP Cost for 1 Edge Point"), gridBagConstraints);
+        panXP.add(new JLabel(resources.getString("lblEdgeCost.text")), gridBagConstraints);
 
         final JTextArea txtInstructionsXP = new JTextArea(resources.getString("txtInstructionsXP.text"));
         txtInstructionsXP.setName("txtInstructions");
@@ -2246,7 +2246,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         phenotypeSpinners = new JSpinner[phenotypes.size()];
 
         JPanel phenotypesPanel = new JPanel(new GridLayout((int) Math.ceil(phenotypes.size() / 2.0), 2));
-        phenotypesPanel.setBorder(BorderFactory.createTitledBorder("Trueborn Phenotype Probabilities"));
+        phenotypesPanel.setBorder(BorderFactory.createTitledBorder(resources.getString("lblPhenotypesPanel.text")));
 
         for (int i = 0; i < phenotypes.size(); i++) {
             JSpinner phenotypeSpinner = new JSpinner(new SpinnerNumberModel(0, 0, 100, 1));
@@ -2321,7 +2321,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         JPanel panArtillery = new JPanel();
         panArtillery.setBorder(BorderFactory.createCompoundBorder(
-                BorderFactory.createTitledBorder("Artillery Skill"),
+                BorderFactory.createTitledBorder(resources.getString("lblArtillerySkill.text")),
                 BorderFactory.createEmptyBorder(5, 5, 5, 5)));
         spnArtyProb = new JSpinner(new SpinnerNumberModel(0, 0, 100, 5));
         ((DefaultEditor) spnArtyProb.getEditor()).getTextField().setEditable(false);
@@ -2343,7 +2343,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         panSecondary.add(spnSecondBonus);
         panSecondary.add(new JLabel("Bonus"));
         panSecondary.setBorder(BorderFactory.createCompoundBorder(
-                BorderFactory.createTitledBorder("Secondary Skills"),
+                BorderFactory.createTitledBorder(resources.getString("lblSecondarySkills.text")),
                 BorderFactory.createEmptyBorder(5, 5, 5, 5)));
         JPanel panTactics = new JPanel();
         spnTacticsGreen = new JSpinner(new SpinnerNumberModel(0, -10, 10, 1));
@@ -2367,7 +2367,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         panTactics.add(spnTacticsElite);
         panTactics.add(new JLabel("Elite"));
         panTactics.setBorder(BorderFactory.createCompoundBorder(
-                BorderFactory.createTitledBorder("Tactics Skill"),
+                BorderFactory.createTitledBorder(resources.getString("lblTacticsSkill.text")),
                 BorderFactory.createEmptyBorder(5, 5, 5, 5)));
         JPanel panSmallArms = new JPanel();
         spnCombatSA = new JSpinner(new SpinnerNumberModel(0, -10, 10, 1));
@@ -2377,11 +2377,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         ((DefaultEditor) spnSupportSA.getEditor()).getTextField().setEditable(false);
         spnSupportSA.setToolTipText(resources.getString("spnSupportSA.toolTipText"));
         panSmallArms.add(spnCombatSA);
-        panSmallArms.add(new JLabel("Combat Personnel"));
+        panSmallArms.add(new JLabel(resources.getString("lblCombatPersonnel.text")));
         panSmallArms.add(spnSupportSA);
-        panSmallArms.add(new JLabel("Support Personnel"));
+        panSmallArms.add(new JLabel(resources.getString("lblSupportPersonnel.text")));
         panSmallArms.setBorder(BorderFactory.createCompoundBorder(
-                BorderFactory.createTitledBorder("Small Arms Skill"),
+                BorderFactory.createTitledBorder(resources.getString("lblSmallArmsSkill.text")),
                 BorderFactory.createEmptyBorder(5, 5, 5, 5)));
         JPanel panAbilities = new JPanel();
         spnAbilGreen = new JSpinner(new SpinnerNumberModel(0, -10, 10, 1));
@@ -2405,7 +2405,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         panAbilities.add(spnAbilElite);
         panAbilities.add(new JLabel("Elite"));
         panAbilities.setBorder(BorderFactory.createCompoundBorder(
-                BorderFactory.createTitledBorder("Special Abilities"),
+                BorderFactory.createTitledBorder(resources.getString("lblSpecialAbilities.text")),
                 BorderFactory.createEmptyBorder(5, 5, 5, 5)));
 
         JPanel panOtherBonuses = new JPanel(new GridLayout(3, 2));
@@ -2576,9 +2576,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         JPanel panSubAtBAdmin = new JPanel(new GridBagLayout());
         JPanel panSubAtBContract = new JPanel(new GridBagLayout());
         JPanel panSubAtBScenario = new JPanel(new GridBagLayout());
-        panSubAtBAdmin.setBorder(BorderFactory.createTitledBorder("Unit Administration"));
-        panSubAtBContract.setBorder(BorderFactory.createTitledBorder("Contract Operations"));
-        panSubAtBScenario.setBorder(BorderFactory.createTitledBorder("Scenarios"));
+        panSubAtBAdmin.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSubAtbAdmin.text")));
+        panSubAtBContract.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSubAtBContract.text")));
+        panSubAtBScenario.setBorder(BorderFactory.createTitledBorder(resources.getString("lblSubAtBScenario.text")));
 
         chkUseAtB = new JCheckBox(resources.getString("chkUseAtB.text"));
         chkUseAtB.setToolTipText(resources.getString("chkUseAtB.toolTipText"));
@@ -3146,7 +3146,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         chkUseExtendedTOEForceName = new JCheckBox(resources.getString("chkUseExtendedTOEForceName.text"));
         chkUseExtendedTOEForceName.setToolTipText(resources.getString("chkUseExtendedTOEForceName.toolTipText"));
-        chkUseExtendedTOEForceName.setName("chkUseExtendedTOEForceName ");
+        chkUseExtendedTOEForceName.setName("chkUseExtendedTOEForceName");
 
         chkPersonnelLogSkillGain = new JCheckBox(resources.getString("chkPersonnelLogSkillGain.text"));
         chkPersonnelLogSkillGain.setToolTipText(resources.getString("chkPersonnelLogSkillGain.toolTipText"));

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -968,23 +968,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnAcquireWaitingPeriod = new JSpinner(new SpinnerNumberModel(1, 1, 365, 1));
         ((DefaultEditor) spnAcquireWaitingPeriod.getEditor()).getTextField().setEditable(false);
 
-        JPanel pnlWaitingPeriod = new JPanel();
-        pnlWaitingPeriod.add(spnAcquireWaitingPeriod);
-        pnlWaitingPeriod.add(new JLabel(resources.getString("lblWaitingPeriod.text")));
-
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
-        gridBagConstraints.weightx = 0.0;
-        gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.gridwidth = 2;
-        gridBagConstraints.fill = GridBagConstraints.NONE;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        panSubAcquire.add(pnlWaitingPeriod, gridBagConstraints);
-
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         panSubAcquire.add(new JLabel(resources.getString("lblAcquireSkill.text")), gridBagConstraints);
@@ -998,7 +984,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         choiceAcquireSkill = new MMComboBox<>("choiceAcquireSkill", acquireSkillModel);
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridy = 1;
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         panSubAcquire.add(choiceAcquireSkill, gridBagConstraints);
@@ -1006,7 +992,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkSupportStaffOnly = new JCheckBox(resources.getString("lblSupportStaffOnly.text"));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridy = 2;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.weightx = 0.0;
@@ -1023,7 +1009,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 4;
+        gridBagConstraints.gridy = 3;
         gridBagConstraints.weightx = 0.0;
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.gridwidth = 2;
@@ -1040,7 +1026,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 5;
+        gridBagConstraints.gridy = 4;
         gridBagConstraints.weightx = 0.0;
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.gridwidth = 2;
@@ -1048,6 +1034,20 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         panSubAcquire.add(pnlIsPenalty, gridBagConstraints);
 
+        JPanel pnlWaitingPeriod = new JPanel();
+        pnlWaitingPeriod.add(spnAcquireWaitingPeriod);
+        pnlWaitingPeriod.add(new JLabel(resources.getString("lblWaitingPeriod.text")));
+
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.weightx = 0.0;
+        gridBagConstraints.weighty = 0.0;
+        gridBagConstraints.gridwidth = 5;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+
+        panSubAcquire.add(pnlWaitingPeriod, gridBagConstraints);
         spnMaxAcquisitions = new JSpinner(new SpinnerNumberModel(0, 0, 100, 1));
         spnMaxAcquisitions.setName("spnMaxAcquisitions");
         spnMaxAcquisitions.setToolTipText(resources.getString("spnMaxAcquisitions.toolTipText"));


### PR DESCRIPTION
I started this with just the goal of updating the label for Max Acquisitions (Issue #3502) and adding a tooltip for it. I did that in the first commit.

I then decided to migrate most of the strings from the code to the properties file.

Lastly I reorganized the options in the Acquisition section to have a more logical flow.

Original:
<img width="541" alt="image" src="https://user-images.githubusercontent.com/20034315/236357382-aaeecf0c-b93f-44c2-b90a-00ed7292e565.png">

Updated:
<img width="533" alt="image" src="https://user-images.githubusercontent.com/20034315/236357293-dc9792ae-8d6a-4783-93e1-69a27ab153f1.png">


Feel free to suggest any changes or drop any commits.
