### PR TITLE
Update refit classes based on CamOps

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -548,38 +548,26 @@ public class Refit extends Part implements IAcquisitionWork {
             /*CHECK REFIT CLASS*/
             // See Campaign Operations, page 211 as of third printing
             if (nPart instanceof MissingEnginePart) {
-                if (oldUnit.getEntity().getEngine().getRating() != newUnit.getEntity().getEngine().getRating()) {
-                    updateRefitClass(CLASS_D);
-                }
-                if (newUnit.getEntity().getEngine().getEngineType() != oldUnit.getEntity().getEngine().getEngineType()) {
-                    updateRefitClass(CLASS_F);
+                if (oldUnit.getEntity().getEngine().getRating() != newUnit.getEntity().getEngine().getRating() || newUnit.getEntity().getEngine().getEngineType() != oldUnit.getEntity().getEngine().getEngineType()) {
+                    updateRefitClass(customJob ? CLASS_E : CLASS_D);
                 }
                 if (((MissingEnginePart) nPart).getEngine().getSideTorsoCriticalSlots().length > 0) {
                     locationHasNewStuff[Mech.LOC_LT] = true;
                     locationHasNewStuff[Mech.LOC_RT] = true;
                 }
             } else if (nPart instanceof MissingMekGyro) {
-                updateRefitClass(CLASS_F);
+                updateRefitClass(CLASS_D);
             } else if (nPart instanceof MissingMekLocation) {
                 replacingLocations = true;
-                if (((Mech) newUnit.getEntity()).hasTSM(true) != ((Mech) oldUnit.getEntity()).hasTSM(true)) {
-                    updateRefitClass(CLASS_E);
-                } else {
-                    updateRefitClass(CLASS_F);
-                }
+
+                // If a location is being replaced, the internal structure or myomer must have been changed.
+                updateRefitClass(CLASS_F);
             } else if (nPart instanceof Armor) {
-                updateRefitClass(CLASS_C);
+                updateRefitClass(CLASS_A);
                 locationHasNewStuff[nPart.getLocation()] = true;
             } else if (nPart instanceof MissingMekCockpit) {
-                updateRefitClass(CLASS_F);
+                updateRefitClass(CLASS_E);
                 locationHasNewStuff[Mech.LOC_HEAD] = true;
-            }else if (nPart instanceof MissingMekActuator) {
-                if (isOmniRefit && nPart.isOmniPoddable()) {
-                    updateRefitClass(CLASS_OMNI);
-                } else {
-                    updateRefitClass(CLASS_D);
-                }
-                locationHasNewStuff[nPart.getLocation()] = true;
             } else if (nPart instanceof MissingInfantryMotiveType || nPart instanceof MissingInfantryArmorPart) {
                 updateRefitClass(CLASS_A);
             } else {

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -546,6 +546,7 @@ public class Refit extends Part implements IAcquisitionWork {
             }
 
             /*CHECK REFIT CLASS*/
+            // See Campaign Operations, page 211 as of third printing
             if (nPart instanceof MissingEnginePart) {
                 if (oldUnit.getEntity().getEngine().getRating() != newUnit.getEntity().getEngine().getRating()) {
                     updateRefitClass(CLASS_D);


### PR DESCRIPTION
While I haven't addressed every problem in #3515, I've updated many of the refit classes to bring MekHQ closer to current tabletop rules.

I've also tested it: assuming refit classes in the window for choosing a refit don't reflect the benefit of a refit kit, it is working as expected.