### PR TITLE
Stratcon Dropship Modifier Clarification

### DIFF
--- a/MekHQ/data/scenariomodifiers/EnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyDropship.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>An enemy dropship has been detected in the area.</additionalBriefingText>
+	<additionalBriefingText>An active enemy dropship has been detected in the area.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>
@@ -17,7 +17,7 @@
 		<fixedUnitCount>1</fixedUnitCount>
 		<forceAlignment>2</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Opfor Grounded Dropship</forceName>
+		<forceName>Opfor Active Dropship</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>


### PR DESCRIPTION
SC Dropship modifier is supposed to be an active instead of grounded dropship.  It functions correctly, but the forceName said  Grounded and caused confusion.

This fixes forceName of Dropship in Stratcon Dropship Modifier.  Removes term "Grounded" and adds "Active" to force name and description, for clarity.  

Addresses #3632 