### PR TITLE
Stratcon Hidden Facility Modifier Fix

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -771,7 +771,7 @@ public class StratconRulesManager {
 
             if (scenarioAtFacility) {
                 modifierIDs = facility.getLocalModifiers();
-            } else if (facility.isVisible() || (Compute.randomInt(100) <= facility.getAggroRating())) {
+            } else if (facility.isVisible() || (Compute.randomInt(100) <= 75)) {
                 modifierIDs = facility.getSharedModifiers();
             }
 


### PR DESCRIPTION
This PR changes one line of code to activate the Hidden Facility Modifiers so they are applied as intended.

Obviously, Stratcon is amazing and I defer to Nick on this.  This was just discussed in discord this morning and I had a little time.  

Discussing this with @PhoenixHeart512 this morning and he pointed out the bug.  Enemy Facility modifers do not apply until they are scouted. This is a long standing issue, although there is no bug report on it that we could find.  I had a little time today so poked around at it.

Per the code comments and @NickAragua, hidden SC facilities should apply their modifier on a %chance based on an "aggro rating."  However, it appears the %chance aggro variable was never triggered for some reason (or the chance was so low as to be imperceptable) and so hidden modifiers are never applied.  

This activates the Hidden Facility modifiers so they now work.  It changes one line of code and changes the untriggered variable to a fixed 75% chance.  Tested it over a few months, and it works.  Per the original code, it works on a per facility per track basis.  e.g.: A track with 2 hidden facilities will 75% of the time apply their modifiers to other battles.  You will sometimes get both mods, 1, or none.  Track 0 facilities will not apply their modifiers to Track 1 battles, etc.

This might later be a canidate for a Campaign Stratcon Option where the user can custom set the % chance to apply the hidden modifiers from between 1-100%.  Like the "Chance for battle by role" option.  But someone else would have to add that, as it is beyond my personal ability.  But in the meantime, this gets them working and playable when they were not before.  Thank you.
