### PR TITLE
Fix Eclipse IDE-package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -37,6 +37,7 @@ dependencies {
         // We don't need the python and javascript engine taking up space
         exclude group: 'org.python', module: 'jython'
         exclude group: 'org.mozilla', module: 'rhino'
+        exclude group: 'xml-apis'
     }
 
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'


### PR DESCRIPTION
This resolves the following Eclipse IDE errors: 
"package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml"  and
"The package javax.xml.parsers is accessible from more than one module: <unnamed>, java.xml"

These packages are included as part of the Java Runtime Environment after Java 11?  

I appears IntelliJ was fixed in the past but Eclipse was still having an issue due to transient dependencies in MekHQ due to the inclusion of the MegaMekLab jar file which includes the xml-apis libraries.

This exclude in the gradle build file prevents Eclipse from tripping over this transient dependency.

This was tested by building from both Eclipse and from the gradle wrapper.
Eclipse Version: 
Version: 2023-03 (4.27.0)
Build id: 20230309-1520