### PR TITLE
Fix: MegaMek#4424 Spelling error in .blk files. Stringray->Stingray.

### DIFF
--- a/MekHQ/data/mechfiles/dropships/TRO3085/Cutting Edge/Clan/Vanir Assault Dropship (Standard).blk
+++ b/MekHQ/data/mechfiles/dropships/TRO3085/Cutting Edge/Clan/Vanir Assault Dropship (Standard).blk
@@ -116,7 +116,7 @@ Ammo Piranha:45
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:30
+Ammo Stingray:30
 (B) CLHAG40
 CLHAG40
 Hyper-Assault Gauss Rifle/40 Ammo:42
@@ -144,7 +144,7 @@ CLAMS Ammo:216
 (R) (B) Sub-Capital Missile Launcher (Stingray)
 (R) Sub-Capital Missile Launcher (Stingray)
 (R) Sub-Capital Missile Launcher (Stingray)
-(R) Ammo Stringray:30
+(R) Ammo Stingray:30
 (R) (B) CLERLargeLaser
 (R) CLERLargeLaser
 (R) CLERLargeLaser
@@ -172,7 +172,7 @@ Ammo Piranha:45
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:30
+Ammo Stingray:30
 (B) CLHAG40
 CLHAG40
 Hyper-Assault Gauss Rifle/40 Ammo:42
@@ -200,7 +200,7 @@ CLAMS Ammo:216
 (R) (B) Sub-Capital Missile Launcher (Stingray)
 (R) Sub-Capital Missile Launcher (Stingray)
 (R) Sub-Capital Missile Launcher (Stingray)
-(R) Ammo Stringray:30
+(R) Ammo Stingray:30
 (R) (B) CLERLargeLaser
 (R) CLERLargeLaser
 (R) CLERLargeLaser

--- a/MekHQ/data/mechfiles/warship/XTR/Republic III/Leviathan III Battleship.blk
+++ b/MekHQ/data/mechfiles/warship/XTR/Republic III/Leviathan III Battleship.blk
@@ -616,11 +616,11 @@ Naval Laser 55
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:150
+Ammo Stingray:150
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:150
+Ammo Stingray:150
 (B) CLERPPC
 CLERPPC
 CLERPPC
@@ -708,11 +708,11 @@ Naval Laser 55
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:150
+Ammo Stingray:150
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:150
+Ammo Stingray:150
 (B) CLERPPC
 CLERPPC
 CLERPPC


### PR DESCRIPTION
Fix: MegaMek#4424 Spelling error in .blk files. Stringray->Stingray.