### PR TITLE
Gradle build fixes

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -429,6 +429,18 @@ windowsDistZip {
     dependsOn createMMLExe
 }
 
+windowsDistTar {
+    description = 'Creates Windows distribution packaged as a tar archive'
+    dependsOn stageFiles
+    dependsOn stageMM
+    dependsOn stageMML
+    dependsOn createExe
+    dependsOn createMMExe
+    dependsOn createMMLExe
+    archiveExtension = 'tar.gz'
+    compression = Compression.GZIP
+}
+
 unixDistTar {
     description = 'Creates *nix distribution packaged as a tar ball'
     dependsOn stageFiles
@@ -437,6 +449,22 @@ unixDistTar {
     dependsOn startScripts
     archiveExtension = 'tar.gz'
     compression = Compression.GZIP
+}
+
+unixDistZip {
+    description = 'Creates *nix distribution packaged as a zip archive'
+    dependsOn stageFiles
+    dependsOn stageMM
+    dependsOn stageMML
+    dependsOn startScripts
+}
+
+distTar {
+    description = 'Creates generic distribution packaged as a tar'
+    dependsOn stageFiles
+    dependsOn stageMM
+    dependsOn stageMML
+    dependsOn startScripts
 }
 
 // The repository can only be cloned into an empty directory so we need to delete anything left over

--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -453,18 +453,29 @@ unixDistTar {
 
 unixDistZip {
     description = 'Creates *nix distribution packaged as a zip archive'
+    dependsOn createStartScripts
+    dependsOn startScripts
     dependsOn stageFiles
     dependsOn stageMM
     dependsOn stageMML
-    dependsOn startScripts
 }
 
 distTar {
     description = 'Creates generic distribution packaged as a tar'
+    dependsOn createStartScripts
+    dependsOn startScripts
     dependsOn stageFiles
     dependsOn stageMM
     dependsOn stageMML
+}
+
+distZip {
+    description = 'Creates generic distribution packaged as a zip'
+    dependsOn createStartScripts
     dependsOn startScripts
+    dependsOn stageFiles
+    dependsOn stageMM
+    dependsOn stageMML
 }
 
 // The repository can only be cloned into an empty directory so we need to delete anything left over


### PR DESCRIPTION
Added explicit dependencies to the MekHQ gradle build file to resolve unspecified implicit or explicit dependency warning when building from the command line `./gradlew clean build`.

Example warning that were appearing in the gradle build execution:  
> Task :MekHQ:createStartScripts
Execution optimizations have been disabled for task ':MekHQ:createStartScripts' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\scripts'. Reason: Task ':MekHQ:distTar' uses this output of task ':MekHQ:createStartScripts' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\scripts'. Reason: Task ':MekHQ:distZip' uses this output of task ':MekHQ:createStartScripts' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.

> Task :MekHQ:unixDistZip
Execution optimizations have been disabled for task ':MekHQ:unixDistZip' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\files'. Reason: Task ':MekHQ:unixDistZip' uses this output of task ':MekHQ:stageFiles' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\scripts'. Reason: Task ':MekHQ:unixDistZip' uses this output of task ':MekHQ:startScripts' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.

> Task :MekHQ:windowsDistTar
Execution optimizations have been disabled for task ':MekHQ:windowsDistTar' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\files'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:stageFiles' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.

> Task :MekHQ:createExe
Execution optimizations have been disabled for task ':MekHQ:createExe' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j\MekHQ.exe'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j\MekHQ.l4j.ini'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.

> Task :MekHQ:createMMExe
Execution optimizations have been disabled for task ':MekHQ:createMMExe' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createMMExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j\MegaMek.exe'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createMMExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j\MegaMek.l4j.ini'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createMMExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.

> Task :MekHQ:createMMLExe
Execution optimizations have been disabled for task ':MekHQ:createMMLExe' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createMMLExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j\MegaMekLab.exe'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createMMLExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\git\mekhq\MekHQ\build\launch4j\MegaMekLab.l4j.ini'. Reason: Task ':MekHQ:windowsDistTar' uses this output of task ':MekHQ:createMMLExe' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
