### PR TITLE
Revert Eclipse Multiple Dependecy Gradle fix.

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -37,7 +37,8 @@ dependencies {
         // We don't need the python and javascript engine taking up space
         exclude group: 'org.python', module: 'jython'
         exclude group: 'org.mozilla', module: 'rhino'
-        exclude group: 'xml-apis'
+        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
+        //exclude group: 'xml-apis'
     }
 
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'


### PR DESCRIPTION
Reverting this fix that fixed 'Multiple dependency errors in Eclipse IDE' as this fix also breaks printing unit record sheets in MekHQ briefing tab in a similar way as megameklab#1263.  

0.49.13

Work-a-round for 0.49.13.
[mekhq_print_workaround.zip](https://github.com/MegaMek/mekhq/files/11571042/mekhq_print_workaround.zip)
