### PR TITLE
prevent npe when running ship search

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -611,8 +611,10 @@ public class Campaign implements ITechManager {
             // TODO : mos zero should make ship available on retainer
             if (roll >= target.getValue()) {
                 report.append("<br/>Search successful. ");
-                MechSummary ms = unitGenerator.generate(getFactionCode(), shipSearchType, -1,
+                
+                MechSummary ms = getUnitGenerator().generate(getFactionCode(), shipSearchType, -1,
                         getGameYear(), getUnitRatingMod());
+                
                 if (ms == null) {
                     ms = getAtBConfig().findShip(shipSearchType);
                 }


### PR DESCRIPTION
Fixes #3621 - this error occurs only when starting mekhq and the ship search runs before the unit generator is otherwise initialized.