### PR TITLE
Revert "BV and MP adaptation to MM changes"

### DIFF
--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -298,7 +298,10 @@ public class MekLabTab extends CampaignGuiTab {
         testEntity.correctEntity(sb);
 
         int walk = entity.getOriginalWalkMP();
-        int run = entity.getRunMP(MPCalculationSetting.NO_MASC);
+        int run = entity.getRunMP();
+        if (entity instanceof Mech) {
+            run = ((Mech) entity).getOriginalRunMPwithoutMASC();
+        }
         int jump = entity.getOriginalJumpMP();
         int heat = entity.getHeatCapacity();
 


### PR DESCRIPTION
Reverts MegaMek/mekhq#3689. I misread the initial PR, so this is broken.