### PR TITLE
Fix Eclipse IDE Multiple Module dependency error - take 2.

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -37,8 +37,8 @@ dependencies {
         // We don't need the python and javascript engine taking up space
         exclude group: 'org.python', module: 'jython'
         exclude group: 'org.mozilla', module: 'rhino'
-        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
-        //exclude group: 'xml-apis'
+        // Eclipse IDE Multiple Dependency errors. 
+        exclude group: 'xml-apis'
     }
 
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
@@ -53,7 +53,9 @@ dependencies {
     implementation 'org.joda:joda-money:1.0.3'
 
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.1'
-
+    // Required for mml printing scaled vector graphics (SVG) - Eclipse IDE Compatability.
+    runtimeOnly 'xml-apis:xml-apis-ext:1.3.04'
+    
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
     testImplementation 'org.mockito:mockito-core:4.10.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:4.10.0'


### PR DESCRIPTION
Follow fix to MekHQ 'Multiple Module Dependency' errors when attempting to import MekHQ into Eclipse IDE.

This fix excludes the `xml-api` library from the Megameklab jar.  Additionally, it sets the `xml-api-ext` to be included in the runtime build as it is needed by Megameklab's xml graphics library and is not included in the Java Runtime library.

This gradle configuration allows MekHQ to be independently imported into the Eclipse IDE using Gradle integration while not breaking the scaled vector graphics functions provided by Megameklab.  (i.e. when printing record sheets while embarking on a scenario in the Briefing Room tab.