### PR TITLE
[Gradle] Add explicit dependencies on MM/MML (might not be correct)

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -137,7 +137,7 @@ task mmJarLibDir (type: Jar, dependsOn: compileMM) {
     outputs.file jarLocation
 }
 
-task compileMML (type: GradleBuild) {
+task compileMML (type: GradleBuild, dependsOn: compileMM) {
     description = 'Compiles the MML directory for packaging in a Jar'
 
     buildName = "mhq-compile-mml"
@@ -163,7 +163,12 @@ task mmlJar (type: Jar, dependsOn: compileMML) {
     outputs.file jarLocation
 }
 
+compileJava.dependsOn 'compileMM'
+compileJava.dependsOn 'compileMML'
+
 jar {
+    dependsOn mmJar
+    dependsOn mmlJar
     archiveFileName = "MekHQ.jar"
     manifest {
         attributes "Main-Class" : mainClassName


### PR DESCRIPTION
Trying to remove the transient nature of the build failures with GitHub actions and it seems like MM/MML do not consistently build before MekHQ, though I'm not sure why Gradle isn't detecting these dependencies when it works "fine" from my IDE.

This change consistently produces a deterministic build order between the three projects, but I'm not sure if it matters.

Thoughts?