### PR TITLE
PersonnelTableMouseAdapter: Assign correct flag when assigning clan personnel

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2083,8 +2083,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             cbMenuItem.setName("miClanPersonnel");
             cbMenuItem.setSelected(person.isClanPersonnel());
             cbMenuItem.addActionListener(evt -> {
-                final boolean marriageable = !person.isMarriageable();
-                Stream.of(selected).forEach(p -> p.setMarriageable(marriageable));
+                final boolean clanPersonnel = !person.isClanPersonnel();
+                Stream.of(selected).forEach(p -> p.setClanPersonnel(clanPersonnel));
             });
             menu.add(cbMenuItem);
         }


### PR DESCRIPTION
This fixes a copy/paste error I made a while ago