### PR TITLE
Fixes a typo in Allied Ground Reinforcements, Fixes Allied Base of Op…

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedGroundSupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedGroundSupport.xml
@@ -30,7 +30,7 @@
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>1</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Opfor Ground Reinforcements</forceName>
+		<forceName>Allied Ground Reinforcements</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>

--- a/MekHQ/data/scenariomodifiers/FacilityAlliedEvac.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityAlliedEvac.xml
@@ -43,7 +43,7 @@
                     <howMuch>1</howMuch>
                 </successEffect>
 		<successEffect>
-                    <effectType>FacilityRemoved</effectType>
+                    <effectType>FacilityRemains</effectType>
                     <effectScaling>Fixed</effectScaling>
                     <howMuch>1</howMuch>
                 </successEffect>
@@ -55,7 +55,7 @@
                     <howMuch>1</howMuch>
                 </failureEffect>
 		<failureEffect>
-                    <effectType>FacilityRemoved</effectType>
+                    <effectType>FacilityCaptured</effectType>
                     <effectScaling>Fixed</effectScaling>
                     <howMuch>1</howMuch>
                 </failureEffect>

--- a/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
+++ b/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
@@ -5,6 +5,6 @@
         <owner>Allied</owner>
 	<localModifiers>Veterans.xml</localModifiers>
 	<localModifiers>GoodEquipment.xml</localModifiers>
-	<localModifiers>EnemyTurrets.xml</localModifiers>
+	<localModifiers>AlliedTurrets.xml</localModifiers>
         <visible>true</visible>
 </StratconFacility>


### PR DESCRIPTION
Three fixes to StratCon Facility & Modifiers :

Fixes a typo in Allied Ground Reinforcements force name, - changed Opfor to Allied.

Fixes Allied Base of Operations Turrets - They were enemy turrets.  Changed Enemy to Allied. This fixes Issue #3713 

An Interim fix for the Allied Evac scenario modifier so it doesnt fail Garrison Contracts even on a victory.  A victory would result in the facility being removed, and it was reported this would fail a Garrison contract.   So, changed "Facility Removed" to "Facility Remins" on victory.  On defeat changed "Facility Removed" to "Facility Captured" by enemy.  So the player has a chance to win it back.  I thought there was a reported issue for this, but I cant seem to find it, so maybe just a discord discussion.

This is labeled as an interim fix as Nick said he had another future plan for this resolution, but this fixes it in the short-term so Garrison contract are not failed even if you win.

Please let me know if there are any quesitons.  