### PR TITLE
prevent unnecessary parts searching

### DIFF
--- a/MekHQ/src/mekhq/campaign/Quartermaster.java
+++ b/MekHQ/src/mekhq/campaign/Quartermaster.java
@@ -40,6 +40,12 @@ import java.util.Objects;
  * Manages machines and materiel for a campaign.
  */
 public class Quartermaster {
+    public enum PartAcquisitionResult {
+        PartInherentFailure,
+        PlanetSpecificFailure,
+        Success
+    }
+    
     private final Campaign campaign;
 
     /**


### PR DESCRIPTION
Pretty straightforward: if we're looking for a part, and we can't find it because of some inherent property of the part that doesn't depend on the planet being searched or the person doing the searching, switching planets won't make a difference - so we stop making search attempts right away.

For campaigns with large numbers of logistics people and with the search radius set high, this will improve part searching performance drastically.

Fixes #3725