### PR TITLE
Initial pass to update MekHQ for fix 1152 on MM

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -612,10 +612,10 @@ public class Campaign implements ITechManager {
             // TODO : mos zero should make ship available on retainer
             if (roll >= target.getValue()) {
                 report.append("<br/>Search successful. ");
-                
+
                 MechSummary ms = getUnitGenerator().generate(getFactionCode(), shipSearchType, -1,
                         getGameYear(), getUnitRatingMod());
-                
+
                 if (ms == null) {
                     ms = getAtBConfig().findShip(shipSearchType);
                 }
@@ -2340,7 +2340,7 @@ public class Campaign implements ITechManager {
                             continue;
                         }
                     }
-                    
+
                     // if we didn't find everything on this planet, then add to the remaining list
                     if (shoppingItem.getQuantity() > 0 || shoppingItem.getDaysToWait() > 0) {
                         // if we can't afford it, then don't keep searching for it on other planets
@@ -2422,11 +2422,11 @@ public class Campaign implements ITechManager {
      */
     public PartAcquisitionResult findContactForAcquisition(IAcquisitionWork acquisition, Person person, PlanetarySystem system) {
         TargetRoll target = getTargetForAcquisition(acquisition, person);
-        
+
         String impossibleSentencePrefix = person == null ? "Can't search for " : person.getFullName() + " can't search for ";
         String failedSentencePrefix = person == null ? "No contacts available for " : person.getFullName() + " is unable to find contacts for ";
         String succeededSentencePrefix = person == null ? "Possible contact for " : person.getFullName() + " has found a contact for ";
-                
+
         // if it's already impossible, don't bother with the rest
         if (target.getValue() == TargetRoll.IMPOSSIBLE) {
             if (getCampaignOptions().isPlanetAcquisitionVerbose()) {
@@ -2435,7 +2435,7 @@ public class Campaign implements ITechManager {
             }
             return PartAcquisitionResult.PartInherentFailure;
         }
-        
+
         target = system.getPrimaryPlanet().getAcquisitionMods(target, getLocalDate(), getCampaignOptions(), getFaction(),
                 acquisition.getTechBase() == Part.T_CLAN);
 
@@ -5081,7 +5081,8 @@ public class Campaign implements ITechManager {
                             partAvailabilityLog.append(";(gauss ammo): -1");
                             break;
                     }
-                    if (((megamek.common.AmmoType) et).getMunitionType() == megamek.common.AmmoType.M_STANDARD) {
+                    if (EnumSet.of(AmmoType.Munitions.M_STANDARD).containsAll(
+                            ((megamek.common.AmmoType) et).getMunitionType())){
                         partAvailability--;
                         partAvailabilityLog.append(";(standard ammo): -1");
                     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -38,6 +38,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.PrintWriter;
+import java.util.EnumSet;
 import java.util.Objects;
 
 /**
@@ -117,7 +118,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
             if (unit.getEntity() instanceof Protomech) {
                 // If protomechs are using alternate munitions then cut in half
-                if (getType().getMunitionType() != AmmoType.M_STANDARD) {
+                if (!EnumSet.of(AmmoType.Munitions.M_STANDARD).containsAll(getType().getMunitionType())){
                     fullShots = fullShots / 2;
                 }
             }
@@ -235,7 +236,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
 
     // FIXME: does not take into account BombType
     @Deprecated
-    public long getMunitionType() {
+    public EnumSet<AmmoType.Munitions> getMunitionType() {
         return getType().getMunitionType();
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SmallSVAmmoSwapDialog.java
@@ -55,7 +55,7 @@ public class SmallSVAmmoSwapDialog extends JDialog {
         // from there.
         for (Part part : unit.getParts()) {
             if ((part instanceof InfantryAmmoBin)
-                    && (((InfantryAmmoBin) part).getType().getMunitionType() == AmmoType.M_INFERNO)) {
+                    && (((InfantryAmmoBin) part).getType().getMunitionType().contains(AmmoType.Munitions.M_INFERNO))) {
                 WeaponRow row = new WeaponRow((InfantryAmmoBin) part);
                 rows.add(row);
                 panMain.add(row);


### PR DESCRIPTION
Replace equality tests for AmmoType.M_* with EnumSet<AmmoType.Munitions>.contains() tests.

Tested by building and running MekHQ with this (and the two other patches) applied.

Will need to be pulled *after* PR https://github.com/MegaMek/megamek/pull/4762