### PR TITLE
Fix #3761: update munitions equality tests

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -124,7 +124,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
      */
     public boolean isSameAmmoType(AmmoType otherAmmoType) {
         return getType().equalsAmmoTypeOnly(otherAmmoType)
-            && (getType().getMunitionType().contains(otherAmmoType.getMunitionType()))
+            && (getType().getMunitionType().containsAll(otherAmmoType.getMunitionType()))
             && (getType().getRackSize() == otherAmmoType.getRackSize());
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -124,7 +124,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
      */
     public boolean isSameAmmoType(AmmoType otherAmmoType) {
         return getType().equalsAmmoTypeOnly(otherAmmoType)
-            && (getType().getMunitionType().containsAll(otherAmmoType.getMunitionType()))
+            && (getType().getMunitionType().equals(otherAmmoType.getMunitionType()))
             && (getType().getRackSize() == otherAmmoType.getRackSize());
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -124,7 +124,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
      */
     public boolean isSameAmmoType(AmmoType otherAmmoType) {
         return getType().equalsAmmoTypeOnly(otherAmmoType)
-            && (getType().getMunitionType() == otherAmmoType.getMunitionType())
+            && (getType().getMunitionType().contains(otherAmmoType.getMunitionType()))
             && (getType().getRackSize() == otherAmmoType.getRackSize());
     }
 


### PR DESCRIPTION
I'd missed a few Munitions == tests; these should be .equals() checks when comparing two EnumSets.

Two related PRs for MM and MML are here:
https://github.com/MegaMek/megameklab/pull/1313
https://github.com/MegaMek/megamek/pull/4797

close #3761 