### PR TITLE
Arano Restoration Campaign - Planetary Control

### DIFF
--- a/MekHQ/data/universe/factionhints.xml
+++ b/MekHQ/data/universe/factionhints.xml
@@ -235,7 +235,7 @@ they shouldn't be fighting DC and Stone's Coalition, so I make them neutral for 
 	</war>
 
 	<!-- Aurigan Civil War: setting for HBS' BattleTech game. The dates are very roughly estimated based on descriptions in game and in the sourcebook. That means they are semi-canon, and should be updated if possible. Ulysses Update: Changed these to match the planetary control dates better in MHQ to help contract generation. -->
-	<war name="Aurigan Civil War" start="3025-01-01" end ="3025-12-30">
+	<war name="Aurigan Civil War" start="3025-01-25" end ="3025-12-30">
 		<parties>ARC,ARD</parties>
 		<parties start="3025-05-09" end="3025-08-15">ARC,TC</parties>
 	</war>

--- a/MekHQ/data/universe/factionhints.xml
+++ b/MekHQ/data/universe/factionhints.xml
@@ -234,8 +234,8 @@ they shouldn't be fighting DC and Stone's Coalition, so I make them neutral for 
 		<parties>FWL,FWLR</parties>
 	</war>
 
-	<!-- Aurigan Civil War: setting for HBS' BattleTech game. The dates are very roughly estimated based on descriptions in game and in the sourcebook. That means they are semi-canon, and should be updated if possible -->
-	<war name="Aurigan Civil War" start="3025-01-25" end ="3025-09-01">
+	<!-- Aurigan Civil War: setting for HBS' BattleTech game. The dates are very roughly estimated based on descriptions in game and in the sourcebook. That means they are semi-canon, and should be updated if possible. Ulysses Update: Changed these to match the planetary control dates better in MHQ to help contract generation. -->
+	<war name="Aurigan Civil War" start="3025-01-01" end ="3025-12-30">
 		<parties>ARC,ARD</parties>
 		<parties start="3025-05-09" end="3025-08-15">ARC,TC</parties>
 	</war>


### PR DESCRIPTION
This PR makes a lot of assumptions about some rough dates of when the battles might have taken place during the Aurigan Restoration campaign. I have also tweaked the war dates slightly to match the planetary control dates.

By putting joint control for planets between the ARC and ARD factions (and some Taurian control too) my hope is this should get MekHQ to trigger contracts during the war.

This should allow players to follow along the HBSTech storyline inside MHQ, and fight for either side. I have manually tested:

- Planet control flipping
- Contract generation (by GM spamming contract generation)
- That the universe doesn't break afterwards

Test evidence screenshots:

**Early War - March 3025 - some planets flipped, others with ongoing fighting**
![image](https://github.com/MegaMek/mekhq/assets/88290873/1e678ea2-3cdf-4732-8cc9-448d02759771)

**Contract Generation**
![image](https://github.com/MegaMek/mekhq/assets/88290873/0606e088-dc34-43f0-a427-4d8bb3cbaf37)

**The universe back to normal in 3026**
![image](https://github.com/MegaMek/mekhq/assets/88290873/dcddfe77-aeee-48bb-975d-cf0675ce817c)
