### PR TITLE
manually set TO&E force commander

### DIFF
--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -11,6 +11,7 @@ VERSION HISTORY:
 + Issue #2854: Implemented CamOps errata for avionics repair times
 + PR #3756: Tech level filtering in the unit selector dialog has been corrected
 + Issue #3747: Unable to Assign Pilots to Tripod Mechs
++ PR #3766: weight calculation for spare mech locations
 
 0.49.14 (2023-07-28 2100 UTC)
 + PR #3676: Gradle build fixes 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3573,6 +3573,11 @@ public class Campaign implements ITechManager {
             return;
         }
 
+        Force force = getForceFor(person);
+        if (force != null) {
+            force.updateCommander(this);
+        }
+        
         person.getGenealogy().clearGenealogyLinks();
 
         final Unit unit = person.getUnit();
@@ -4804,6 +4809,12 @@ public class Campaign implements ITechManager {
         if (null != u) {
             u.resetPilotAndEntity();
         }
+        
+        Force force = getForceFor(p);
+        if (force != null) {
+            force.updateCommander(this);
+        }
+        
         MekHQ.triggerEvent(new PersonChangedEvent(p));
     }
 

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -401,7 +401,7 @@ public class Force {
         // then they're not really the highest ranked person in the force.
         if ((highestRankPerson != null) && 
                 ((highestRankPerson.getUnit() == null) ||
-                (highestRankPerson.getUnit().getForceId() == Force.FORCE_NONE))) {
+                (!getUnits().contains(highestRankPerson.getUnit().getId())))) {
             highestRankPerson = null;
         }
         

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -71,6 +71,7 @@ public class Force {
     private Vector<Force> subForces;
     private Vector<UUID> units;
     private int scenarioId;
+    private UUID forceCommanderID;
 
     protected UUID techId;
 
@@ -310,6 +311,8 @@ public class Force {
                 }
             }
         }
+        
+        updateCommander(campaign);
     }
 
     /**
@@ -338,30 +341,9 @@ public class Force {
                     }
                 }
             }
+            
+            updateCommander(campaign);
         }
-    }
-
-    public boolean removeUnitFromAllForces(UUID id) {
-        int idx = 0;
-        boolean found = false;
-        for (UUID uid : getUnits()) {
-            if (uid.equals(id)) {
-                found = true;
-                break;
-            }
-            idx++;
-        }
-        if (found) {
-            units.remove(idx);
-        } else {
-            for (Force sub : getSubForces()) {
-                found = sub.removeUnitFromAllForces(id);
-                if (found) {
-                    break;
-                }
-            }
-        }
-        return found;
     }
 
     public void clearScenarioIds(Campaign c) {
@@ -402,7 +384,63 @@ public class Force {
     public void setId(int i) {
         this.id = i;
     }
-
+    
+    public UUID getForceCommanderID() {
+        return forceCommanderID;
+    }
+    
+    public void setForceCommanderID(UUID commanderID) {
+        forceCommanderID = commanderID;
+    }
+    
+    public List<UUID> getEligibleCommanders(Campaign c) {
+        List<UUID> people = new ArrayList<>();
+        Person highestRankPerson = c.getPerson(getForceCommanderID());
+        
+        // safety check: if the person is no longer assigned to a unit or the force, 
+        // then they're not really the highest ranked person in the force.
+        if ((highestRankPerson.getUnit() == null) ||
+                (highestRankPerson.getUnit().getForceId() == Force.FORCE_NONE)) {
+            highestRankPerson = null;
+        }
+        
+        for (UUID uid : getAllUnits(false)) {
+            Unit u = c.getUnit(uid);
+            if (null != u) {
+                Person p = u.getCommander();
+                if (null != p) {
+                    // if we found someone with a higher rank, clear everything out and start again with the new highest rank person
+                    if (p.outRanks(highestRankPerson)) {
+                        people.clear();
+                        people.add(p.getId());
+                        highestRankPerson = p;
+                    // if we are looking at someone with a lower rank, ignore them and move on
+                    } else if ((highestRankPerson != null) && highestRankPerson.outRanks(p)) {
+                        continue;
+                    // someone with an equivalent rank can be commander
+                    } else {
+                        people.add(p.getId());
+                    }
+                }
+            }
+        }
+        
+        return people;
+    }
+    
+    /**
+     * Automatically update the force's commander
+     */
+    public void updateCommander(Campaign c) {
+        List<UUID> eligibleCommanders = getEligibleCommanders(c);
+        
+        // logic: if we found someone eligible who is a higher rank, the first one of those becomes the new commander
+        // otherwise, the existing commander remains the commander
+        if (!eligibleCommanders.contains(getForceCommanderID()) && (eligibleCommanders.size() > 0)) {
+            forceCommanderID = eligibleCommanders.get(0);
+        }
+    }
+    
     public void removeSubForce(int id) {
         int idx = 0;
         boolean found = false;
@@ -470,6 +508,7 @@ public class Force {
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "combatForce", combatForce);
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "scenarioId", scenarioId);
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "techId", techId);
+        MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "forceCommanderID", forceCommanderID);
         if (!units.isEmpty()) {
             MHQXMLUtility.writeSimpleXMLOpenTag(pw1, indent++, "units");
             for (UUID uid : units) {
@@ -528,6 +567,8 @@ public class Force {
                     retVal.scenarioId = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("techId")) {
                     retVal.techId = UUID.fromString(wn2.getTextContent());
+                }  else if (wn2.getNodeName().equalsIgnoreCase("forceCommanderID")) {
+                    retVal.forceCommanderID = UUID.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("units")) {
                     processUnitNodes(retVal, wn2, version);
                 } else if (wn2.getNodeName().equalsIgnoreCase("subforces")) {
@@ -563,6 +604,8 @@ public class Force {
         } else if (version.isLowerThan("0.49.7")) {
             retVal.setForceIcon(ForceIconMigrator.migrateForceIcon0496To0497(retVal.getForceIcon()));
         }
+        
+        retVal.updateCommander(c);
 
         return retVal;
     }

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -399,12 +399,13 @@ public class Force {
         
         // safety check: if the person is no longer assigned to a unit or the force, 
         // then they're not really the highest ranked person in the force.
-        if ((highestRankPerson.getUnit() == null) ||
-                (highestRankPerson.getUnit().getForceId() == Force.FORCE_NONE)) {
+        if ((highestRankPerson != null) && 
+                ((highestRankPerson.getUnit() == null) ||
+                (highestRankPerson.getUnit().getForceId() == Force.FORCE_NONE))) {
             highestRankPerson = null;
         }
         
-        for (UUID uid : getAllUnits(false)) {
+        for (UUID uid : getUnits()) {
             Unit u = c.getUnit(uid);
             if (null != u) {
                 Person p = u.getCommander();

--- a/MekHQ/src/mekhq/campaign/force/Lance.java
+++ b/MekHQ/src/mekhq/campaign/force/Lance.java
@@ -250,24 +250,8 @@ public class Lance {
     }
 
     /* Code to find unit commander from ForceViewPanel */
-
     public static UUID findCommander(int forceId, Campaign c) {
-        ArrayList<Person> people = new ArrayList<>();
-        for (UUID uid : c.getForce(forceId).getAllUnits(false)) {
-            Unit u = c.getUnit(uid);
-            if (null != u) {
-                Person p = u.getCommander();
-                if (null != p) {
-                    people.add(p);
-                }
-            }
-        }
-        // sort person vector by rank
-        people.sort((p1, p2) -> ((Comparable<Integer>) p2.getRankNumeric()).compareTo(p1.getRankNumeric()));
-        if (!people.isEmpty()) {
-            return people.get(0).getId();
-        }
-        return null;
+        return c.getForce(forceId).getForceCommanderID();
     }
 
     public static LocalDate getBattleDate(LocalDate today) {

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -197,11 +197,13 @@ public final class TOETab extends CampaignGuiTab {
     @Subscribe
     public void personChanged(PersonChangedEvent ev) {
         orgTree.repaint();
+        orgRefreshScheduler.schedule();
     }
 
     @Subscribe
     public void personRemoved(PersonRemovedEvent ev) {
         orgTree.repaint();
+        orgRefreshScheduler.schedule();
     }
 
     @Subscribe

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -104,6 +104,10 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
 
     private static final String COMMAND_ADD_LANCE_TECH = "ADD_LANCE_TECH|FORCE|";
     private static final String COMMAND_REMOVE_LANCE_TECH = "REMOVE_LANCE_TECH|FORCE|";
+    
+    // Commander-Related
+    private static final String SET_LANCE_COMMANDER = "SET_LANCE_COMMANDER";
+    private static final String COMMAND_SET_LANCE_COMMANDER = "SET_LANCE_COMMANDER|FORCE|";
 
     // Icons and Descriptions
     private static final String CHANGE_CAMO = "CHANGE_CAMO";
@@ -267,6 +271,11 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 }
 
                 MekHQ.triggerEvent(new OrganizationChangedEvent(singleForce));
+            }
+        } else if (command.contains(TOEMouseAdapter.SET_LANCE_COMMANDER)) {
+            if (null != singleForce) {
+                singleForce.setForceCommanderID(UUID.fromString(target));
+                gui.getTOETab().refreshForceView();
             }
         } else if (command.contains(TOEMouseAdapter.ASSIGN_TO_SHIP)) {
             Unit ship = gui.getCampaign().getUnit(UUID.fromString(target));
@@ -899,6 +908,23 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 }
                 JMenuHelpers.addMenuIfNonEmpty(menu, unsorted);
                 JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+                
+                // still in the multiple selection block
+                List<UUID> eligibleCommanders = force.getEligibleCommanders(gui.getCampaign());
+                if (eligibleCommanders.size() > 0) {                
+                    menuItem = new JScrollableMenu("setCommanderMenu", "Set Commander");
+                    
+                    for (UUID personID : eligibleCommanders) {
+                        Person person = gui.getCampaign().getPerson(personID);
+                        
+                        JMenuItem commanderOption = new JMenuItem(person.getFullTitle() + " (" + person.getRoleDesc() + ")");
+                        commanderOption.setActionCommand(COMMAND_SET_LANCE_COMMANDER + personID + "|" + forceIds);
+                        commanderOption.addActionListener(this);
+                        menuItem.add(commanderOption);
+                    }
+                    
+                    popup.add(menuItem);
+                }
             }
 
             menu = new JMenu("Force Icon");

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -167,11 +167,13 @@ public class ForceViewPanel extends JScrollablePanel {
         String lanceTech = "";
         String assigned = "";
         String type = null;
-        ArrayList<Person> people = new ArrayList<>();
+        
+        Person commanderPerson = campaign.getPerson(force.getForceCommanderID());
+        commander = commanderPerson != null ? commanderPerson.getFullTitle() : "";
+        
         for (UUID uid : force.getAllUnits(false)) {
             Unit u = campaign.getUnit(uid);
             if (null != u) {
-                Person p = u.getCommander();
                 bv += u.getEntity().calculateBattleValue(true, !u.hasPilot());
                 cost = cost.plus(u.getEntity().getCost(true));
                 ton += u.getEntity().getWeight();
@@ -181,16 +183,7 @@ public class ForceViewPanel extends JScrollablePanel {
                 } else if (!utype.equals(type)) {
                     type = resourceMap.getString("mixed");
                 }
-                if (null != p) {
-                    people.add(p);
-                }
             }
-        }
-
-        // sort person vector by rank
-        people.sort((p1, p2) -> ((Comparable<Integer>) p2.getRankNumeric()).compareTo(p1.getRankNumeric()));
-        if (!people.isEmpty()) {
-            commander = people.get(0).getFullTitle();
         }
 
         if (force.getTechID() != null) {


### PR DESCRIPTION
Implements  #3540 by allowing the manual selection of a force commander from the TO&E menu if there's more than one "highest rank". Automatically updates the force commander if a unit/person is added/removed from the force/campaign.