### PR TITLE
Made possible to set custom date for non AtB scenarios

### DIFF
--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -100,3 +100,5 @@ ScenarioStatus.DEFEAT.text=Defeat
 ScenarioStatus.DEFEAT.toolTipText=<html>The unit was defeated by their opponent(s). <br>This is also referred to as a "Substantial Defeat" in the BattleTech rules.</html>
 ScenarioStatus.DECISIVE_DEFEAT.text=Decisive Defeat
 ScenarioStatus.DECISIVE_DEFEAT.toolTipText=The unit was decisively defeated by their opponent(s).
+ScenarioStatus.NEW.text=Pending
+ScenarioStatus.NEW.toolTipText=This scenario has not happened yet.

--- a/MekHQ/resources/mekhq/resources/Mission_en_US.properties
+++ b/MekHQ/resources/mekhq/resources/Mission_en_US.properties
@@ -1,0 +1,2 @@
+MissionStatus.NEW.text=New
+MissionStatus.NEW.toolTipText=This mission/contract hasn't started yet

--- a/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
@@ -25,6 +25,7 @@ import java.util.ResourceBundle;
 
 public enum ScenarioStatus {
     //region Enum Declarations
+    NEW("ScenarioStatus.NEW.text", "ScenarioStatus.NEW.toolTipText"),
     CURRENT("ScenarioStatus.CURRENT.text", "ScenarioStatus.CURRENT.toolTipText"),
     DECISIVE_VICTORY("ScenarioStatus.DECISIVE_VICTORY.text", "ScenarioStatus.DECISIVE_VICTORY.toolTipText"),
     VICTORY("ScenarioStatus.VICTORY.text", "ScenarioStatus.VICTORY.toolTipText"),

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -88,6 +88,9 @@ public class CustomizeScenarioDialog extends JDialog {
             scenario = s;
             newScenario = false;
         }
+        if (newScenario) {
+            scenario.setStatus(ScenarioStatus.NEW);
+        }
         campaign = c;
         if (scenario.getDate() == null) {
             scenario.setDate(campaign.getLocalDate());


### PR DESCRIPTION
Not sure if this is the right way to do it but as of now it's not possible to set a date for a custom scenario. What I did was to create a new ScenarioStatus so when the "Add Scenario" button is clicked a scenario that is not "current" is created (if you add a scenario and you want to set a custom date it cant be current). Maybe a bit more validation on the date should be done but I'm not an expert of the code base :) 