### PR TITLE
Beast mounted infantry

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5658,6 +5658,7 @@ public class Campaign implements ITechManager {
         entity.setHullDown(false);
         entity.heat = 0;
         entity.heatBuildup = 0;
+        entity.underwaterRounds = 0;
         entity.setTransportId(Entity.NONE);
         entity.resetTransporter();
         entity.setDeployRound(0);


### PR DESCRIPTION
This simply resets the underwater counter used for aquatic mounts. I started working on a part class to track mounts, but there's not simple way to have a part that is repaired by medics instead of techs. The only practical use I could see is to refit a unit, the way InfantryMotiveType is used, but in my opinion this is better handled by adding the unit and transferring the personnel.

Depends on  MegaMek/megamek#4883