### PR TITLE
[Nightly] Attempt to temporarily fix nightly gradle heap JVM out of mem thrashing.

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: clean build -x test --continue --stacktrace --scan
+        arguments: clean build -x test --continue --stacktrace --max-workers=1 --scan
         build-root-directory: mekhq
 
     - name: Upload Test Logs on Failure


### PR DESCRIPTION
I would like to try this as an experiment to see what impact it has on the nightly.  I suspect it could be a temporary fix for the Gradle JVM heap out of memory and thrashing errors that preventing nightly builds from succeeding while continuing investigation to a correct fix.

By default Gradle will use a max number of workers equal to the number of logical processors available.  Multiple workers could be competing for available heap space and starving each other out.  This should prevent that but at the cost of longer build times. 

If build times are too long, it might be required to specify a larger heap space for Gradle to use while increasing the max number of workers to something that makes sense.