### PR TITLE
Adjust campaign creation dialogs to have correct jdialod owner for re…

### DIFF
--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQButtonDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQButtonDialog.java
@@ -28,9 +28,9 @@ import java.util.ResourceBundle;
  * This is the Base Dialog for a dialog with buttons in MegaMek. It extends Base Dialog, and adds a
  * button panel with base Ok and Cancel buttons. It also includes an enum tracker for the result of
  * the dialog.
- *
+ * <p>
  * Inheriting classes must call initialize() in their constructors and override createCenterPane()
- *
+ * <p>
  * The resources associated with this dialog need to contain at least the following keys:
  * - "Ok.text" - text for the ok button
  * - "Ok.toolTipText" - toolTipText for the ok button
@@ -39,12 +39,17 @@ import java.util.ResourceBundle;
  */
 public abstract class AbstractMHQButtonDialog extends AbstractButtonDialog {
     //region Constructors
+
     /**
      * This creates a modal AbstractMHQButtonDialog using the default MHQ resource bundle. This is
      * the normal constructor to use for an AbstractMHQButtonDialog.
      */
     protected AbstractMHQButtonDialog(final JFrame frame, final String name, final String title) {
         this(frame, true, name, title);
+    }
+
+    protected AbstractMHQButtonDialog(final JDialog dialog, final JFrame frame, final String name, final String title) {
+        this(dialog, frame, true, name, title);
     }
 
     /**
@@ -57,6 +62,12 @@ public abstract class AbstractMHQButtonDialog extends AbstractButtonDialog {
                 MekHQ.getMHQOptions().getLocale()), name, title);
     }
 
+    protected AbstractMHQButtonDialog(final JDialog dialog, final JFrame frame, final boolean modal, final String name,
+                                      final String title) {
+        this(dialog, frame, modal, ResourceBundle.getBundle("mekhq.resources.GUI",
+                MekHQ.getMHQOptions().getLocale()), name, title);
+    }
+
     /**
      * This creates an AbstractMHQButtonDialog using the specified resource bundle. This is not
      * recommended by default.
@@ -65,12 +76,19 @@ public abstract class AbstractMHQButtonDialog extends AbstractButtonDialog {
                                       final String name, final String title) {
         super(frame, modal, resources, name, title);
     }
+
+    protected AbstractMHQButtonDialog(final JDialog dialog, final JFrame frame, final boolean modal, final ResourceBundle resources,
+                                      final String name, final String title) {
+        super(dialog, frame, modal, resources, name, title);
+    }
+    //endregion Constructors
     //endregion Constructors
 
     /**
      * This override forces the preferences for this class to be tracked in MekHQ instead of MegaMek.
+     *
      * @throws Exception if there's an issue initializing the preferences. Normally this means
-     * a component has <strong>not</strong> had its name value set.
+     *                   a component has <strong>not</strong> had its name value set.
      */
     @Override
     protected void setPreferences() throws Exception {

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQValidationButtonDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQValidationButtonDialog.java
@@ -72,6 +72,16 @@ public abstract class AbstractMHQValidationButtonDialog extends AbstractValidati
                                                 final String title) {
         super(frame, modal, resources, name, title);
     }
+
+    /**
+     * This creates an AbstractMHQValidationButtonDialog using the specified resource bundle. This
+     * is not recommended by default. Allows a JDialog to be specified as parent.
+     */
+    protected AbstractMHQValidationButtonDialog(final JDialog dialog, final JFrame frame, final boolean modal,
+                                                final ResourceBundle resources, final String name,
+                                                final String title) {
+        super(dialog, frame, modal, resources, name, title);
+    }
     //endregion Constructors
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignOptionsDialog.java
@@ -53,6 +53,18 @@ public class CampaignOptionsDialog extends AbstractMHQValidationButtonDialog {
         this.startup = startup;
         initialize();
     }
+
+    /**
+     * Allows dialog to be constructed with an owner being another dialog
+     */
+    public CampaignOptionsDialog(final JDialog owner, final JFrame frame, final Campaign campaign, final boolean startup) {
+        super(owner, frame, true, ResourceBundle.getBundle("mekhq.resources.CampaignOptionsDialog",
+                        MekHQ.getMHQOptions().getLocale()),
+                "CampaignOptionsDialog", "CampaignOptionsDialog.title");
+        this.campaign = campaign;
+        this.startup = startup;
+        initialize();
+    }
     //endregion Constructors
 
     //region Getters/Setters

--- a/MekHQ/src/mekhq/gui/dialog/CampaignPresetSelectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignPresetSelectionDialog.java
@@ -32,8 +32,16 @@ public class CampaignPresetSelectionDialog extends AbstractMHQButtonDialog {
     //endregion Variable Declarations
 
     //region Constructors
-    public CampaignPresetSelectionDialog(final JFrame parent) {
-        super(parent, "CampaignPresetSelectionDialog", "CampaignPresetSelectionDialog.title");
+    public CampaignPresetSelectionDialog(final JFrame parentFrame) {
+        super(parentFrame, "CampaignPresetSelectionDialog", "CampaignPresetSelectionDialog.title");
+        initialize();
+    }
+
+    /**
+     * Allows dialog to be constructed using a dialog as owner
+     */
+    public CampaignPresetSelectionDialog(final JDialog parentDialog, final JFrame parentFrame) {
+        super(parentDialog, parentFrame, "CampaignPresetSelectionDialog", "CampaignPresetSelectionDialog.title");
         initialize();
     }
     //endregion Constructors

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -71,7 +71,7 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
         super(frame, "DataLoadingDialog", "DataLoadingDialog.title");
         this.application = application;
         this.campaignFile = campaignFile;
-        this.task = new Task();
+        this.task = new Task(this);
         getTask().addPropertyChangeListener(this);
         initialize();
         getTask().execute();
@@ -191,6 +191,10 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
      * Main task. This is executed in a background thread.
      */
     private class Task extends SwingWorker<Campaign, Campaign> {
+        JDialog dialog;
+        public Task(JDialog dialog) {
+            this.dialog = dialog;
+        }
         /**
          * This uses the following stages of loading:
          * 0 : Basics
@@ -261,7 +265,7 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
                 campaign = new Campaign();
 
                 // Campaign Preset
-                final CampaignPresetSelectionDialog presetSelectionDialog = new CampaignPresetSelectionDialog(getFrame());
+                final CampaignPresetSelectionDialog presetSelectionDialog = new CampaignPresetSelectionDialog(dialog, getFrame());
                 if (presetSelectionDialog.showDialog().isCancelled()) {
                     return null;
                 }
@@ -270,7 +274,7 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
                 // Date
                 final LocalDate date = ((preset == null) || (preset.getDate() == null))
                         ? campaign.getLocalDate() : preset.getDate();
-                final DateChooser dc = new DateChooser(getFrame(), date);
+                final DateChooser dc = new DateChooser(dialog, date);
                 dc.setLocationRelativeTo(getFrame());
                 // user can either choose a date or cancel by closing
                 if (dc.showDateChooser() != DateChooser.OK_OPTION) {
@@ -288,7 +292,7 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
                 setVisible(false);
 
                 // Campaign Options
-                CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(getFrame(), campaign, true);
+                CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(dialog, getFrame(), campaign, true);
                 optionsDialog.setLocationRelativeTo(getFrame());
                 optionsDialog.applyPreset(preset);
                 if (optionsDialog.showDialog().isCancelled()) {

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -73,7 +73,21 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
     private JFormattedTextField dateField;
 
     /**
-     * Constructor for DateChooser
+     * Constructor for DateChooser which has parent dialog
+     *
+     * @param parentDialog
+     *            JDialog istance. Dialog that owns this
+     * @param d
+     *            LocalDate instance that will be the initial date for
+     *            this dialog
+     */
+    public DateChooser(JDialog parentDialog, LocalDate d) {
+        super(parentDialog, "Date Chooser", true);
+        init(parentDialog, d);
+    }
+
+    /**
+     * Constructor for DateChooser which does not have a parent dialog
      *
      * @param owner
      *            JFrame instance, owner of DateChooser dialog
@@ -83,6 +97,12 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
      */
     public DateChooser(JFrame owner, LocalDate d) {
         super(owner, "Date Chooser", true);
+        init(owner, d);
+    }
+
+    private void init(Component owner, LocalDate d) {
+
+
         date = d;
         workingDate = date;
 


### PR DESCRIPTION
Motivation:
In MekHq, the campaign creation user interface wasn't showing up.   After tracking this down, the modal campaign dialog was coming up behind the original dialog that spawned it.

Without rearranging things too much, a straight-forward fix appeared to be to make sure that the modal dialog had the owner of the JDialog that created it, not the owning JFrame.

I am guessing that this works ok on some platforms so it's not an issue for some. I'm also guessing that this is the case because which JDialog is rendered in front is arbitrary if they have the same JFrame. Regardless, this feels like a fairly benign change.

Change Description:

This is a companion PR to the one I just threw up for Megamek. That would have to go in first as this change depends on the function signature being there for the abstract dialog classes. 

These changes are isolated to creating the MekHQ Campaign dialogs with their proper JDialog owners so they don't show up behind the other dialogs.


(Please forgive if this doesn't follow the right standards, but we can work that out in the PRs if that works)