### PR TITLE
User files directory setting in MHQ

### DIFF
--- a/MekHQ/docs/UserDirHelp.html
+++ b/MekHQ/docs/UserDirHelp.html
@@ -1,0 +1,39 @@
+<HTML><H2>How to Use the User Data Directory</H2>
+
+<P>Use this directory for resources you want to share between different installs or versions of MegaMek, MegaMekLab and MekHQ. Fonts, units, camos, portraits and unit fluff images will also be loaded from this directory (in addition to what is loaded from MegaMek's own data). The directory should be an absolute path such as D:/MyBTStuff (in other words, not relative to your MegaMek directory).</P>
+
+<P>How to place files within the user data directory:
+<UL>
+    <LI><B>Fonts</B> can be placed anywhere in the user data directory (i.e., in the directory itself or in any subfolder)
+
+    <LI><B>Units</B> (.mtf and .blk files) can be placed anywhere in the user data directory
+
+    <LI><B>Camo</B> images must be placed in &lt;user data directory&gt;/data/images/camo/. In this subfolder, further subfolders can be used (optional).
+
+    <LI><B>Portrait</B> images must be placed in &lt;user data directory&gt;/data/images/portraits/. In this subfolder, further subfolders can be used (optional).
+
+    <LI><B>Unit fluff</B> images must be placed in &lt;user data directory&gt;/data/images/fluff/&lt;unit type&gt;/. To find the exact subfolders to use, go to your megamek folder and open /data/images/fluff/.
+</UL>
+
+<P>This is an example of a suitable directory structure with a few example files:
+<BR><BR>
+D:/myBTStuff<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;Oxanium.ttf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;Exo.ttf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;/campaign_units<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas AS8-XT.mtf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;/data<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jura.ttf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/images<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/camo<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myForceCamo.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/oldcamo<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;camo1.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;camo2.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/portraits<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myPortrait1.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/fluff<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/Mech<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/DropShip<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Colossus.png<BR>

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -648,6 +648,9 @@ optionOutstandingScenariosNag.text=Hide Outstanding Scenarios Nag
 optionOutstandingScenariosNag.toolTipText=This allows you to ignore the daily warning for having unfinished scenarios on the current day.
 ## Miscellaneous Tab
 miscellaneousTab.title=Miscellaneous Options
+lblUserDir.text=User Files Directory:
+lblUserDir.toolTipText=<html>Use this directory for resources you want to share between different installs or versions of MegaMek, MegaMekLab and MekHQ. Fonts, units, camos, portraits and fluff images will also be loaded from this directory.<BR>Note: Inside the user directory, use the directory structure of MM/MML/MHQ for camos, portraits and fluff images, i.e. data/images/camo, data/images/portraits and data/images/fluff/. <BR>Fonts and units can be placed anywhere in the user directory.
+userDirChooser.title=Choose User Data Folder
 lblStartGameDelay.text=Start Game Base Delay (ms)
 lblStartGameDelay.toolTipText=<html>This is the base start game delay, in milliseconds. <br>Increase this value when settings are not being set properly, the board isn't being loaded, and / or planetary conditions aren't loading properly. <br>This is limited to values between 250 and 2,500, with a default value of 1,000.</html>
 lblStartGameClientDelay.text=Start Game Client Delay (ms)

--- a/MekHQ/src/mekhq/campaign/personnel/AwardsFactory.java
+++ b/MekHQ/src/mekhq/campaign/personnel/AwardsFactory.java
@@ -21,7 +21,9 @@ package mekhq.campaign.personnel;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
+import megamek.client.ui.swing.CommonSettingsDialog;
 import megamek.common.annotations.Nullable;
+import megamek.common.preference.PreferenceManager;
 import mekhq.MHQConstants;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.AwardSet;
@@ -55,8 +57,9 @@ public class AwardsFactory {
 
     private AwardsFactory() {
         awardsMap = new HashMap<>();
-
-        loadAwards();
+        loadAwards(MHQConstants.AWARDS_DIRECTORY_PATH);
+        String userDir = PreferenceManager.getClientPreferences().getUserDir();
+        loadAwards(new File(userDir, MHQConstants.AWARDS_DIRECTORY_PATH).toString());
     }
 
     public static AwardsFactory getInstance() {
@@ -147,17 +150,10 @@ public class AwardsFactory {
     /**
      * Generates the "blueprint" awards by reading the data from XML sources.
      */
-    private void loadAwards() {
-        File dir = new File(MHQConstants.AWARDS_DIRECTORY_PATH);
-        File[] files = dir.listFiles((dir1, filename) -> filename.endsWith(".xml"));
-
-        if (files == null) {
-            return;
-        }
-
-        for (File file : files) {
+    private void loadAwards(String path) {
+        for (String file : CommonSettingsDialog.filteredFilesWithSubDirs(new File(path), ".xml")) {
             try (InputStream inputStream = new FileInputStream(file)) {
-                loadAwardsFromStream(inputStream, file.getName());
+                loadAwardsFromStream(inputStream, new File(file).getName());
             } catch (IOException e) {
                 LogManager.getLogger().error("", e);
             }

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
@@ -23,10 +23,11 @@ package mekhq.campaign.personnel.ranks;
 
 import megamek.Version;
 import megamek.common.annotations.Nullable;
+import megamek.common.preference.PreferenceManager;
 import mekhq.MHQConstants;
-import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.enums.RankSystemType;
+import mekhq.utilities.MHQXMLUtility;
 import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -118,6 +119,15 @@ public class Ranks {
                 continue;
             }
             final List<RankSystem> rankSystems = loadRankSystemsFromFile(new File(type.getFilePath()), type);
+            if (type.isUserData()) {
+                String userDir = PreferenceManager.getClientPreferences().getUserDir();
+                if (!userDir.isBlank() && new File(userDir).isDirectory()) {
+                    File userDirRanks = new File(userDir + "/" + MHQConstants.RANKS_FILE_PATH);
+                    if (userDirRanks.exists()) {
+                        rankSystems.addAll(loadRankSystemsFromFile(new File(userDir + "/" + MHQConstants.RANKS_FILE_PATH), type));
+                    }
+                }
+            }
             for (final RankSystem rankSystem : rankSystems) {
                 if (rankValidator.validate(rankSystem, true)) {
                     getRankSystems().put(rankSystem.getCode(), rankSystem);

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -22,6 +22,8 @@ import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.comboBoxes.FontComboBox;
 import megamek.client.ui.displayWrappers.FontDisplay;
 import megamek.client.ui.swing.ColourSelectorButton;
+import megamek.client.ui.swing.CommonSettingsDialog;
+import megamek.common.preference.PreferenceManager;
 import mekhq.MHQConstants;
 import mekhq.MHQOptionsChangedEvent;
 import mekhq.MekHQ;
@@ -144,6 +146,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     //endregion Nag Tab
 
     //region Miscellaneous
+    private JTextField txtUserDir;
     private JSpinner spnStartGameDelay;
     private JSpinner spnStartGameClientDelay;
     private JSpinner spnStartGameClientRetryCount;
@@ -891,6 +894,18 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
 
     private JPanel createMiscellaneousTab() {
         // Create Panel Components
+        final JLabel lblUserDir = new JLabel(resources.getString("lblUserDir.text"));
+        lblUserDir.setToolTipText(resources.getString("lblUserDir.toolTipText"));
+        lblUserDir.setName("lblUserDir");
+
+        txtUserDir = new JTextField(20);
+        txtUserDir.setToolTipText(resources.getString("lblUserDir.toolTipText"));
+        txtUserDir.setName("txtUserDir");
+
+        JButton userDirChooser = new JButton("...");
+        userDirChooser.addActionListener(e -> CommonSettingsDialog.fileChooseUserDir(txtUserDir, getFrame()));
+        userDirChooser.setToolTipText(resources.getString("userDirChooser.title"));
+
         final JLabel lblStartGameDelay = new JLabel(resources.getString("lblStartGameDelay.text"));
         lblStartGameDelay.setToolTipText(resources.getString("lblStartGameDelay.toolTipText"));
         lblStartGameDelay.setName("lblStartGameDelay");
@@ -961,6 +976,11 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         layout.setVerticalGroup(
                 layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                .addComponent(lblUserDir)
+                                .addComponent(txtUserDir)
+                                .addComponent(userDirChooser, GroupLayout.DEFAULT_SIZE,
+                                        GroupLayout.DEFAULT_SIZE, 40))
+                        .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(lblStartGameDelay)
                                 .addComponent(spnStartGameDelay, GroupLayout.DEFAULT_SIZE,
                                         GroupLayout.DEFAULT_SIZE, 40))
@@ -987,6 +1007,10 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
 
         layout.setHorizontalGroup(
                 layout.createParallelGroup(Alignment.LEADING)
+                        .addGroup(layout.createSequentialGroup()
+                                .addComponent(lblUserDir)
+                                .addComponent(txtUserDir)
+                                .addComponent(userDirChooser))
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(lblStartGameDelay)
                                 .addComponent(spnStartGameDelay))
@@ -1104,6 +1128,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS, optionUnresolvedStratConContactsNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS, optionOutstandingScenariosNag.isSelected());
 
+        PreferenceManager.getClientPreferences().setUserDir(txtUserDir.getText());
+        PreferenceManager.getInstance().save();
         MekHQ.getMHQOptions().setStartGameDelay((Integer) spnStartGameDelay.getValue());
         MekHQ.getMHQOptions().setStartGameClientDelay((Integer) spnStartGameClientDelay.getValue());
         MekHQ.getMHQOptions().setStartGameClientRetryCount((Integer) spnStartGameClientRetryCount.getValue());
@@ -1210,6 +1236,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionUnresolvedStratConContactsNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS));
         optionOutstandingScenariosNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS));
 
+        txtUserDir.setText(PreferenceManager.getClientPreferences().getUserDir());
         spnStartGameDelay.setValue(MekHQ.getMHQOptions().getStartGameDelay());
         spnStartGameClientDelay.setValue(MekHQ.getMHQOptions().getStartGameClientDelay());
         spnStartGameClientRetryCount.setValue(MekHQ.getMHQOptions().getStartGameClientRetryCount());

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -18,11 +18,14 @@
  */
 package mekhq.gui.dialog;
 
+import megamek.MMConstants;
+import megamek.client.ui.Messages;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.comboBoxes.FontComboBox;
 import megamek.client.ui.displayWrappers.FontDisplay;
 import megamek.client.ui.swing.ColourSelectorButton;
 import megamek.client.ui.swing.CommonSettingsDialog;
+import megamek.client.ui.swing.HelpDialog;
 import megamek.common.preference.PreferenceManager;
 import mekhq.MHQConstants;
 import mekhq.MHQOptionsChangedEvent;
@@ -31,11 +34,15 @@ import mekhq.campaign.universe.enums.CompanyGenerationMethod;
 import mekhq.gui.baseComponents.AbstractMHQButtonDialog;
 import mekhq.gui.enums.ForceIconOperationalStatusStyle;
 import mekhq.gui.enums.PersonnelFilterStyle;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.GroupLayout.Alignment;
 import java.awt.*;
 import java.awt.event.KeyEvent;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
@@ -906,6 +913,16 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         userDirChooser.addActionListener(e -> CommonSettingsDialog.fileChooseUserDir(txtUserDir, getFrame()));
         userDirChooser.setToolTipText(resources.getString("userDirChooser.title"));
 
+        JButton userDirHelp = new JButton("Help");
+        try {
+            String helpTitle = Messages.getString("UserDirHelpDialog.title");
+            URL helpFile = new File(MMConstants.USER_DIR_README_FILE).toURI().toURL();
+            userDirHelp.addActionListener(e -> new HelpDialog(helpTitle, helpFile, getFrame()).setVisible(true));
+        } catch (MalformedURLException e) {
+            LogManager.getLogger().error("Could not find the user data directory readme file at "
+                    + MMConstants.USER_DIR_README_FILE);
+        }
+
         final JLabel lblStartGameDelay = new JLabel(resources.getString("lblStartGameDelay.text"));
         lblStartGameDelay.setToolTipText(resources.getString("lblStartGameDelay.toolTipText"));
         lblStartGameDelay.setName("lblStartGameDelay");
@@ -978,7 +995,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(lblUserDir)
                                 .addComponent(txtUserDir)
-                                .addComponent(userDirChooser, GroupLayout.DEFAULT_SIZE,
+                                .addComponent(userDirChooser)
+                                .addComponent(userDirHelp, GroupLayout.DEFAULT_SIZE,
                                         GroupLayout.DEFAULT_SIZE, 40))
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(lblStartGameDelay)
@@ -1010,7 +1028,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(lblUserDir)
                                 .addComponent(txtUserDir)
-                                .addComponent(userDirChooser))
+                                .addComponent(userDirChooser)
+                                .addComponent(userDirHelp))
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(lblStartGameDelay)
                                 .addComponent(spnStartGameDelay))


### PR DESCRIPTION
This adds a setting to the misc MekHQ settings for the user directory of MegaMek/megamek#4961

Requires MegaMek/megamek#4961

As per requests, awards and rank systems are now read from the user directory.