### PR TITLE
Implement #4397 Internal Bomb Bay (MHQ compatibility)

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5683,17 +5683,23 @@ public class Campaign implements ITechManager {
             IBomber bomber = (IBomber) entity;
             List<Mounted> mountedBombs = bomber.getBombs();
             if (!mountedBombs.isEmpty()) {
-                // This should return an int[] filled with 0's
-                int[] bombChoices = bomber.getBombChoices();
+                // These should return an int[] filled with 0's
+                int[] intBombChoices = bomber.getIntBombChoices();
+                int[] extBombChoices = bomber.getExtBombChoices();
                 for (Mounted m : mountedBombs) {
                     if (!(m.getType() instanceof BombType)) {
                         continue;
                     }
                     if (m.getBaseShotsLeft() == 1) {
-                        bombChoices[BombType.getBombTypeFromInternalName(m.getType().getInternalName())] += 1;
+                        if (m.isInternalBomb()) {
+                            intBombChoices[BombType.getBombTypeFromInternalName(m.getType().getInternalName())] += 1;
+                        } else {
+                            extBombChoices[BombType.getBombTypeFromInternalName(m.getType().getInternalName())] += 1;
+                        }
                     }
                 }
-                bomber.setBombChoices(bombChoices);
+                bomber.setIntBombChoices(intBombChoices);
+                bomber.setExtBombChoices(extBombChoices);
                 bomber.clearBombs();
             }
         }

--- a/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BombsDialog.java
@@ -86,6 +86,7 @@ public class BombsDialog extends JDialog implements ActionListener {
             typeMax[type] = availBombs[type] + bombChoices[type];
         }
 
+        // BombChoicePanel takes care of managing internal and external stores, so we don't need to here.
         bombPanel = new BombChoicePanel(bomber, campaign.getGameOptions().booleanOption("at2_nukes"),
                 true, typeMax);
 
@@ -127,6 +128,7 @@ public class BombsDialog extends JDialog implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {
         if (okayButton.equals(e.getSource())) {
+            // internal and external choices are applied by bombPanel; here we only care about the totals.
             bombPanel.applyChoice();
             int[] newLoadout = bombPanel.getChoice();
 

--- a/MekHQ/src/mekhq/utilities/MHQXMLUtility.java
+++ b/MekHQ/src/mekhq/utilities/MHQXMLUtility.java
@@ -254,10 +254,7 @@ public class MHQXMLUtility extends MMXMLUtility {
         return retVal.toString();
     }
 
-    private static String getBombChoiceString(IBomber bomber, int indentLvl) {
-        StringBuilder retVal = new StringBuilder();
-
-        int[] bombChoices = bomber.getBombChoices();
+    private static void compileBombChoices(int[] bombChoices, StringBuilder retVal, int indentLvl, boolean isInternal) {
         if (bombChoices.length > 0) {
             retVal.append(MHQXMLUtility.indentStr(indentLvl + 1)).append("<bombs>\n");
             for (int type = 0; type < BombType.B_NUM; type++) {
@@ -267,11 +264,21 @@ public class MHQXMLUtility extends MMXMLUtility {
                     retVal.append(typeName);
                     retVal.append("\" load=\"");
                     retVal.append(bombChoices[type]);
+                    retVal.append((isInternal) ? "\" Internal=\"true" : "\" Internal=\"false");
                     retVal.append("\"/>\n");
                 }
             }
             retVal.append(MHQXMLUtility.indentStr(indentLvl + 1)).append("</bombs>\n");
         }
+
+    }
+    private static String getBombChoiceString(IBomber bomber, int indentLvl) {
+        StringBuilder retVal = new StringBuilder();
+
+        int[] bombChoices = bomber.getIntBombChoices();
+        compileBombChoices(bombChoices, retVal, indentLvl, true);
+        bombChoices = bomber.getExtBombChoices();
+        compileBombChoices(bombChoices, retVal, indentLvl, false);
 
         return retVal.toString();
     }

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTestUtilities.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTestUtilities.java
@@ -60,7 +60,7 @@ public final class UnitTestUtilities {
         try {
             InputStream in = new ByteArrayInputStream(TestUtilities.Decode(base64));
             IMechLoader loader;
-            
+
             BuildingBlock bb = new BuildingBlock(in);
             if (bb.exists("UnitType")) {
                 String sType = bb.getDataAsString("UnitType")[0];
@@ -85,8 +85,10 @@ public final class UnitTestUtilities {
                     loader = new BLKLargeSupportTankFile(bb);
                 } else if (sType.equals("SupportVTOL")) {
                     loader = new BLKSupportVTOLFile(bb);
+                } else if (sType.equals("AeroSpaceFighter")) {
+                    loader = new BLKAeroSpaceFighterFile(bb);
                 } else if (sType.equals("Aero")) {
-                    loader = new BLKAeroFile(bb);
+                    loader = new BLKAeroSpaceFighterFile(bb);
                 } else if (sType.equals("FixedWingSupport")) {
                     loader = new BLKFixedWingSupportFile(bb);
                 } else if (sType.equals("ConvFighter")) {


### PR DESCRIPTION
This PR must be taken into MHQ after MegaMek PR #4974 is pulled.

Changes: 
- fixes a unit test that fails once AeroSpaceFighter class is introduced.
- Makes clearGameData (called after MM games return to MHQ) aware of Internal and External bomb stores.
- Add handling for internal bombs in XML writer.
- Misc. commenting around bomb panel code explaining changes.

Testing:
- Added, changed, removed bombs from various Aerospace units with and without Internal Bomb Bay quirk.
- Ran all unit tests.

Note: tests for this PR will fail until MegaMek PR ~~#4974~~ #5003 is pulled.