### PR TITLE
MekHQ part of fix for #4648

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -551,9 +551,10 @@ public class SpecialAbility {
             return false;
         }
 
+        // Should only apply to Large Ship-mounted weapons
         if (wt.getAtClass() == WeaponType.CLASS_NONE ||
                 wt.getAtClass() == WeaponType.CLASS_POINT_DEFENSE ||
-                wt.getAtClass() >= WeaponType.CLASS_CAPITAL_LASER) {
+                (wt.getAtClass() >= WeaponType.CLASS_CAPITAL_LASER && wt.getAtClass() <= WeaponType.CLASS_TELE_MISSILE)) {
             return false;
         }
 


### PR DESCRIPTION
Mek Mortars and IS BA Tube Artillery are excluded from the MekHQ "Spend XP" SPA menu because they have an AT2 Class of "NONE".  By rights this whole AT2 class thing should be torn out, but it seemed more sensible to massage the existing check and add classes to the missing weapons, rather than refactoring a lot of code across all three projects.

This patch restricts the range of AT classes that will be rejected to just the existing Naval / Large Ship weapons.
The full fix also relies on the MegaMek PR [here](https://github.com/MegaMek/megamek/pull/5027).