### PR TITLE
#3194 Awarding non-stackable medals to multiple people

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
@@ -108,12 +108,18 @@ public class PersonAwardController {
         final Award award;
         if (hasAward(setName, awardName)) {
             award = getAward(setName, awardName);
+
+            if (!award.canBeAwarded(person)) {
+                LogManager.getLogger().info("Award not stackable, returning.");
+                return;
+            }
         } else {
             award = AwardsFactory.getInstance().generateNew(setName, awardName);
             if (award == null) {
                 LogManager.getLogger().error("Cannot award a null award, returning.");
                 return;
             }
+
             awards.add(award);
         }
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1297,7 +1297,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             Collections.sort(awardsOfSet);
 
             for (Award award : awardsOfSet) {
-                if (!award.canBeAwarded(selected)) {
+                if (oneSelected && !award.canBeAwarded(selected)) {
                     continue;
                 }
 


### PR DESCRIPTION
This fixes #3194. Allows selecting multiple personnel and awarding a non-stackable award, which will only be added to those who do not already have it. When a single person is selected, the awards list will still be filtered as normal.