### PR TITLE
#3763 reversing quality names in unit set quality GM menu

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
@@ -107,10 +107,14 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
         } else if (command.contains("SET_QUALITY")) {
             int q = -1;
             boolean reverse = gui.getCampaign().getCampaignOptions().isReverseQualityNames();
-            Object[] possibilities = { Part.getQualityName(Part.QUALITY_A, reverse),
-                    Part.getQualityName(Part.QUALITY_B, reverse), Part.getQualityName(Part.QUALITY_C, reverse),
-                    Part.getQualityName(Part.QUALITY_D, reverse), Part.getQualityName(Part.QUALITY_E, reverse),
-                    Part.getQualityName(Part.QUALITY_F, reverse) };
+            Object[] possibilities = {
+                Part.getQualityName(Part.QUALITY_A, reverse),
+                Part.getQualityName(Part.QUALITY_B, reverse),
+                Part.getQualityName(Part.QUALITY_C, reverse),
+                Part.getQualityName(Part.QUALITY_D, reverse),
+                Part.getQualityName(Part.QUALITY_E, reverse),
+                Part.getQualityName(Part.QUALITY_F, reverse)
+            };
             String quality = (String) JOptionPane.showInputDialog(gui.getFrame(), "Choose the new quality level",
                     "Set Quality", JOptionPane.PLAIN_MESSAGE, null, possibilities,
                     Part.getQualityName(Part.QUALITY_D, reverse));

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -176,43 +176,28 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
         } else if (command.equals(COMMAND_SUPPLY_COST)) { // Single Unit only
             new MonthlyUnitCostReportDialog(gui.getFrame(), selectedUnit).setVisible(true);
         } else if (command.equals(COMMAND_SET_QUALITY)) {
-            int q;
-            Object[] possibilities = { "F", "E", "D", "C", "B", "A" }; // TODO : this probably shouldn't be inline
-            String quality = (String) JOptionPane.showInputDialog(gui.getFrame(),
-                    "Choose the new quality level", "Set Quality",
-                    JOptionPane.PLAIN_MESSAGE, null, possibilities, "F");
-
-            // showInputDialog returns null when cancel is clicked, so we set a default here
-            if (quality == null) {
-                quality = "CANCELED";
-            }
-
-            switch (quality) {
-                case "A":
-                    q = 0;
+            // TODO : Duplicated in PartsTableMouseAdapter#actionPerformed
+            int q = -1;
+            boolean reverse = gui.getCampaign().getCampaignOptions().isReverseQualityNames();
+            Object[] possibilities = { Part.getQualityName(Part.QUALITY_A, reverse),
+                Part.getQualityName(Part.QUALITY_B, reverse), Part.getQualityName(Part.QUALITY_C, reverse),
+                Part.getQualityName(Part.QUALITY_D, reverse), Part.getQualityName(Part.QUALITY_E, reverse),
+                Part.getQualityName(Part.QUALITY_F, reverse) };
+            String quality = (String) JOptionPane.showInputDialog(gui.getFrame(), "Choose the new quality level",
+                "Set Quality", JOptionPane.PLAIN_MESSAGE, null, possibilities,
+                Part.getQualityName(Part.QUALITY_D, reverse));
+            for (int i = 0; i < possibilities.length; i++) {
+                if (possibilities[i].equals(quality)) {
+                    q = i;
                     break;
-                case "B":
-                    q = 1;
-                    break;
-                case "C":
-                    q = 2;
-                    break;
-                case "D":
-                    q = 3;
-                    break;
-                case "E":
-                    q = 4;
-                    break;
-                case "F":
-                    q = 5;
-                    break;
-                default:
-                    q = -1;
-                    break;
+                }
             }
             if (q != -1) {
                 for (Unit unit : units) {
-                    unit.setQuality(q);
+                    if (unit != null) {
+                        unit.setQuality(q);
+                        MekHQ.triggerEvent(new UnitChangedEvent(unit));
+                    }
                 }
             }
         } else if (command.equals(COMMAND_SELL)) {

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -179,10 +179,14 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             // TODO : Duplicated in PartsTableMouseAdapter#actionPerformed
             int q = -1;
             boolean reverse = gui.getCampaign().getCampaignOptions().isReverseQualityNames();
-            Object[] possibilities = { Part.getQualityName(Part.QUALITY_A, reverse),
-                Part.getQualityName(Part.QUALITY_B, reverse), Part.getQualityName(Part.QUALITY_C, reverse),
-                Part.getQualityName(Part.QUALITY_D, reverse), Part.getQualityName(Part.QUALITY_E, reverse),
-                Part.getQualityName(Part.QUALITY_F, reverse) };
+            Object[] possibilities = {
+                Part.getQualityName(Part.QUALITY_A, reverse),
+                Part.getQualityName(Part.QUALITY_B, reverse),
+                Part.getQualityName(Part.QUALITY_C, reverse),
+                Part.getQualityName(Part.QUALITY_D, reverse),
+                Part.getQualityName(Part.QUALITY_E, reverse),
+                Part.getQualityName(Part.QUALITY_F, reverse)
+            };
             String quality = (String) JOptionPane.showInputDialog(gui.getFrame(), "Choose the new quality level",
                 "Set Quality", JOptionPane.PLAIN_MESSAGE, null, possibilities,
                 Part.getQualityName(Part.QUALITY_D, reverse));

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -909,9 +909,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         reverseQualityNames.addActionListener(evt -> {
             if (reverseQualityNames.isSelected()) {
-                recreateUPVMSpinners(true);
+                recreateFinancesPanel(true);
             } else {
-                recreateUPVMSpinners(false);
+                recreateFinancesPanel(false);
             }
         });
 
@@ -7122,7 +7122,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         panSpecialAbilities.repaint();
     }
 
-    public void recreateUPVMSpinners(boolean reverseQualities) {
+    /**
+     * Recreates the finances panel to reverse the qualities labels.
+     * @param reverseQualities boolean for if the qualities are reversed.
+     */
+    private void recreateFinancesPanel(boolean reverseQualities) {
         int financesTabIndex = indexOfTab(resources.getString("financesPanel.title"));
         removeTabAt(financesTabIndex);
         insertTab(resources.getString("financesPanel.title"), null, createFinancesTab(reverseQualities), null, financesTabIndex);

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -560,7 +560,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         addTab(resources.getString("suppliesAndAcquisitionsPanel.title"), createSuppliesAndAcquisitionsTab());
         addTab(resources.getString("techLimitsPanel.title"), createTechLimitsTab());
         addTab(resources.getString("personnelPanel.title"), createPersonnelTab());
-        addTab(resources.getString("financesPanel.title"), createFinancesTab());
+        addTab(resources.getString("financesPanel.title"), createFinancesTab(campaign.getCampaignOptions().isReverseQualityNames()));
         addTab(resources.getString("mercenaryPanel.title"), createMercenaryTab());
         addTab(resources.getString("experiencePanel.title"), createExperienceTab());
         addTab(resources.getString("skillsPanel.title"), createSkillsTab());
@@ -906,6 +906,14 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         panSubMaintenance.add(reverseQualityNames, gridBagConstraints);
+
+        reverseQualityNames.addActionListener(evt -> {
+            if (reverseQualityNames.isSelected()) {
+                recreateUPVMSpinners(true);
+            } else {
+                recreateUPVMSpinners(false);
+            }
+        });
 
         useUnofficialMaintenance = new JCheckBox(resources.getString("useUnofficialMaintenance.text"));
         useUnofficialMaintenance.setToolTipText(resources.getString("useUnofficialMaintenance.toolTipText"));
@@ -1415,7 +1423,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         return new JScrollPane(panTech);
     }
 
-    private JScrollPane createFinancesTab() {
+    private JScrollPane createFinancesTab(boolean reverseQualities) {
         int gridy = 0;
 
         AbstractMHQScrollablePanel panFinances = new DefaultMHQScrollablePanel(getFrame(),
@@ -1623,7 +1631,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.gridheight = 20;
-        panFinances.add(createPriceModifiersPanel(), gridBagConstraints);
+        panFinances.add(createPriceModifiersPanel(reverseQualities), gridBagConstraints);
 
         return new JScrollPane(panFinances);
     }
@@ -5221,7 +5229,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     //endregion Personnel Tab
 
     //region Finances Tab
-    private JPanel createPriceModifiersPanel() {
+    private JPanel createPriceModifiersPanel(boolean reverseQualities) {
         // Create Panel Components
         final JLabel lblCommonPartPriceMultiplier = new JLabel(resources.getString("lblCommonPartPriceMultiplier.text"));
         lblCommonPartPriceMultiplier.setToolTipText(resources.getString("lblCommonPartPriceMultiplier.toolTipText"));
@@ -5271,7 +5279,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnMixedTechUnitPriceMultiplier.setToolTipText(resources.getString("lblMixedTechUnitPriceMultiplier.toolTipText"));
         spnMixedTechUnitPriceMultiplier.setName("spnMixedTechUnitPriceMultiplier");
 
-        final JPanel usedPartsValueMultipliersPanel = createUsedPartsValueMultipliersPanel();
+        final JPanel usedPartsValueMultipliersPanel = createUsedPartsValueMultipliersPanel(reverseQualities);
 
         final JLabel lblDamagedPartsValueMultiplier = new JLabel(resources.getString("lblDamagedPartsValueMultiplier.text"));
         lblDamagedPartsValueMultiplier.setToolTipText(resources.getString("lblDamagedPartsValueMultiplier.toolTipText"));
@@ -5388,14 +5396,14 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         return panel;
     }
 
-    private JPanel createUsedPartsValueMultipliersPanel() {
+    private JPanel createUsedPartsValueMultipliersPanel(boolean reverseQualities) {
         final JPanel panel = new JPanel(new GridLayout(0, 2));
         panel.setBorder(BorderFactory.createTitledBorder(resources.getString("usedPartsValueMultipliersPanel.title")));
         panel.setName("usedPartsValueMultipliersPanel");
 
         spnUsedPartPriceMultipliers = new JSpinner[Part.QUALITY_F + 1];
         for (int i = Part.QUALITY_A; i <= Part.QUALITY_F; i++) {
-            final String qualityLevel = Part.getQualityName(i, false);
+            final String qualityLevel = Part.getQualityName(i, reverseQualities);
 
             final JLabel label = new JLabel(qualityLevel);
             label.setToolTipText(resources.getString("lblUsedPartPriceMultiplier.toolTipText"));
@@ -7112,6 +7120,12 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         });
         panSpecialAbilities.revalidate();
         panSpecialAbilities.repaint();
+    }
+
+    public void recreateUPVMSpinners(boolean reverseQualities) {
+        int financesTabIndex = indexOfTab(resources.getString("financesPanel.title"));
+        removeTabAt(financesTabIndex);
+        insertTab(resources.getString("financesPanel.title"), null, createFinancesTab(reverseQualities), null, financesTabIndex);
     }
 
     private void enableAtBComponents(JPanel panel, boolean enabled) {


### PR DESCRIPTION
This fixes #3763. When setting the quality of a unit in the Hangar the quality names are properly reversed.

Code duplicated from [PartsTableMouseAdapter#actionPerformed](../blob/master/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java#L107-L130)