### PR TITLE
Fix jvm thrashing in github actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: clean build --no-build-cache --info --continue --stacktrace --scan
+        arguments: clean build --no-build-cache --info --continue --stacktrace --max-workers=1 --scan
         build-root-directory: mekhq
 
     # If the build step fails, try to upload any test logs in case it was a unit test failure.

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: clean build --no-build-cache --info --stacktrace --scan
+        arguments: clean build --no-build-cache --info --stacktrace --max-workers=1 --scan
         build-root-directory: mekhq
       
     # If the build step fails, try to upload any test logs in case it was a unit test failure.

--- a/.github/workflows/nightly-maven-ci.yml
+++ b/.github/workflows/nightly-maven-ci.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: clean build --continue --stacktrace --scan
+        arguments: clean build --continue --stacktrace --max-workers=1 --scan
         build-root-directory: mekhq
 
     - name: Upload Test Logs on Failure


### PR DESCRIPTION
Applied the same fix as the nightly-ci git hub action to the remaining github actions to prevent Gradle JVM memory thrashing when building from a clean project.  This has been working with good performance with the Nightly-ci github action for the past few months.

See #3785