### PR TITLE
Closing opening comment in eras.xml

### DIFF
--- a/MekHQ/data/universe/eras.xml
+++ b/MekHQ/data/universe/eras.xml
@@ -5,7 +5,7 @@ Code: The unique String code for the era.
 Name: The display name for the era.
 End: The end date for the era. This can be in the formats "yyyy-MM-dd", "yyyy-MM" (assuming first day of the month), and "yyyy" (assuming first day of the year). One era should have this value missing, which will put it as the final era. For the canon dates, these will be one year after their end date in the MUL, as that will swapover on the first day of the new era.
 Flag: The internal flags for the base eras. You can have multiple flag fields (multiple lines each with a single flag) per custom era, which isn't used in base MekHQ, but allows one to customize things.
-
+-->
 <eras>
 	<era>
 		<code>PSF</code>


### PR DESCRIPTION
MekHQ stopped being able to run, crashing whenever I tried to start a new campaign, or load an existing one. After some digging, I found that [eras.xml](../blob/master/MekHQ/data/universe/eras.xml) was missing the closing tag on the opening comment.

Adding that, I can now start and load campaigns.

Interestingly, it seems to have been missing for quite some time, so potentially the xml parser we use got an update, or got set more strict recently. Not sure.