### PR TITLE
Fix chassis lookup

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -1913,7 +1913,7 @@ public class ResolveScenarioTracker {
         public UnitStatus(Unit unit) {
             this.unit = unit;
             this.name = unit.getName();
-            chassis = unit.getEntity().getChassis();
+            chassis = unit.getEntity().getFullChassis();
             model = unit.getEntity().getModel();
             //assume its a total loss until we find something that says otherwise
             totalLoss = true;


### PR DESCRIPTION
Fixes the MechSummaryCache lookup for meks with clan chassis names during scenario resolution. The MSC still uses the full names internally, e.g. Mad Cat (Timber Wolf) = entity.getFullChassis()