### PR TITLE
Fix 3848: Unit bays not accepting Aeros for transport, with unit test

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1283,8 +1283,9 @@ public class Unit implements ITechnology {
         switch (unitType) {
             case UnitType.MEK:
                 return getCurrentMechCapacity();
-            case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
             case UnitType.CONV_FIGHTER:
+            case UnitType.AERO:
                 // Return a small craft slot if no ASF slots exist
                 if (getCurrentASFCapacity() > 0) {
                     return getCurrentASFCapacity();
@@ -1347,8 +1348,9 @@ public class Unit implements ITechnology {
             case UnitType.MEK:
                 setMechCapacity(Math.min((getCurrentMechCapacity() + amount), getMechCapacity()));
                 break;
-            case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
             case UnitType.CONV_FIGHTER:
+            case UnitType.AERO:
                 // Use the assigned bay number to determine if we need to update ASF or Small Craft capacity
                 Bay aeroBay = getEntity().getBayById(bayNumber);
                 if (aeroBay != null) {
@@ -3420,7 +3422,7 @@ public class Unit implements ITechnology {
             return UIManager.getColor(type + ".Foreground");
         }
     }
-    
+
     public Color determineBackgroundColor(String type) {
         if (isDeployed()) {
             return MekHQ.getMHQOptions().getDeployedBackground();
@@ -3446,7 +3448,7 @@ public class Unit implements ITechnology {
             return UIManager.getColor(type + ".Background");
         }
     }
-    
+
     /**
      * Determines which crew member is considered the unit commander. For solo-piloted units there is
      * only one option, but units with multiple crew (vehicles, aerospace vessels, infantry) use the following

--- a/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/RefitTest.java
@@ -33,6 +33,7 @@ import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.UnitTestUtilities;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,6 +77,11 @@ public class RefitTest {
 
     @Mock
     private Warehouse mockWarehouse;
+
+    @BeforeAll
+    static void before() {
+        EquipmentType.initializeTypes();
+    }
 
     @BeforeEach
     public void beforeEach() {

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTransportTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTransportTest.java
@@ -18,12 +18,12 @@
  */
 package mekhq.campaign.unit;
 
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.Mech;
+import megamek.common.*;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+import java.util.Vector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -32,6 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class UnitTransportTest {
+
+    @BeforeAll
+    static void before() {
+        EquipmentType.initializeTypes();
+    }
+
     @Test
     public void basicTransportedUnits() {
         Unit transport = new Unit();
@@ -135,6 +141,32 @@ public class UnitTransportTest {
         assertTrue(transport.hasTransportedUnits());
         assertTrue(transport.isCarryingSmallerAero());
         assertFalse(transport.isCarryingGround());
+    }
+
+    @Test
+    public void testUnitTypeForAerosMatchesAeroBayType() {
+        // Create a fake entity to back the real transport Unit
+        Dropship mockVengeance = mock(Dropship.class);
+        Unit transport = new Unit();
+        ASFBay mockASFBay = mock(ASFBay.class);
+        when(mockASFBay.getCapacity()).thenReturn(100.0);
+        transport.setEntity(mockVengeance);
+
+        // Initialize bays
+        Vector<Bay> bays = new Vector<>();
+        bays.add(mockASFBay);
+        when(mockVengeance.getTransportBays()).thenReturn(bays);
+        transport.initializeBaySpace();
+
+        // Add an aero unit
+        Entity aero = new AeroSpaceFighter();
+        Unit mockAeroUnit = mock(Unit.class);
+        when(mockAeroUnit.getId()).thenReturn(UUID.randomUUID());
+        when(mockAeroUnit.getEntity()).thenReturn(aero);
+
+        // Verify the AeroSpaceFighter is recognized as a valid ASFBay occupant
+        double remainingCap = transport.getCorrectBayCapacity(aero.getUnitType(), 50);
+        assertEquals(100.0, remainingCap);
     }
 
     @Test


### PR DESCRIPTION
Add "AeroSpaceFighter" UnitType to the list of acceptable UnitTypes for ASFBay transport.
This is another place where the Aero -> AeroSpaceFighter transition was incomplete.

Testing:
- Ran all projects' unit tests (Some MekHQ tests failing due to other issues)
- Verified ability to load ASF onto transport in UI.

Close #3848 