### PR TITLE
Fix 3775: unable to assign nonsuperheavy crew

### DIFF
--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -225,7 +225,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                 // Pilot Menu
                 if (unit.canTakeMoreDrivers()) {
                     // Pilot Menu - Solo Pilot and VTOL Pilot Assignment
-                    if (singlePerson && (unit.usesSoloPilot() || (entity instanceof VTOL))) {
+                    if (singlePerson && (unit.usesSoloPilot() || (entity instanceof VTOL) || entity.isSuperHeavy() || entity.isTripodMek())) {
                         final boolean valid;
                         if (entity instanceof Mech) {
                             valid = areAllBattleMechPilots;

--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -152,7 +152,8 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     .sort(campaign.getHangar().getUnitsStream().filter(Unit::isAvailable))
                     .collect(Collectors.toList());
             for (final Unit unit : units) {
-                if (unit.getEntity().getUnitType() != unitType) {
+                Entity entity = unit.getEntity();
+                if (entity.getUnitType() != unitType) {
                     // Add the current menus, first the Entity Weight Class menu to the related Unit
                     // Type menu, then the Unit Type menu to the grouping menu
                     pilotUnitTypeMenu.add(pilotEntityWeightMenu);
@@ -173,12 +174,12 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     navigatorMenu.add(navigatorUnitTypeMenu);
 
                     // Update parsing variables
-                    unitType = unit.getEntity().getUnitType();
-                    weightClass = unit.getEntity().getWeightClass();
+                    unitType = entity.getUnitType();
+                    weightClass = entity.getWeightClass();
 
                     // And create the new menus
                     final String unitTypeName = UnitType.getTypeDisplayableName(unitType);
-                    final String entityWeightClassName = EntityWeightClass.getClassName(weightClass, unit.getEntity());
+                    final String entityWeightClassName = EntityWeightClass.getClassName(weightClass, entity);
                     pilotUnitTypeMenu = new JScrollableMenu("pilotUnitTypeMenu", unitTypeName);
                     pilotEntityWeightMenu = new JScrollableMenu("pilotEntityWeightMenu", entityWeightClassName);
                     driverUnitTypeMenu = new JScrollableMenu("driverUnitTypeMenu", unitTypeName);
@@ -195,7 +196,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     soldierEntityWeightMenu = new JScrollableMenu("soldierEntityWeightMenu", entityWeightClassName);
                     navigatorUnitTypeMenu = new JScrollableMenu("navigatorUnitTypeMenu", unitTypeName);
                     navigatorEntityWeightMenu = new JScrollableMenu("navigatorEntityWeightMenu", entityWeightClassName);
-                } else if (unit.getEntity().getWeightClass() != weightClass) {
+                } else if (entity.getWeightClass() != weightClass) {
                     // Add the current Entity Weight Class menu to the Unit Type menu
                     pilotUnitTypeMenu.add(pilotEntityWeightMenu);
                     driverUnitTypeMenu.add(driverEntityWeightMenu);
@@ -207,10 +208,10 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     navigatorUnitTypeMenu.add(navigatorEntityWeightMenu);
 
                     // Update parsing variable
-                    weightClass = unit.getEntity().getWeightClass();
+                    weightClass = entity.getWeightClass();
 
                     // And create the new Entity Weight Class menus
-                    final String entityWeightClassName = EntityWeightClass.getClassName(weightClass, unit.getEntity());
+                    final String entityWeightClassName = EntityWeightClass.getClassName(weightClass, entity);
                     pilotEntityWeightMenu = new JScrollableMenu("pilotEntityWeightMenu", entityWeightClassName);
                     driverEntityWeightMenu = new JScrollableMenu("driverEntityWeightMenu", entityWeightClassName);
                     gunnerEntityWeightMenu = new JScrollableMenu("gunnerEntityWeightMenu", entityWeightClassName);
@@ -224,17 +225,17 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                 // Pilot Menu
                 if (unit.canTakeMoreDrivers()) {
                     // Pilot Menu - Solo Pilot and VTOL Pilot Assignment
-                    if (singlePerson && (unit.usesSoloPilot() || (unit.getEntity() instanceof VTOL))) {
+                    if (singlePerson && (unit.usesSoloPilot() || (entity instanceof VTOL))) {
                         final boolean valid;
-                        if (unit.getEntity() instanceof Mech) {
+                        if (entity instanceof Mech) {
                             valid = areAllBattleMechPilots;
-                        } else if (unit.getEntity() instanceof Protomech) {
+                        } else if (entity instanceof Protomech) {
                             valid = areAllProtoMechPilots;
-                        } else if (unit.getEntity() instanceof ConvFighter) {
+                        } else if (entity instanceof ConvFighter) {
                             valid = areAllConventionalAerospacePilots;
-                        } else if (unit.getEntity() instanceof Aero) {
+                        } else if (entity instanceof Aero) {
                             valid = areAllAerospacePilots;
-                        } else if (unit.getEntity() instanceof VTOL) {
+                        } else if (entity instanceof VTOL) {
                             valid = areAllVTOLPilots;
                         } else {
                             valid = false;
@@ -253,7 +254,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                     useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                 }
 
-                                if (unit.getEntity() instanceof VTOL) {
+                                if (entity instanceof VTOL) {
                                     unit.addDriver(people[0], useTransfers);
                                 } else {
                                     unit.addPilotOrSoldier(people[0], useTransfers);
@@ -264,7 +265,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     }
 
                     // Pilot Menu - Small Craft and JumpShip Vessel Pilot Assignment
-                    if (((unit.getEntity() instanceof SmallCraft) || (unit.getEntity() instanceof Jumpship))
+                    if (((entity instanceof SmallCraft) || (entity instanceof Jumpship))
                             && areAllVesselPilots) {
                         final JMenuItem miVesselPilot = new JMenuItem(unit.getName());
                         miVesselPilot.setName("miVesselPilot");
@@ -289,9 +290,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     }
 
                     // Driver Menu - Non-VTOL Tank Driver Assignments
-                    if (singlePerson && (unit.getEntity() instanceof Tank)
-                            && !(unit.getEntity() instanceof VTOL)) {
-                        if (unit.getEntity().getMovementMode().isMarine()
+                    if (singlePerson && (entity instanceof Tank)
+                            && !(entity instanceof VTOL)) {
+                        if (entity.getMovementMode().isMarine()
                                 ? areAllNavalVehicleDrivers : areAllGroundVehicleDrivers) {
                             final JMenuItem miDriver = new JMenuItem(unit.getName());
                             miDriver.setName("miDriver");
@@ -314,11 +315,13 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                 // Gunnery Menu
                 if (unit.canTakeMoreGunners()) {
                     final boolean valid;
-                    if (unit.getEntity() instanceof Tank) {
+                    if (entity instanceof Tank) {
                         valid = areAllVehicleGunners;
-                    } else if ((unit.getEntity() instanceof SmallCraft)
-                            || (unit.getEntity() instanceof Jumpship)) {
+                    } else if ((entity instanceof SmallCraft)
+                            || (entity instanceof Jumpship)) {
                         valid = areAllVesselGunners;
+                    } else if (entity.isTripodMek() || entity.isSuperHeavy()) {
+                        valid = areAllBattleMechPilots;
                     } else {
                         valid = false;
                     }
@@ -352,9 +355,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                 // TODO : also be based on crewmembers
                 if (unit.canTakeMoreVesselCrew()) {
                     final boolean valid;
-                    if (unit.getEntity() instanceof Aero) {
+                    if (entity instanceof Aero) {
                         valid = areAllVesselCrew;
-                    } else if (unit.getEntity().isSupportVehicle()) {
+                    } else if (entity.isSupportVehicle()) {
                         // TODO : Expand for Command and Control, Medical, Technician, and Salvage Assignments
                         valid = areAllVehicleCrew;
                     } else {
@@ -393,8 +396,8 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                 if (singlePerson && unit.canTakeTechOfficer()) {
                     // For a vehicle command console we will require the commander to be a driver
                     // or a gunner, but not necessarily both
-                    if (unit.getEntity() instanceof Tank) {
-                        if (people[0].canDrive(unit.getEntity()) || people[0].canGun(unit.getEntity())) {
+                    if (entity instanceof Tank) {
+                        if (people[0].canDrive(entity) || people[0].canGun(entity)) {
                             final JMenuItem miConsoleCommander = new JMenuItem(unit.getName());
                             miConsoleCommander.setName("miConsoleCommander");
                             miConsoleCommander.setForeground(unit.determineForegroundColor("Menu"));
@@ -410,7 +413,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                             });
                             consoleCommanderEntityWeightMenu.add(miConsoleCommander);
                         }
-                    } else if (people[0].canDrive(unit.getEntity()) && people[0].canGun(unit.getEntity())) {
+                    } else if (people[0].canDrive(entity) && people[0].canGun(entity)) {
                         final JMenuItem miTechOfficer = new JMenuItem(unit.getName());
                         miTechOfficer.setName("miTechOfficer");
                         miTechOfficer.setForeground(unit.determineForegroundColor("Menu"));

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -396,7 +396,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
             filteredPersonnel = personnel.stream()
                     .filter(person -> (isSmallCraftOrJumpShip && person.hasRole(PersonnelRole.VESSEL_GUNNER)) ||
                             (isTank && person.hasRole(PersonnelRole.VEHICLE_GUNNER)) ||
-                            (isSuperHeavyMech && person.getPrimaryRole().isMechWarriorGrouping()
+                            ((isSuperHeavyMech || isTripod) && person.getPrimaryRole().isMechWarriorGrouping()
                                 || person.getSecondaryRole().isMechWarriorGrouping()))
                     .collect(Collectors.toList());
             if (!filteredPersonnel.isEmpty()) {

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -94,18 +94,20 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         final JScrollableMenu navigatorMenu = new JScrollableMenu("navigatorMenu", resources.getString("navigatorMenu.text"));
 
         // Parsing Booleans
+        final Entity entity = units[0].getEntity();
         final boolean canTakeMoreDrivers = units[0].canTakeMoreDrivers();
         final boolean usesSoloPilot = units[0].usesSoloPilot();
-        final boolean isVTOL = units[0].getEntity() instanceof VTOL;
-        final boolean isMech = units[0].getEntity() instanceof Mech;
-        final boolean isSuperHeavyMech = isMech && units[0].getEntity().isSuperHeavy();
-        final boolean isProtoMech = units[0].getEntity() instanceof Protomech;
-        final boolean isConventionalAircraft = units[0].getEntity() instanceof ConvFighter;
-        final boolean isSmallCraftOrJumpShip = (units[0].getEntity() instanceof SmallCraft)
-                || (units[0].getEntity() instanceof Jumpship);
-        final boolean isTank = units[0].getEntity() instanceof Tank;
+        final boolean isVTOL = entity instanceof VTOL;
+        final boolean isMech = entity instanceof Mech;
+        final boolean isTripod = entity instanceof TripodMech;
+        final boolean isSuperHeavyMech = isMech && entity.isSuperHeavy();
+        final boolean isProtoMech = entity instanceof Protomech;
+        final boolean isConventionalAircraft = entity instanceof ConvFighter;
+        final boolean isSmallCraftOrJumpShip = (entity instanceof SmallCraft)
+                || (entity instanceof Jumpship);
+        final boolean isTank = entity instanceof Tank;
         final boolean canTakeMoreGunners = units[0].canTakeMoreGunners();
-        final boolean isAero = units[0].getEntity() instanceof Aero;
+        final boolean isAero = entity instanceof Aero;
         final boolean canTakeTechOfficer = units[0].canTakeTechOfficer();
         final boolean usesSoldiers = units[0].usesSoldiers();
         final boolean isConventionalInfantry = units[0].isConventionalInfantry();
@@ -198,7 +200,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         // Pilot Menu
         if (canTakeMoreDrivers) {
             // Pilot Menu
-            if (usesSoloPilot || isVTOL || isSmallCraftOrJumpShip || isSuperHeavyMech) {
+            if (usesSoloPilot || isVTOL || isSmallCraftOrJumpShip || isSuperHeavyMech || isTripod) {
                 if (isMech) {
                     filteredPersonnel = personnel.stream()
                             .filter(person -> person.getPrimaryRole().isMechWarriorGrouping()
@@ -390,7 +392,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         }
 
         // Gunners Menu
-        if (canTakeMoreGunners && (isTank || isSmallCraftOrJumpShip || isSuperHeavyMech)) {
+        if (canTakeMoreGunners && (isTank || isSmallCraftOrJumpShip || isSuperHeavyMech || isTripod)) {
             filteredPersonnel = personnel.stream()
                     .filter(person -> (isSmallCraftOrJumpShip && person.hasRole(PersonnelRole.VESSEL_GUNNER)) ||
                             (isTank && person.hasRole(PersonnelRole.VEHICLE_GUNNER)) ||
@@ -410,17 +412,17 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                 // Add the person to the proper menu
                 for (final Person person : filteredPersonnel) {
                     final JScrollableMenu subMenu;
-                    
+
                     SkillLevel skillLevel = SkillLevel.NONE;
-                    // determine skill level based on unit and person's role 
+                    // determine skill level based on unit and person's role
                     if (isSmallCraftOrJumpShip) {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isVesselGunner());
                     } else if (isTank) {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isVehicleGunner());
-                    } else if (isSuperHeavyMech) {
+                    } else if (isSuperHeavyMech || isTripod) {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isMechWarriorGrouping());
                     }
-                    
+
                     switch (skillLevel) {
                         case LEGENDARY:
                             subMenu = legendaryMenu;


### PR DESCRIPTION
Includes a couple of fixes for non-standard Mek crew complements:

1. Non-SH Tripods can now be assigned to crews, or have crews assigned to them.
2. Pilots can be assigned to SH and Tripods in the Personnel tab (previously broken)

Testing:
- Ran all unit tests across 3 projects (several still failing in MekHQ, unrelated)
- Tested crew assignments in a campaign with both SuperHeavy and Medium Tripod meks.

Close #3775 