### PR TITLE
Fix 3856: aeros dont appear in basic unit information

### DIFF
--- a/MekHQ/mmconf/serialkiller.xml
+++ b/MekHQ/mmconf/serialkiller.xml
@@ -10,6 +10,7 @@
         <regexps>
             <regexp>\[C$</regexp>
             <regexp>\[I$</regexp>
+            <regexp>\[Ljava\.lang.Enum;$</regexp>
             <regexp>java\.io\.File$</regexp>
             <regexp>java\.lang\.Boolean$</regexp>
             <regexp>java\.lang\.Enum$</regexp>
@@ -31,6 +32,7 @@
             <regexp>java\.util\.concurrent\.locks\.ReentrantLock\$Sync$</regexp>
             <regexp>java\.util\.UUID$</regexp>
             <regexp>java\.util\.EnumMap$</regexp>
+            <regexp>java\.util\.EnumSet.*</regexp>
             <regexp>java\.util\.HashMap$</regexp>
             <regexp>java\.util\.HashSet$</regexp>
             <regexp>java\.util\.Hashtable$</regexp>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3577,7 +3577,7 @@ public class Campaign implements ITechManager {
         if (force != null) {
             force.updateCommander(this);
         }
-        
+
         person.getGenealogy().clearGenealogyLinks();
 
         final Unit unit = person.getUnit();
@@ -4523,7 +4523,7 @@ public class Campaign implements ITechManager {
         int nMech = stats.getNumberOfUnitsByType(Entity.ETYPE_MECH);
         int nLVee = stats.getNumberOfUnitsByType(Entity.ETYPE_TANK, false, true);
         int nHVee = stats.getNumberOfUnitsByType(Entity.ETYPE_TANK);
-        int nAero = stats.getNumberOfUnitsByType(Entity.ETYPE_AERO);
+        int nAero = stats.getNumberOfUnitsByType(Entity.ETYPE_AEROSPACEFIGHTER);
         int nSC = stats.getNumberOfUnitsByType(Entity.ETYPE_SMALL_CRAFT);
         int nCF = stats.getNumberOfUnitsByType(Entity.ETYPE_CONV_FIGHTER);
         int nBA = stats.getNumberOfUnitsByType(Entity.ETYPE_BATTLEARMOR);
@@ -4544,7 +4544,7 @@ public class Campaign implements ITechManager {
         int noDS = Math.max(nDropship - stats.getOccupiedBays(Entity.ETYPE_DROPSHIP), 0);
         int noSC = Math.max(nSC - stats.getOccupiedBays(Entity.ETYPE_SMALL_CRAFT), 0);
         int noCF = Math.max(nCF - stats.getOccupiedBays(Entity.ETYPE_CONV_FIGHTER), 0);
-        int noASF = Math.max(nAero - stats.getOccupiedBays(Entity.ETYPE_AERO), 0);
+        int noASF = Math.max(nAero - stats.getOccupiedBays(Entity.ETYPE_AEROSPACEFIGHTER), 0);
         int nolv = Math.max(nLVee - stats.getOccupiedBays(Entity.ETYPE_TANK, true), 0);
         int nohv = Math.max(nHVee - stats.getOccupiedBays(Entity.ETYPE_TANK), 0);
         int noinf = Math.max(stats.getNumberOfUnitsByType(Entity.ETYPE_INFANTRY) - stats.getOccupiedBays(Entity.ETYPE_INFANTRY), 0);
@@ -4809,12 +4809,12 @@ public class Campaign implements ITechManager {
         if (null != u) {
             u.resetPilotAndEntity();
         }
-        
+
         Force force = getForceFor(p);
         if (force != null) {
             force.updateCommander(this);
         }
-        
+
         MekHQ.triggerEvent(new PersonChangedEvent(p));
     }
 

--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -122,6 +122,7 @@ public class CampaignSummary {
                 case UnitType.TANK:
                     veeCount++;
                     break;
+                case UnitType.AEROSPACEFIGHTER:
                 case UnitType.AERO:
                 case UnitType.CONV_FIGHTER:
                     aeroCount++;
@@ -165,7 +166,7 @@ public class CampaignSummary {
         int noSC = Math.max(hangarStats.getNumberOfUnitsByType(Entity.ETYPE_SMALL_CRAFT) - hangarStats.getOccupiedBays(Entity.ETYPE_SMALL_CRAFT), 0);
         @SuppressWarnings("unused") // FIXME: What type of bays do ConvFighters use?
         int noCF = Math.max(hangarStats.getNumberOfUnitsByType(Entity.ETYPE_CONV_FIGHTER) - hangarStats.getOccupiedBays(Entity.ETYPE_CONV_FIGHTER), 0);
-        int noASF = Math.max(hangarStats.getNumberOfUnitsByType(Entity.ETYPE_AERO) - hangarStats.getOccupiedBays(Entity.ETYPE_AERO), 0);
+        int noASF = Math.max(hangarStats.getNumberOfUnitsByType(Entity.ETYPE_AEROSPACEFIGHTER) - hangarStats.getOccupiedBays(Entity.ETYPE_AEROSPACEFIGHTER), 0);
         int nolv = Math.max(hangarStats.getNumberOfUnitsByType(Entity.ETYPE_TANK, false, true) - hangarStats.getOccupiedBays(Entity.ETYPE_TANK, true), 0);
         int nohv = Math.max(hangarStats.getNumberOfUnitsByType(Entity.ETYPE_TANK) - hangarStats.getOccupiedBays(Entity.ETYPE_TANK), 0);
         int noinf = Math.max(hangarStats.getNumberOfUnitsByType(Entity.ETYPE_INFANTRY) - hangarStats.getOccupiedBays(Entity.ETYPE_INFANTRY), 0);
@@ -182,7 +183,7 @@ public class CampaignSummary {
         unitsOver = noMech + noASF + nolv + nohv + noinf + noBA + noProto;
         unitsTransported = hangarStats.getOccupiedBays(Entity.ETYPE_MECH) +
                 hangarStats.getOccupiedBays(Entity.ETYPE_SMALL_CRAFT) +
-                hangarStats.getOccupiedBays(Entity.ETYPE_AERO) +
+                hangarStats.getOccupiedBays(Entity.ETYPE_AEROSPACEFIGHTER) +
                 hangarStats.getOccupiedBays(Entity.ETYPE_TANK, true) +
                 hangarStats.getOccupiedBays(Entity.ETYPE_TANK) +
                 hangarStats.getOccupiedBays(Entity.ETYPE_INFANTRY) +

--- a/MekHQ/src/mekhq/campaign/force/Lance.java
+++ b/MekHQ/src/mekhq/campaign/force/Lance.java
@@ -165,7 +165,7 @@ public class Lance {
                 if (null != entity) {
                     if ((entity.getEntityType() & Entity.ETYPE_MECH) != 0) {
                         armor += 1;
-                    } else if ((entity.getEntityType() & Entity.ETYPE_AERO) != 0) {
+                    } else if ((entity.getEntityType() & Entity.ETYPE_AEROSPACEFIGHTER) != 0) {
                         other += 0.5;
                     } else if ((entity.getEntityType() & Entity.ETYPE_TANK) != 0) {
                         armor += 0.5;
@@ -499,7 +499,7 @@ public class Lance {
                         } else {
                             weight += entity.getWeight();
                         }
-                    } else if ((entity.getEntityType() & Entity.ETYPE_AERO) != 0) {
+                    } else if ((entity.getEntityType() & Entity.ETYPE_AEROSPACEFIGHTER) != 0) {
                         if (c.getFaction().isClan()) {
                             weight += entity.getWeight() * 0.5;
                         } else {

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -312,8 +312,8 @@ public class PersonnelMarket {
             return Entity.ETYPE_MECH;
         } else if ((mostTypes & Entity.ETYPE_TANK) != 0) {
             return Entity.ETYPE_TANK;
-        } else if ((mostTypes & Entity.ETYPE_AERO) != 0) {
-            return Entity.ETYPE_AERO;
+        } else if ((mostTypes & Entity.ETYPE_AEROSPACEFIGHTER) != 0) {
+            return Entity.ETYPE_AEROSPACEFIGHTER;
         } else if ((mostTypes & Entity.ETYPE_BATTLEARMOR) != 0) {
             return Entity.ETYPE_BATTLEARMOR;
         } else if ((mostTypes & Entity.ETYPE_INFANTRY) != 0) {
@@ -337,7 +337,7 @@ public class PersonnelMarket {
         int ds = hangarStats.getNumberOfUnitsByType(Entity.ETYPE_DROPSHIP);
         int sc = hangarStats.getNumberOfUnitsByType(Entity.ETYPE_SMALL_CRAFT);
         int cf = hangarStats.getNumberOfUnitsByType(Entity.ETYPE_CONV_FIGHTER);
-        int asf = hangarStats.getNumberOfUnitsByType(Entity.ETYPE_AERO);
+        int asf = hangarStats.getNumberOfUnitsByType(Entity.ETYPE_AEROSPACEFIGHTER);
         int vee = hangarStats.getNumberOfUnitsByType(Entity.ETYPE_TANK, true) + hangarStats.getNumberOfUnitsByType(Entity.ETYPE_TANK);
         int inf = hangarStats.getNumberOfUnitsByType(Entity.ETYPE_INFANTRY);
         int ba = hangarStats.getNumberOfUnitsByType(Entity.ETYPE_BATTLEARMOR);
@@ -381,7 +381,7 @@ public class PersonnelMarket {
             retval = retval | Entity.ETYPE_CONV_FIGHTER;
         }
         if (most == asf) {
-            retval = retval | Entity.ETYPE_AERO;
+            retval = retval | Entity.ETYPE_AEROSPACEFIGHTER;
         }
         if (most == vee) {
             retval = retval | Entity.ETYPE_TANK;

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarketDylan.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarketDylan.java
@@ -49,8 +49,8 @@ public class PersonnelMarketDylan extends PersonnelMarketRandom {
             mtf.add(Entity.ETYPE_MECH);
         } else if ((mostTypes & Entity.ETYPE_TANK) != 0) {
             mtf.add(Entity.ETYPE_TANK);
-        } else if ((mostTypes & Entity.ETYPE_AERO) != 0) {
-            mtf.add(Entity.ETYPE_AERO);
+        } else if ((mostTypes & Entity.ETYPE_AEROSPACEFIGHTER) != 0) {
+            mtf.add(Entity.ETYPE_AEROSPACEFIGHTER);
         } else if ((mostTypes & Entity.ETYPE_BATTLEARMOR) != 0) {
             mtf.add(Entity.ETYPE_BATTLEARMOR);
         } else if ((mostTypes & Entity.ETYPE_INFANTRY) != 0) {
@@ -79,7 +79,7 @@ public class PersonnelMarketDylan extends PersonnelMarketRandom {
                 } else if (choice == Entity.ETYPE_TANK) {
                     p = c.newPerson((Compute.d6() < 3) ? PersonnelRole.GROUND_VEHICLE_DRIVER
                             : PersonnelRole.VEHICLE_GUNNER);
-                } else if (choice == Entity.ETYPE_AERO) {
+                } else if (choice == Entity.ETYPE_AEROSPACEFIGHTER) {
                     p = c.newPerson(PersonnelRole.AEROSPACE_PILOT);
                 } else if (choice == Entity.ETYPE_BATTLEARMOR) {
                     p = c.newPerson(PersonnelRole.BATTLE_ARMOUR);

--- a/MekHQ/src/mekhq/campaign/parts/Avionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/Avionics.java
@@ -63,7 +63,7 @@ public class Avionics extends Part {
     public void updateConditionFromEntity(boolean checkForDestruction) {
         int priorHits = hits;
         if (null != unit
-                && (unit.getEntity().getEntityType() & (Entity.ETYPE_AERO | Entity.ETYPE_LAND_AIR_MECH)) != 0) {
+                && (unit.getEntity().getEntityType() & (Entity.ETYPE_AEROSPACEFIGHTER | Entity.ETYPE_LAND_AIR_MECH)) != 0) {
             hits = ((IAero) unit.getEntity()).getAvionicsHits();
             if (checkForDestruction
                     && hits > priorHits

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -252,7 +252,7 @@ public class CampaignOpsReputation extends AbstractUnitRating {
                 //noinspection UnnecessaryContinue
                 continue;
             } else if ((u.getEntity().getEntityType() &
-                        Entity.ETYPE_AERO) == Entity.ETYPE_AERO) {
+                        Entity.ETYPE_AEROSPACEFIGHTER) == Entity.ETYPE_AEROSPACEFIGHTER) {
                 totalAero++;
             } else if ((u.getEntity().getEntityType() &
                         Entity.ETYPE_DROPSHIP) == Entity.ETYPE_DROPSHIP) {

--- a/MekHQ/src/mekhq/campaign/report/TransportReport.java
+++ b/MekHQ/src/mekhq/campaign/report/TransportReport.java
@@ -45,7 +45,7 @@ public class TransportReport extends AbstractReport {
         @SuppressWarnings("unused") // FIXME: What type of bays do ConvFighters use?
         int noCF = Math
                 .max(stats.getNumberOfUnitsByType(Entity.ETYPE_CONV_FIGHTER) - stats.getOccupiedBays(Entity.ETYPE_CONV_FIGHTER), 0);
-        int noASF = Math.max(stats.getNumberOfUnitsByType(Entity.ETYPE_AERO) - stats.getOccupiedBays(Entity.ETYPE_AERO), 0);
+        int noASF = Math.max(stats.getNumberOfUnitsByType(Entity.ETYPE_AEROSPACEFIGHTER) - stats.getOccupiedBays(Entity.ETYPE_AEROSPACEFIGHTER), 0);
         int nolv = Math.max(stats.getNumberOfUnitsByType(Entity.ETYPE_TANK, false, true) - stats.getOccupiedBays(Entity.ETYPE_TANK, true), 0);
         int nohv = Math.max(stats.getNumberOfUnitsByType(Entity.ETYPE_TANK) - stats.getOccupiedBays(Entity.ETYPE_TANK), 0);
         int noinf = Math.max(stats.getNumberOfUnitsByType(Entity.ETYPE_INFANTRY) - stats.getOccupiedBays(Entity.ETYPE_INFANTRY), 0);
@@ -91,7 +91,7 @@ public class TransportReport extends AbstractReport {
 
         // Lets do ASF next.
         sb.append(String.format("%-35s      %4d (%4d)      %-35s     %4d%s\n", "ASF Bays (Occupied):",
-                stats.getTotalASFBays(), stats.getOccupiedBays(Entity.ETYPE_AERO), "ASF Not Transported:", noASF, asfAppend));
+                stats.getTotalASFBays(), stats.getOccupiedBays(Entity.ETYPE_AEROSPACEFIGHTER), "ASF Not Transported:", noASF, asfAppend));
 
         // Lets do Light Vehicles next.
         sb.append(String.format("%-35s      %4d (%4d)      %-35s     %4d%s\n", "Light Vehicle Bays (Occupied):",

--- a/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
+++ b/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
@@ -89,16 +89,6 @@ public class CargoStatistics {
 
         double cargoTonnage = 0;
         double mothballedTonnage = 0;
-        int mechs = stats.getNumberOfUnitsByType(Entity.ETYPE_MECH);
-        int ds = stats.getNumberOfUnitsByType(Entity.ETYPE_DROPSHIP);
-        int sc = stats.getNumberOfUnitsByType(Entity.ETYPE_SMALL_CRAFT);
-        int cf = stats.getNumberOfUnitsByType(Entity.ETYPE_CONV_FIGHTER);
-        int asf = stats.getNumberOfUnitsByType(Entity.ETYPE_AEROSPACEFIGHTER);
-        int inf = stats.getNumberOfUnitsByType(Entity.ETYPE_INFANTRY);
-        int ba = stats.getNumberOfUnitsByType(Entity.ETYPE_BATTLEARMOR);
-        int lv = stats.getNumberOfUnitsByType(Entity.ETYPE_TANK, true);
-        int hv = stats.getNumberOfUnitsByType(Entity.ETYPE_TANK, false);
-        int protos = stats.getNumberOfUnitsByType(Entity.ETYPE_PROTOMECH);
 
         cargoTonnage += getCampaign().getWarehouse().streamSpareParts().filter(p -> inTransit || p.isPresent())
                             .mapToDouble(p -> p.getQuantity() * p.getTonnage())

--- a/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
+++ b/MekHQ/src/mekhq/campaign/unit/CargoStatistics.java
@@ -93,7 +93,7 @@ public class CargoStatistics {
         int ds = stats.getNumberOfUnitsByType(Entity.ETYPE_DROPSHIP);
         int sc = stats.getNumberOfUnitsByType(Entity.ETYPE_SMALL_CRAFT);
         int cf = stats.getNumberOfUnitsByType(Entity.ETYPE_CONV_FIGHTER);
-        int asf = stats.getNumberOfUnitsByType(Entity.ETYPE_AERO);
+        int asf = stats.getNumberOfUnitsByType(Entity.ETYPE_AEROSPACEFIGHTER);
         int inf = stats.getNumberOfUnitsByType(Entity.ETYPE_INFANTRY);
         int ba = stats.getNumberOfUnitsByType(Entity.ETYPE_BATTLEARMOR);
         int lv = stats.getNumberOfUnitsByType(Entity.ETYPE_TANK, true);

--- a/MekHQ/src/mekhq/campaign/unit/HangarStatistics.java
+++ b/MekHQ/src/mekhq/campaign/unit/HangarStatistics.java
@@ -24,11 +24,15 @@ package mekhq.campaign.unit;
 import megamek.common.*;
 import mekhq.campaign.Hangar;
 
+import java.util.HashMap;
+
 /**
  * Provides methods to gather statistics on units in a hangar.
  */
 public class HangarStatistics {
     private final Hangar hangar;
+    private long LIGHT_VEHICLE_BIT = 1L << 62;
+    private long SUPER_HEAVY_BIT = 1L << 63;
 
     public HangarStatistics(Hangar hangar) {
         this.hangar = hangar;
@@ -46,64 +50,70 @@ public class HangarStatistics {
         return getNumberOfUnitsByType(type, inTransit, false);
     }
 
-    public int getNumberOfUnitsByType(long type, boolean inTransit, boolean lv) {
-        int num = 0;
+    /**
+     * Tally all used bay types and return a hashmap of ETYPE : Count
+     * @param inTransit
+     * @param lv
+     * @return
+     */
+    public HashMap<Long, Integer> tallyBaysByType(boolean inTransit) {
+        HashMap<Long, Integer> hashMap = new HashMap<>();
         for (Unit unit : getHangar().getUnits()) {
             if (!inTransit && !unit.isPresent()) {
                 continue;
             }
             if (unit.isMothballed()) {
-                if (type == Unit.ETYPE_MOTHBALLED) {
-                    num++;
-                }
-                continue;
+                hashMap.put((long) Unit.ETYPE_MOTHBALLED, hashMap.getOrDefault((long) Unit.ETYPE_MOTHBALLED, 0) + 1);
             }
+
             Entity en = unit.getEntity();
-            if ((en instanceof GunEmplacement) || (en instanceof FighterSquadron) || (en instanceof Jumpship)) {
-                continue;
-            }
-            if ((type == Entity.ETYPE_MECH) && (en instanceof Mech)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_DROPSHIP) && (en instanceof Dropship)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_SMALL_CRAFT) && (en instanceof SmallCraft)
-                    && !(en instanceof Dropship)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_CONV_FIGHTER) && (en instanceof ConvFighter)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_AERO) && (en instanceof Aero)
-                    && !((en instanceof SmallCraft) || (en instanceof ConvFighter))) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_INFANTRY) && (en instanceof Infantry) && !(en instanceof BattleArmor)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_BATTLEARMOR) && (en instanceof BattleArmor)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_TANK) && (en instanceof Tank)) {
-                if (((en.getWeight() <= 50) && lv) || ((en.getWeight() > 50) && !lv)) {
-                    num++;
+
+            // Can be expanded to account for arbitrary types of transportable units.
+            if (en instanceof GunEmplacement) {
+                hashMap.put(Entity.ETYPE_GUN_EMPLACEMENT, hashMap.getOrDefault(Entity.ETYPE_GUN_EMPLACEMENT, 0) + 1);
+            } else if (en instanceof FighterSquadron) {
+                hashMap.put(Entity.ETYPE_FIGHTER_SQUADRON, hashMap.getOrDefault(Entity.ETYPE_FIGHTER_SQUADRON, 0) + 1);
+            } else if (en instanceof Jumpship) {
+                hashMap.put(Entity.ETYPE_JUMPSHIP, hashMap.getOrDefault(Entity.ETYPE_JUMPSHIP, 0) + 1);
+            } else if (en instanceof Mech) {
+                hashMap.put(Entity.ETYPE_MECH, hashMap.getOrDefault(Entity.ETYPE_MECH, 0) + 1);
+            } else if (en instanceof Dropship) {
+                hashMap.put(Entity.ETYPE_DROPSHIP, hashMap.getOrDefault(Entity.ETYPE_DROPSHIP, 0) + 1);
+            } else if (en instanceof SmallCraft) {
+                hashMap.put(Entity.ETYPE_SMALL_CRAFT, hashMap.getOrDefault(Entity.ETYPE_SMALL_CRAFT, 0) + 1);
+            } else if (en instanceof ConvFighter) {
+                hashMap.put(Entity.ETYPE_CONV_FIGHTER, hashMap.getOrDefault(Entity.ETYPE_CONV_FIGHTER, 0) + 1);
+            } else if (en instanceof AeroSpaceFighter) {
+                hashMap.put(Entity.ETYPE_AEROSPACEFIGHTER, hashMap.getOrDefault(Entity.ETYPE_AEROSPACEFIGHTER, 0) + 1);
+            } else if ((en instanceof Infantry) && !(en instanceof BattleArmor)) {
+                hashMap.put(Entity.ETYPE_INFANTRY, hashMap.getOrDefault(Entity.ETYPE_INFANTRY, 0) + 1);
+            } else if (en instanceof BattleArmor) {
+                hashMap.put(Entity.ETYPE_BATTLEARMOR, hashMap.getOrDefault(Entity.ETYPE_BATTLEARMOR, 0) + 1);
+            } else if (en instanceof Tank) {
+                // Split Tank into three indices, to match the two currently supported bay types and SH.
+                double weight = en.getWeight();
+                if (weight <= 50.0) {
+                    hashMap.put(Entity.ETYPE_TANK | LIGHT_VEHICLE_BIT,
+                            hashMap.getOrDefault(Entity.ETYPE_TANK | LIGHT_VEHICLE_BIT, 0) + 1);
+                } else if (weight > 50.0 && weight <= 100.0) {
+                    hashMap.put(Entity.ETYPE_TANK, hashMap.getOrDefault(Entity.ETYPE_TANK, 0) + 1);
+                } else {
+                    hashMap.put(Entity.ETYPE_TANK | SUPER_HEAVY_BIT,
+                            hashMap.getOrDefault(Entity.ETYPE_TANK | SUPER_HEAVY_BIT, 0) + 1);
                 }
-                continue;
-            }
-            if ((type == Entity.ETYPE_PROTOMECH) && (en instanceof Protomech)) {
-                num++;
+            } else if (en instanceof Protomech) {
+                hashMap.put(Entity.ETYPE_PROTOMECH, hashMap.getOrDefault(Entity.ETYPE_PROTOMECH, 0) + 1);
             }
         }
 
-        return num;
+        return hashMap;
+    }
+
+    public int getNumberOfUnitsByType(long type, boolean inTransit, boolean lv) {
+        HashMap<Long, Integer> bayMap = tallyBaysByType(inTransit);
+        long key = (lv) ? type | LIGHT_VEHICLE_BIT : type;
+
+        return bayMap.getOrDefault(key, 0);
     }
 
     public int getOccupiedBays(long type) {
@@ -111,60 +121,17 @@ public class HangarStatistics {
     }
 
     public int getOccupiedBays(long type, boolean lv) {
-        int num = 0;
-        for (Unit unit : getHangar().getUnits()) {
-            if (unit.isMothballed()) {
-                continue;
-            }
-            Entity en = unit.getEntity();
-            if ((en instanceof GunEmplacement) || (en instanceof Jumpship)) {
-                continue;
-            }
-            if ((type == Entity.ETYPE_MECH) && (en instanceof Mech)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_DROPSHIP) && (en instanceof Dropship)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_SMALL_CRAFT) && (en instanceof SmallCraft) && !(en instanceof Dropship)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_CONV_FIGHTER) && (en instanceof ConvFighter)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_AERO) && (en instanceof Aero)
-                    && !((en instanceof SmallCraft) || (en instanceof ConvFighter))) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_INFANTRY) && (en instanceof Infantry) && !(en instanceof BattleArmor)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_BATTLEARMOR) && (en instanceof BattleArmor)) {
-                num++;
-                continue;
-            }
-            if ((type == Entity.ETYPE_TANK) && (en instanceof Tank)) {
-                if (((en.getWeight() <= 50) && lv) || ((en.getWeight() > 50) && !lv)) {
-                    num++;
-                }
-                continue;
-            }
-            if ((type == Entity.ETYPE_PROTOMECH) && (en instanceof Protomech)) {
-                num++;
-            }
-        }
+        HashMap<Long, Integer> bayMap = tallyBaysByType(false);
+        long key = (lv) ? type | LIGHT_VEHICLE_BIT : type;
+
+        int num = bayMap.getOrDefault(key, 0);
 
         if (type == Entity.ETYPE_MECH) {
             return Math.min(getTotalMechBays(), num);
         }
 
-        if (type == Entity.ETYPE_AERO) {
+        // Okay to do an equality check here because this is the hash key, not the entity's ETYPE value.
+        if (type == Entity.ETYPE_AEROSPACEFIGHTER) {
             return Math.min(getTotalASFBays(), num);
         }
 

--- a/MekHQ/src/mekhq/campaign/unit/HangarStatistics.java
+++ b/MekHQ/src/mekhq/campaign/unit/HangarStatistics.java
@@ -53,11 +53,11 @@ public class HangarStatistics {
     /**
      * Tally all used bay types and return a hashmap of ETYPE : Count
      * @param inTransit
-     * @param lv
      * @return
      */
     public HashMap<Long, Integer> tallyBaysByType(boolean inTransit) {
         HashMap<Long, Integer> hashMap = new HashMap<>();
+
         for (Unit unit : getHangar().getUnits()) {
             if (!inTransit && !unit.isPresent()) {
                 continue;

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -1383,7 +1383,7 @@ public class CampaignOpsReputationTest {
         mockCorsair1Pilot = mock(Person.class);
         mockCorsair1Tech = mock(Person.class);
 
-        when(mockCorsair1.getEntityType()).thenReturn(Entity.ETYPE_AERO);
+        when(mockCorsair1.getEntityType()).thenReturn(Entity.ETYPE_AEROSPACEFIGHTER);
         when(mockCorsair1.getUnitType()).thenCallRealMethod();
         when(mockCorsairUnit1.getEntity()).thenReturn(mockCorsair1);
         when(mockCorsair1Pilot.isAdministrator()).thenReturn(false);
@@ -1419,7 +1419,7 @@ public class CampaignOpsReputationTest {
         mockCorsair2Pilot = mock(Person.class);
         mockCorsair2Tech = mock(Person.class);
 
-        when(mockCorsair2.getEntityType()).thenReturn(Entity.ETYPE_AERO);
+        when(mockCorsair2.getEntityType()).thenReturn(Entity.ETYPE_AEROSPACEFIGHTER);
         when(mockCorsair2.getUnitType()).thenCallRealMethod();
         when(mockCorsairUnit2.getEntity()).thenReturn(mockCorsair2);
         when(mockCorsair2Pilot.isAdministrator()).thenReturn(false);


### PR DESCRIPTION
This PR replaces most of the remaining instances of `Entity.ETYPE_AERO` checks (except those that don't actually check real entity values) with `Entity.ETYPE_AEROSPACEFIGHTER` checks.  The ETYPE flags should really go away as we're doing most tests with Entity methods anyhow.

The root cause of this issue was MHQ code doing equality checks on Entity ETYPE flags, when we should be using `entity.hasETypeFlag()` in case the entity uses more than one flag together.  Barring that, replacing ETYPE_AERO with ETYPE_AEROSPACEFIGHTER for most of these checks is the right move.

I collapsed the unit tabulation into a smaller function for A) ease of testing, and B) less copy-pasted boilerplate.  This should also allow us to more cleanly implement new unit and bay types, e.g. SuperHeavy Vehicles and Bays, in the future.

I also updated the MHQ copy of `serialkiller.xml` to match the MM version.  This should get overwritten by the MM copy during actual compilation, but it's used when running MHQ from within Idea, for testing purposes.

Testing:
- Ran all unit tests, updated ones that failed due to changed ETYPE values.
- Tested with 2nd save from

Close #3856 