### PR TITLE
[Refactor] Typo Fix & Indents Replaced with Whitespaces

### DIFF
--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -10,6 +10,9 @@ Joshua Bartz (Bonepart)
 Modified 21-MAR-2021
 Justin 'Windchild' Bowen
 
+Modified MAR-2024
+Illiani CBT
+
 
 This file defines the factions used by MekHQ. Keep in mind that the faction shortnames are used by the planets.xml file, so if you remove a faction here, you need to remove all references to it in that file. Not all of the factions listed here are available to play by default. To add a faction as playable, just add the playable tag.
 
@@ -95,7 +98,7 @@ successor - unimplemented tag describing another faction code as the specified f
     </faction>
     <faction>
         <shortname>Alf</shortname>
-        <fullname>Alfrik</fullname>
+        <fullname>Alfik</fullname>
         <colorRGB>103,169,57</colorRGB>
         <tags>is,minor</tags>
         <start>2200</start> <!-- estimated -->

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -1061,7 +1061,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <start>3078</start>
         <end>3139</end>
     </faction>
-        <faction>
+    <faction>
         <shortname>DT</shortname>
         <fullname>Duchy of Tamarind</fullname>
         <startingPlanet>Tamarind</startingPlanet>
@@ -1086,7 +1086,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <shortname>CEI</shortname>
         <fullname>Escorpión Imperio</fullname>
         <altNamesByYear year='3141'>Scorpion Empire</altNamesByYear>
-		<!-- Per Hanseatic Crusade PDF, the Empire was formed at the end of the war, in 3141 -->
+        <!-- Per Hanseatic Crusade PDF, the Empire was formed at the end of the war, in 3141 -->
         <alternativeFactionCodes>CGS,NC,UC</alternativeFactionCodes>
         <startingPlanet>Granada</startingPlanet>
         <eraMods>1,1,1,1,2,3,2,2,1</eraMods>
@@ -1188,7 +1188,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <layeredForceIconLogoFilename>Hanseatic League.png</layeredForceIconLogoFilename>
         <tags>deep_periphery,playable</tags>
         <start>2891</start>
-		<end>3141</end>
+        <end>3141</end>
     </faction>
     <faction>
         <shortname>IP</shortname>
@@ -1922,7 +1922,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <layeredForceIconLogoFilename>Umayyad Caliphate.png</layeredForceIconLogoFilename>
         <tags>deep_periphery</tags>
         <start>2830</start>
-		<end>3080</end>
+        <end>3080</end>
     </faction>
     <faction>
         <shortname>REB</shortname>
@@ -2070,8 +2070,8 @@ successor - unimplemented tag describing another faction code as the specified f
         <start>3148</start>
     </faction>
 
-	<!-- Tamar Rising Factions -->
-	<faction>
+    <!-- Tamar Rising Factions -->
+    <faction>
         <shortname>AML</shortname>
         <fullname>Alyina Mercantile League</fullname>
         <startingPlanet>Alyina</startingPlanet>
@@ -2079,7 +2079,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <tags>clan,minor</tags>
         <start>3151</start>
     </faction>
-	<faction>
+    <faction>
         <shortname>NTamP</shortname>
         <fullname>Tamar Pact</fullname>
         <startingPlanet>Arcturus</startingPlanet>
@@ -2087,7 +2087,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <tags>is,minor</tags>
         <start>3151</start>
     </faction>
-	<faction>
+    <faction>
         <shortname>VSM</shortname>
         <fullname>Vesper Marches</fullname>
         <startingPlanet>Melissia</startingPlanet>
@@ -2095,7 +2095,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <tags>is,minor</tags>
         <start>3151</start>
     </faction>
-	<faction>
+    <faction>
         <shortname>ARL</shortname>
         <fullname>Arc Royal Liberty Coalition</fullname>
         <startingPlanet>Arc-Royal</startingPlanet>
@@ -2103,7 +2103,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <tags>is,minor</tags>
         <start>3151</start>
     </faction>
-	<faction>
+    <faction>
         <shortname>MalC</shortname>
         <fullname>Malthus Confederation</fullname>
         <startingPlanet>Dustball</startingPlanet>
@@ -2112,8 +2112,8 @@ successor - unimplemented tag describing another faction code as the specified f
         <start>3151</start>
     </faction>
 
-	<!-- Dominions Divided Factions -->
-	<faction>
+    <!-- Dominions Divided Factions -->
+    <faction>
         <shortname>IoS</shortname>
         <fullname>Isle of Skye</fullname>
         <startingPlanet>Skye</startingPlanet>

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -10,6 +10,9 @@ Joshua Bartz (Bonepart)
 Modified 21-MAR-2021
 Justin 'Windchild' Bowen
 
+Modified MAR-2024
+IllianiCBT
+
 This file defines the factions used by MekHQ. Keep in mind that the faction shortnames are used by the planets.xml file, so if you remove a faction here, you need to remove all references to it in that file. Not all of the factions listed here are available to play by default. To add a faction as playable, just add the playable tag.
 
 Here is a description of what goes in each faction tag
@@ -94,7 +97,7 @@ successor - unimplemented tag describing another faction code as the specified f
     </faction>
     <faction>
         <shortname>Alf</shortname>
-        <fullname>Alfrik</fullname>
+        <fullname>Alfik</fullname>
         <colorRGB>103,169,57</colorRGB>
         <tags>is,minor</tags>
         <start>2200</start> <!-- estimated -->
@@ -2066,7 +2069,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <tags>periphery,minor</tags>
         <start>3148</start>
     </faction>
-	
+
 	<!-- Tamar Rising Factions -->
 	<faction>
         <shortname>AML</shortname>
@@ -2108,7 +2111,7 @@ successor - unimplemented tag describing another faction code as the specified f
         <tags>is,minor</tags>
         <start>3151</start>
     </faction>
-	
+
 	<!-- Dominions Divided Factions -->
 	<faction>
         <shortname>IoS</shortname>

--- a/MekHQ/data/universe/factions.xml
+++ b/MekHQ/data/universe/factions.xml
@@ -10,8 +10,6 @@ Joshua Bartz (Bonepart)
 Modified 21-MAR-2021
 Justin 'Windchild' Bowen
 
-Modified MAR-2024
-IllianiCBT
 
 This file defines the factions used by MekHQ. Keep in mind that the faction shortnames are used by the planets.xml file, so if you remove a faction here, you need to remove all references to it in that file. Not all of the factions listed here are available to play by default. To add a faction as playable, just add the playable tag.
 
@@ -97,7 +95,7 @@ successor - unimplemented tag describing another faction code as the specified f
     </faction>
     <faction>
         <shortname>Alf</shortname>
-        <fullname>Alfik</fullname>
+        <fullname>Alfrik</fullname>
         <colorRGB>103,169,57</colorRGB>
         <tags>is,minor</tags>
         <start>2200</start> <!-- estimated -->

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -172,7 +172,7 @@ public class RetirementDefectionTracker {
                 continue;
             }
 
-            TargetRoll target = new TargetRoll(5, "Target");
+            TargetRoll target = new TargetRoll(2, "Target");
             target.addModifier(p.getExperienceLevel(campaign, false) - campaign.getUnitRatingMod(),
                     "Experience");
             /* Retirement rolls are made before the contract status is set */

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -177,7 +177,7 @@ public class RetirementDefectionTracker {
                     "Experience");
             /* Retirement rolls are made before the contract status is set */
             if ((contract != null) && (contract.getStatus().isFailed() || contract.getStatus().isBreach())) {
-                target.addModifier(1, "Failed mission");
+                target.addModifier( 1, "Failed mission");
             }
 
             if (campaign.getCampaignOptions().isTrackUnitFatigue() && (campaign.getFatigueLevel() >= 10)) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -185,7 +185,7 @@ public class RetirementDefectionTracker {
             }
 
             if (campaign.getFaction().isPirate()) {
-                target.addModifier(2, "Pirate");
+                target.addModifier(1, "Pirate");
             }
 
             if (p.getRank().isOfficer()) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -172,7 +172,7 @@ public class RetirementDefectionTracker {
                 continue;
             }
 
-            TargetRoll target = new TargetRoll(3, "Target");
+            TargetRoll target = new TargetRoll(5, "Target");
             target.addModifier(p.getExperienceLevel(campaign, false) - campaign.getUnitRatingMod(),
                     "Experience");
             /* Retirement rolls are made before the contract status is set */

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -185,7 +185,7 @@ public class RetirementDefectionTracker {
             }
 
             if (campaign.getFaction().isPirate()) {
-                target.addModifier(1, "Pirate");
+                target.addModifier(2, "Pirate");
             }
 
             if (p.getRank().isOfficer()) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -177,7 +177,7 @@ public class RetirementDefectionTracker {
                     "Experience");
             /* Retirement rolls are made before the contract status is set */
             if ((contract != null) && (contract.getStatus().isFailed() || contract.getStatus().isBreach())) {
-                target.addModifier( 1, "Failed mission");
+                target.addModifier(1, "Failed mission");
             }
 
             if (campaign.getCampaignOptions().isTrackUnitFatigue() && (campaign.getFatigueLevel() >= 10)) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -172,7 +172,7 @@ public class RetirementDefectionTracker {
                 continue;
             }
 
-            TargetRoll target = new TargetRoll(2, "Target");
+            TargetRoll target = new TargetRoll(3, "Target");
             target.addModifier(p.getExperienceLevel(campaign, false) - campaign.getUnitRatingMod(),
                     "Experience");
             /* Retirement rolls are made before the contract status is set */


### PR DESCRIPTION
Replaced 'Alfrik' with 'Alfik' as this appears to be a typo.

Replaced Indents with Whitespaces, as per style guide.