### PR TITLE
[Balance] Adjusted Retirement TN and Payout Values

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -172,7 +172,7 @@ public class RetirementDefectionTracker {
                 continue;
             }
 
-            TargetRoll target = new TargetRoll(5, "Target");
+            TargetRoll target = new TargetRoll(3, "Target");
             target.addModifier(p.getExperienceLevel(campaign, false) - campaign.getUnitRatingMod(),
                     "Experience");
             /* Retirement rolls are made before the contract status is set */
@@ -403,14 +403,14 @@ public class RetirementDefectionTracker {
                 person.getPrimaryRole()).isMechWarrior();
         switch (person.getExperienceLevel(campaign, false)) {
             case SkillType.EXP_ELITE:
-                return Money.of(isMechWarriorProfession ? 300000 : 150000);
+                return Money.of(isMechWarriorProfession ? 9600 : 5920);
             case SkillType.EXP_VETERAN:
-                return Money.of(isMechWarriorProfession ? 150000 : 50000);
+                return Money.of(isMechWarriorProfession ? 4800 : 2960);
             case SkillType.EXP_REGULAR:
-                return Money.of(isMechWarriorProfession ? 50000 : 20000);
+                return Money.of(isMechWarriorProfession ? 3000 : 1850);
             case SkillType.EXP_GREEN:
             default:
-                return Money.of(isMechWarriorProfession ? 20000 : 10000);
+                return Money.of(isMechWarriorProfession ? 1800 : 1110);
         }
     }
 
@@ -483,7 +483,7 @@ public class RetirementDefectionTracker {
                 } else {
                     payoutAmount = getBonusCost(campaign, person);
                     if (person.getRank().isOfficer()) {
-                        payoutAmount = payoutAmount.multipliedBy(2);
+                        payoutAmount = payoutAmount.multipliedBy(1.2);
                     }
                 }
 


### PR DESCRIPTION
### Modification
Reduced the base TN for retirement/defection rolls from 5 to 3.

Reduced retirement/death payouts from a value equal to roughly 62.5 months of employment, to a more sane 2 months of employment.

Reduced the multiplier applied to payouts for officers from *2 to *1.2 to match the monthly wage increase for officers assigned by the default AtB Campaign Preset.

### Reasoning
Retirement/Defection rolls have been a point of contention for a while. While there has been a lot of discussion on Discord regarding this point, and a lot of really good ideas. This simple change attempts to act as a stop-gap until a more permanent solution can be found.

I have also adjusted the value of payouts made when employees depart (voluntarily or via death). This is predominately a sanity check as the original payout values were astronomically high, when compared to an employee's monthly wage. The base payout is now equal to two months' wages.

For non-MechWarriors, the payout values are based on the mean monthly wage for all non-MechWarrior employee types (minus Dependent and None) and is 925c-bills per month. So a payout of 1,850c-bills modified by veterancy and officer status.