### PR TITLE
Fix 3839: load last save loads clientsettings.xml instead

### DIFF
--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -53,7 +53,7 @@ public class StartupScreenPanel extends AbstractMHQPanel {
     private BufferedImage backgroundIcon;
 
     // Save file filtering needs to avoid loading some special files
-    public FilenameFilter saveFilter = new FilenameFilter() {
+    static public FilenameFilter saveFilter = new FilenameFilter() {
         @Override
         public boolean accept(File dir, String name) {
             // Allow any .xml, .cpnx, and .cpnx.gz file that is not in the list of excluded files

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -25,6 +25,7 @@ import megamek.client.ui.swing.widget.SkinSpecification.UIComponents;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
 import megamek.common.Configuration;
 import megamek.common.annotations.Nullable;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 import mekhq.MHQConstants;
@@ -41,12 +42,39 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.FilenameFilter;
+import java.util.Arrays;
+import java.util.List;
 
 public class StartupScreenPanel extends AbstractMHQPanel {
     //region Variable Declarations
     private MekHQ app;
     private File lastSaveFile;
     private BufferedImage backgroundIcon;
+
+    // Save file filtering needs to avoid loading some special files
+    public FilenameFilter saveFilter = new FilenameFilter() {
+        @Override
+        public boolean accept(File dir, String name) {
+            // Allow any .xml, .cpnx, and .cpnx.gz file that is not in the list of excluded files
+            boolean accepted = false;
+            List<String> toReject = Arrays.asList(
+                    PreferenceManager.DEFAULT_CFG_FILE_NAME.toLowerCase()
+            );
+            accepted = (
+                    (
+                        (
+                            name.toLowerCase().endsWith(".cpnx")
+                            || name.toLowerCase().endsWith(".xml")
+                        )
+                        || name.toLowerCase().endsWith(".cpnx.gz")
+                    )
+                            && !toReject.contains(name.toLowerCase())
+            );
+            return accepted;
+        }
+    };
+
     //endregion Variable Declarations
 
     //region Constructors
@@ -54,9 +82,7 @@ public class StartupScreenPanel extends AbstractMHQPanel {
         super(new JFrame(MHQConstants.PROJECT_NAME), "StartupScreenPanel");
 
         this.app = app;
-        lastSaveFile = Utilities.lastFileModified(MekHQ.getCampaignsDirectory().getValue(),
-                (dir, name) -> (name.toLowerCase().endsWith(".cpnx") || name.toLowerCase().endsWith(".xml"))
-                        || name.toLowerCase().endsWith(".cpnx.gz"));
+        lastSaveFile = Utilities.lastFileModified(MekHQ.getCampaignsDirectory().getValue(), saveFilter);
 
         initialize();
     }

--- a/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/StartupScreenPanel.java
@@ -57,21 +57,11 @@ public class StartupScreenPanel extends AbstractMHQPanel {
         @Override
         public boolean accept(File dir, String name) {
             // Allow any .xml, .cpnx, and .cpnx.gz file that is not in the list of excluded files
-            boolean accepted = false;
             List<String> toReject = Arrays.asList(
                     PreferenceManager.DEFAULT_CFG_FILE_NAME.toLowerCase()
             );
-            accepted = (
-                    (
-                        (
-                            name.toLowerCase().endsWith(".cpnx")
-                            || name.toLowerCase().endsWith(".xml")
-                        )
-                        || name.toLowerCase().endsWith(".cpnx.gz")
-                    )
-                            && !toReject.contains(name.toLowerCase())
-            );
-            return accepted;
+            return (((name.toLowerCase().endsWith(".cpnx") || name.toLowerCase().endsWith(".xml"))
+                        || name.toLowerCase().endsWith(".cpnx.gz")) && !toReject.contains(name.toLowerCase()));
         }
     };
 

--- a/MekHQ/unittests/mekhq/gui/panels/StartupScreenPanelTest.java
+++ b/MekHQ/unittests/mekhq/gui/panels/StartupScreenPanelTest.java
@@ -1,0 +1,37 @@
+package mekhq.gui.panels;
+
+import megamek.common.preference.PreferenceManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StartupScreenPanelTest {
+    File dir;
+
+    @BeforeEach
+    void setUp() {
+        dir = mock(File.class);
+    }
+
+    @Test
+    void testSaveFilterAllowsValidCampaignSaves(){
+        String fileName = "MySave.xml";
+        assertTrue(StartupScreenPanel.saveFilter.accept(dir, fileName));
+        fileName = "MySave.CPNX";
+        assertTrue(StartupScreenPanel.saveFilter.accept(dir, fileName));
+        fileName = "20240306T2344 Save Campaign No 666.cpnx.gz";
+        assertTrue(StartupScreenPanel.saveFilter.accept(dir, fileName));
+    }
+
+    @Test
+    void testSaveFilterNotAllowClientSettingsXML(){
+        String fileName = PreferenceManager.DEFAULT_CFG_FILE_NAME.toLowerCase();
+        boolean allowed = StartupScreenPanel.saveFilter.accept(dir, fileName);
+        assertFalse(allowed);
+    }
+}

--- a/MekHQ/unittests/mekhq/gui/panels/StartupScreenPanelTest.java
+++ b/MekHQ/unittests/mekhq/gui/panels/StartupScreenPanelTest.java
@@ -30,7 +30,7 @@ class StartupScreenPanelTest {
 
     @Test
     void testSaveFilterNotAllowClientSettingsXML(){
-        String fileName = PreferenceManager.DEFAULT_CFG_FILE_NAME.toLowerCase();
+        String fileName = PreferenceManager.DEFAULT_CFG_FILE_NAME;
         boolean allowed = StartupScreenPanel.saveFilter.accept(dir, fileName);
         assertFalse(allowed);
     }


### PR DESCRIPTION
Filter out `clientsettings.xml` when searching the user dir for the most recent MekHQ campaign save file.

Testing:
- Ran all 3 projects' unit tests
- Added unit tests for new FilenameFilter static member
- Tested with manually-created empty `clientsettings.xml` file alongside existing campaign saves.

Close #3839 