### PR TITLE
BadEvent Modifier Fix

### DIFF
--- a/MekHQ/data/scenariomodifiers/BadEvent.xml
+++ b/MekHQ/data/scenariomodifiers/BadEvent.xml
@@ -1,7 +1,8 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Hostiles are coordinating additional forces in the area.</additionalBriefingText>
+	<additionalBriefingText>Hostiles are coordinating more front line units in the area.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<eventRecipient>Opposing</eventRecipient>
-	<numExtraEvents>1</numExtraEvents>
+    <qualityAdjustment>1</qualityAdjustment>
+    <bvBudgetAdditiveMultiplier>-1</bvBudgetAdditiveMultiplier>
 </AtBScenarioModifier>


### PR DESCRIPTION
This PR fixes the BadEvent StratCon modifier to add a working bonus.  It did not appear to do anything before based on my observations and other bug report.  Its description states if you have a "Bad Event" then you should also have another negative modifier generated by it.  That didnt happen. 

I changed bad event to add +1 equipment quality and 1 hostile BV budget increase.  So it is now a combination of Good Equipment and Hostile BV budget increase.

Ill be honest - I cannot tell if the BV budget increase is working.  I copied the other modifier exactly, but I ran many test with spreadsheet tracking and changed the number to extremes and I could see no patter whatsoever.  Im not sure of exactly how to test it to see if its working, but even if it is, its effect is negligable.  But if it does work, then its part of this modifier.  If it doesnt, then the equipment quality will still provide a bonus.

This fixes #3815 