### PR TITLE
add EnumSet to serialkiller.xml

### DIFF
--- a/MekHQ/mmconf/serialkiller.xml
+++ b/MekHQ/mmconf/serialkiller.xml
@@ -10,6 +10,7 @@
         <regexps>
             <regexp>\[C$</regexp>
             <regexp>\[I$</regexp>
+            <regexp>\[Ljava\.lang.Enum;$</regexp>
             <regexp>java\.io\.File$</regexp>
             <regexp>java\.lang\.Boolean$</regexp>
             <regexp>java\.lang\.Enum$</regexp>
@@ -31,6 +32,7 @@
             <regexp>java\.util\.concurrent\.locks\.ReentrantLock\$Sync$</regexp>
             <regexp>java\.util\.UUID$</regexp>
             <regexp>java\.util\.EnumMap$</regexp>
+            <regexp>java\.util\.EnumSet.*</regexp>
             <regexp>java\.util\.HashMap$</regexp>
             <regexp>java\.util\.HashSet$</regexp>
             <regexp>java\.util\.Hashtable$</regexp>


### PR DESCRIPTION
- add EnumSet to serialkiller.xml
- error when running megamek from mekhq

10:28:54,315 INFO  [megamek.MegaMek] {main}
megamek.MegaMek.initializeLogging(MegaMek.java:118) - Starting MegaMek v0.49.19-SNAPSHOT
	Build Date: 2024-03-10T10:28:50.551556400
	Today: 2024-03-10
	Origin Project: MekHQ
	Java Vendor: Eclipse Adoptium
	Java Version: 17.0.6
	Platform: Windows 11 10.0 (amd64)
	System Locale: en_US
	Total memory available to MegaMek: 2 GB


10:43:23,997 ERROR [megamek.common.net.connections.AbstractConnection] {Connection 8}
megamek.common.net.connections.AbstractConnection.update(AbstractConnection.java:288) - Server
java.io.InvalidClassException: java.util.EnumSet$SerializationProxy; Class blocked from deserialization (non-whitelist)
	at org.nibblesec.tools.SerialKiller.resolveClass(SerialKiller.java:106)
	at java.base/java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:2034)
	at java.base/java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1898)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2224)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2606)
	at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2457)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream.readArray(ObjectInputStream.java:2157)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1721)
	at java.base/java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2606)
	at java.base/java.io.ObjectInputStream.readFields(ObjectInputStream.java:691)
	at java.base/java.util.Vector.readObject(Vector.java:1158)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor12.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.io.ObjectStreamClass.invokeReadObject(ObjectStreamClass.java:1100)
	at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2423)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream.readArray(ObjectInputStream.java:2157)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1721)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:509)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:467)
	at megamek.common.net.marshalling.NativeSerializationMarshaller.unmarshall(NativeSerializationMarshaller.java:43)
	at megamek.common.net.connections.AbstractConnection.processPacket(AbstractConnection.java:332)
	at megamek.common.net.connections.AbstractConnection.update(AbstractConnection.java:285)
	at megamek.server.ConnectionHandler.run(ConnectionHandler.java:47)
	at java.base/java.lang.Thread.run(Thread.java:833)