### PR TITLE
Interstellar Map Hiring Hall Highlight

### DIFF
--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -691,8 +691,8 @@ public class InterstellarMapPanel extends JPanel {
                                     }
                                     if (campaign.getCampaignOptions().isUseAtB()
                                             && campaign.getAtBConfig().isHiringHall(system.getId(), campaign.getLocalDate())) {
-                                        g2.setPaint(new Color(192, 192, 192));
-                                        arc.setArcByCenter(x, y, size + 2, 0, 360.0 * (1 - ((double) i) / factions.size()), Arc2D.PIE);
+                                        g2.setPaint(new Color(248, 150, 60));
+                                        arc.setArcByCenter(x, y, size + 4, 0, 360.0 * (1 - ((double) i) / factions.size()), Arc2D.PIE);
                                         g2.fill(arc);
                                     }
                                     g2.setPaint(faction.getColor());


### PR DESCRIPTION
This PR doubles the size of the border on Hiring Halls and Changes the color from light grey to orange.

Before:
![Screenshot 2024-03-10 172419](https://github.com/MegaMek/mekhq/assets/23645569/00898577-976d-4ac4-848f-b80d450dce30)

After:
![Screenshot 2024-03-10 172608](https://github.com/MegaMek/mekhq/assets/23645569/122e0a82-47f5-4f3e-9fec-c4eeacc5c603)

This closes RFE #3802 