### PR TITLE
[Balance] [AtB/StratCon] Base Attack (Defender) Objective Changes

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -166,8 +166,6 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
         destroyHostiles.addForce(String.format("%s%s", contract.getEnemyBotName(), SECOND_ENEMY_FORCE_SUFFIX));
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
                 50, false);
-        ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,
-                this);
 
         ScenarioObjective preserveBaseUnits = null;
         if (!isAttacker()) {
@@ -202,9 +200,6 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
             getScenarioObjectives().add(preserveBaseUnits);
         }
 
-        if (keepAttachedUnitsAlive != null) {
-            getScenarioObjectives().add(keepAttachedUnitsAlive);
-        }
         getScenarioObjectives().add(destroyHostiles);
         getScenarioObjectives().add(keepFriendliesAlive);
     }


### PR DESCRIPTION
### Current Implementation
Currently, when the players' base comes under attack (usually due to a difficult contract) they are presented with a special scenario. The failure of which results in a Contract Defeat.

Current objectives task players with keeping allied units alive, including their own. For each allied unit that is defeated the contract Victory Points (not Scenario) are reduced by 1. As allied losses are inevitable, contract loss is almost a given, even if the player plays well.

### Modification
This patch removes the Victory Point loss from allied defeats, but leaves all other objectives untouched. These are as follows:

- Ensure that at least 3 base units (turrets/civilians) survive
- Destroy, cripple or force the withdrawal of at least 50% of opposing forces
- Ensure that at least 50% of friendly forces survive

This still leaves margin for defeat, but removes the likelihood of suffering a 'failure in victory'.