### PR TITLE
[Typo] Corrected Typo in Mass Repair Dialog

### DIFF
--- a/MekHQ/src/mekhq/service/mrms/MRMSService.java
+++ b/MekHQ/src/mekhq/service/mrms/MRMSService.java
@@ -167,7 +167,7 @@ public class MRMSService {
 
             if (!parts.isEmpty()) {
                 if (parts.size() == 1) {
-                    campaign.addReport("<font color='red'>There in still 1 part that in not being worked on.</font>");
+                    campaign.addReport("<font color='red'>There in still 1 part that is not being worked on.</font>");
                 } else {
                     campaign.addReport(String.format(
                             "<font color='red'>There are still %s parts that are not being worked on.</font>",
@@ -309,7 +309,7 @@ public class MRMSService {
 
                 if (count > 0) {
                     if (count == 1) {
-                        campaign.addReport("<font color='red'>There in still 1 part that in not being worked on.</font>");
+                        campaign.addReport("<font color='red'>There in still 1 part that is not being worked on.</font>");
                     } else {
                         campaign.addReport(String.format(
                                 "<font color='red'>There are still %s parts that are not being worked on %s unit%s.</font>",


### PR DESCRIPTION
This is a simple fix that changes 'part that _in_ not being worked on' to 'part that _is_ not being worked on in the Mass Repair print to Daily Activity Log.

<img width="297" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/2427f101-d2e3-4d2f-88d1-1bd83a92e37a">
