### PR TITLE
[Bug] [Company Generator] Correct Starting Cash Dice Count

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
+++ b/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
@@ -239,7 +239,7 @@ public class CompanyGenerationOptions {
         setProcessFinances(true);
         setStartingCash(60000000);
         setRandomizeStartingCash(method.isWindchild());
-        setRandomStartingCashDiceCount(17);
+        setRandomStartingCashDiceCount(18);
         setMinimumStartingFloat(method.isWindchild() ? 3500000 : 0);
         setIncludeInitialContractPayment(method.isWindchild());
         setStartingLoan(!method.isWindchild());


### PR DESCRIPTION
The tooltip for starting cash dice count states that the base value of 18 dice is enough for a company. However, the default dice count is 17, not 18.

<img width="732" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/4c58d7be-a4ce-427a-9e84-bd77ffe46f92">


This patch changes default starting cash dice count from 17 to 18.

I opted to change the default dice count, and not the tooltip, as 18 is easily divided by 3 for players who wish to base their starting funds on their initial lance count. i.e. 6 dice per lance.