### PR TITLE
Disconnect quietly from GameThread for MekHQ

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -401,6 +401,7 @@ public class AtBGameThread extends GameThread {
         } catch (Exception ex) {
             LogManager.getLogger().error("", ex);
         } finally {
+            swingGui.setDisconnectQuietly(true);
             client.die();
             client = null;
             swingGui = null;

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -236,6 +236,7 @@ class GameThread extends Thread implements CloseClientListener {
         } catch (Exception e) {
             LogManager.getLogger().error("", e);
         } finally {
+            swingGui.setDisconnectQuietly(true);
             client.die();
             client = null;
             swingGui = null;


### PR DESCRIPTION
This uses the new feature  in Megamek from PR Megamek/megamek#5277 to disconnect quietly from the GameThread and AtBGameThread in MekHQ. So when users complete a scenario, they will no longer get the "Disconnected!" popup window which just gets in the way. 