### PR TITLE
Correct writing to XML of EMI and Blowing Sand conditions

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -817,8 +817,8 @@ public class Scenario {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "temperature", temperature);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "atmosphere", atmosphere.ordinal());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "gravity", gravity);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "emi", emi.ordinal());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "blowingSand", blowingSand.ordinal());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "emi", emi.isEMI());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "blowingSand", blowingSand.isBlowingSand());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "shiftWindDirection", shiftWindDirection);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "shiftWindStrength", shiftWindStrength);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "maxWindStrength", maxWindStrength.ordinal());


### PR DESCRIPTION
This is for a bug that was introduced by PR #3834. The XML has stored EMI and blowing sand as boolean conditions. Backwards compatability is respected in the `Scenario.generateInstancefromXML` method. However in the `writeToXML` functions, these conditions are being written as an ordinal numeric value rather than a boolean. The result is that once a campaign is saved again, the EMI and blowingSand conditions, if true, will be lost. This is currently affecting Story Arcs. See AaronGullickson/MekHQ#25 for further discussion.

The fix is easy. Just write the results back out as a boolean. I have tested the code and it works correctly. 