### PR TITLE
Adjusted Default Tech Counts 

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
+++ b/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
@@ -153,9 +153,9 @@ public class CompanyGenerationOptions {
         // Personnel
         final Map<PersonnelRole, Integer> supportPersonnel = new HashMap<>();
         if (method.isWindchild()) {
-            supportPersonnel.put(PersonnelRole.MECH_TECH, 5);
-            supportPersonnel.put(PersonnelRole.MECHANIC, 1);
-            supportPersonnel.put(PersonnelRole.AERO_TECH, 1);
+            supportPersonnel.put(PersonnelRole.MECH_TECH, 7);
+            supportPersonnel.put(PersonnelRole.MECHANIC, 0);
+            supportPersonnel.put(PersonnelRole.AERO_TECH, 0);
             supportPersonnel.put(PersonnelRole.DOCTOR, 1);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_COMMAND, 1);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_LOGISTICS, 1);


### PR DESCRIPTION
### Original Behavior
Currently, the Company Generator defaults to the following tech personnel:

Mech Tech: 5
Mechanic: 1
Aerospace Tech: 1
Battle Armor Tech: 0

### Problem
This suggests that the default recommended Techs for a starting company are 5 Mech Techs, a Mechanic, and an Aerospace Tech. The majority of our players do not use vehicles or aerospace out of the gate, and those who do are very capable of changing their starting Techs.

More importantly, 5 Mech Techs are not enough to maintain a 12 mech company, which only penalizes inexperienced players who do not know better.

### Solution
I have adjusted the default techs as follows:

Mech Tech: 7 (+2)
Mechanic: 0 (-1)
Aerospace Tech: 0 (-1)
Battle Armor Tech: 0

This better fits the needs of the largest portion of our player base and means inexperienced players will enter play with enough Mech Techs to maintain their entire company.
