### PR TITLE
[Bandaid] Commented out 'New Campaign' to Remove From Toolbar [Option B]

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -345,11 +345,11 @@ public class CampaignGUI extends JPanel {
         menuSave.addActionListener(this::saveCampaign);
         menuFile.add(menuSave);
 
-        JMenuItem menuNew = new JMenuItem(resourceMap.getString("menuNew.text"));
-        menuNew.setMnemonic(KeyEvent.VK_N);
-        menuNew.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.ALT_DOWN_MASK));
-        menuNew.addActionListener(evt -> new DataLoadingDialog(frame, app, null).setVisible(true));
-        menuFile.add(menuNew);
+        // JMenuItem menuNew = new JMenuItem(resourceMap.getString("menuNew.text"));
+        // menuNew.setMnemonic(KeyEvent.VK_N);
+        // menuNew.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.ALT_DOWN_MASK));
+        // menuNew.addActionListener(evt -> new DataLoadingDialog(frame, app, null).setVisible(true));
+        // menuFile.add(menuNew);
 
         //region menuImport
         // The Import menu uses the following Mnemonic keys as of 25-MAR-2022:


### PR DESCRIPTION
This is the sister PR to https://github.com/MegaMek/mekhq/pull/3909. Only one should be merged, not both.

### Current Implementation
Currently the option to start a new campaign is available through 'toolbar/files/new campaign' and is listed immediately beneath Save Campaign and Load Campaign.

### Problem
I am aware of a long standing bug where clicking 'new campaign' and then cancelling out can have adverse effects on a campaigns' 'campaign settings'. The proximity of the option near 'save' and 'load' increases the chances of a user accidentally interacting with 'new campaign'. In these events, the user will naturally cancel out of the option and (unless they're on Discord a lot) they will likely be unaware of the damage this potentially caused.

### Solution
This has been a problem for years at this point, while the issue being fully resolved is the more desirable outcome, this patch is designed to reduce the chance of users accidentally clicking 'new campaign' when attempting to save or load.

Option B
I am presenting two possible bandaids to mitigate this issue.

Option B (this PR) removes 'new campaign' entirely. This is achieved by commenting out the 'new campaign' option. I opted to use the commenting out approach, as this enables easy restoration of the option at a later date - once the root issue has been investigated and resolved.