### PR TITLE
Retirement Improvements (Wave Two)

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -20,6 +20,7 @@
  */
 package mekhq.campaign.personnel;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.TargetRoll;
 import megamek.common.annotations.Nullable;
@@ -403,14 +404,14 @@ public class RetirementDefectionTracker {
                 person.getPrimaryRole()).isMechWarrior();
         switch (person.getExperienceLevel(campaign, false)) {
             case SkillType.EXP_ELITE:
-                return Money.of(isMechWarriorProfession ? 9600 : 5920);
+                return Money.of(isMechWarriorProfession ? 14400 : 8880);
             case SkillType.EXP_VETERAN:
-                return Money.of(isMechWarriorProfession ? 4800 : 2960);
+                return Money.of(isMechWarriorProfession ? 7200 : 4440);
             case SkillType.EXP_REGULAR:
-                return Money.of(isMechWarriorProfession ? 3000 : 1850);
+                return Money.of(isMechWarriorProfession ? 4500 : 2775);
             case SkillType.EXP_GREEN:
             default:
-                return Money.of(isMechWarriorProfession ? 1800 : 1110);
+                return Money.of(isMechWarriorProfession ? 2400 : 1665);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -20,7 +20,6 @@
  */
 package mekhq.campaign.personnel;
 
-import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.TargetRoll;
 import megamek.common.annotations.Nullable;

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -173,8 +173,9 @@ public class RetirementDefectionTracker {
             }
 
             TargetRoll target = new TargetRoll(3, "Target");
-            target.addModifier(p.getExperienceLevel(campaign, false) - campaign.getUnitRatingMod(),
-                    "Experience");
+            target.addModifier(p.getExperienceLevel(campaign, false), "Experience");
+            target.addModifier(- campaign.getUnitRatingMod(), "Unit Rating");
+
             /* Retirement rolls are made before the contract status is set */
             if ((contract != null) && (contract.getStatus().isFailed() || contract.getStatus().isBreach())) {
                 target.addModifier(1, "Failed mission");

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -20,10 +20,12 @@
  */
 package mekhq.campaign.personnel;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.TargetRoll;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.IOption;
+import mekhq.campaign.rating.IUnitRating;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -174,7 +176,8 @@ public class RetirementDefectionTracker {
 
             TargetRoll target = new TargetRoll(3, "Target");
             target.addModifier(p.getExperienceLevel(campaign, false), "Experience");
-            target.addModifier(- campaign.getUnitRatingMod(), "Unit Rating");
+            target.addModifier(- MathUtility.clamp(campaign.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR),
+                "Unit Rating");
 
             /* Retirement rolls are made before the contract status is set */
             if ((contract != null) && (contract.getStatus().isFailed() || contract.getStatus().isBreach())) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -280,7 +280,7 @@ public class RetirementDefectionTracker {
                     }
                 }
 
-                if ((c != null) && (c.getSharesPct() >= 20)) {
+                if (c != null) {
                     target.addModifier(-((c.getSharesPct() - 20) / 10), "Shares");
                 }
             }

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -245,8 +245,24 @@ public class RetirementDefectionTracker {
                 }
             }
 
-            if (p.getAge(campaign.getLocalDate()) >= 50) {
-                target.addModifier(1, "Over 50");
+            // Old Age modifier
+            int age = p.getAge(campaign.getLocalDate());
+            int oldAgeMod = 0;
+
+            if ((age >= 50) && (age < 70)) {
+                oldAgeMod = 1;
+            } else if ((age >= 70) && (age < 80)) {
+                oldAgeMod = 2;
+            } else if ((age >= 80) && (age < 90)) {
+                oldAgeMod = 3;
+            } else if ((age >= 90) && (age < 100)) {
+                oldAgeMod = 4;
+            } else if ((age >= 100)) {
+                oldAgeMod = 5;
+            }
+
+            if (oldAgeMod > 0) {
+                target.addModifier(oldAgeMod, "Old Age");
             }
 
             if (campaign.getCampaignOptions().isUseShareSystem()) {
@@ -263,7 +279,7 @@ public class RetirementDefectionTracker {
                         }
                     }
                 }
-                if ((c != null) && (c.getSharesPct() > 20)) {
+                if ((c != null) && (c.getSharesPct() >= 20)) {
                     target.addModifier(-((c.getSharesPct() - 20) / 10), "Shares");
                 }
             }

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -176,20 +176,47 @@ public class RetirementDefectionTracker {
             TargetRoll target = new TargetRoll(3, "Target");
 
             // Skill Rating modifier
-            target.addModifier(p.getExperienceLevel(campaign, false), "Veterancy");
+            int skillRating = p.getExperienceLevel(campaign, false);
+            String skillRatingDescription;
 
-            // Unit Rating modifier
-            int ratingMod = 0;
-
-            if (campaign.getUnitRatingMod() < 1) {
-                ratingMod = 2;
-            } else if (campaign.getUnitRatingMod() == 1) {
-                ratingMod = 1;
-            } else if (campaign.getUnitRatingMod() > 3) {
-                ratingMod = -1;
+            switch (skillRating) {
+                case -1:
+                    skillRatingDescription = "Unskilled";
+                    break;
+                case 0:
+                    skillRatingDescription = "Ultra-Green";
+                    break;
+                case 1:
+                    skillRatingDescription = "Green";
+                    break;
+                case 2:
+                    skillRatingDescription = "Regular";
+                    break;
+                case 3:
+                    skillRatingDescription = "Veteran";
+                    break;
+                case 4:
+                    skillRatingDescription = "Elite";
+                    break;
+                default:
+                    skillRatingDescription = "Error, please see log";
+                    LogManager.getLogger().error("Unable to parse skillRating in Retirement check: returning " + skillRating);
             }
 
-            target.addModifier(ratingMod, "Unit Rating");
+            target.addModifier(skillRating, skillRatingDescription);
+
+            // Unit Rating modifier
+            int unitRating = 0;
+
+            if (campaign.getUnitRatingMod() < 1) {
+                unitRating = 2;
+            } else if (campaign.getUnitRatingMod() == 1) {
+                unitRating = 1;
+            } else if (campaign.getUnitRatingMod() > 3) {
+                unitRating = -1;
+            }
+
+            target.addModifier(unitRating, "Unit Rating");
 
             /* Retirement rolls are made before the contract status is set */
             if ((contract != null) && (contract.getStatus().isFailed() || contract.getStatus().isBreach())) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -174,10 +174,24 @@ public class RetirementDefectionTracker {
                 continue;
             }
 
+            // Base TN
             TargetRoll target = new TargetRoll(3, "Target");
-            target.addModifier(p.getExperienceLevel(campaign, false), "Experience");
-            target.addModifier(- MathUtility.clamp(campaign.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR),
-                "Unit Rating");
+
+            // Skill Rating modifier
+            target.addModifier(p.getExperienceLevel(campaign, false), "Veterancy");
+
+            // Unit Rating modifier
+            int ratingMod = 0;
+
+            if (campaign.getUnitRatingMod() < 1) {
+                ratingMod = 2;
+            } else if (campaign.getUnitRatingMod() == 1) {
+                ratingMod = 1;
+            } else if (campaign.getUnitRatingMod() > 3) {
+                ratingMod = -1;
+            }
+
+            target.addModifier(ratingMod, "Unit Rating");
 
             /* Retirement rolls are made before the contract status is set */
             if ((contract != null) && (contract.getStatus().isFailed() || contract.getStatus().isBreach())) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -279,6 +279,7 @@ public class RetirementDefectionTracker {
                         }
                     }
                 }
+
                 if ((c != null) && (c.getSharesPct() >= 20)) {
                     target.addModifier(-((c.getSharesPct() - 20) / 10), "Shares");
                 }

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -266,8 +266,6 @@ public class RetirementDefectionTracker {
                 if ((c != null) && (c.getSharesPct() > 20)) {
                     target.addModifier(-((c.getSharesPct() - 20) / 10), "Shares");
                 }
-            } else {
-                // Bonus payments handled by dialog
             }
 
             if (p.getPrimaryRole().isSoldier()) {

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -20,12 +20,10 @@
  */
 package mekhq.campaign.personnel;
 
-import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.TargetRoll;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.IOption;
-import mekhq.campaign.rating.IUnitRating;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -217,7 +217,7 @@ public class RetirementDefectionDialog extends JDialog {
                 int row = personnelTable.convertRowIndexToModel(personnelTable.getSelectedRow());
                 UUID id = ((RetirementTableModel)(personnelTable.getModel())).getPerson(row).getId();
                 txtTargetDetails.setText(targetRolls.get(id).getDesc() +
-                        (payBonus(id)?" -1 (Bonus)":"") +
+                        (payBonus(id)?" - 2 (Bonus)":"") +
                         ((miscModifier(id) != 0)?miscModifier(id) + " (Misc)":""));
             });
 
@@ -429,7 +429,7 @@ public class RetirementDefectionDialog extends JDialog {
             if (ev.getSource().equals(btnRoll)) {
                 for (UUID id : targetRolls.keySet()) {
                     if (payBonus(id)) {
-                        targetRolls.get(id).addModifier(-1, "Bonus");
+                        targetRolls.get(id).addModifier(-2, "Bonus");
                     }
 
                     if (miscModifier(id) != 0) {

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -221,7 +221,7 @@ public class RetirementTableModel extends AbstractTableModel {
                     return 0;
                 }
                 return targets.get(p.getId()).getValue() -
-                        (payBonus.get(p.getId()) ? 1 : 0) +
+                        (payBonus.get(p.getId()) ? 2 : 0) +
                         miscMods.get(p.getId()) + generalMod;
             case COL_BONUS_COST:
                 return RetirementDefectionTracker.getBonusCost(campaign, p).toAmountAndSymbolString();


### PR DESCRIPTION
# Experience Modifier
## Current Implementation
Retirement TN is 3 plus modifiers: experience, officer-status, misc modifiers. Experience is a combination of employee skill rating (regular, veteran, elite, etc) and company Unit Rating.
<img width="344" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/c30fe47a-2884-4358-83aa-34e1a6a1710b">

## Problem
By combining these two modifiers it obfuscates where modifiers are coming from, making it difficult for users to understand how the TN is being calculated.

## Solution
I have split 'experience' into 'experience' (employee skill rating) and 'unit rating' (company unit rating).
<img width="463" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/461988ac-d4b3-4f76-88cc-7e72ef328418">

Full credit to https://github.com/SuperStucco

# Bonus Modifiers
## Current Implementation
During a Retirement Check, Commanders can pay an employee roughly 2 months' wages to reduce the retirement TN by 1.

## Problem
This still results in overly high TNs when considering Elite employees.

An Elite (non-officer) employee has a retirement TN of 7 (plus Unit Rating), reduced to 6 by paying the Bonus. This has a failure chance of 27.78%. Effectively a 5in20 chance of losing the pilot.

A Regular (non-officer) employee has a retirement TN of 5 (plus Unit Rating), reduced to 5 by paying the Bonus. This has a failure chance of 16.67%. Effectively a 3in20 chance of losing the pilot.

## Solution
Increase bonus payout from 2 months' wage, to 3. Improve Bonus modifier to -2.

Elite employee's failure rate is improved to 16.67% (3in20).
Regular employee's failure rate is improved to 8.33% (2in20).

# Shares
## Shares Modifiers
### Current Implementation
When selecting the contract through the contract market (or new contract dialog) users can specify shares percentage for the contract, from 20%-50% in increments of 10%.

If the contract shares percentage is above 20% pilots reduce their retirement TN by an amount based on the shares percentage:
- 30%: - 1
- 40%: -2
- 50%: -3

### Problem
The default value for shares percentage is 20%. This means users are likely to be unaware that this modifier exists.

### Solution
This modifier is now always visible, when shares are used.

# Misc Modifiers
## Old Age
### Current Implementation
Once an employee reaches 50 they incur a penalty, increasing the retirement TN by 1.

### Problem
This lacks nuance. A 120 year old has the same old age penalty as a 60 year old.

### Solution
Old Age penalties are now along a gradient:

- 50-60: TN + 1
- 70: TN + 2
- 80: TN +3
- 90: TN + 4
- 100+: TN + 5