### PR TITLE
Clamp OpFor Unit Rating within FM:M Bounds

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3222,7 +3222,7 @@ public class Campaign implements ITechManager {
             rating.reInitialize();
 
             for (AtBContract contract : getActiveAtBContracts()) {
-                contract.checkMorale(getLocalDate(), getUnitRatingMod());
+                contract.checkMorale(getLocalDate(), MathUtility.clamp(getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR));
                 addReport("Enemy morale is now " + contract.getMoraleLevel()
                         + " on contract " + contract.getName());
             }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3187,7 +3187,8 @@ public class Campaign implements ITechManager {
                 }
             }
 
-            final int roll = MathUtility.clamp(Compute.d6(2) + getUnitRatingMod() - 2, 2, 12);
+            final int roll = MathUtility.clamp(Compute.d6(2)
+                + MathUtility.clamp(getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR) - 2, 2, 12);
 
             int change = numPersonnel * (roll - 5) / 100;
             if (change < 0) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5223,7 +5223,7 @@ public class Campaign implements ITechManager {
             }
         }
 
-        return getUnitRatingMod() + modifier;
+        return MathUtility.clamp(getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR) + modifier;
     }
 
     public void resetAstechMinutes() {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -614,7 +614,7 @@ public class Campaign implements ITechManager {
                 report.append("<br/>Search successful. ");
 
                 MechSummary ms = getUnitGenerator().generate(getFactionCode(), shipSearchType, -1,
-                        getGameYear(), getUnitRatingMod());
+                        getGameYear(), MathUtility.clamp(getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR));
 
                 if (ms == null) {
                     ms = getAtBConfig().findShip(shipSearchType);

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -21,6 +21,7 @@
 package mekhq.campaign;
 
 import megamek.client.Client;
+import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.GameVictoryEvent;
@@ -39,9 +40,11 @@ import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.enums.PrisonerStatus;
+import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.unit.TestUnit;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.actions.AdjustLargeCraftAmmoAction;
+import mekhq.campaign.unit.actions.IUnitAction;
 import mekhq.gui.FileDialogs;
 import org.apache.logging.log4j.LogManager;
 
@@ -1600,7 +1603,7 @@ public class ResolveScenarioTracker {
         }
 
         if (campaign.getCampaignOptions().isUseAtB() && isAtBContract) {
-            final int unitRatingMod = campaign.getUnitRatingMod();
+            final int unitRatingMod = MathUtility.clamp(campaign.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
             for (Unit unit : getUnits()) {
                 unit.setSite(((AtBContract) mission).getRepairLocation(unitRatingMod));
             }

--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
@@ -21,6 +21,7 @@
  */
 package mekhq.campaign.againstTheBot;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
@@ -334,7 +335,7 @@ public class AtBConfiguration {
             }
         }
         target.addModifier(SkillType.EXP_REGULAR - adminLogExp, "Admin/Logistics");
-        target.addModifier(IUnitRating.DRAGOON_C - campaign.getUnitRatingMod(),
+        target.addModifier(IUnitRating.DRAGOON_C - MathUtility.clamp(campaign.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR),
                 "Unit Rating");
         return target;
     }

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -565,7 +565,8 @@ public class ContractMarket {
                         AtBContractType.SECURITY_DUTY, AtBContractType.OBJECTIVE_RAID, AtBContractType.GARRISON_DUTY,
                         AtBContractType.CADRE_DUTY, AtBContractType.DIVERSIONARY_RAID }
         };
-        int roll = MathUtility.clamp(Compute.d6(2) + unitRatingMod - IUnitRating.DRAGOON_C, 2, 12);
+      int roll = MathUtility.clamp(Compute.d6(2) + MathUtility.clamp(unitRatingMod, IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR)
+          - IUnitRating.DRAGOON_C, 2, 12);
         return table[majorPower ? 0 : 1][roll - 2];
     }
 

--- a/MekHQ/src/mekhq/campaign/market/ContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/ContractMarket.java
@@ -110,7 +110,8 @@ public class ContractMarket {
     }
 
     public AtBContract addAtBContract(Campaign campaign) {
-        AtBContract c = generateAtBContract(campaign, campaign.getUnitRatingMod());
+        AtBContract c = generateAtBContract(campaign,
+            MathUtility.clamp(campaign.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR));
         if (c != null) {
             contracts.add(c);
         }
@@ -155,7 +156,7 @@ public class ContractMarket {
             // need to copy to prevent concurrent modification errors
             new ArrayList<>(contracts).forEach(this::removeContract);
 
-            int unitRatingMod = campaign.getUnitRatingMod();
+            int unitRatingMod = MathUtility.clamp(campaign.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
 
             for (AtBContract contract : campaign.getActiveAtBContracts()) {
                 checkForSubcontracts(campaign, contract, unitRatingMod);
@@ -534,7 +535,8 @@ public class ContractMarket {
         followup.setEnemySkill(contract.getEnemySkill());
         followup.setEnemyQuality(contract.getEnemyQuality());
         followup.calculateLength(campaign.getCampaignOptions().isVariableContractLength());
-        setAtBContractClauses(followup, campaign.getUnitRatingMod(), campaign);
+        setAtBContractClauses(followup,
+            MathUtility.clamp(campaign.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR), campaign);
 
         followup.calculatePaymentMultiplier(campaign);
 

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarketFMMr.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarketFMMr.java
@@ -21,6 +21,7 @@ package mekhq.campaign.market;
 import java.util.ArrayList;
 import java.util.List;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import mekhq.campaign.Campaign;
@@ -56,7 +57,7 @@ public class PersonnelMarketFMMr implements PersonnelMarketMethod {
         for (PersonnelRole role : PersonnelRole.getMilitaryRoles()) {
             int roll = Compute.d6(2);
             // TODO: Modifiers for hiring hall, but first needs to track the hiring hall
-            switch (c.getUnitRatingMod()) {
+            switch (MathUtility.clamp(c.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR)) {
                 case IUnitRating.DRAGOON_A:
                 case IUnitRating.DRAGOON_ASTAR:
                     roll += 3;

--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -20,10 +20,12 @@
  */
 package mekhq.campaign.personnel;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.TargetRoll;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.IOption;
+import mekhq.campaign.rating.IUnitRating;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -173,8 +175,9 @@ public class RetirementDefectionTracker {
             }
 
             TargetRoll target = new TargetRoll(3, "Target");
-            target.addModifier(p.getExperienceLevel(campaign, false) - campaign.getUnitRatingMod(),
-                    "Experience");
+            target.addModifier(p.getExperienceLevel(campaign, false)
+                    - MathUtility.clamp(campaign.getUnitRatingMod(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR),
+                "Experience");
             /* Retirement rolls are made before the contract status is set */
             if ((contract != null) && (contract.getStatus().isFailed() || contract.getStatus().isBreach())) {
                 target.addModifier(1, "Failed mission");


### PR DESCRIPTION
### Current Implementation
Currently, CamOps Unit Rating is uncapped. AtB relies on Unit Rating to generate TN modifiers to a number of different functions.

### Problem
With CamOps being uncapped there is no upper or lower boundary to the modifiers it can create undesirable effects. Such as...

- Only generating Relief missions
- Making Retirement checks impossible to pass/fail.
- Making Ship Search checks impossible to pass/fail.
- Influencing what large craft are found, through the Ship Search.
- Influencing the arrival/departure of Dependents.
- Influencing enemy Morale Checks, causing enemy morale to snowball towards Invincible/Rout.
- Influencing part availability, during contracts. Potentially making the availability of parts much easier/harder than intended.
- Influencing where units are placed, after scenarios (Field Repair, Repair Bay, etc).
- Influencing the hiring hall, making better pilots more/less common than intended.

### Solution
Using `MathUtility.clamp()` I have bound `UnitRating` so fit within the lower/upper bounds of the FM:M Dragoon Rating System (F-A*). This is only limited to the above instances, so things like `Unit Report` are unaffected.

All issues listed under 'Problems' have been closed by this PR.

### Credit
Credit for this solution goes to https://github.com/SuperStucco. All I did was go through the code to find other examples of where this was a problem, and applied their fix where appropriate.

### Closes
Closes #3729
Closes #3817
Closes #3753