### PR TITLE
Added Dialog to Confirm New Campaign (redux)

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -348,7 +348,12 @@ public class CampaignGUI extends JPanel {
         JMenuItem menuNew = new JMenuItem(resourceMap.getString("menuNew.text"));
         menuNew.setMnemonic(KeyEvent.VK_N);
         menuNew.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.ALT_DOWN_MASK));
-        menuNew.addActionListener(evt -> new DataLoadingDialog(frame, app, null).setVisible(true));
+        menuNew.addActionListener(evt -> {
+            int decision = new NewCampaignConfirmationDialog().YesNoOption();
+            if (decision == JOptionPane.YES_OPTION) {
+                new DataLoadingDialog(frame, app, null).setVisible(true);
+            }
+        });
         menuFile.add(menuNew);
 
         //region menuImport

--- a/MekHQ/src/mekhq/gui/dialog/NewCampaignConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewCampaignConfirmationDialog.java
@@ -23,7 +23,7 @@ import javax.swing.JOptionPane;
 public class NewCampaignConfirmationDialog {
   public int YesNoOption() {
     return JOptionPane.showConfirmDialog(null, "Are you sure you want to start a new campaign?\n" +
-            "Do not save your campaign, if you cancel after this point", "Start New Campaign?",
+            "Do not save your current campaign if you cancel after this point!", "Start New Campaign?",
         JOptionPane.YES_NO_OPTION);
   }
 }

--- a/MekHQ/src/mekhq/gui/dialog/NewCampaignConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewCampaignConfirmationDialog.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import javax.swing.JOptionPane;
+
+public class NewCampaignConfirmationDialog {
+  public int YesNoOption() {
+    return JOptionPane.showConfirmDialog(null, "Are you sure you want to start a new campaign?\n" +
+            "Do not save your campaign, if you cancel after this point", "Start New Campaign?",
+        JOptionPane.YES_NO_OPTION);
+  }
+}


### PR DESCRIPTION
This is a redux of #3909 which was closed due to an unusually high volume of dirty edits.

### Current Implementation
Currently the option to start a new campaign is available through 'toolbar/files/new campaign' and is listed immediately beneath Save Campaign and Load Campaign.

### Problem
I am aware of a long standing bug where clicking 'new campaign' and then cancelling out can have adverse effects on a campaigns' 'campaign settings'. The proximity of the option near 'save' and 'load' increases the chances of a user accidentally interacting with 'new campaign'. In these events, the user will naturally cancel out of the option and (unless they're on Discord a lot) they will likely be unaware of the damage this potentially caused.

### Solution
This has been a problem for years at this point, while the issue being fully resolved is the more desirable outcome, this patch is designed to reduce the chance of users accidentally clicking 'new campaign' when attempting to save or load.

### Update
Since the initial introduction of this PR I have significantly changed its implementation.

When selecting 'New Campaign' users will be presented with a dialog asking them to confirm that they wish to start a new campaign. Selecting 'no' or closing the dialog does nothing. Selecting 'yes' initiates the new campaign process (this process is identical to current implementation).

<img width="501" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/01a2aa85-cb23-4dd9-b67a-7bda8aeb2f7a">