### PR TITLE
Add Tech/Vessel Column to Tech Skills View

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -833,6 +833,7 @@ PersonnelTableModelColumn.TECH_MEK.text=Tech/Mek
 PersonnelTableModelColumn.TECH_AERO.text=Tech/Aero
 PersonnelTableModelColumn.TECH_MECHANIC.text=Mechanic
 PersonnelTableModelColumn.TECH_BA.text=Tech/BA
+PersonnelTableModelColumn.TECH_VESSEL.text=Tech/Vessel
 PersonnelTableModelColumn.MEDICAL.text=Medical
 PersonnelTableModelColumn.ADMINISTRATION.text=Admin
 PersonnelTableModelColumn.NEGOTIATION.text=Negotiation

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -80,6 +80,7 @@ public enum PersonnelTableModelColumn {
     TECH_AERO("PersonnelTableModelColumn.TECH_AERO.text"),
     TECH_MECHANIC("PersonnelTableModelColumn.TECH_MECHANIC.text"),
     TECH_BA("PersonnelTableModelColumn.TECH_BA.text"),
+    TECH_VESSEL("PersonnelTableModelColumn.TECH_VESSEL.text"),
     MEDICAL("PersonnelTableModelColumn.MEDICAL.text"),
     ADMINISTRATION("PersonnelTableModelColumn.ADMINISTRATION.text"),
     NEGOTIATION("PersonnelTableModelColumn.NEGOTIATION.text"),
@@ -266,6 +267,9 @@ public enum PersonnelTableModelColumn {
 
     public boolean isTechBA() {
         return this == TECH_BA;
+    }
+    public boolean isTechVessel() {
+        return this == TECH_VESSEL;
     }
 
     public boolean isMedical() {
@@ -595,6 +599,10 @@ public enum PersonnelTableModelColumn {
                 return person.hasSkill(SkillType.S_TECH_BA)
                         ? Integer.toString(person.getSkill(SkillType.S_TECH_BA).getFinalSkillValue())
                         : "-";
+            case TECH_VESSEL:
+                return person.hasSkill(SkillType.S_TECH_VESSEL)
+                        ? Integer.toString(person.getSkill(SkillType.S_TECH_VESSEL).getFinalSkillValue())
+                        : "-";
             case MEDICAL:
                 return person.hasSkill(SkillType.S_DOCTOR)
                         ? Integer.toString(person.getSkill(SkillType.S_DOCTOR).getFinalSkillValue())
@@ -836,6 +844,7 @@ public enum PersonnelTableModelColumn {
                     case TECH_AERO:
                     case TECH_MECHANIC:
                     case TECH_BA:
+                    case TECH_VESSEL:
                     case MEDICAL:
                         return true;
                     default:
@@ -981,6 +990,7 @@ public enum PersonnelTableModelColumn {
             case TECH_AERO:
             case TECH_MECHANIC:
             case TECH_BA:
+            case TECH_VESSEL:
             case MEDICAL:
             case ADMINISTRATION:
             case NEGOTIATION:

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -426,6 +426,17 @@ public class PersonnelTableModelColumnTest {
     }
 
     @Test
+    public void testIsTechVessel() {
+        for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
+            if (personnelTableModelColumn == PersonnelTableModelColumn.TECH_VESSEL) {
+                assertTrue(personnelTableModelColumn.isTechVessel());
+            } else {
+                assertFalse(personnelTableModelColumn.isTechVessel());
+            }
+        }
+    }
+
+    @Test
     public void testIsMedical() {
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
             if (personnelTableModelColumn == PersonnelTableModelColumn.MEDICAL) {

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -875,6 +875,7 @@ public class PersonnelTableModelColumnTest {
                 case TECH_AERO:
                 case TECH_MECHANIC:
                 case TECH_BA:
+                case TECH_VESSEL:
                 case MEDICAL:
                 case ADMINISTRATION:
                 case NEGOTIATION:


### PR DESCRIPTION
### Current Implementation
Currently the Tech Skills view has the following tabs:
<img width="1437" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/74f118d5-e383-43f7-9802-6cae32d4cd46">

### Problem
This makes it difficult to find those employees with the Tech/Vessel skill.

### Solution
Added Tech/Vessel column
<img width="1435" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/604aa90d-3391-4f3a-b08f-39aeb9c4b413">

Also added appropriate Unit Test.

Closes #3890.