### PR TITLE
[Typo] Corrected Typo in testIsTechBA

### DIFF
--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -415,7 +415,7 @@ public class PersonnelTableModelColumnTest {
     }
 
     @Test
-    public void testIsechBABA() {
+    public void testIsTechBA() {
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
             if (personnelTableModelColumn == PersonnelTableModelColumn.TECH_BA) {
                 assertTrue(personnelTableModelColumn.isTechBA());


### PR DESCRIPTION
### Current Implementation
Currently `PersonnelTableModelColumnTest` features the unit test `testIsechBABA`

### Problem
`testIsechBABA` is a typo and should read `testIsTechBA`.

### Solution
Changed `testIsechBABA` to `testIsTechBA`.