### PR TITLE
[Tweak] Adjusted rate of multiplePregnancyOccurrences

### DIFF
--- a/MekHQ/mmconf/campaignPresets/AtB.xml
+++ b/MekHQ/mmconf/campaignPresets/AtB.xml
@@ -187,7 +187,7 @@
 		<useManualProcreation>true</useManualProcreation>
 		<useClannerProcreation>false</useClannerProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
-		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
+		<multiplePregnancyOccurrences>30</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
 		<assignNonPrisonerBabiesFounderTag>false</assignNonPrisonerBabiesFounderTag>
 		<assignChildrenOfFoundersFounderTag>false</assignChildrenOfFoundersFounderTag>

--- a/MekHQ/mmconf/campaignPresets/AtBStarterGuidev40.xml
+++ b/MekHQ/mmconf/campaignPresets/AtBStarterGuidev40.xml
@@ -187,7 +187,7 @@
 		<useManualProcreation>true</useManualProcreation>
 		<useClannerProcreation>false</useClannerProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
-		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
+		<multiplePregnancyOccurrences>30</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
 		<assignNonPrisonerBabiesFounderTag>false</assignNonPrisonerBabiesFounderTag>
 		<assignChildrenOfFoundersFounderTag>false</assignChildrenOfFoundersFounderTag>

--- a/MekHQ/mmconf/campaignPresets/CamOps.xml
+++ b/MekHQ/mmconf/campaignPresets/CamOps.xml
@@ -179,7 +179,7 @@
 		<useManualProcreation>true</useManualProcreation>
 		<useClannerProcreation>false</useClannerProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
-		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
+		<multiplePregnancyOccurrences>30</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
 		<assignNonPrisonerBabiesFounderTag>false</assignNonPrisonerBabiesFounderTag>
 		<assignChildrenOfFoundersFounderTag>false</assignChildrenOfFoundersFounderTag>

--- a/MekHQ/mmconf/campaignPresets/DefaultTotalWarfare.xml
+++ b/MekHQ/mmconf/campaignPresets/DefaultTotalWarfare.xml
@@ -179,7 +179,7 @@
 		<useManualProcreation>true</useManualProcreation>
 		<useClannerProcreation>false</useClannerProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
-		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
+		<multiplePregnancyOccurrences>30</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
 		<assignNonPrisonerBabiesFounderTag>false</assignNonPrisonerBabiesFounderTag>
 		<assignChildrenOfFoundersFounderTag>false</assignChildrenOfFoundersFounderTag>

--- a/MekHQ/mmconf/campaignPresets/SimpleOptions.xml
+++ b/MekHQ/mmconf/campaignPresets/SimpleOptions.xml
@@ -179,7 +179,7 @@
 		<useManualProcreation>true</useManualProcreation>
 		<useClannerProcreation>false</useClannerProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
-		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
+		<multiplePregnancyOccurrences>30</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
 		<assignNonPrisonerBabiesFounderTag>false</assignNonPrisonerBabiesFounderTag>
 		<assignChildrenOfFoundersFounderTag>false</assignChildrenOfFoundersFounderTag>

--- a/MekHQ/mmconf/campaignPresets/StratConAlpha.xml
+++ b/MekHQ/mmconf/campaignPresets/StratConAlpha.xml
@@ -187,7 +187,7 @@
 		<useManualProcreation>true</useManualProcreation>
 		<useClannerProcreation>false</useClannerProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
-		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
+		<multiplePregnancyOccurrences>30</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
 		<assignNonPrisonerBabiesFounderTag>false</assignNonPrisonerBabiesFounderTag>
 		<assignChildrenOfFoundersFounderTag>false</assignChildrenOfFoundersFounderTag>

--- a/MekHQ/mmconf/campaignPresets/TaharqaMW2ish.xml
+++ b/MekHQ/mmconf/campaignPresets/TaharqaMW2ish.xml
@@ -179,7 +179,7 @@
 		<useManualProcreation>true</useManualProcreation>
 		<useClannerProcreation>false</useClannerProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
-		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
+		<multiplePregnancyOccurrences>30</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
 		<assignNonPrisonerBabiesFounderTag>false</assignNonPrisonerBabiesFounderTag>
 		<assignChildrenOfFoundersFounderTag>false</assignChildrenOfFoundersFounderTag>

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -745,7 +745,7 @@ public class CampaignOptions {
         setUseManualProcreation(true);
         setUseClanPersonnelProcreation(false);
         setUsePrisonerProcreation(true);
-        setMultiplePregnancyOccurrences(50); // Hellin's Law is 89, but we make it more common so it shows up more
+        setMultiplePregnancyOccurrences(30); // Based on 2015 US birthrates: https://www.cdc.gov/nchs/data/nvsr/nvsr66/nvsr66_01.pdf
         setBabySurnameStyle(BabySurnameStyle.MOTHERS);
         setAssignNonPrisonerBabiesFounderTag(false);
         setAssignChildrenOfFoundersFounderTag(false);


### PR DESCRIPTION
### Current Implementation
Currently, by default, there is a 1in50 (0.02%) chance of twins, and a 4in250,000 (0.000004%) of triplets.

### Problem
This results in very low chances of multiple pregnancies occurring and an astronomically low chance of triplets (or greater). It is also not backed up by real world data:

In 2015, in the USA, there were...
- 3,978,497 recorded births
Of which...
- 3.35% were twin births
- 0.10% were triplet births+
_source: https://www.cdc.gov/nchs/data/nvsr/nvsr66/nvsr66_01.pdf_

### Solution
Changing the default rate from 1in50 to 1in30 creates percentiles much closer to the real world data:
- 3.33% chance of twins
- 0.11% chance of triplets+

As all presets used the default value (1in50), I went through and updated them all to match 1in30.