### PR TITLE
Hide Toughness When 0

### DIFF
--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1306,7 +1306,7 @@ public class PersonViewPanel extends JScrollablePanel {
             firsty++;
         }
 
-        if (campaign.getCampaignOptions().isUseToughness()) {
+        if ((campaign.getCampaignOptions().isUseToughness()) && (person.getToughness() > 0)) {
             lblTough1.setName("lblTough1");
             lblTough1.setText(resourceMap.getString("lblTough1.text"));
             gridBagConstraints = new GridBagConstraints();


### PR DESCRIPTION
### Current Implementation
When enabled, via Campaign Options, Toughness will always be visible on the personnel panel.
<p align=center>
  <img width="493" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/150d5adb-deec-46b6-b2ff-8a47a95a768e">
</p>

### Problem
This does not follow the standard set out by other optional characteristics, such as 'Edge', which only display when having a non-zero value.

### Solution
Expanded the existing conditional to check that Toughness is enabled _and_ above zero.
<p align=center>
  <img width="495" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/3cfd432a-93ed-40b3-9438-03ea62d2ca6b">
</p>
<p align=center>
  <img width="491" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/0a16189b-3f3b-4fb8-aa17-2c15b3719a7f">
</p>