### PR TITLE
Fix 3882: update Aerospace handling and reporting in MHQ

### DIFF
--- a/MekHQ/data/forcegenerator/2398.xml
+++ b/MekHQ/data/forcegenerator/2398.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2398' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2398' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2398' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2398' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:6,FWL:2</salvage>
@@ -46,7 +46,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2398' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2398' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2398' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2398' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -59,7 +59,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2398' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2398' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:6,LA:10,FWL:9,FS:3,DC:2</salvage>
@@ -229,7 +229,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:8</availability>
@@ -301,7 +301,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:2,OA:1,LA:2,FWL:8,IS:1,FS:1,DC:1,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:8</availability>
@@ -360,7 +360,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Firebird' unitType='Aero'>
+	<chassis name='Firebird' unitType='AeroSpaceFighter'>
 		<availability>CC:4,TC:2</availability>
 		<model name='FR-1'>
 			<availability>General:8</availability>
@@ -417,7 +417,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>TH:4</availability>
 		<model name='HMR-HA'>
 			<availability>TH:8</availability>
@@ -662,7 +662,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>

--- a/MekHQ/data/forcegenerator/2440.xml
+++ b/MekHQ/data/forcegenerator/2440.xml
@@ -29,7 +29,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2440' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2440' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2440' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2440' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:6,FWL:2,DC:1</salvage>
@@ -47,7 +47,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2440' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2440' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2440' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2440' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -60,7 +60,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2440' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2440' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:9,FWL:9,FS:4,DC:2</salvage>
@@ -274,7 +274,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:1,IS:1,FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:8</availability>
@@ -361,7 +361,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:1,DC:1,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:8</availability>
@@ -433,7 +433,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Firebird' unitType='Aero'>
+	<chassis name='Firebird' unitType='AeroSpaceFighter'>
 		<availability>CC:1,TC:1</availability>
 		<model name='FR-1'>
 			<availability>General:8</availability>
@@ -490,7 +490,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>TH:5</availability>
 		<model name='HMR-HA'>
 			<availability>TH:8</availability>
@@ -790,7 +790,7 @@
 			<availability>IS:5,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>

--- a/MekHQ/data/forcegenerator/2460.xml
+++ b/MekHQ/data/forcegenerator/2460.xml
@@ -29,7 +29,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2460' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2460' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2460' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2460' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:6,FWL:2,DC:2</salvage>
@@ -47,7 +47,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2460' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2460' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2460' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2460' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -60,7 +60,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2460' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2460' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:10,FS:4,DC:3</salvage>
@@ -280,7 +280,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:1,IS:1,FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:8</availability>
@@ -390,7 +390,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:2,DC:2,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:6</availability>
@@ -525,7 +525,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>TH:7</availability>
 		<model name='HMR-HA'>
 			<availability>TH:8</availability>
@@ -623,7 +623,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8</availability>
 		<model name='LTN-G14'>
 			<availability>CC:8</availability>
@@ -875,7 +875,7 @@
 			<availability>IS:4,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>
@@ -932,7 +932,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:4</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>

--- a/MekHQ/data/forcegenerator/2470.xml
+++ b/MekHQ/data/forcegenerator/2470.xml
@@ -29,7 +29,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2470' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2470' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2470' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2470' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:6,FWL:5,DC:1</salvage>
@@ -47,7 +47,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2470' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2470' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2470' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2470' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -60,7 +60,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2470' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2470' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:9,FS:4,DC:3</salvage>
@@ -300,7 +300,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:1,IS:1,FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:7</availability>
@@ -432,7 +432,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:2,DC:2,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:5</availability>
@@ -585,7 +585,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:2,TH:7,LA:1,FWL:2,IS:1,FS:2,DC:2</availability>
 		<model name='HMR-HA'>
 			<availability>TH:6</availability>
@@ -771,7 +771,7 @@
 			<availability>General:1-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8</availability>
 		<model name='LTN-G14'>
 			<availability>CC:8</availability>
@@ -1053,13 +1053,13 @@
 			<availability>IS:3,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CC:6,OA:4,LA:6,IS:6,FWL:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -1113,7 +1113,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>LA:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -1141,7 +1141,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5,MERC:1,DC:1</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>

--- a/MekHQ/data/forcegenerator/2490.xml
+++ b/MekHQ/data/forcegenerator/2490.xml
@@ -29,7 +29,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2490' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2490' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2490' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2490' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:7,FWL:2</salvage>
@@ -47,7 +47,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2490' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2490' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2490' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2490' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -60,7 +60,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2490' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2490' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:9,FS:4,DC:3</salvage>
@@ -347,7 +347,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:6</availability>
@@ -507,7 +507,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:2,DC:2,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:4</availability>
@@ -738,7 +738,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:3,TH:7,LA:2,FWL:3,IS:2,FS:3,DC:3</availability>
 		<model name='HMR-HA'>
 			<availability>TH:5</availability>
@@ -949,7 +949,7 @@
 			<availability>General:1-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8</availability>
 		<model name='LTN-G14'>
 			<availability>CC:6</availability>
@@ -1329,7 +1329,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6-</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>
@@ -1338,7 +1338,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CC:6,OA:4,LA:6,IS:6,FWL:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -1351,7 +1351,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>LA:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -1430,7 +1430,7 @@
 			<availability>TH:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -1467,7 +1467,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5,MERC:2,DC:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>

--- a/MekHQ/data/forcegenerator/2520.xml
+++ b/MekHQ/data/forcegenerator/2520.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2520' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2520' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2520' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2520' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:7,FWL:3,DC:2</salvage>
@@ -49,7 +49,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2520' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2520' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2520' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2520' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -59,7 +59,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2520' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2520' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:9,FS:4,DC:3</salvage>
@@ -423,7 +423,7 @@
 			<availability>TH:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8,MERC:3,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:6</availability>
@@ -621,7 +621,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:1,OA:1,LA:3,FWL:8,IS:1,FS:3,DC:3,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:2</availability>
@@ -886,7 +886,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:3,TH:7,LA:2,FWL:3,IS:2,FS:3,DC:3</availability>
 		<model name='HMR-HA'>
 			<availability>TH:4</availability>
@@ -1108,7 +1108,7 @@
 			<availability>General:1-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8</availability>
 		<model name='LTN-G14'>
 			<availability>CC:4</availability>
@@ -1145,7 +1145,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>LA:6</availability>
 		<model name='LCF-R15'>
 			<availability>LA:6,General:6,Periphery.Deep:6,MERC:8,Periphery:6</availability>
@@ -1553,7 +1553,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:5-,OA:5-,LA:5-,FWL:5-,IS:5-,Periphery.Deep:5-,FS:5-,MERC:5-,DC:6-,Periphery:5-</availability>
 		<model name='SB-26'>
 			<availability>DC:6</availability>
@@ -1562,7 +1562,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:6,OA:4,LA:6,IS:6,FWL:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -1575,7 +1575,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FWL:2,FS:2,MERC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -1611,7 +1611,7 @@
 			<availability>TH:5,IS:3,TC:5,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>TH:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -1671,7 +1671,7 @@
 			<availability>TH:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>LA:9,FWL:2,DC:3</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -1719,7 +1719,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5,MERC:2,DC:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -1797,7 +1797,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>RWR:6</availability>
 		<model name='VLC-3N'>
 			<availability>General:8</availability>

--- a/MekHQ/data/forcegenerator/2571.xml
+++ b/MekHQ/data/forcegenerator/2571.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2571' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2571' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2571' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2571' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>TH:7,SL:5,FWL:2,RWR:2,DC:3</salvage>
@@ -49,7 +49,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2571' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2571' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2571' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2571' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -61,11 +61,11 @@
 		<salvage pct='5'>CC:10,LA:10,FWL:9,FS:4,DC:7</salvage>
 		<weightDistribution era='2571' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2571' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2571' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2571' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>CC:6,SL:10,FS:9</salvage>
-		<weightDistribution era='2571' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2571' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:9,FS:4,DC:3</salvage>
@@ -552,7 +552,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -594,7 +594,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:6,Periphery.ME:3,FWL:4,SL.R:6,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -608,7 +608,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:1,OA:1,LA:3,SL:6,FWL:3,RWR:1,FS:3,MERC:3,DC:3,Periphery:1,TC:1</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -869,7 +869,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,OA:1,LA:4,SL:5,FWL:8,IS:2,FS:4,DC:4,TC:2</availability>
 		<model name='EGL-R4'>
 			<availability>LA:6,General:3,FS:6</availability>
@@ -1228,7 +1228,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:1,OA:1,TH:7,LA:3,SL:7,FWL:4,IS:3,FS:4,DC:4,TC:1</availability>
 		<model name='HMR-HC'>
 			<availability>TH:6,SL:5,IS:8</availability>
@@ -1390,7 +1390,7 @@
 			<availability>CC:1,IS:2,DC:1,Periphery:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>SL:6</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -1577,7 +1577,7 @@
 			<availability>LA:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,SL:5</availability>
 		<model name='LTN-G14'>
 			<availability>CC:2,Periphery.Deep:4,Periphery:4</availability>
@@ -1642,7 +1642,7 @@
 			<availability>MOC:3,OA:3,TH:4,LA:3,SL:4,FWL:3,RWR:2,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,Periphery.R:2,OA:1,LA:8,Periphery.MW:2,MERC:3,Periphery:1,TC:1</availability>
 		<model name='LCF-R15'>
 			<availability>LA:6,General:6,Periphery.Deep:6,MERC:8,Periphery:6</availability>
@@ -2146,7 +2146,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>SL:7</availability>
 		<model name='RPR-100'>
 			<availability>General:8,SL.R:8</availability>
@@ -2181,7 +2181,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>SL:4</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
@@ -2213,7 +2213,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-26'>
 			<availability>DC:4</availability>
@@ -2229,7 +2229,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:6,IS:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,OA:4,LA:6,SL:8,FWL:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -2254,7 +2254,7 @@
 			<availability>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,Periphery.R:3,OA:3,LA:4,FWL:3,FS:3,MERC:3,DC:3,Periphery:3,TC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -2299,7 +2299,7 @@
 			<availability>TH:6,IS:4,TC:5,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:2,RWR:1,MERC:2,Periphery.OS:1,FS:2,Periphery:1,TC:1,OA:1,TH:5,LA:2,Periphery.HR:1,SL:6,FWL:2,SL.R:6,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -2328,7 +2328,7 @@
 			<availability>MOC:1,OA:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>TH:6,DC:4</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -2375,7 +2375,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>CC:3,LA:3,SL:6,FWL:2,FS:3,MERC:2,DC:2</availability>
 		<model name='STU-K5'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
@@ -2418,7 +2418,7 @@
 			<availability>SL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:8</availability>
@@ -2430,7 +2430,7 @@
 			<availability>SL:8,FWL:8+,IS:8+,SL.R:8,FS:8+,DC:8+</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,OA:5,LA:9,SL:7,IS:5,FWL:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -2475,7 +2475,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:4</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -2499,7 +2499,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5,MERC:1,DC:1</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -2584,7 +2584,7 @@
 			<availability>SL:8,IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>RWR:6</availability>
 		<model name='VLC-3N'>
 			<availability>General:8</availability>

--- a/MekHQ/data/forcegenerator/2650.xml
+++ b/MekHQ/data/forcegenerator/2650.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2650' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2650' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2650' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2650' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>TH:10,SL:10,FWL:4,RWR:2,DC:4</salvage>
@@ -49,7 +49,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2650' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2650' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2650' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2650' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -61,11 +61,11 @@
 		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:3,DC:6</salvage>
 		<weightDistribution era='2650' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2650' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2650' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2650' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:1,SL:1,FS:10</salvage>
-		<weightDistribution era='2650' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2650' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:7,LA:10,FWL:7,FS:2,DC:5</salvage>
@@ -198,7 +198,7 @@
 	</faction>
 	<faction key='RWR.HG'>
 		<pctSL>0,0,3,5,10</pctSL>
-		<pctSL unitType='Aero'>0,0,3,5,10</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>0,0,3,5,10</pctSL>
 		<pctSL unitType='Vehicle'>0,0,3,5,10</pctSL>
 		<salvage pct='5'>LA:10,SL:2</salvage>
 	</faction>
@@ -582,7 +582,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -634,7 +634,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RWR:4,FS:4,MERC:4,Periphery:2,TC:4,OA:4,LA:4,Periphery.MW:4,SL:6,Periphery.ME:4,FWL:5,SL.R:4,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -648,7 +648,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,OA:2,LA:4,SL:8,FWL:4,RWR:2,FS:4,MERC:4,DC:3,Periphery:2,TC:2</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -878,7 +878,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:2,LA:4,SL:5,FWL:8,IS:3,RWR:2,FS:4,DC:4,Periphery:2,TC:3</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1213,7 +1213,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,OA:2,LA:2,SL:8,IS:2,FWL:8,RWR:2,FS:2,MERC:2,TC:2,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:6</availability>
@@ -1269,7 +1269,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,TH:6,LA:4,SL:7,FWL:4,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
 		<model name='HMR-HC'>
 			<availability>TH:5,SL:4,IS:8</availability>
@@ -1454,7 +1454,7 @@
 			<availability>CC:2,IS:5,DC:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:2,LA:2,SL:7,FWL:2,IS:2,FWL.OH:2,RWR:2,FS:2,DC:2,TC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -1658,7 +1658,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery.Deep:4,Periphery:4</availability>
@@ -1730,7 +1730,7 @@
 			<availability>MOC:4,OA:4,TH:6,LA:5,SL:6,FWL:5,RWR:3,FS:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
@@ -2309,7 +2309,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,SL:8</availability>
 		<model name='RPR-100'>
 			<availability>General:8,SL.R:8</availability>
@@ -2365,7 +2365,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,OA:2,LA:4,SL:5,FWL:4,IS:3,RWR:2,FS:3,DC:3,TC:2</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
@@ -2406,7 +2406,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,SL:8,SL.R:8</availability>
@@ -2422,7 +2422,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:7,FWL:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -2456,7 +2456,7 @@
 			<availability>LA:4+,SL:6,FWL:4+,SL.R:8,RWR:4,FS:4+,MERC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,Periphery.R:4,OA:5,LA:4,FWL:3,Periphery.Deep:4,FS:3,MERC:3,DC:3,Periphery:4,TC:4</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -2508,7 +2508,7 @@
 			<availability>TH:4,IS:4,TC:5,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:3,Periphery:3,TC:2,OA:2,TH:5,LA:3,Periphery.HR:3,SL:6,FWL:3,SL.R:5,DC:3</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -2543,7 +2543,7 @@
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>TH:4,DC:6</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -2598,13 +2598,13 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,RWR:2,MERC:3,Periphery.OS:2,FS:4,TC:2,Periphery:1,OA:2,LA:4,Periphery.HR:2,SL:8,FWL:3,DC:3</availability>
 		<model name='STU-K5'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>SL:7</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -2658,7 +2658,7 @@
 			<availability>SL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:8</availability>
@@ -2670,7 +2670,7 @@
 			<availability>SL:8,FWL:8+,IS:8+,SL.R:8,RWR:8,FS:8+,DC:8+</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,OA:5,LA:9,SL:7,IS:5,FWL:5,Periphery.Deep:5,FS:5,Periphery:5,TC:5,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -2693,7 +2693,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>SL:8</availability>
 		<model name='THK-33'>
 			<availability>General:3</availability>
@@ -2729,7 +2729,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:5</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -2753,7 +2753,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -2855,7 +2855,7 @@
 			<availability>SL:6,IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>RWR:6</availability>
 		<model name='VLC-3N'>
 			<availability>General:6</availability>

--- a/MekHQ/data/forcegenerator/2700.xml
+++ b/MekHQ/data/forcegenerator/2700.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2700' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2700' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2700' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2700' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>TH:10,SL:10,FWL:4,RWR:2,DC:5</salvage>
@@ -50,7 +50,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2700' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2700' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2700' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2700' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -62,11 +62,11 @@
 		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:3,DC:6</salvage>
 		<weightDistribution era='2700' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2700' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2700' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2700' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:1,SL:1,FS:10</salvage>
-		<weightDistribution era='2700' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2700' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:7,LA:10,FWL:7,FS:2,DC:5</salvage>
@@ -221,7 +221,7 @@
 	</faction>
 	<faction key='RWR.HG'>
 		<pctSL>0,0,2,3,5</pctSL>
-		<pctSL unitType='Aero'>0,0,2,3,5</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>0,0,2,3,5</pctSL>
 		<pctSL unitType='Vehicle'>0,0,2,3,5</pctSL>
 		<salvage pct='5'>LA:10,SL:2</salvage>
 	</faction>
@@ -298,7 +298,7 @@
 			<availability>CC:2,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:2+,LA:2+,SL:6,FWL:2+,IS:2+,FS:2+,DC:2+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,SL.R:4</availability>
@@ -660,7 +660,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -715,7 +715,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RWR:4,FS:4,MERC:4,Periphery:3,TC:4,OA:4,LA:4,Periphery.MW:4,SL:5,Periphery.ME:4,FWL:5,SL.R:2,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -729,7 +729,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:7,FWL:4,RWR:3,FS:4,MERC:4,DC:4,Periphery:2,TC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,SL:6,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -969,7 +969,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1059,7 +1059,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,OA:3,LA:4,SL:4,IS:4,FWL:8,RWR:3,FS:4,Periphery:3,TC:4,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1438,7 +1438,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:2,SL:9,Periphery.ME:2,FWL:9,DC:3</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:6</availability>
@@ -1510,7 +1510,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4,OA:4,TH:5,LA:5,SL:7,FWL:5,IS:5,RWR:4,FS:5,DC:5,TC:4</availability>
 		<model name='HMR-HC'>
 			<availability>TH:4,SL:2,IS:8</availability>
@@ -1610,7 +1610,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>SL:5</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -1623,7 +1623,7 @@
 			<availability>IS:4,SL.R:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:4-,OA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,MERC:6-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -1737,7 +1737,7 @@
 			<availability>CC:3,IS:7,DC:3,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,OA:2,LA:3,SL:7,FWL:3,IS:3,FWL.OH:3,RWR:2,FS:3,DC:3,TC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2006,7 +2006,7 @@
 			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2092,7 +2092,7 @@
 			<availability>MOC:4,OA:4,TH:8,LA:6,SL:8,FWL:6,RWR:3,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
@@ -2803,7 +2803,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,SL:8</availability>
 		<model name='RPR-100'>
 			<availability>General:8,SL.R:8</availability>
@@ -2883,7 +2883,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:5,FWL:5,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
@@ -2935,7 +2935,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,SL:8,SL.R:6</availability>
@@ -2957,7 +2957,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:6,FWL:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3000,7 +3000,7 @@
 			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,Periphery.R:4,OA:4,LA:4,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3068,7 +3068,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>SL:5</availability>
 		<model name='SPD-502'>
 			<availability>General:8,SL.R:6</availability>
@@ -3077,7 +3077,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:4,Periphery:3,TC:2,OA:2,TH:6,LA:3,Periphery.HR:3,SL:5-,FWL:3,SL.R:3,DC:3</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3118,7 +3118,7 @@
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -3162,7 +3162,7 @@
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:2,LA:2,SL:2,FWL:2,IS:2,FS:2,MERC:2,DC:2</availability>
 		<model name='F-90'>
 			<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
@@ -3190,7 +3190,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,RWR:2,MERC:4,Periphery.OS:2,FS:5,TC:2,Periphery:2,OA:2,LA:5,Periphery.HR:2,SL:8,FWL:4,DC:4</availability>
 		<model name='STU-K10'>
 			<availability>FS.DMM:8</availability>
@@ -3202,7 +3202,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:2,SL:9,FWL:2,RWR:2,FS:2,MERC:2,DC:3,TC:2</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3256,7 +3256,7 @@
 			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:3</availability>
 		<model name='TR-5'>
 			<availability>CC:8</availability>
@@ -3278,7 +3278,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:6,OA:6,LA:9,SL:5,IS:6,FWL:6,Periphery.Deep:6,FS:6,Periphery:6,TC:6,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3315,7 +3315,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,OA:2,LA:4,SL:9,FWL:3,RWR:2,FS:2,MERC:2,DC:2,TC:2</availability>
 		<model name='THK-33'>
 			<availability>General:1</availability>
@@ -3374,13 +3374,13 @@
 			<availability>SL:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:2,SL:7,FWL:3,RWR:3,FS:4,MERC:4,DC:4,TC:3</availability>
 		<model name='TRN-3T'>
 			<availability>OA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
@@ -3410,7 +3410,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:3</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -3530,7 +3530,7 @@
 			<availability>SL:4,IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,OA:3,RWR:6,TC:3</availability>
 		<model name='VLC-3N'>
 			<availability>General:4</availability>
@@ -3716,7 +3716,7 @@
 			<availability>General:4,SL.R:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,OA:2,LA:3,SL:4,FWL:3,IS:3,RWR:2,FS:3,DC:4,Periphery:2,TC:2</availability>
 		<model name='ZRO-114'>
 			<availability>General:8,SL.R:6</availability>

--- a/MekHQ/data/forcegenerator/2765.xml
+++ b/MekHQ/data/forcegenerator/2765.xml
@@ -31,7 +31,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2765' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2765' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2765' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2765' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>TH:10,SL:10,FWL:8,RWR:6,DC:7</salvage>
@@ -58,7 +58,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2765' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2765' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2765' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2765' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -70,11 +70,11 @@
 		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:4,DC:6</salvage>
 		<weightDistribution era='2765' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2765' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2765' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2765' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:5,SL:2,FS:10</salvage>
-		<weightDistribution era='2765' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2765' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:9,LA:10,FWL:7,FS:3,DC:5</salvage>
@@ -233,13 +233,13 @@
 	</faction>
 	<faction key='RWR.HG'>
 		<pctSL>0,0,1,2,5</pctSL>
-		<pctSL unitType='Aero'>0,0,1,2,5</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>0,0,1,2,5</pctSL>
 		<pctSL unitType='Vehicle'>0,0,1,2,5</pctSL>
 		<salvage pct='5'>LA:10,SL:2,SL.R:1</salvage>
 	</faction>
 	<faction key='RWR.TC'>
 		<pctSL>30,40</pctSL>
-		<pctSL unitType='Aero'>30,40</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>30,40</pctSL>
 		<pctSL unitType='Vehicle'>30,40</pctSL>
 		<salvage pct='7'>SL:8,SL.R:2</salvage>
 	</faction>
@@ -318,7 +318,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:5+,LA:5+,SL:7,FWL:5+,IS:4+,RWR:3+,FS:5+,DC:5+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,SL.R:4</availability>
@@ -703,7 +703,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:6,MERC:4,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -761,7 +761,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,RWR:5,FS:4,MERC:4,Periphery:3,TC:5,OA:5,LA:4,Periphery.MW:4,SL:4-,Periphery.ME:4,FWL:5,SL.R:2,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -775,7 +775,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,OA:3,LA:5,SL:7,FWL:5,RWR:3,MERC:5,FS:5,Periphery:2,TC:3,DC:4</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,SL:4,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -921,7 +921,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>SL:6</availability>
 		<model name='CSR-V12'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
@@ -1038,7 +1038,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1131,7 +1131,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,OA:4,LA:4,SL:4-,IS:4,FWL:8,RWR:4,FS:4,Periphery:3,TC:4,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1512,7 +1512,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,DC:3</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:5</availability>
@@ -1584,7 +1584,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:4,OA:4,TH:5,LA:6,SL:7,FWL:6,IS:6,RWR:4,FS:6,DC:6,TC:4</availability>
 		<model name='HMR-HC'>
 			<availability>TH:4,IS:8</availability>
@@ -1684,7 +1684,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2+,OA:2+,LA:2,SL:5,FWL:2,IS:2,RWR:2,FS:2,DC:2,TC:2+</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -1697,7 +1697,7 @@
 			<availability>IS:4,SL.R:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:4-,OA:4-,LA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,FS:4-,MERC:6-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -1811,7 +1811,7 @@
 			<availability>CC:4,IS:8,DC:4,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:7,IS:3,FWL:4,FWL.OH:4,RWR:3,FS:4,TC:3,DC:4</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2108,7 +2108,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:3,FS:3,DC:3,Periphery:2,TC:2</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2194,7 +2194,7 @@
 			<availability>MOC:4,OA:4,TH:8,LA:5,SL:8,FWL:5,RWR:5,FS:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
@@ -2956,7 +2956,7 @@
 			<availability>FWL:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,SL:8,IS:2,RWR:3,MERC:2</availability>
 		<model name='RPR-100'>
 			<availability>General:8,SL.R:8</availability>
@@ -3040,7 +3040,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:5,FWL:5,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:7</availability>
@@ -3092,7 +3092,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,SL:6,SL.R:4</availability>
@@ -3114,7 +3114,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:6,FWL:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3161,7 +3161,7 @@
 			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,Periphery.R:4,OA:4,LA:5,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3216,7 +3216,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3256,7 +3256,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>SL:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,SL.R:5</availability>
@@ -3265,7 +3265,7 @@
 			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,RWR:2,MERC:4,Periphery.OS:4,FS:5,Periphery:4,TC:2,OA:2,TH:6,LA:4,Periphery.HR:4,SL:5-,FWL:4,SL.R:2,DC:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3317,7 +3317,7 @@
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>DC:3</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -3368,7 +3368,7 @@
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,IS:4,RWR:2,MERC:4,FS:4,Periphery:2,TC:2,OA:2,LA:4,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:4,DC:4</availability>
 		<model name='F-90'>
 			<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
@@ -3396,7 +3396,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,RWR:3,MERC:4,Periphery.OS:3,FS:5,TC:3,Periphery:2,OA:3,LA:5,Periphery.HR:3,SL:8,FWL:4,DC:4</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -3408,7 +3408,7 @@
 			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:3,OA:3,SL:9,FWL:4,RWR:3,FS:4,MERC:4,DC:5,TC:3</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3462,7 +3462,7 @@
 			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:3</availability>
 		<model name='TR-5'>
 			<availability>CC:6</availability>
@@ -3490,7 +3490,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:6,OA:6,LA:9,SL:5,IS:6,FWL:6,Periphery.Deep:6,FS:7,Periphery:6,TC:7,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3527,7 +3527,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,OA:3,LA:6,SL:9,FWL:5,RWR:3,FS:3,MERC:3,DC:3,TC:3</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -3579,13 +3579,13 @@
 			<availability>SL:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:5,OA:5,LA:3,SL:7,FWL:4,RWR:5,FS:6,MERC:6,DC:6,TC:5</availability>
 		<model name='TRN-3T'>
 			<availability>OA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
@@ -3615,7 +3615,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:3</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -3735,7 +3735,7 @@
 			<availability>SL:2,IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,RWR:8,Periphery:2,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -3939,7 +3939,7 @@
 			<availability>General:4,SL.R:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:3,SL:6,IS:3,FWL:3,RWR:2,FS:3,Periphery:2,TC:2,DC:5</availability>
 		<model name='ZRO-114'>
 			<availability>General:8,SL.R:5</availability>

--- a/MekHQ/data/forcegenerator/2780.xml
+++ b/MekHQ/data/forcegenerator/2780.xml
@@ -35,7 +35,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2780' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2780' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2780' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2780' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>FWL:10,Periphery:2,DC:9</salvage>
@@ -61,7 +61,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2780' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2780' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2780' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2780' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -70,12 +70,12 @@
 		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:4,DC:6</salvage>
 		<weightDistribution era='2780' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2780' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2780' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2780' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='SLIE'/>
 	<faction key='TC'>
 		<salvage pct='6'>CC:6,SL:10,FS:10</salvage>
-		<weightDistribution era='2780' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2780' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:16,LA:20,FWL:14,FS:8,DC:12</salvage>
@@ -315,7 +315,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:6+,LA:6+,SL:7,FWL:7+,IS:5+,NIOPS:7,FS:6+,DC:6+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,SL.R:4</availability>
@@ -699,7 +699,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -757,7 +757,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,OA:5,LA:6,Periphery.MW:5,SL:2-,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -775,7 +775,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,OA:3,LA:8,SL:7,FWL:6,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -917,7 +917,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:3,OA:3,LA:4,SL:6,FWL:5,MERC:3,FS:6,CIR:2,Periphery:2,TC:3,DC:3</availability>
 		<model name='CSR-V12'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
@@ -1047,7 +1047,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1140,7 +1140,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,OA:4,LA:4,SL:4-,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1524,7 +1524,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,OA:2,LA:2,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:4</availability>
@@ -1602,7 +1602,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:4,OA:4,LA:6,SL:7,IS:6,FWL:6,NIOPS:7,FS:6,CIR:4,TC:4,DC:6</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -1705,7 +1705,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3+,OA:3+,LA:4,SL:6,IS:3,FWL:4,NIOPS:6,FS:4,TC:3+,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -1718,7 +1718,7 @@
 			<availability>IS:4,NIOPS:4,SL.R:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,SL:4-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -1832,7 +1832,7 @@
 			<availability>CC:5,CS:5,IS:8,MERC:6,DC:5,TC:7,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,OA:3,LA:6,SL:7,FWL:6,NIOPS:6,DC:6</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2150,7 +2150,7 @@
 			<availability>SL.R:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,IS:3,FWL:2,NIOPS:5-,FS:3,Periphery:2,TC:2,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2236,7 +2236,7 @@
 			<availability>MOC:4,CS:6,OA:4,SLIE:5,LA:4,SL:6,FWL:4,FS:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
@@ -2955,7 +2955,7 @@
 			<availability>FWL:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>OA:2,LA:6,SL:8,IS:3,NIOPS:8,MERC:3</availability>
 		<model name='RPR-100'>
 			<availability>General:8,NIOPS:8,SL.R:7</availability>
@@ -3032,7 +3032,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:5,IS:4,FWL:4,NIOPS:4,FS:3,CIR:2,TC:3,DC:3</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,NIOPS:8,SL.R:6</availability>
@@ -3080,7 +3080,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,SL:4</availability>
@@ -3102,7 +3102,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,OA:6,LA:6,SL:5,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3149,7 +3149,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3217,7 +3217,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3257,7 +3257,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>OA:2,SL:6,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,SL.R:4</availability>
@@ -3266,7 +3266,7 @@
 			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,OA:3,LA:4,Periphery.HR:4,SL:4-,FWL:2,NIOPS:3,DC:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3318,7 +3318,7 @@
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>DC:2</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -3369,7 +3369,7 @@
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,OA:2,LA:6,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 		<model name='F-90'>
 			<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
@@ -3391,7 +3391,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,SL:7,FWL:3,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -3403,7 +3403,7 @@
 			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:3,OA:3,LA:2,SL:9,FWL:4,NIOPS:8,FS:4,MERC:4,DC:5,TC:3</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3451,7 +3451,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:5</availability>
@@ -3483,7 +3483,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,OA:6,LA:8,SL:5,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3523,7 +3523,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:2,OA:2,LA:6,SL:9,FWL:5,NIOPS:9,FS:3,MERC:3,CIR:1,TC:2,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -3561,7 +3561,7 @@
 			<availability>SLIE:8,SL:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -3578,7 +3578,7 @@
 			<availability>CC:2,MOC:2,NIOPS:2,FWL:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:5,OA:5,LA:3,SL:7,FWL:4,NIOPS:7,FS:6,MERC:6,CIR:4,TC:5,DC:6</availability>
 		<model name='TRN-3T'>
 			<availability>OA:7,SL:8,IS:7,NIOPS:8,Periphery.Deep:7,SL.R:4,Periphery:7</availability>
@@ -3604,7 +3604,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -3724,7 +3724,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -3941,7 +3941,7 @@
 			<availability>General:3,SL.R:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:2,LA:2,SL:6,IS:2,FWL:2,NIOPS:5,FS:2,Periphery:2,TC:2,DC:4</availability>
 		<model name='ZRO-114'>
 			<availability>General:8,NIOPS:8,SL.R:4</availability>

--- a/MekHQ/data/forcegenerator/2807.xml
+++ b/MekHQ/data/forcegenerator/2807.xml
@@ -56,7 +56,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2807' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2807' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2807' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2807' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>FWL:10,Periphery:2,DC:9</salvage>
@@ -81,14 +81,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2807' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2807' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2807' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2807' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>CC:6,FS:10</salvage>
-		<weightDistribution era='2807' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2807' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -322,7 +322,7 @@
 			<availability>CS:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6+,CS:7,LA:6+,FWL:7+,IS:5+,NIOPS:7,FS:6+,DC:6+</availability>
 		<model name='AHB-443'>
 			<availability>General:8</availability>
@@ -699,7 +699,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -764,7 +764,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -782,7 +782,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,PP:6,CC:5,OA:3,LA:8,FWL:6,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -920,7 +920,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,PP:6,CC:3,OA:3,LA:4,FWL:5,MERC:3,FS:6,CIR:2,Periphery:2,TC:3,DC:3</availability>
 		<model name='CSR-V12'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1056,7 +1056,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1161,7 +1161,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1582,7 +1582,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>PP:6,General:6</availability>
@@ -1657,7 +1657,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6,MOC:4,IS:6,FS:6,CIR:4,TC:4,CS:7,OA:4,LA:6,FWL:6,NIOPS:7,DC:6</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -1767,7 +1767,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CC:4,MOC:3+,CS:6,OA:3+,LA:4,IS:3,FWL:4,NIOPS:6,FS:4,TC:3+,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -1780,7 +1780,7 @@
 			<availability>CS:4,PP:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -1920,7 +1920,7 @@
 			<availability>CS:6,CLAN:7,IS:8,MERC:6,TC:7,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6,MOC:3,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,FWL:6,NIOPS:6,DC:6</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2226,7 +2226,7 @@
 			<availability>PP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:8,MOC:2,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2313,7 +2313,7 @@
 			<availability>MOC:4,CS:6,OA:4,IS:6,MERC:2,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
@@ -3027,7 +3027,7 @@
 			<availability>FWL:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>PP:8,CS:8,OA:3,LA:6,IS:4,NIOPS:8,MERC:4</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -3096,7 +3096,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:4,MOC:3,IS:4,FS:3,CIR:2,TC:3,CS:4,OA:3,LA:4,FWL:4,NIOPS:4,DC:3</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -3153,7 +3153,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -3172,7 +3172,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,PP:5,CC:6,OA:6,LA:6,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3235,7 +3235,7 @@
 			<availability>PP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3261,7 +3261,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3273,7 +3273,7 @@
 			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:6</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:8</availability>
@@ -3312,7 +3312,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3352,7 +3352,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CS:6,OA:3,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8</availability>
@@ -3361,7 +3361,7 @@
 			<availability>PP:4,CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3454,7 +3454,7 @@
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -3476,7 +3476,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,PP:8,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -3488,7 +3488,7 @@
 			<availability>PP:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:2,MOC:3,CS:8,OA:3,LA:2,FWL:4,NIOPS:8,FS:4,MERC:4,TC:3,DC:5</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3539,7 +3539,7 @@
 			<availability>PP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:4</availability>
@@ -3571,7 +3571,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3618,7 +3618,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:5,MOC:2,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,LA:6,FWL:5,NIOPS:9,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -3656,7 +3656,7 @@
 			<availability>CS:5+</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -3673,7 +3673,7 @@
 			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6,MOC:5,FS:6,MERC:6,CIR:4,TC:5,CS:7,OA:5,LA:3,FWL:4,NIOPS:7,DC:6</availability>
 		<model name='TRN-3T'>
 			<availability>PP:8,CS:8,OA:6,IS:6,NIOPS:8,Periphery.Deep:6,Periphery:6</availability>
@@ -3703,7 +3703,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -3830,7 +3830,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -4037,7 +4037,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,PP:6,CC:1,IS:1,FS:1,TC:2,Periphery:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:4</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2815.xml
+++ b/MekHQ/data/forcegenerator/2815.xml
@@ -16,7 +16,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2815' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2815' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2815' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -40,9 +40,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='5'>CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
@@ -79,9 +79,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='5'>CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
@@ -148,9 +148,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='5'>CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
@@ -159,9 +159,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='5'>CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
@@ -224,7 +224,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2815' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2815' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2815' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'></salvage>
@@ -255,14 +255,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2815' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2815' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2815' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:6,FS:10</salvage>
-		<weightDistribution era='2815' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -361,9 +361,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -506,7 +506,7 @@
 			<availability>CS:8,General:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:5+,CS:7,LA:5+,CLAN:7,FWL:7+,IS:4+,NIOPS:7,FS:5+,DC:5+</availability>
 		<model name='AHB-443'>
 			<availability>General:8</availability>
@@ -906,7 +906,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -974,7 +974,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -992,7 +992,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CC:5,MOC:3,CLAN:5,FS:5,MERC:5,CIR:3,Periphery:2,TC:3,OA:3,LA:8,FWL:6,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -1253,7 +1253,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CC:3,MOC:3,CLAN:5,FS:6,MERC:3,CIR:2,Periphery:2,TC:3,OA:3,LA:4,FWL:5,DC:3</availability>
 		<model name='CSR-V12'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1395,7 +1395,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1500,7 +1500,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1933,7 +1933,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:4,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:9,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>PP:6,General:6</availability>
@@ -2008,7 +2008,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,PP:7,CC:5,CLAN:7,IS:5,FS:5,CIR:4,TC:4,CS:7,OA:4,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2118,7 +2118,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -2131,7 +2131,7 @@
 			<availability>CS:4,PP:4,CLAN:2,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2274,7 +2274,7 @@
 			<availability>CS:7,CLAN:7,IS:8,MERC:6,TC:7,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6,MOC:3,CLAN:7,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,CNC:7,FWL:6,NIOPS:6,DC:6</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2590,7 +2590,7 @@
 			<availability>PP:4,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:8,MOC:2,CLAN:5,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2677,7 +2677,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:6,MERC:2,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
@@ -3419,7 +3419,7 @@
 			<availability>MOC:6,OA:6,FWL:8,DC:8,TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>PP:8,CS:8,OA:3,LA:6,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -3452,7 +3452,7 @@
 			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:4,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
@@ -3500,7 +3500,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:3,MOC:2,CLAN:4,IS:3,FS:3,CIR:2,TC:2,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:2</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -3560,7 +3560,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,CLAN:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
@@ -3585,7 +3585,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,PP:5,CC:6,OA:6,LA:6,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3655,7 +3655,7 @@
 			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3681,7 +3681,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3693,7 +3693,7 @@
 			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:8</availability>
@@ -3732,7 +3732,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:2,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3772,7 +3772,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CS:6,OA:3,CSR:6,CLAN:6,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8</availability>
@@ -3781,7 +3781,7 @@
 			<availability>PP:4,CS:4,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,Periphery:4,TC:3,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3877,7 +3877,7 @@
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -3899,7 +3899,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,PP:8,CC:4,CLAN:6,MERC:4,Periphery.OS:3,FS:6,CIR:2,TC:3,Periphery:2,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -3919,7 +3919,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:2+,PP:9,CC:2+,CLAN:9,MERC:3+,FS:3+,TC:2+,CS:8,OA:3,LA:2,FWL:3+,NIOPS:8,DC:4+</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3973,7 +3973,7 @@
 			<availability>PP:2,CLAN:8,CGS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:4-</availability>
@@ -4005,7 +4005,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4055,7 +4055,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:5,MOC:2,CLAN:9,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:6,FWL:5,NIOPS:9,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4096,7 +4096,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -4113,7 +4113,7 @@
 			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:4,TC:4,CS:7,OA:5,LA:2,FWL:3,NIOPS:7,DC:5</availability>
 		<model name='TRN-3T'>
 			<availability>PP:8,CS:8,OA:5+,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
@@ -4146,7 +4146,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -4273,7 +4273,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -4486,7 +4486,7 @@
 			<availability>CHH:4,General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,PP:6,CC:1,CLAN:6,IS:1,FS:1,Periphery:2,TC:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:3</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2823.xml
+++ b/MekHQ/data/forcegenerator/2823.xml
@@ -16,7 +16,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2823' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2823' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2823' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -40,9 +40,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,9</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
@@ -79,9 +79,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,10,15</pctClan>
-		<pctSL unitType='Aero'>100,100,95,90,85</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,10,15</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,90,85</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
@@ -148,9 +148,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
@@ -159,9 +159,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
@@ -224,7 +224,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2823' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2823' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2823' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'></salvage>
@@ -252,14 +252,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2823' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2823' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2823' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:6,FS:10</salvage>
-		<weightDistribution era='2823' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -361,9 +361,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -375,9 +375,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
@@ -410,9 +410,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
@@ -576,7 +576,7 @@
 			<availability>CS:8,General:5,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:5+,CS:7,LA:5+,CLAN:7,FWL:6+,IS:4+,NIOPS:7,FS:5+,DC:5+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -983,7 +983,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:3,Periphery.Deep:4,FS:4,MERC:2,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1057,7 +1057,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:5</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1078,7 +1078,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:8,CLAN:5,FWL:5,FS:5,MERC:4,CIR:3,Periphery:2,TC:3,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -1360,7 +1360,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1590,7 +1590,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2021,7 +2021,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,CLAN:4</availability>
@@ -2107,7 +2107,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,CLAN:7,IS:5,FS:5,CIR:3,TC:3,CS:7,OA:3,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2214,7 +2214,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -2227,7 +2227,7 @@
 			<availability>CS:4,CLAN:2,IS:2,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2381,7 +2381,7 @@
 			<availability>CS:7,CLAN:7,IS:8,MERC:6,TC:7,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:3,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:6,CNC:6</availability>
@@ -2713,7 +2713,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -2800,7 +2800,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3566,7 +3566,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:3,LA:5,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:6,General:5,NIOPS:8</availability>
@@ -3605,7 +3605,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
@@ -3656,7 +3656,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
@@ -3707,7 +3707,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
@@ -3732,7 +3732,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,OA:6,LA:5,CLAN:4,IS:5,FWL:5,MERC:5,FS:5,Periphery:5,TC:5,DC:5</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3818,7 +3818,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3844,7 +3844,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3856,7 +3856,7 @@
 			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -3895,7 +3895,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3935,7 +3935,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:6,CLAN:6,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -3944,7 +3944,7 @@
 			<availability>CS:4,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:8,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:1,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4058,7 +4058,7 @@
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4083,7 +4083,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,TC:3,Periphery:2,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4118,7 +4118,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:2+,CC:1+,CS:8,OA:3,LA:2+,CLAN:9,FWL:3+,NIOPS:8,MERC:3+,FS:3+,TC:2+,DC:4+</availability>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:6</availability>
@@ -4169,7 +4169,7 @@
 			<availability>CLAN:8,CGS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:3-</availability>
@@ -4201,7 +4201,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4257,7 +4257,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4298,7 +4298,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -4318,7 +4318,7 @@
 			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:2,TC:4,CS:7,OA:4,LA:2,FWL:3,NIOPS:7,DC:5</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:5+,CLAN:6,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
@@ -4351,7 +4351,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -4500,7 +4500,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -4697,7 +4697,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:4,CIH:4,CSR:4,CLAN:4,CFM:4,CSJ:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4731,7 +4731,7 @@
 			<availability>CHH:4,General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CS:5,OA:1,CLAN:6,NIOPS:5,DC:3,Periphery:1,TC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2830.xml
+++ b/MekHQ/data/forcegenerator/2830.xml
@@ -22,7 +22,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2830' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2830' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2830' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -46,9 +46,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,10,15,20</pctClan>
 		<pctSL>100,100,90,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,15,25</pctClan>
-		<pctSL unitType='Aero'>100,100,95,85,75</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,15,25</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,85,75</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
@@ -85,9 +85,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,10,15,20</pctClan>
 		<pctSL>100,100,90,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,10,15</pctClan>
-		<pctSL unitType='Aero'>100,100,95,90,85</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,10,15</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,90,85</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:1,CWI:3,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
@@ -154,9 +154,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,15,20</pctClan>
 		<pctSL>100,100,100,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,20,30</pctClan>
-		<pctSL unitType='Aero'>100,100,95,80,70</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,20,30</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,80,70</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CCC:1,CHH:7,CIH:7,CSV:5,CFM:7,CCO:7,CGS:1,CSA:1,CDS:3,CW:3,CWI:1,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
@@ -165,9 +165,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,20,30</pctClan>
 		<pctSL>100,100,100,80,70</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,25,20</pctClan>
-		<pctSL unitType='Aero'>100,100,100,75,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,25,20</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,75,80</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,90,90</pctSL>
 		<salvage pct='10'>CCC:2,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:3,CGS:5,CDS:5,CW:10,CSJ:1,CMG:3,CJF:10,CGB:3,CB:1</salvage>
@@ -222,7 +222,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2830' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2830' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2830' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -250,14 +250,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2830' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2830' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2830' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:5,FS:10</salvage>
-		<weightDistribution era='2830' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -363,9 +363,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -377,9 +377,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,15,20</pctClan>
 		<pctSL>100,100,100,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,15,20</pctClan>
-		<pctSL unitType='Aero'>100,100,100,85,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,15,20</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,85,80</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
@@ -412,9 +412,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,15,20</pctClan>
 		<pctSL>100,100,100,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,15,20</pctClan>
-		<pctSL unitType='Aero'>100,100,100,85,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,15,20</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,85,80</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
@@ -575,7 +575,7 @@
 			<availability>CS:8,General:5,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:4+,CS:7,LA:4+,CLAN:7,FWL:6+,IS:3+,NIOPS:7,FS:4+,DC:4+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -998,7 +998,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:3,Periphery.Deep:4,FS:4,MERC:2,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1072,7 +1072,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1093,7 +1093,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,OA:3,LA:8,CLAN:4,FWL:5,MERC:4,FS:5,CIR:3,TC:3,Periphery:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1379,7 +1379,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1612,7 +1612,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2057,7 +2057,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:5,CLAN:4</availability>
@@ -2150,7 +2150,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,CLAN:7,IS:4,FS:4,CIR:3,TC:3,CS:7,OA:3,LA:4,CNC:7,FWL:4,NIOPS:7,DC:4</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2257,7 +2257,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -2270,7 +2270,7 @@
 			<availability>CS:4,CLAN:2,IS:2,NIOPS:4,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2446,7 +2446,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:6,CNC:6</availability>
@@ -2786,7 +2786,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -2879,7 +2879,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3667,7 +3667,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:3,LA:5,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:6,General:5,NIOPS:8</availability>
@@ -3703,7 +3703,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
@@ -3754,7 +3754,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
@@ -3805,7 +3805,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
@@ -3830,7 +3830,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,OA:6,LA:4,CLAN:4,IS:4,FWL:4,MERC:4,FS:4,TC:4,Periphery:4,DC:5</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3916,7 +3916,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3948,7 +3948,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3960,7 +3960,7 @@
 			<availability>General:8,CLAN:8,BAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -3999,7 +3999,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4039,7 +4039,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:6,CLAN:6,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4048,7 +4048,7 @@
 			<availability>CS:4,CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:8,CIR:3,Periphery:4,TC:3,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:1,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4156,7 +4156,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4181,7 +4181,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,Periphery:2,TC:3,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:2</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4216,7 +4216,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:2+,CC:1+,CS:8,OA:3,LA:2+,CLAN:9,FWL:3+,NIOPS:8,MERC:3+,FS:3+,TC:2+,DC:3+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:6</availability>
@@ -4270,7 +4270,7 @@
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:2-</availability>
@@ -4302,7 +4302,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,TC:7,Periphery:6,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4358,7 +4358,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4399,7 +4399,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -4419,7 +4419,7 @@
 			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,CIR:2,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:4+,CLAN:6,IS:4+,NIOPS:8,Periphery.Deep:4+,BAN:8,Periphery:4+</availability>
@@ -4452,7 +4452,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -4601,7 +4601,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:4,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -4801,7 +4801,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:4,CIH:4,CSR:4,CLAN:4,CFM:4,CSJ:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4832,7 +4832,7 @@
 			<availability>CHH:4,General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CS:5,OA:1,CLAN:6,NIOPS:5,DC:2,Periphery:1,TC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2835.xml
+++ b/MekHQ/data/forcegenerator/2835.xml
@@ -24,7 +24,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2835' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2835' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2835' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -48,9 +48,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,15,30,40</pctClan>
 		<pctSL>100,100,85,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,25,40</pctClan>
-		<pctSL unitType='Aero'>100,100,90,75,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,25,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,75,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:7,CDS:1,CW:5,CBS:2,CNC:7,CJF:5,CGB:2,CB:1</salvage>
@@ -87,9 +87,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,15,20,35</pctClan>
 		<pctSL>100,100,85,80,65</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,15,20</pctClan>
-		<pctSL unitType='Aero'>100,100,90,85,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,15,20</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,85,80</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:2,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
@@ -156,9 +156,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,10,30,40</pctClan>
 		<pctSL>90,90,90,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,40,50</pctClan>
-		<pctSL unitType='Aero'>100,100,85,60,50</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,40,50</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,60,50</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:7,CIH:10,CSV:4,CFM:7,CCO:10,CGS:1,CSA:2,CDS:7,CW:10,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
@@ -167,9 +167,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,10,30,40</pctClan>
 		<pctSL>100,100,90,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,90,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,80,80</pctSL>
 		<salvage pct='10'>CCC:3,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:4,CGS:4,CDS:4,CW:10,CNC:3,CSJ:1,CMG:2,CJF:10,CGB:3,CB:2</salvage>
@@ -216,7 +216,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2835' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2835' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2835' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -244,14 +244,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2835' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2835' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2835' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:5,FS:10</salvage>
-		<weightDistribution era='2835' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -356,9 +356,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -370,9 +370,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,5,30,40</pctClan>
 		<pctSL>100,100,95,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,95,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -405,9 +405,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,5,30,40</pctClan>
 		<pctSL>100,100,95,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,95,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -572,7 +572,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:4+,CS:7,LA:4+,CLAN:7,FWL:5+,IS:3+,NIOPS:7,FS:4+,DC:4+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1039,7 +1039,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:3,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1073,7 +1073,7 @@
 			<availability>CFM:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1119,7 +1119,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1140,7 +1140,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:4,FWL:4,MERC:3,FS:4,CIR:2,TC:2,Periphery:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1438,7 +1438,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1677,7 +1677,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2126,7 +2126,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:3,CLAN:8,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:8,LA:2,Periphery.MW:2,Periphery.ME:2,CNC:8,FWL:5,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:4,CLAN:3</availability>
@@ -2238,7 +2238,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,CLAN:7,IS:4,FS:4,CIR:2,TC:3,CS:7,OA:3,LA:4,CNC:7,FWL:4,NIOPS:7,DC:4</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2354,7 +2354,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:3+,CLAN:5,IS:3,FS:3,TC:3+,CS:6,OA:3+,LA:3,CNC:5,FWL:2,NIOPS:6,DC:3</availability>
 		<model name='HCT-212'>
 			<availability>LA:6,IS:6,FS:6,Periphery:6</availability>
@@ -2370,7 +2370,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:3-,OA:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2495,7 +2495,7 @@
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2565,7 +2565,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:6,IS:3,FWL.OH:5,FS:4,CIR:2,TC:2,CS:6,OA:2,LA:4,CNC:6,FWL:5,NIOPS:6,DC:4</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:5,CNC:5</availability>
@@ -2587,7 +2587,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2938,7 +2938,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -3044,7 +3044,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:6,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3921,7 +3921,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:3,LA:4,CLAN:7,IS:3,NIOPS:8,MERC:3</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:5,General:3+,NIOPS:8</availability>
@@ -3962,7 +3962,7 @@
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:3,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4019,7 +4019,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:3,CS:4,OA:3,LA:3,CLAN:3,FWL:3,IS:3,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
@@ -4070,7 +4070,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
@@ -4095,7 +4095,7 @@
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,OA:5,LA:3,CLAN:2,IS:4,FWL:3,MERC:4,FS:4,TC:4,Periphery:4,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4181,7 +4181,7 @@
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4220,7 +4220,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4238,7 +4238,7 @@
 			<availability>General:8,CLAN:8,BAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4285,7 +4285,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4338,7 +4338,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:5,CLAN:5,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4347,7 +4347,7 @@
 			<availability>CS:4,CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4455,7 +4455,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,IS:2,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4484,7 +4484,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4532,7 +4532,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:2+,CC:1+,CS:8,OA:3,LA:1+,CLAN:9,FWL:2+,NIOPS:8,MERC:2+,FS:2+,TC:2+,DC:3+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4596,7 +4596,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:2-</availability>
@@ -4631,7 +4631,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4693,7 +4693,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:8,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:8,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4734,7 +4734,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -4757,7 +4757,7 @@
 			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:3+,CLAN:6,IS:3+,NIOPS:8,BAN:8,Periphery:3+</availability>
@@ -4790,7 +4790,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:1</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -4953,7 +4953,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,OA:4,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5154,7 +5154,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5185,7 +5185,7 @@
 			<availability>CHH:4,General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:2</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2855.xml
+++ b/MekHQ/data/forcegenerator/2855.xml
@@ -24,7 +24,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2855' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2855' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2855' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -48,9 +48,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>0,0,20,35,45</pctClan>
 		<pctSL>100,100,80,65,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,30,50</pctClan>
-		<pctSL unitType='Aero'>100,100,85,70,50</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,30,50</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,70,50</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
@@ -87,9 +87,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>10,10,20,30,45</pctClan>
 		<pctSL>90,90,80,70,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,20,30</pctClan>
-		<pctSL unitType='Aero'>100,100,85,80,70</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,20,30</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,80,70</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
@@ -156,9 +156,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>0,0,15,35,45</pctClan>
 		<pctSL>100,100,85,65,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,15,55</pctClan>
-		<pctSL unitType='Aero'>100,100,80,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,15,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
@@ -167,9 +167,9 @@
 		<pctOmni>0,0,0,10,15</pctOmni>
 		<pctClan>0,0,15,40,45</pctClan>
 		<pctSL>100,100,85,60,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,40,50</pctClan>
-		<pctSL unitType='Aero'>100,100,80,60,50</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,40,50</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,60,50</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,80,80</pctSL>
 		<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -216,7 +216,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2855' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2855' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2855' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -247,14 +247,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2855' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2855' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2855' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:5,FS:10</salvage>
-		<weightDistribution era='2855' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -356,9 +356,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -370,9 +370,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>0,0,10,35,45</pctClan>
 		<pctSL>100,100,90,65,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,35,45</pctClan>
-		<pctSL unitType='Aero'>100,100,90,65,55</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,35,45</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,65,55</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -405,9 +405,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>0,0,10,35,45</pctClan>
 		<pctSL>100,100,90,65,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,35,45</pctClan>
-		<pctSL unitType='Aero'>100,100,90,65,55</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,35,45</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,65,55</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -572,7 +572,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:3+,CS:7,LA:3+,CLAN:6,FWL:4+,IS:3+,NIOPS:7,FS:3+,DC:3+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1050,7 +1050,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:2,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1084,7 +1084,7 @@
 			<availability>CFM:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1130,7 +1130,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1151,7 +1151,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1456,7 +1456,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1707,7 +1707,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2153,7 +2153,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='GTHA-100'>
 			<availability>General:4,CLAN:2</availability>
@@ -2265,7 +2265,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,CLAN:6,IS:3,FS:3,CIR:2,TC:2,CS:7,OA:2,LA:3,CNC:6,FWL:3,NIOPS:7,DC:3</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2381,7 +2381,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:3,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -2397,7 +2397,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2537,7 +2537,7 @@
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2607,7 +2607,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:5,IS:3,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
@@ -2629,7 +2629,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2970,7 +2970,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -3076,7 +3076,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3967,7 +3967,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:2,LA:4,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:4,General:3+,NIOPS:8</availability>
@@ -4008,7 +4008,7 @@
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4065,7 +4065,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
@@ -4116,7 +4116,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
@@ -4141,7 +4141,7 @@
 			<availability>DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:3,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:4,TC:4,Periphery:4,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4221,7 +4221,7 @@
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4260,7 +4260,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4278,7 +4278,7 @@
 			<availability>General:8,CLAN:6-,BAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4325,7 +4325,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4378,7 +4378,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:4,CLAN:4,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4387,7 +4387,7 @@
 			<availability>CS:4,CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4495,7 +4495,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4521,7 +4521,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4569,7 +4569,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:1+,CC:1+,CS:8,OA:2,LA:1+,CLAN:8,FWL:1+,NIOPS:8,MERC:1+,FS:1+,TC:1+,DC:2+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4637,7 +4637,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -4678,7 +4678,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4740,7 +4740,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4777,7 +4777,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -4800,7 +4800,7 @@
 			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:6,CLAN:6,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:2+,CLAN:6,IS:2+,NIOPS:8,BAN:8,Periphery:2+</availability>
@@ -4981,7 +4981,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,OA:3,MERC:5,Periphery:3,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5182,7 +5182,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5213,7 +5213,7 @@
 			<availability>CHH:4,General:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2860.xml
+++ b/MekHQ/data/forcegenerator/2860.xml
@@ -24,7 +24,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2860' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2860' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2860' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -48,9 +48,9 @@
 		<pctOmni>0,0,0,20,25</pctOmni>
 		<pctClan>0,0,25,40,50</pctClan>
 		<pctSL>100,100,75,60,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,15</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,35,50</pctClan>
-		<pctSL unitType='Aero'>100,100,85,65,50</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,15</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,35,50</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,65,50</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
@@ -87,9 +87,9 @@
 		<pctOmni>0,0,0,15,25</pctOmni>
 		<pctClan>12,12,25,35,50</pctClan>
 		<pctSL>88,88,75,65,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,25,35</pctClan>
-		<pctSL unitType='Aero'>100,100,80,75,65</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,25,35</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,75,65</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
@@ -149,9 +149,9 @@
 		<pctOmni>0,0,0,15,30</pctOmni>
 		<pctClan>5,5,20,40,50</pctClan>
 		<pctSL>95,95,80,60,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,5,10,30</pctOmni>
-		<pctClan unitType='Aero'>0,0,25,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,75,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,5,10,30</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,25,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,75,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
@@ -160,9 +160,9 @@
 		<pctOmni>0,0,0,20,25</pctOmni>
 		<pctClan>0,0,20,45,50</pctClan>
 		<pctSL>100,100,80,55,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,20</pctOmni>
-		<pctClan unitType='Aero'>0,0,25,45,55</pctClan>
-		<pctSL unitType='Aero'>100,100,75,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,20</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,25,45,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,75,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,25,25</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,75,75</pctSL>
 		<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -209,7 +209,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2860' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2860' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2860' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -240,14 +240,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2860' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2860' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2860' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:4,FS:10</salvage>
-		<weightDistribution era='2860' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -349,9 +349,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -363,9 +363,9 @@
 		<pctOmni>0,0,0,10,20</pctOmni>
 		<pctClan>0,0,10,45,55</pctClan>
 		<pctSL>100,100,90,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,20</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,45,55</pctClan>
-		<pctSL unitType='Aero'>100,100,90,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,20</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,45,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -398,9 +398,9 @@
 		<pctOmni>0,0,0,10,20</pctOmni>
 		<pctClan>0,0,10,45,55</pctClan>
 		<pctSL>100,100,90,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,20</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,45,55</pctClan>
-		<pctSL unitType='Aero'>100,100,90,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,20</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,45,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -566,7 +566,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:3+,CS:7,LA:3+,CLAN:6,FWL:4+,IS:3+,NIOPS:7,FS:3+,DC:3+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1018,7 +1018,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:2,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1052,7 +1052,7 @@
 			<availability>CFM:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1098,7 +1098,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1119,7 +1119,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>CMG:4</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1128,7 +1128,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:3,TC:2,Periphery:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1409,7 +1409,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1624,7 +1624,7 @@
 			<availability>General:5-,CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2083,7 +2083,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='GTHA-100'>
 			<availability>General:3,CLAN:2</availability>
@@ -2195,7 +2195,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,CLAN:6,IS:3,FS:3,CIR:2,TC:2,CS:7,OA:2,LA:3,CNC:6,FWL:3,NIOPS:7,DC:3</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2311,7 +2311,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:2,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -2327,7 +2327,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2467,7 +2467,7 @@
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2540,7 +2540,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,CLAN:5,IS:2,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
@@ -2562,7 +2562,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2892,7 +2892,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -2998,7 +2998,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3874,7 +3874,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:2,LA:4,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:4,General:3+,NIOPS:8</availability>
@@ -3915,7 +3915,7 @@
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -3961,7 +3961,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
@@ -4012,7 +4012,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
@@ -4027,7 +4027,7 @@
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:2,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:3,TC:3,Periphery:3,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4107,7 +4107,7 @@
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4146,7 +4146,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4164,7 +4164,7 @@
 			<availability>General:8,CLAN:4-,BAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4211,7 +4211,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4258,7 +4258,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:4,CLAN:4,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4267,7 +4267,7 @@
 			<availability>CS:4,CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4378,7 +4378,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4410,7 +4410,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4458,7 +4458,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:1+,MOC:1+,CS:8,OA:2,CLAN:8,FWL:1+,NIOPS:8,FS:1+,MERC:1+,TC:1+,DC:1+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4519,7 +4519,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -4560,7 +4560,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4619,7 +4619,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4656,7 +4656,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -4682,7 +4682,7 @@
 			<availability>FWL:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:6,CLAN:6,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:2+,CLAN:6,IS:2+,NIOPS:8,BAN:8,Periphery:2+</availability>
@@ -4856,7 +4856,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,OA:3,MERC:5,Periphery:3,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5057,7 +5057,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5088,7 +5088,7 @@
 			<availability>CHH:4,General:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2865.xml
+++ b/MekHQ/data/forcegenerator/2865.xml
@@ -26,7 +26,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2865' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2865' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2865' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,5,10</pctOmni>
@@ -50,9 +50,9 @@
 		<pctOmni>0,0,0,30,40</pctOmni>
 		<pctClan>5,5,30,45,55</pctClan>
 		<pctSL>95,95,70,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,25</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,40,55</pctClan>
-		<pctSL unitType='Aero'>100,100,85,60,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,25</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,40,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,60,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
@@ -89,9 +89,9 @@
 		<pctOmni>0,0,0,15,35</pctOmni>
 		<pctClan>13,13,25,35,55</pctClan>
 		<pctSL>87,87,75,65,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,25,35</pctClan>
-		<pctSL unitType='Aero'>100,100,80,75,65</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,25,35</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,75,65</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
@@ -151,9 +151,9 @@
 		<pctOmni>0,0,5,25,40</pctOmni>
 		<pctClan>5,5,20,45,55</pctClan>
 		<pctSL>95,95,80,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,20,40</pctOmni>
-		<pctClan unitType='Aero'>10,10,25,55,65</pctClan>
-		<pctSL unitType='Aero'>90,90,75,45,35</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,20,40</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,25,55,65</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,75,45,35</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
@@ -162,9 +162,9 @@
 		<pctOmni>0,0,0,30,40</pctOmni>
 		<pctClan>0,0,20,45,55</pctClan>
 		<pctSL>100,100,80,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,25,35</pctOmni>
-		<pctClan unitType='Aero'>0,0,25,45,55</pctClan>
-		<pctSL unitType='Aero'>100,100,75,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,25,35</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,25,45,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,75,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,25,25</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,75,75</pctSL>
 		<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -211,7 +211,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2865' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2865' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2865' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -242,14 +242,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2865' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2865' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2865' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:4,FS:10</salvage>
-		<weightDistribution era='2865' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -351,9 +351,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -365,9 +365,9 @@
 		<pctOmni>0,0,0,15,35</pctOmni>
 		<pctClan>0,0,10,45,55</pctClan>
 		<pctSL>100,100,90,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,15,35</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,55</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,15,35</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -400,9 +400,9 @@
 		<pctOmni>0,0,0,15,35</pctOmni>
 		<pctClan>0,0,10,45,55</pctClan>
 		<pctSL>100,100,90,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,15,35</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,55</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,15,35</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -570,7 +570,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:2+,CS:7,LA:2+,CLAN:6,FWL:3+,IS:2+,NIOPS:7,FS:2+,DC:2+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1015,7 +1015,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:1,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1049,7 +1049,7 @@
 			<availability>CFM:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:6</availability>
@@ -1101,7 +1101,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1122,7 +1122,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>CMG:5,BAN:2</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1131,7 +1131,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1412,7 +1412,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1627,7 +1627,7 @@
 			<availability>General:5-,CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2098,7 +2098,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9,DC:1</availability>
 		<model name='GTHA-100'>
 			<availability>General:3,CLAN:2</availability>
@@ -2210,7 +2210,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:2,CLAN:6,IS:2,FS:2,CIR:1,TC:1,CS:7,OA:1,LA:2,CNC:6,FWL:2,NIOPS:7,DC:2</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2326,7 +2326,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -2342,7 +2342,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2491,7 +2491,7 @@
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2564,7 +2564,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:1,CLAN:5,IS:1,FWL.OH:4,FS:2,CIR:1,TC:1,CS:6,OA:2,LA:2,CNC:5,FWL:3,NIOPS:6,DC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:3,CNC:3</availability>
@@ -2586,7 +2586,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2926,7 +2926,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:3,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -3025,7 +3025,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3905,7 +3905,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:2,LA:3,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:3,General:3+,NIOPS:8</availability>
@@ -3946,7 +3946,7 @@
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -3992,7 +3992,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
@@ -4043,7 +4043,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
@@ -4058,7 +4058,7 @@
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:5,LA:1,CLAN:1,IS:2,FWL:1,MERC:2,FS:2,Periphery:2,TC:2,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4153,7 +4153,7 @@
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4192,7 +4192,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4210,7 +4210,7 @@
 			<availability>General:8,CLAN:2-,BAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4257,7 +4257,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4304,7 +4304,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:3,CLAN:3,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4313,7 +4313,7 @@
 			<availability>CS:4,CLAN:5,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4417,7 +4417,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4449,7 +4449,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4497,7 +4497,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:1+,MOC:1+,CS:8,OA:1,CLAN:8,FWL:1+,NIOPS:8,FS:1+,MERC:1+,TC:1+,DC:1+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4558,7 +4558,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -4599,7 +4599,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4658,7 +4658,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4695,7 +4695,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -4721,7 +4721,7 @@
 			<availability>MOC:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
@@ -4898,7 +4898,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,OA:2,MERC:5,Periphery:2,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5108,7 +5108,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5139,7 +5139,7 @@
 			<availability>CHH:4,General:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2870.xml
+++ b/MekHQ/data/forcegenerator/2870.xml
@@ -26,7 +26,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2870' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2870' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2870' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,5,10</pctOmni>
@@ -50,9 +50,9 @@
 		<pctOmni>0,0,0,40,50</pctOmni>
 		<pctClan>10,10,35,50,60</pctClan>
 		<pctSL>90,90,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,40,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,80,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,40,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
@@ -89,9 +89,9 @@
 		<pctOmni>0,0,0,20,40</pctOmni>
 		<pctClan>15,15,30,40,60</pctClan>
 		<pctSL>85,85,70,60,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,30</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,80,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,30</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
@@ -150,9 +150,9 @@
 		<pctOmni>0,0,20,30,50</pctOmni>
 		<pctClan>10,10,25,50,60</pctClan>
 		<pctSL>90,90,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>10,10,20,30,50</pctOmni>
-		<pctClan unitType='Aero'>20,20,30,60,70</pctClan>
-		<pctSL unitType='Aero'>80,80,70,40,30</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>10,10,20,30,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>20,20,30,60,70</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,80,70,40,30</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:2,CSV:4,CFM:3,CCO:5,CGS:1,CSA:1,CDS:3,CW:5,CNC:10,CSJ:2,CJF:3,CB:8</salvage>
@@ -161,9 +161,9 @@
 		<pctOmni>0,0,0,40,50</pctOmni>
 		<pctClan>0,0,25,50,60</pctClan>
 		<pctSL>100,100,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,40,50</pctOmni>
-		<pctClan unitType='Aero'>10,10,30,50,60</pctClan>
-		<pctSL unitType='Aero'>90,90,70,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,40,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,30,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,70,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,70,70</pctSL>
 		<salvage pct='10'>CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
@@ -213,7 +213,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2870' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2870' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2870' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -244,14 +244,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2870' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2870' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2870' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:4,FS:10</salvage>
-		<weightDistribution era='2870' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -352,9 +352,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -364,9 +364,9 @@
 		<pctOmni>0,0,0,20,50</pctOmni>
 		<pctClan>0,0,10,50,60</pctClan>
 		<pctSL>100,100,90,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
@@ -399,9 +399,9 @@
 		<pctOmni>0,0,0,15,50</pctOmni>
 		<pctClan>0,0,10,50,60</pctClan>
 		<pctSL>100,100,90,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
@@ -561,7 +561,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:2+,CS:7,LA:1+,CLAN:6,FWL:2+,IS:1+,NIOPS:7,FS:1+,DC:1+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -781,7 +781,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1136,7 +1136,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:1,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1178,7 +1178,7 @@
 			<availability>CFM:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:6</availability>
@@ -1230,7 +1230,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1251,7 +1251,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:2</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1260,7 +1260,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1551,7 +1551,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1795,7 +1795,7 @@
 			<availability>General:5-,CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2290,7 +2290,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:4,CSR:3,CW:3,CLAN:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2302,7 +2302,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CS:9,CDS:7,Periphery.MW:1,CLAN:7,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9</availability>
 		<model name='GTHA-100'>
 			<availability>General:2,CLAN:2</availability>
@@ -2420,7 +2420,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:1,CLAN:6,IS:1,FS:1,CIR:1,TC:1,CS:7,OA:1,LA:1,CNC:6,FWL:1,NIOPS:7,DC:1</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2536,7 +2536,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -2552,7 +2552,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2716,7 +2716,7 @@
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2789,7 +2789,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:1,CLAN:5,IS:1,FWL.OH:3,FS:1,TC:1,CS:6,OA:1,LA:1,CNC:5,FWL:2,NIOPS:6,DC:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:3,CNC:3</availability>
@@ -2815,7 +2815,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>CSR:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2827,7 +2827,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3045,7 +3045,7 @@
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3215,7 +3215,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:8,CLAN:3,IS:2,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -3314,7 +3314,7 @@
 			<availability>MOC:2,CS:6,OA:2,IS:4,MERC:3,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3831,7 +3831,7 @@
 			<availability>CW:0,CLAN:8,CJF:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:5,CW:4,CLAN:3,CSJ:4</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -4231,7 +4231,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:2,LA:3,CLAN:6,IS:1,NIOPS:8,MERC:1</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:3,General:3+,NIOPS:8</availability>
@@ -4278,7 +4278,7 @@
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4324,7 +4324,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:1,CS:4,OA:2,LA:1,CLAN:3,FWL:1,IS:1,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
@@ -4375,7 +4375,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
@@ -4390,7 +4390,7 @@
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:1,OA:5,LA:1,CLAN:1,IS:1,FWL:1,MERC:1,FS:1,Periphery:1,TC:1,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4495,7 +4495,7 @@
 			<availability>CLAN:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4540,7 +4540,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4558,7 +4558,7 @@
 			<availability>General:8,CLAN:1-,BAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4609,7 +4609,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4662,7 +4662,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:3,CLAN:3,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4671,7 +4671,7 @@
 			<availability>CS:4,CLAN:5,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -4782,7 +4782,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4814,7 +4814,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4869,7 +4869,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:8,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4951,7 +4951,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -4992,7 +4992,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -5058,7 +5058,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -5095,7 +5095,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -5104,7 +5104,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -5130,7 +5130,7 @@
 			<availability>MOC:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
@@ -5331,7 +5331,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,OA:1,MERC:5,Periphery:1,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5548,7 +5548,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5579,7 +5579,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2900.xml
+++ b/MekHQ/data/forcegenerator/2900.xml
@@ -26,7 +26,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2900' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2900' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2900' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,5,10</pctOmni>
@@ -50,9 +50,9 @@
 		<pctOmni>0,0,0,40,50</pctOmni>
 		<pctClan>10,10,35,50,60</pctClan>
 		<pctSL>90,90,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,40,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,80,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,40,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
@@ -89,9 +89,9 @@
 		<pctOmni>0,0,0,20,40</pctOmni>
 		<pctClan>20,20,30,40,60</pctClan>
 		<pctSL>80,80,70,60,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,30</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,80,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,30</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
@@ -150,9 +150,9 @@
 		<pctOmni>0,0,20,30,50</pctOmni>
 		<pctClan>10,10,25,50,60</pctClan>
 		<pctSL>90,90,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>10,10,20,30,50</pctOmni>
-		<pctClan unitType='Aero'>20,20,30,60,70</pctClan>
-		<pctSL unitType='Aero'>80,80,70,40,30</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>10,10,20,30,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>20,20,30,60,70</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,80,70,40,30</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:3,CSV:3,CFM:5,CCO:5,CGS:1,CSA:2,CDS:3,CW:5,CNC:10,CSJ:2,CJF:5,CB:8</salvage>
@@ -161,9 +161,9 @@
 		<pctOmni>0,0,0,40,50</pctOmni>
 		<pctClan>0,0,25,50,60</pctClan>
 		<pctSL>100,100,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,40,50</pctOmni>
-		<pctClan unitType='Aero'>10,10,30,50,60</pctClan>
-		<pctSL unitType='Aero'>90,90,70,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,40,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,30,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,70,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,70,70</pctSL>
 		<salvage pct='10'>CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
@@ -213,7 +213,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2900' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2900' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2900' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -247,14 +247,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2900' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2900' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2900' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:4,FS:10</salvage>
-		<weightDistribution era='2900' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -355,9 +355,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -367,9 +367,9 @@
 		<pctOmni>0,0,0,20,50</pctOmni>
 		<pctClan>0,0,10,50,60</pctClan>
 		<pctSL>100,100,90,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
@@ -402,9 +402,9 @@
 		<pctOmni>0,0,0,15,50</pctOmni>
 		<pctClan>0,0,10,50,60</pctClan>
 		<pctSL>100,100,90,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
@@ -559,7 +559,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:5,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -779,7 +779,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -897,7 +897,7 @@
 			<availability>FWL:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1163,7 +1163,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>HL:1,LA:3,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1205,7 +1205,7 @@
 			<availability>CFM:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:6</availability>
@@ -1257,7 +1257,7 @@
 			<availability>CC:8-,LA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1278,7 +1278,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:2</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1287,7 +1287,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:2,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
@@ -1587,7 +1587,7 @@
 	<chassis name='Corone' unitType='Warship'>
 		<availability>CSR:2</availability>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -1859,7 +1859,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2354,7 +2354,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:5,CW:4,CLAN:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2366,7 +2366,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CS:9,CDS:6,Periphery.MW:1,CLAN:6,Periphery.ME:1,CNC:6,FWL:1,NIOPS:9</availability>
 		<model name='GTHA-100'>
 			<availability>General:1,CLAN:1</availability>
@@ -2481,7 +2481,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:5,CNC:5,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:2,CNC:2</availability>
@@ -2597,7 +2597,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -2613,7 +2613,7 @@
 			<availability>CS:4,CLAN:1,NIOPS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:1-,MOC:3-,OA:3-,HL:1,LA:6-,FWL:1-,Periphery.Deep:3-,FS:5-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2786,7 +2786,7 @@
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2848,7 +2848,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:4,CNC:4,FWL:1,NIOPS:6,FWL.OH:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:2,CNC:2</availability>
@@ -2871,7 +2871,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>CSR:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2883,7 +2883,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3101,7 +3101,7 @@
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3284,7 +3284,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:8,CS:5-,OA:2,LA:3,CLAN:3,IS:1,NIOPS:5-,FS:3,TC:2,Periphery:2,DC:3</availability>
 		<model name='LTN-G15'>
 			<availability>General:8,CLAN:3</availability>
@@ -3389,7 +3389,7 @@
 			<availability>MOC:2,CS:6,OA:2,IS:4,MERC:3,Periphery:2,TC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3957,7 +3957,7 @@
 			<availability>CW:0,CLAN:8,CJF:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:5,CW:4,CSJ:4</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -4359,7 +4359,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:1,LA:2,CLAN:5,IS:1,NIOPS:8,MERC:1</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:2,General:3+,NIOPS:8</availability>
@@ -4400,7 +4400,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4446,7 +4446,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,OA:1,CLAN:3,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:2,NIOPS:8</availability>
@@ -4516,7 +4516,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:2</availability>
@@ -4534,7 +4534,7 @@
 			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:5,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4657,7 +4657,7 @@
 			<availability>CLAN:3,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,HL:4,LA:8,Periphery.Deep:4,CIR:3,FS:1,Periphery:4,TC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4702,7 +4702,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4720,7 +4720,7 @@
 			<availability>General:8,CLAN:1-,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -4775,7 +4775,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
@@ -4827,7 +4827,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:2,CLAN:2,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4836,7 +4836,7 @@
 			<availability>CS:4,CLAN:4,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -4944,7 +4944,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:6,IS:8,FS:8,Periphery:8</availability>
@@ -4976,7 +4976,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,OA:2,LA:2,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -5031,7 +5031,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:7,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -5110,7 +5110,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -5151,7 +5151,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -5214,7 +5214,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:6,CLAN:5,FWL:1,NIOPS:9</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -5254,7 +5254,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -5263,7 +5263,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -5290,7 +5290,7 @@
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,CS:7,OA:4,CSR:4,CLAN:4,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -5316,7 +5316,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:7,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5427,7 +5427,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -5492,7 +5492,7 @@
 			<availability>CC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5530,7 +5530,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5735,7 +5735,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5757,7 +5757,7 @@
 			<availability>CHH:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:4,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/2950.xml
+++ b/MekHQ/data/forcegenerator/2950.xml
@@ -27,7 +27,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2950' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2950' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2950' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2950' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,10,20</pctOmni>
@@ -51,9 +51,9 @@
 		<pctOmni>0,0,10,70,80</pctOmni>
 		<pctClan>10,10,50,80,90</pctClan>
 		<pctSL>90,90,50,20,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,70,80</pctOmni>
-		<pctClan unitType='Aero'>0,0,30,80,90</pctClan>
-		<pctSL unitType='Aero'>100,100,70,20,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,70,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,30,80,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,70,20,10</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
@@ -90,9 +90,9 @@
 		<pctOmni>0,0,10,40,70</pctOmni>
 		<pctClan>25,25,50,60,90</pctClan>
 		<pctSL>75,75,50,40,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,30,60</pctOmni>
-		<pctClan unitType='Aero'>0,0,40,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,60,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,30,60</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,40,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,60,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
@@ -151,9 +151,9 @@
 		<pctOmni>15,15,50,60,80</pctOmni>
 		<pctClan>30,30,50,80,90</pctClan>
 		<pctSL>70,70,50,20,10</pctSL>
-		<pctOmni unitType='Aero'>25,25,50,60,80</pctOmni>
-		<pctClan unitType='Aero'>40,40,60,90,100</pctClan>
-		<pctSL unitType='Aero'>60,60,40,10,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>25,25,50,60,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>40,40,60,90,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>60,60,40,10,0</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:3,CFM:4,CCO:4,CSA:2,CDS:4,CW:4,CNC:10,CSJ:2,CJF:2,CB:6</salvage>
@@ -162,9 +162,9 @@
 		<pctOmni>0,0,10,70,80</pctOmni>
 		<pctClan>20,20,50,80,90</pctClan>
 		<pctSL>80,80,50,20,10</pctSL>
-		<pctOmni unitType='Aero'>5,5,15,70,80</pctOmni>
-		<pctClan unitType='Aero'>50,50,50,80,90</pctClan>
-		<pctSL unitType='Aero'>50,50,50,20,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>5,5,15,70,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>50,50,50,80,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>50,50,50,20,10</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,40,40</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,60,60</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:3,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
@@ -217,7 +217,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2950' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2950' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2950' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2950' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,MH:1,CIR:1</salvage>
@@ -252,14 +252,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2950' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2950' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2950' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2950' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:3,FS:10</salvage>
-		<weightDistribution era='2950' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2950' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -368,9 +368,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -381,9 +381,9 @@
 		<pctOmni>0,0,3,35,70</pctOmni>
 		<pctClan>15,15,30,80,90</pctClan>
 		<pctSL>85,85,70,20,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,5,40,80</pctOmni>
-		<pctClan unitType='Aero'>15,15,30,80,90</pctClan>
-		<pctSL unitType='Aero'>85,85,70,20,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,5,40,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,30,80,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,70,20,10</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -416,9 +416,9 @@
 		<pctOmni>0,0,3,20,70</pctOmni>
 		<pctClan>15,15,30,80,90</pctClan>
 		<pctSL>85,85,70,20,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,5,40,80</pctOmni>
-		<pctClan unitType='Aero'>15,15,30,80,90</pctClan>
-		<pctSL unitType='Aero'>85,85,70,20,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,5,40,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,30,80,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,70,20,10</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -586,7 +586,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -816,7 +816,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -940,7 +940,7 @@
 			<availability>FWL:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:4</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1006,7 +1006,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1266,7 +1266,7 @@
 			<availability>DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>HL:1,LA:3,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1305,7 +1305,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -1357,7 +1357,7 @@
 			<availability>CC:8-,LA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1382,7 +1382,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:2</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1391,7 +1391,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:1,FWL:4,MERC:3,FS:3,CIR:2,Periphery:2,TC:2,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
@@ -1691,7 +1691,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -1959,7 +1959,7 @@
 			<availability>CLAN:3-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:7,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2470,7 +2470,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:5,CSR:4,CW:2,CLAN:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2482,7 +2482,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:6,CLAN:6,CNC:6,NIOPS:9</availability>
 		<model name='GTHA-300'>
 			<availability>CLAN:1,BAN:1</availability>
@@ -2597,7 +2597,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:5,CNC:5,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:1,CNC:1</availability>
@@ -2712,7 +2712,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:1,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -2728,7 +2728,7 @@
 			<availability>CS:4,CLAN:1,NIOPS:4,BAN:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:3-,FS:4-,MERC:5-,Periphery:3-,TC:3-,DC:1-</availability>
 		<model name='HCT-213'>
 			<availability>General:7</availability>
@@ -2917,7 +2917,7 @@
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2979,7 +2979,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:3,CNC:3,NIOPS:6,FWL.OH:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:1,CNC:1</availability>
@@ -3002,7 +3002,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>CSR:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3014,7 +3014,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3242,7 +3242,7 @@
 			<availability>CLAN:6,CGS:7,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:5,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3398,7 +3398,7 @@
 			<availability>CLAN:8,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:7,CS:5-,OA:6,LA:4,CLAN:2,NIOPS:5-,FS:4,TC:3,Periphery:2,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:8,CLAN:2</availability>
@@ -3503,13 +3503,13 @@
 			<availability>CS:5-,IS:4,MERC:3,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
@@ -4117,7 +4117,7 @@
 			<availability>CW:0,CLAN:8,CJF:0,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:3,CSJ:3</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -4333,7 +4333,7 @@
 			<availability>IS:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Pella' unitType='Aero'>
+	<chassis name='Pella' unitType='AeroSpaceFighter'>
 		<availability>CCC:1,CCO:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -4552,7 +4552,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:1,CLAN:5,NIOPS:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:1,NIOPS:8</availability>
@@ -4593,7 +4593,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4639,7 +4639,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:3,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:1,NIOPS:8</availability>
@@ -4709,7 +4709,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:1</availability>
@@ -4730,7 +4730,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:4,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4810,7 +4810,7 @@
 			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:6</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4871,7 +4871,7 @@
 			<availability>CLAN:2,BAN:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:6,OA:2,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:4,TC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4916,7 +4916,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4934,7 +4934,7 @@
 			<availability>CLAN:1-,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -4989,7 +4989,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
@@ -5041,7 +5041,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,CSR:1,CLAN:1,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -5050,7 +5050,7 @@
 			<availability>CS:4,CLAN:2,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:4</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -5154,7 +5154,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,FS:2,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:5,IS:8,FS:8,Periphery:8</availability>
@@ -5201,7 +5201,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -5216,7 +5216,7 @@
 			<availability>CGS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -5283,7 +5283,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:7,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -5365,7 +5365,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -5406,7 +5406,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -5466,7 +5466,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:5,NIOPS:9</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -5506,7 +5506,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -5515,7 +5515,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -5542,7 +5542,7 @@
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:1,CS:7,OA:3,CSR:2,CLAN:2,NIOPS:7,FS:1,MERC:1,DC:1,TC:1</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -5568,7 +5568,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:8,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5676,7 +5676,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -5748,7 +5748,7 @@
 			<availability>CC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5801,7 +5801,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -6029,7 +6029,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6058,7 +6058,7 @@
 			<availability>CHH:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:4,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:3,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/3019.xml
+++ b/MekHQ/data/forcegenerator/3019.xml
@@ -27,7 +27,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3019' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3019' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3019' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3019' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,20,40</pctOmni>
@@ -51,9 +51,9 @@
 		<pctOmni>0,0,20,100,100</pctOmni>
 		<pctClan>50,50,75,100,100</pctClan>
 		<pctSL>50,50,25,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,100,100</pctOmni>
-		<pctClan unitType='Aero'>2,2,40,10,100</pctClan>
-		<pctSL unitType='Aero'>98,98,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>2,2,40,10,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>98,98,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
@@ -90,9 +90,9 @@
 		<pctOmni>0,0,30,60,90</pctOmni>
 		<pctClan>40,40,70,80,100</pctClan>
 		<pctSL>60,60,30,20,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>2,2,60,70,90</pctClan>
-		<pctSL unitType='Aero'>98,98,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>2,2,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>98,98,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
@@ -151,9 +151,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:3,CFM:4,CCO:4,CSA:2,CDS:4,CW:4,CNC:10,CSJ:2,CJF:2,CB:6</salvage>
@@ -162,9 +162,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>60,60,80,100,100</pctClan>
 		<pctSL>40,40,20,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:3,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
@@ -217,7 +217,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3019' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3019' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3019' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3019' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,FWL:1,MH:1,CIR:4</salvage>
@@ -255,14 +255,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3019' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3019' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3019' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3019' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3019' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3019' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -370,9 +370,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -385,9 +385,9 @@
 		<pctOmni>0,0,5,45,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,50,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,50,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -420,9 +420,9 @@
 		<pctOmni>0,0,5,35,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,50,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,50,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -591,7 +591,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -822,7 +822,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1008,7 +1008,7 @@
 			<availability>FWL:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1074,7 +1074,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1356,7 +1356,7 @@
 			<availability>DC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1395,7 +1395,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -1456,7 +1456,7 @@
 			<availability>LA:3,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1481,7 +1481,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1490,7 +1490,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:2,LA:5,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
@@ -1827,7 +1827,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -2120,7 +2120,7 @@
 			<availability>CLAN:4-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:2,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2630,7 +2630,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:4,CSR:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2642,7 +2642,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:5,NIOPS:9</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:5,FWL:5,MH:5,MERC:5</availability>
@@ -2766,7 +2766,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
@@ -2881,7 +2881,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -2894,7 +2894,7 @@
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
@@ -3104,7 +3104,7 @@
 			<availability>CLAN:3,BAN:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3160,7 +3160,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,FWL.OH:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -3176,7 +3176,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3242,7 +3242,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -3427,7 +3427,7 @@
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3605,7 +3605,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:2,CLAN:1,IS:3,FS:5,TC:5,Periphery:4,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -3714,13 +3714,13 @@
 			<availability>CS:4-,MERC.KH:5,MERC.WD:6,IS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
@@ -4361,7 +4361,7 @@
 			<availability>CW:0,CLAN:8,CJF:0,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:3,CW:2,CSJ:2</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -4817,7 +4817,7 @@
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,NIOPS:8</availability>
@@ -4858,7 +4858,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4908,7 +4908,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -4978,7 +4978,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -4999,7 +4999,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:4,DC:2</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -5079,7 +5079,7 @@
 			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5137,7 +5137,7 @@
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:6,TC:7</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -5197,7 +5197,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5215,7 +5215,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -5270,7 +5270,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
@@ -5325,7 +5325,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -5334,7 +5334,7 @@
 			<availability>CS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:5</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -5436,7 +5436,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
@@ -5496,7 +5496,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:5,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:3,FS.DMM:8</availability>
@@ -5517,7 +5517,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:5,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -5584,7 +5584,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -5666,7 +5666,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -5707,7 +5707,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -5763,7 +5763,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
 		<model name='THK-53'>
 			<roles>escort</roles>
@@ -5799,7 +5799,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -5808,7 +5808,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -5835,7 +5835,7 @@
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -5868,7 +5868,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:4,CJF:4,CGB:4</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5883,7 +5883,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5991,7 +5991,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -6063,7 +6063,7 @@
 			<availability>CC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6125,7 +6125,7 @@
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -6360,7 +6360,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6396,7 +6396,7 @@
 			<availability>CHH:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/3028.xml
+++ b/MekHQ/data/forcegenerator/3028.xml
@@ -27,7 +27,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3028' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3028' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3028' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,40,60</pctOmni>
@@ -51,9 +51,9 @@
 		<pctOmni>0,0,22,100,100</pctOmni>
 		<pctClan>66,66,78,100,100</pctClan>
 		<pctSL>34,34,22,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>4,4,40,10,100</pctClan>
-		<pctSL unitType='Aero'>96,96,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>4,4,40,10,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>96,96,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:2,CW:7,CBS:2,CNC:10,CSJ:7,CJF:5,CGB:2,CB:3</salvage>
@@ -90,9 +90,9 @@
 		<pctOmni>0,0,32,60,92</pctOmni>
 		<pctClan>50,50,75,83,100</pctClan>
 		<pctSL>50,50,25,17,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>4,4,60,70,90</pctClan>
-		<pctSL unitType='Aero'>96,96,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>4,4,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>96,96,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
@@ -151,9 +151,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:4,CCO:4,CSA:2,CDS:10,CW:4,CNC:10,CSJ:2,CJF:2,CB:6</salvage>
@@ -162,9 +162,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>70,70,85,100,100</pctClan>
 		<pctSL>30,30,15,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:4,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
@@ -230,7 +230,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3028' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3028' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3028' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,FWL:1,MH:1,CIR:3</salvage>
@@ -270,18 +270,18 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3028' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3028' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3028' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='SIC'>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3028' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3028' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TFR'>
 		<salvage pct='5'></salvage>
@@ -399,9 +399,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -419,9 +419,9 @@
 		<pctOmni>0,0,5,45,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,55,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,55,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -454,9 +454,9 @@
 		<pctOmni>0,0,5,35,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,55,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,55,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -639,7 +639,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -883,7 +883,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1074,7 +1074,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1143,7 +1143,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1453,7 +1453,7 @@
 			<availability>FRR:3,DC:4:3033</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1492,7 +1492,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -1563,7 +1563,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1588,7 +1588,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1597,7 +1597,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:3,CIR:2,Periphery:2,TC:2,OA:2,LA:7,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -1935,7 +1935,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,FS:8,MERC:3,CIR:2,Periphery:2,TC:2,OA:3,LA:4,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -2259,7 +2259,7 @@
 			<availability>CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2769,7 +2769,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:3,CSR:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2781,7 +2781,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:6,NIOPS:9</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
@@ -2905,7 +2905,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
@@ -3052,7 +3052,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -3065,7 +3065,7 @@
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
@@ -3281,7 +3281,7 @@
 			<availability>CLAN:3,BAN:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3337,7 +3337,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,FWL.OH:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -3353,7 +3353,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3416,7 +3416,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -3453,7 +3453,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:6,CLAN:4,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3629,7 +3629,7 @@
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3807,7 +3807,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:3,SIC:6,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -3920,13 +3920,13 @@
 			<availability>CS:3-,MERC.KH:5,MERC.WD:5,IS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,Periphery:2,TC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,DC:4</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
@@ -4561,7 +4561,7 @@
 			<availability>CW:0,CLAN:8,CJF:0,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:2,CW:1,CSJ:1</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -5042,7 +5042,7 @@
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,NIOPS:8</availability>
@@ -5090,7 +5090,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
@@ -5144,7 +5144,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -5220,7 +5220,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -5241,7 +5241,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:3,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -5331,7 +5331,7 @@
 			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5389,7 +5389,7 @@
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,Periphery.R:6,OA:7,MERC.KH:6,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:3,CIR:3,Periphery:6,TC:7</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -5449,7 +5449,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5467,7 +5467,7 @@
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -5522,7 +5522,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:5</availability>
 		<model name='SL-15'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
@@ -5577,7 +5577,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -5586,7 +5586,7 @@
 			<availability>CS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:4,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -5688,7 +5688,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
@@ -5748,7 +5748,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
@@ -5772,7 +5772,7 @@
 			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -5839,7 +5839,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -5921,7 +5921,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:9,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -5962,7 +5962,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -6021,7 +6021,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
 		<model name='THK-53'>
 			<roles>escort</roles>
@@ -6057,7 +6057,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,SIC:8,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -6066,7 +6066,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:3,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -6097,7 +6097,7 @@
 			<availability>FRR:2,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -6130,7 +6130,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:4,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6145,7 +6145,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6253,7 +6253,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -6331,7 +6331,7 @@
 			<availability>CC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6393,7 +6393,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -6628,7 +6628,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6664,7 +6664,7 @@
 			<availability>CHH:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/3039.xml
+++ b/MekHQ/data/forcegenerator/3039.xml
@@ -16,7 +16,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,0,0</pctSL>
 		<salvage pct='6'>MOC:3,FWL:5,SIC:4,FS:10,DA:8,TC:1</salvage>
-		<weightDistribution era='3039' unitType='Aero'>2,2,1</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>2,2,1</weightDistribution>
 	</faction>
 	<faction key='NC'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -33,7 +33,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3039' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3039' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3039' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,40,60</pctOmni>
@@ -57,9 +57,9 @@
 		<pctOmni>0,0,25,100,100</pctOmni>
 		<pctClan>68,68,83,100,100</pctClan>
 		<pctSL>32,32,17,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,28,100,100</pctOmni>
-		<pctClan unitType='Aero'>6,6,40,100,100</pctClan>
-		<pctSL unitType='Aero'>94,94,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,28,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>6,6,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>94,94,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
@@ -96,9 +96,9 @@
 		<pctOmni>0,0,33,60,93</pctOmni>
 		<pctClan>56,56,78,85,100</pctClan>
 		<pctSL>44,44,22,15,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>6,6,60,70,90</pctClan>
-		<pctSL unitType='Aero'>94,94,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>6,6,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>94,94,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:6,CSV:8,CFM:8,CCO:2,CSA:4,CDS:4,CW:1,CNC:4,CSJ:2,CJF:10,CGB:2,CB:2</salvage>
@@ -157,9 +157,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:3,CCO:3,CSA:2,CDS:3,CW:7,CNC:10,CSJ:1,CJF:4,CB:3</salvage>
@@ -168,9 +168,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>80,80,90,100,100</pctClan>
 		<pctSL>20,20,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:1,CJF:5,CGB:2,CB:2</salvage>
@@ -242,7 +242,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3039' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3039' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3039' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,MH:1,CIR:1</salvage>
@@ -279,7 +279,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3039' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3039' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3039' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -290,11 +290,11 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,0,0</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3039' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3039' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -443,9 +443,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -463,9 +463,9 @@
 		<pctOmni>0,0,5,45,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,55,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,55,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -498,9 +498,9 @@
 		<pctOmni>0,0,5,35,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,55,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,55,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -685,7 +685,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -936,7 +936,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1140,7 +1140,7 @@
 			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1212,7 +1212,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1526,7 +1526,7 @@
 			<availability>DC:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1565,7 +1565,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -1636,7 +1636,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1661,7 +1661,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1670,7 +1670,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:5,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -2011,7 +2011,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:6,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -2360,7 +2360,7 @@
 			<availability>CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2899,7 +2899,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:2,CSR:1</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2911,7 +2911,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:8,NIOPS:9</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
@@ -3038,7 +3038,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
@@ -3212,7 +3212,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -3225,7 +3225,7 @@
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
@@ -3454,7 +3454,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3510,7 +3510,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,FWL.OH:1-</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -3526,7 +3526,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3589,7 +3589,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -3626,7 +3626,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:7,CLAN:4,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3835,7 +3835,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4013,7 +4013,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:4,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -4126,13 +4126,13 @@
 			<availability>CS:2-,MERC.KH:5,MERC.WD:4,IS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:4</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
@@ -4784,7 +4784,7 @@
 			<availability>CW:0,CLAN:8,CJF:0,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:1</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -5281,7 +5281,7 @@
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,NIOPS:8</availability>
@@ -5343,7 +5343,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
@@ -5397,7 +5397,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -5473,7 +5473,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -5485,7 +5485,7 @@
 			<availability>CS:6,NIOPS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:4,CJF:4</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5501,7 +5501,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>DC:3</availability>
 		<model name='S-3'>
 			<availability>DC:8</availability>
@@ -5519,7 +5519,7 @@
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:3,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -5609,7 +5609,7 @@
 			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5670,7 +5670,7 @@
 			<availability>DC.GHO:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:4,CIR:3,Periphery:6,TC:7</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -5733,7 +5733,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
@@ -5757,7 +5757,7 @@
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -5812,7 +5812,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 		<model name='SL-15'>
 			<availability>HL:5,IS:7,Periphery.Deep:7,FS:0,Periphery:7</availability>
@@ -5864,7 +5864,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -5873,7 +5873,7 @@
 			<availability>CS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -5949,7 +5949,7 @@
 			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -5981,7 +5981,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
@@ -6041,7 +6041,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,TC:1,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
@@ -6062,7 +6062,7 @@
 			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -6129,7 +6129,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -6214,7 +6214,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -6255,7 +6255,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -6320,7 +6320,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
 		<model name='THK-53'>
 			<roles>escort</roles>
@@ -6360,7 +6360,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -6369,7 +6369,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -6404,7 +6404,7 @@
 			<availability>FWL:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -6444,7 +6444,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:4,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6459,7 +6459,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6567,7 +6567,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -6645,7 +6645,7 @@
 			<availability>CC:1,SIC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6707,7 +6707,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -6957,7 +6957,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6993,7 +6993,7 @@
 			<availability>CHH:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>

--- a/MekHQ/data/forcegenerator/3049.xml
+++ b/MekHQ/data/forcegenerator/3049.xml
@@ -14,7 +14,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,4,12,20</pctSL>
 		<salvage pct='5'>FWL:7,SIC:4,FS:10,FC:10,TC:1</salvage>
-		<weightDistribution era='3049' unitType='Aero'>3,3,1</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>3,3,1</weightDistribution>
 	</faction>
 	<faction key='NC'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -34,7 +34,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3049' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3049' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3049' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,50,75</pctOmni>
@@ -58,9 +58,9 @@
 		<pctOmni>0,0,30,100,100</pctOmni>
 		<pctClan>70,70,85,100,100</pctClan>
 		<pctSL>30,30,15,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,32,100,100</pctOmni>
-		<pctClan unitType='Aero'>8,8,40,100,100</pctClan>
-		<pctSL unitType='Aero'>92,92,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,32,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>8,8,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92,92,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
@@ -97,9 +97,9 @@
 		<pctOmni>0,0,35,65,95</pctOmni>
 		<pctClan>60,60,80,87,100</pctClan>
 		<pctSL>40,40,20,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>8,8,60,70,90</pctClan>
-		<pctSL unitType='Aero'>92,92,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>8,8,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92,92,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:6,CSV:8,CFM:8,CCO:2,CSA:4,CDS:4,CW:1,CNC:4,CSJ:2,CJF:10,CGB:2,CB:2</salvage>
@@ -158,9 +158,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:3,CCO:3,CSA:2,CDS:3,CW:7,CNC:10,CSJ:1,CJF:4,CB:3</salvage>
@@ -169,9 +169,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>80,80,95,100,100</pctClan>
 		<pctSL>20,20,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:1,CJF:5,CGB:2,CB:2</salvage>
@@ -247,7 +247,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3049' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3049' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3049' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,MH:1,CIR:1</salvage>
@@ -290,8 +290,8 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctSL unitType='Aero'>0,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctSL unitType='AeroSpaceFighter'>0,0,0,0,0</pctSL>
 		<salvage pct='5'>FS:1,FC:10,DC:7</salvage>
 		<weightDistribution era='3049' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3049' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -299,7 +299,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3049' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3049' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3049' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -312,11 +312,11 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,4,12,20</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3049' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:2,FS:10,FC:10</salvage>
-		<weightDistribution era='3049' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FC:10</salvage>
@@ -548,9 +548,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -577,9 +577,9 @@
 		<pctOmni>0,0,5,45,100</pctOmni>
 		<pctClan>32,32,55,100,100</pctClan>
 		<pctSL>68,68,45,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,60,100</pctOmni>
-		<pctClan unitType='Aero'>32,32,65,100,100</pctClan>
-		<pctSL unitType='Aero'>68,68,35,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,60,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>32,32,65,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>68,68,35,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -612,9 +612,9 @@
 		<pctOmni>0,0,5,35,100</pctOmni>
 		<pctClan>32,32,55,100,100</pctClan>
 		<pctSL>68,68,45,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,60,100</pctOmni>
-		<pctClan unitType='Aero'>32,32,65,100,100</pctClan>
-		<pctSL unitType='Aero'>68,68,35,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,60,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>32,32,65,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>68,68,35,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -882,7 +882,7 @@
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:2,FWL:2+,NIOPS:7,WOB:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1180,7 +1180,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1406,7 +1406,7 @@
 			<availability>LA:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1499,7 +1499,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1929,7 +1929,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1986,7 +1986,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -2063,7 +2063,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,WOB:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -2098,7 +2098,7 @@
 			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -2107,7 +2107,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -2484,7 +2484,7 @@
 			<availability>FC:6-,FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -2906,7 +2906,7 @@
 			<availability>CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -3529,7 +3529,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:5,Periphery.MW:3,PIR:3,CLAN:5,Periphery.ME:3,CNC:5,FWL:8,NIOPS:9,WOB:9,MERC:4</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
@@ -3760,7 +3760,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7,WOB:7,DC:2</availability>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
@@ -3944,7 +3944,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:2,NIOPS:6,WOB:6,FS:2,DC:3</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -3957,7 +3957,7 @@
 			<availability>CS:5,NIOPS:5,WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
@@ -4233,7 +4233,7 @@
 			<availability>CS:4,LA:4,WOB:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4344,7 +4344,7 @@
 			<availability>CSJ:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -4360,7 +4360,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4437,7 +4437,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -4485,7 +4485,7 @@
 			<availability>FS:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:4,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4704,7 +4704,7 @@
 			<availability>DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4907,7 +4907,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:5,WOB:5-,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -5060,7 +5060,7 @@
 			<availability>MERC.KH:5,MERC.WD:3,IS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
@@ -5069,7 +5069,7 @@
 			<availability>FRR:3+,DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:3</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
@@ -6428,7 +6428,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:4+,NIOPS:8,WOB:8</availability>
@@ -6516,7 +6516,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:3,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
@@ -6588,7 +6588,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8,WOB:6</availability>
@@ -6677,7 +6677,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,HL:1-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -6689,7 +6689,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6705,7 +6705,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CSJ:5,DC:5</availability>
 		<model name='S-3'>
 			<availability>DC:8</availability>
@@ -6729,7 +6729,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:3,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -6837,7 +6837,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CIH:3,CFM:3,CSJ:3,CJF:7,CGS:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -6898,7 +6898,7 @@
 			<availability>DC.GHO:8,DC:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:2,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -6984,7 +6984,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
@@ -7008,7 +7008,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,FS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -7063,7 +7063,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 		<model name='SL-15'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,FS:0,Periphery:6</availability>
@@ -7127,7 +7127,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -7136,7 +7136,7 @@
 			<availability>CS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 		<model name='SPR-6D'>
 			<availability>FS:4+</availability>
@@ -7238,7 +7238,7 @@
 			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -7281,7 +7281,7 @@
 			<availability>FWL:4+,WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,FS:1,MERC:5,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:7,LA:4,IS:7,FS:7,Periphery:7</availability>
@@ -7350,7 +7350,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 		<model name='STU-D6'>
 			<availability>LA:4+,FS:6+,MERC:4+</availability>
@@ -7374,7 +7374,7 @@
 			<availability>LA:3,FS:3,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -7429,7 +7429,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -7530,7 +7530,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -7571,7 +7571,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -7649,7 +7649,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:3</availability>
@@ -7692,7 +7692,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -7704,7 +7704,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -7739,7 +7739,7 @@
 			<availability>FWL:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:3,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:4,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -7769,7 +7769,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -7803,7 +7803,7 @@
 			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -7930,7 +7930,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -8038,7 +8038,7 @@
 			<availability>CSV:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8100,7 +8100,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -8429,7 +8429,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8461,7 +8461,7 @@
 			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:6,CLAN:2,NIOPS:6,WOB:6</availability>

--- a/MekHQ/data/forcegenerator/3055.xml
+++ b/MekHQ/data/forcegenerator/3055.xml
@@ -13,7 +13,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,9,18,30</pctSL>
 		<salvage pct='5'>FWL:7,SIC:4,FS:10,FC:10,TC:1</salvage>
-		<weightDistribution era='3055' unitType='Aero'>3,3,1</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>3,3,1</weightDistribution>
 	</faction>
 	<faction key='NC'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -34,7 +34,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3055' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3055' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3055' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,50,75</pctOmni>
@@ -58,9 +58,9 @@
 		<pctOmni>0,0,32,100,100</pctOmni>
 		<pctClan>76,76,88,100,100</pctClan>
 		<pctSL>24,24,12,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,36,100,100</pctOmni>
-		<pctClan unitType='Aero'>10,10,40,100,100</pctClan>
-		<pctSL unitType='Aero'>90,90,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,36,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
@@ -97,9 +97,9 @@
 		<pctOmni>0,0,35,65,98</pctOmni>
 		<pctClan>64,64,82,87,100</pctClan>
 		<pctSL>36,36,18,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:5,CSV:7,CFM:7,CCO:2,CSA:3,CDS:4,CW:1,CNC:3,CSJ:2,CJF:10,CGB:1,CB:2</salvage>
@@ -158,9 +158,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:3,CCO:3,CSA:2,CDS:3,CW:7,CNC:10,CSJ:1,CJF:5,CB:3</salvage>
@@ -169,9 +169,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>80,80,95,100,100</pctClan>
 		<pctSL>20,20,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:3,CJF:7,CGB:2,CB:2</salvage>
@@ -259,7 +259,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3055' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3055' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3055' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,MH:1,CIR:1</salvage>
@@ -301,8 +301,8 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,0,5</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctSL unitType='Aero'>0,0,0,2,5</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctSL unitType='AeroSpaceFighter'>0,0,0,2,5</pctSL>
 		<salvage pct='5'>FS:1,FC:10,DC:7</salvage>
 		<weightDistribution era='3055' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3055' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -310,7 +310,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3055' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3055' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3055' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,BAN:2,DC:2</salvage>
@@ -326,7 +326,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,9,18,30</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3055' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='SKC'>
 		<salvage pct='6'>CC:10,FWL:1,CM:2,FC:3</salvage>
@@ -336,7 +336,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,3,6</pctSL>
 		<salvage pct='5'>CC:2,FS:10,FC:10</salvage>
-		<weightDistribution era='3055' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TCC'>
 		<salvage pct='6'>CC:1,ST:1,CM:10,FC:3</salvage>
@@ -583,9 +583,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -612,9 +612,9 @@
 		<pctOmni>0,0,5,50,100</pctOmni>
 		<pctClan>32,32,55,100,100</pctClan>
 		<pctSL>68,68,45,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,60,100</pctOmni>
-		<pctClan unitType='Aero'>32,32,65,100,100</pctClan>
-		<pctSL unitType='Aero'>68,68,35,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,60,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>32,32,65,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>68,68,35,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
@@ -647,9 +647,9 @@
 		<pctOmni>0,0,5,40,100</pctOmni>
 		<pctClan>32,32,55,100,100</pctClan>
 		<pctSL>68,68,45,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,60,100</pctOmni>
-		<pctClan unitType='Aero'>32,32,65,100,100</pctClan>
-		<pctSL unitType='Aero'>68,68,35,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,60,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>32,32,65,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>68,68,35,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
@@ -934,7 +934,7 @@
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:2,FWL:3+,NIOPS:7,WOB:7,DC:2+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1272,7 +1272,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1524,7 +1524,7 @@
 			<availability>LA:7+,FRR:3+,FS:6+,MERC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1626,7 +1626,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -2134,7 +2134,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -2197,7 +2197,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -2295,7 +2295,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -2340,7 +2340,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
@@ -2726,7 +2726,7 @@
 			<availability>FC:6-,FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
@@ -3177,7 +3177,7 @@
 			<availability>CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -3971,7 +3971,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
@@ -4222,7 +4222,7 @@
 			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:5,NIOPS:7,WOB:7,DC:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:2</availability>
@@ -4422,7 +4422,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:3,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -4435,7 +4435,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
@@ -4751,7 +4751,7 @@
 			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4866,7 +4866,7 @@
 			<availability>CSJ:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -4882,7 +4882,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4959,7 +4959,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5019,7 +5019,7 @@
 			<availability>LA:3+,FS:3+,MERC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5263,7 +5263,7 @@
 			<availability>MERC:5,DC:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5521,7 +5521,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -5711,7 +5711,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:6</availability>
@@ -5720,7 +5720,7 @@
 			<availability>FRR:5+,MERC:2+,DC:5+</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
@@ -7281,7 +7281,7 @@
 			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:5+,NIOPS:8,WOB:8</availability>
@@ -7378,7 +7378,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
@@ -7458,7 +7458,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
@@ -7561,7 +7561,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -7573,7 +7573,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -7589,7 +7589,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:3,CW:3,CNC:4,CSJ:5,BAN:1,CGB:3,DC:5,CWIE:3</availability>
 		<model name='S-3'>
 			<availability>DC:6</availability>
@@ -7628,7 +7628,7 @@
 			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:2,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -7736,7 +7736,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CIH:3,CFM:3,CSJ:3,CJF:7,CGS:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -7807,7 +7807,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2,DC:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -7897,7 +7897,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
@@ -7921,7 +7921,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,FS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -7976,7 +7976,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 		<model name='SL-15'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
@@ -8047,7 +8047,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -8056,7 +8056,7 @@
 			<availability>CS:5,WOB:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
 		<model name='SPR-6D'>
 			<availability>FRR:4+,FS:6+,MERC:4+</availability>
@@ -8173,7 +8173,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -8227,7 +8227,7 @@
 			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:6,LA:4,IS:6,FS:6,Periphery:6</availability>
@@ -8331,7 +8331,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 		<model name='STU-D6'>
 			<availability>LA:5+,FS:7+,MERC:5+</availability>
@@ -8355,7 +8355,7 @@
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -8427,7 +8427,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -8543,7 +8543,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -8593,7 +8593,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -8674,7 +8674,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:4,CLAN:3</availability>
@@ -8726,7 +8726,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
 		<model name='TR-13'>
 			<availability>CC:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
@@ -8741,7 +8741,7 @@
 			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -8776,7 +8776,7 @@
 			<availability>CC:4+,LA:3+,FRR:4+,FWL:6+,WOB:4,MH:3+,FS:4+,MERC:4+,TC:3+,DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:5,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:6,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -8834,7 +8834,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CWIE:4,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8874,7 +8874,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9008,7 +9008,7 @@
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -9132,7 +9132,7 @@
 			<availability>CSR:2,CSV:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9194,7 +9194,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:6</availability>
@@ -9544,7 +9544,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9576,7 +9576,7 @@
 			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>

--- a/MekHQ/data/forcegenerator/3058.xml
+++ b/MekHQ/data/forcegenerator/3058.xml
@@ -19,7 +19,7 @@
 		<pctClan>0,0,0,1,3</pctClan>
 		<pctSL>0,4,14,22,36</pctSL>
 		<salvage pct='5'>CLAN:1,FWL:7,SIC:4,FS:10,TC:1</salvage>
-		<weightDistribution era='3058' unitType='Aero'>3,3,1</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>3,3,1</weightDistribution>
 	</faction>
 	<faction key='NC'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -45,7 +45,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3058' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3058' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3058' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,8,54,78</pctOmni>
@@ -69,9 +69,9 @@
 		<pctOmni>0,0,32,100,100</pctOmni>
 		<pctClan>78,78,89,100,100</pctClan>
 		<pctSL>22,22,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,38,100,100</pctOmni>
-		<pctClan unitType='Aero'>11,11,40,100,100</pctClan>
-		<pctSL unitType='Aero'>88,88,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,38,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>11,11,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>88,88,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
@@ -108,9 +108,9 @@
 		<pctOmni>0,0,36,66,99</pctOmni>
 		<pctClan>66,66,83,87,100</pctClan>
 		<pctSL>34,34,16,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CIH:4,CSR:0,CSV:4,CFM:5,CCO:2,CSA:3,CDS:3,CW:1,CNC:3,CSJ:1,CJF:10,CGB:1,CB:2</salvage>
@@ -169,9 +169,9 @@
 		<pctOmni>35,35,75,95,100</pctOmni>
 		<pctClan>70,70,92,100,100</pctClan>
 		<pctSL>30,30,7,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,43,43,43</pctClan>
 		<pctSL unitType='Vehicle'>88,88,57,57,57</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:7,CFM:7,CCO:7,CGS:2,CSA:3,CDS:3,CW:10,CNC:10,CSJ:1,CJF:10,CB:3</salvage>
@@ -180,9 +180,9 @@
 		<pctOmni>13,13,18,95,100</pctOmni>
 		<pctClan>76,76,91,100,100</pctClan>
 		<pctSL>23,23,8,0,0</pctSL>
-		<pctOmni unitType='Aero'>18,18,27,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>18,18,27,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,43,50,50</pctClan>
 		<pctSL unitType='Vehicle'>88,88,57,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:3,CFM:10,CCO:3,CGS:3,CDS:2,CW:5,CNC:5,CSJ:3,CJF:7,CGB:2,CB:2</salvage>
@@ -267,7 +267,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3058' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3058' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3058' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<pctOmni>0,0,2,3,4</pctOmni>
@@ -306,8 +306,8 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,1,4,8</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctSL unitType='Aero'>0,0,0,8,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctSL unitType='AeroSpaceFighter'>0,0,0,8,10</pctSL>
 		<salvage pct='5'>FS:1,DC:7</salvage>
 		<weightDistribution era='3058' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3058' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -315,7 +315,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3058' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3058' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3058' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,BAN:2,DC:2</salvage>
@@ -331,7 +331,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,4,14,22,36</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3058' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='SKC'>
 		<salvage pct='6'>CC:10,FWL:1,CM:2</salvage>
@@ -341,7 +341,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,1,4,9</pctSL>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3058' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TCC'>
 		<salvage pct='6'>CC:1,ST:1,CM:10</salvage>
@@ -590,9 +590,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -619,9 +619,9 @@
 		<pctOmni>0,0,5,50,100</pctOmni>
 		<pctClan>33,33,58,100,100</pctClan>
 		<pctSL>66,66,42,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,63,100</pctOmni>
-		<pctClan unitType='Aero'>33,33,68,100,100</pctClan>
-		<pctSL unitType='Aero'>66,66,32,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,63,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>33,33,68,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>66,66,32,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
@@ -654,9 +654,9 @@
 		<pctOmni>0,0,5,40,100</pctOmni>
 		<pctClan>33,33,58,100,100</pctClan>
 		<pctSL>66,66,42,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,63,100</pctOmni>
-		<pctClan unitType='Aero'>33,33,68,100,100</pctClan>
-		<pctSL unitType='Aero'>66,66,32,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,63,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>33,33,68,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>66,66,32,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
@@ -973,7 +973,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:2,FWL:3+,NIOPS:7,WOB:7,DC:2+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1345,7 +1345,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1610,7 +1610,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1712,7 +1712,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6,DC:2+</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -2255,7 +2255,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -2318,7 +2318,7 @@
 			<availability>LA:5,FS:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -2416,7 +2416,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -2461,7 +2461,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
@@ -2847,7 +2847,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
@@ -3348,7 +3348,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -4221,7 +4221,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
@@ -4480,7 +4480,7 @@
 			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,CNC:5,FWL:1,NIOPS:7,WOB:7,DC:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:2</availability>
@@ -4692,7 +4692,7 @@
 			<availability>CC:8,CS:8,MOC:8,SIC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:3,CNC:1,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -4705,7 +4705,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
@@ -5056,7 +5056,7 @@
 			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:7,CSR:6,CLAN:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5197,7 +5197,7 @@
 			<availability>CSJ:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-,DC:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:2</availability>
@@ -5213,7 +5213,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5290,7 +5290,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5360,7 +5360,7 @@
 			<availability>LA:3+,FS:3+,MERC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5633,7 +5633,7 @@
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5897,7 +5897,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -6109,7 +6109,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:6</availability>
@@ -6118,7 +6118,7 @@
 			<availability>FRR:5+,MERC:2+,DC:5+</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
@@ -7811,7 +7811,7 @@
 			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:5+,NIOPS:8,WOB:8</availability>
@@ -7908,7 +7908,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
@@ -7998,7 +7998,7 @@
 			<availability>CHH:6,CSJ:6,CCO:4,CGS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
@@ -8105,7 +8105,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -8117,7 +8117,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8133,7 +8133,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:3,CW:3,CNC:4,CSJ:5,BAN:1,CGB:3,DC:5,CWIE:3</availability>
 		<model name='S-3'>
 			<availability>DC:6</availability>
@@ -8178,7 +8178,7 @@
 			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:2,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -8330,7 +8330,7 @@
 			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:3,CCC:2,CIH:3,CSR:2,CSV:2,CFM:3,CGS:3,CCO:2,CWIE:2,CSA:3,CW:2,CNC:2,CSJ:3,CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8401,7 +8401,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,FWL:1,MH:2,DC:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -8491,7 +8491,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
@@ -8515,7 +8515,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,FS:3,DC:8,Periphery:1</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -8583,7 +8583,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 		<model name='SL-15'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
@@ -8654,7 +8654,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -8663,7 +8663,7 @@
 			<availability>CS:5,WOB:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
 		<model name='SPR-6D'>
 			<availability>FRR:4+,FS:6+,MERC:4+</availability>
@@ -8786,7 +8786,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -8840,7 +8840,7 @@
 			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:5,LA:4,IS:5,FS:5,Periphery:5</availability>
@@ -8947,7 +8947,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 		<model name='STU-D6'>
 			<availability>LA:5+,FS:7+,MERC:5+</availability>
@@ -8971,7 +8971,7 @@
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -9046,7 +9046,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -9168,7 +9168,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -9225,7 +9225,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -9316,7 +9316,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:5,CLAN:4</availability>
@@ -9374,7 +9374,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
 		<model name='TR-13'>
 			<availability>CC:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
@@ -9389,7 +9389,7 @@
 			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -9428,7 +9428,7 @@
 			<availability>DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:5,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:6,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -9490,7 +9490,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CWIE:4,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9530,7 +9530,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9677,7 +9677,7 @@
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -9808,7 +9808,7 @@
 			<availability>CSR:4,CSV:4,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9870,7 +9870,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:5</availability>
@@ -10226,7 +10226,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -10279,7 +10279,7 @@
 			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>

--- a/MekHQ/data/forcegenerator/3060.xml
+++ b/MekHQ/data/forcegenerator/3060.xml
@@ -45,7 +45,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3060' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3060' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3060' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -59,9 +59,9 @@
 		<pctOmni>0,0,33,100,100</pctOmni>
 		<pctClan>80,80,90,100,100</pctClan>
 		<pctSL>20,20,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,40,100,100</pctOmni>
-		<pctClan unitType='Aero'>12,12,40,100,100</pctClan>
-		<pctSL unitType='Aero'>88,88,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,40,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>12,12,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>88,88,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2</salvage>
@@ -98,9 +98,9 @@
 		<pctOmni>0,0,38,68,100</pctOmni>
 		<pctClan>68,68,84,87,100</pctClan>
 		<pctSL>32,32,16,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:4,CSV:3,CFM:5,CCO:2,CSA:3,CDS:3,CW:1,CNC:3,CSJ:1,CJF:10,CGB:1</salvage>
@@ -159,9 +159,9 @@
 		<pctOmni>39,39,75,96,100</pctOmni>
 		<pctClan>70,70,94,100,100</pctClan>
 		<pctSL>30,30,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>88,88,55,55,55</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:7,CFM:7,CCO:7,CGS:2,CSA:3,CDS:3,CW:10,CNC:10,CSJ:1,CJF:10</salvage>
@@ -170,9 +170,9 @@
 		<pctOmni>13,13,18,92,100</pctOmni>
 		<pctClan>74,74,89,100,100</pctClan>
 		<pctSL>26,26,11,0,0</pctSL>
-		<pctOmni unitType='Aero'>18,18,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>18,18,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>88,88,55,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:3,CFM:10,CCO:3,CGS:3,CDS:2,CW:5,CNC:5,CSJ:3,CJF:8,CGB:2</salvage>
@@ -261,7 +261,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3060' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3060' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3060' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<pctOmni>0,0,4,6,7</pctOmni>
@@ -306,8 +306,8 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,2,7,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctSL unitType='Aero'>0,0,0,12,16</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctSL unitType='AeroSpaceFighter'>0,0,0,12,16</pctSL>
 		<salvage pct='5'>FS:1,DC:7</salvage>
 		<weightDistribution era='3060' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3060' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -315,7 +315,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3060' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3060' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3060' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,BAN:3,DC:2</salvage>
@@ -331,7 +331,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,8,18,26,40</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3060' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='SKC'>
 		<salvage pct='6'>CC:10,FWL:1,CM:2</salvage>
@@ -341,7 +341,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,2,6,12</pctSL>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3060' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TCC'>
 		<salvage pct='6'>CC:1,ST:1,CM:10</salvage>
@@ -605,9 +605,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -634,9 +634,9 @@
 		<pctOmni>0,0,5,50,100</pctOmni>
 		<pctClan>34,34,60,100,100</pctClan>
 		<pctSL>66,66,40,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,65,100</pctOmni>
-		<pctClan unitType='Aero'>34,34,70,100,100</pctClan>
-		<pctSL unitType='Aero'>66,66,30,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,65,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>34,34,70,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>66,66,30,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
@@ -669,9 +669,9 @@
 		<pctOmni>0,0,5,40,100</pctOmni>
 		<pctClan>34,34,60,100,100</pctClan>
 		<pctSL>66,66,40,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,65,100</pctOmni>
-		<pctClan unitType='Aero'>34,34,70,100,100</pctClan>
-		<pctSL unitType='Aero'>66,66,30,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,65,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>34,34,70,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>66,66,30,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
@@ -1046,7 +1046,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:1,FWL:5,NIOPS:7,WOB:7,DC:3</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1115,7 +1115,7 @@
 			<availability>IS:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:3,CIH:3,CDS:4,CGS:3,CCO:3,CGB:3</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1558,7 +1558,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:5,CLAN:3,CNC:5,BAN:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1874,7 +1874,7 @@
 			<availability>LA:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:6,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -2029,7 +2029,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,DC:3+</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -2726,7 +2726,7 @@
 			<availability>LA:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -2801,7 +2801,7 @@
 			<availability>LA:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -2921,7 +2921,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -2975,7 +2975,7 @@
 			<availability>:0,IS:4+,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:5,TC:4,Periphery:4</availability>
@@ -3390,7 +3390,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:1,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:4,Periphery:5</availability>
@@ -3641,7 +3641,7 @@
 			<availability>CLAN:6-,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:5+</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -4013,7 +4013,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:3,IS:3,WOB:3-,SIC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -4039,13 +4039,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>LA:4+</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:2+</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -5068,7 +5068,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
@@ -5444,7 +5444,7 @@
 			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:2,NIOPS:7,WOB:7,DC:4</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:3</availability>
@@ -5732,7 +5732,7 @@
 			<availability>CC:5,MOC:5,SIC:5,MERC:5,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:3,CNC:2,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -5745,7 +5745,7 @@
 			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,OA:3-,HL:2,LA:3-,Periphery.Deep:1-,FS:3-,MERC:3-,Periphery:3-,TC:2-</availability>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
@@ -6156,7 +6156,7 @@
 			<availability>CC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CS:2+,FRR:4+</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -6193,7 +6193,7 @@
 			<availability>CS:4,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:7,CSR:6,CLAN:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6373,7 +6373,7 @@
 			<availability>CSJ:8,DC:8+:3062</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-,DC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:4</availability>
@@ -6389,7 +6389,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6472,7 +6472,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6557,7 +6557,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -6871,7 +6871,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -7087,7 +7087,7 @@
 			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>FWL:3,WOB:2</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -7217,7 +7217,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:5,HL:3,FRR:5,CLAN:2,IS:4,WOB:3-,SIC:7,FS:4,Periphery:4,TC:4,CS:3-,OA:6,LA:4,FWL:2,NIOPS:3-,DC:6</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -7477,7 +7477,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:5,MERC:3,DC:5</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5</availability>
@@ -7486,7 +7486,7 @@
 			<availability>FRR:5,MERC:2,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:4,SIC:4,FS:5,MERC:4,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:9,Periphery.MW:3</availability>
 		<model name='LCF-R15'>
 			<availability>LA:2,General:2,Periphery.Deep:4,MERC:8,Periphery:2</availability>
@@ -9655,7 +9655,7 @@
 			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:4,CLAN:3,NIOPS:8,WOB:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:6,NIOPS:8,WOB:8</availability>
@@ -9784,7 +9784,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:6,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:5,HL:3,LA:2,FRR:2,FWL:5,Periphery.Deep:8,SIC:5,MERC:5,DC:2,Periphery:5</availability>
@@ -9902,7 +9902,7 @@
 			<availability>CSR:4,CBS:4,CNC:3,CFM:4,CCO:3,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:5,General:8,NIOPS:5,WOB:6</availability>
@@ -10026,7 +10026,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -10038,7 +10038,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -10060,7 +10060,7 @@
 			<availability>FS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,FRR:4,CNC:5,CSJ:5,FS:2,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:3</availability>
@@ -10128,7 +10128,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:1,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -10320,7 +10320,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:3,CCC:3,CIH:3,CSR:3,CSV:3,CFM:3,CGS:3,CCO:4,CWIE:4,CSA:3,CW:4,CNC:3,CSJ:3,CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10391,7 +10391,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:4,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:2,MH:2,DC:4</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -10524,7 +10524,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:8,MERC:4,Periphery.OS:4,DC:8,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:2,IS:4,Periphery.Deep:8,Periphery:4</availability>
@@ -10536,7 +10536,7 @@
 			<availability>OA:4,FRR:6,MERC:4,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FWL:3+,WOB:3+,FWL.KIS:4+,FWL.FWG:4+</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -10569,7 +10569,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:7,MERC:3,Periphery.OS:3,FS:3,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -10667,7 +10667,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:7</availability>
 		<model name='SL-15'>
 			<availability>HL:2,IS:4,Periphery.Deep:8,FS:0,Periphery:4</availability>
@@ -10747,7 +10747,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -10756,7 +10756,7 @@
 			<availability>CS:6,WOB:6,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:3</availability>
 		<model name='SPR-6D'>
 			<availability>FRR:5,FS:8,MERC:5</availability>
@@ -10933,7 +10933,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -11008,7 +11008,7 @@
 			<availability>CC:4,MOC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,DC:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:7,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:4,LA:3,IS:4,FS:4,Periphery:4</availability>
@@ -11130,7 +11130,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:2,CLAN:4,SIC:4,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 		<model name='STU-D6'>
 			<availability>LA:6,FS:8,MERC:6</availability>
@@ -11193,7 +11193,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:4,General:2,CGB:7</availability>
@@ -11280,7 +11280,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -11329,7 +11329,7 @@
 			<availability>FWL:3,IS:4,MERC:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FRR:3+,DC:4+</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -11489,7 +11489,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:6,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -11558,7 +11558,7 @@
 			<availability>CC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:2,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:4-,OA:5,LA:6,FWL:5,NIOPS:4-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -11662,7 +11662,7 @@
 			<availability>FRR:7,DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:3</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6,CLAN:4</availability>
@@ -11753,7 +11753,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:5,HL:3,IS:5,MERC:5,Periphery:5</availability>
@@ -11768,7 +11768,7 @@
 			<availability>CC:5,MOC:5,SIC:2,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:7,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:7,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:7,MOC:7,General:7,TC:7</availability>
@@ -11810,7 +11810,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -11845,7 +11845,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,TC:4</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
@@ -11924,7 +11924,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:4,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -11991,7 +11991,7 @@
 			<availability>FRR:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -12163,7 +12163,7 @@
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -12332,7 +12332,7 @@
 			<availability>CSR:6,CSV:6,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -12406,7 +12406,7 @@
 			<availability>LA:6,FRR:5,FWL:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:2</availability>
 		<model name='VLC-5N'>
 			<availability>General:4</availability>
@@ -12791,7 +12791,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:6,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -12863,7 +12863,7 @@
 			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>

--- a/MekHQ/data/forcegenerator/3067.xml
+++ b/MekHQ/data/forcegenerator/3067.xml
@@ -23,7 +23,7 @@
 		<pctOmni>0,2,7,10,17</pctOmni>
 		<pctClan>0,0,3,5,7</pctClan>
 		<pctSL>0,11,21,29,50</pctSL>
-		<pctSL unitType='Aero'>0,8,18,25,40</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>0,8,18,25,40</pctSL>
 		<pctSL unitType='Vehicle'>0,8,15,20,25</pctSL>
 		<salvage pct='5'>CLAN:2,FWL:6,CM:4,WOB:1,FS:10</salvage>
 	</faction>
@@ -51,7 +51,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3067' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3067' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3067' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3067' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -73,9 +73,9 @@
 		<pctOmni>0,0,34,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CIH:3,CSR:3,CSV:10,CFM:5,CGS:2,CCO:10,CSA:6,CDS:3,CW:7,CBS:2,CJF:10,CGB:2</salvage>
@@ -112,9 +112,9 @@
 		<pctOmni>0,0,38,68,100</pctOmni>
 		<pctClan>68,68,84,87,100</pctClan>
 		<pctSL>32,32,16,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CSA:4,CHH:3,CIH:6,CSR:1,CDS:2,CW:3,CSV:2,CFM:10,CCO:1,CJF:6</salvage>
@@ -165,9 +165,9 @@
 		<pctOmni>39,39,75,96,100</pctOmni>
 		<pctClan>70,70,94,100,100</pctClan>
 		<pctSL>30,30,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,55,55</pctSL>
 		<salvage pct='10'>CSA:4,CHH:10,CCC:1,CIH:6,CDS:8,CW:10,CSV:4,CFM:4,CGS:2,CCO:4,CJF:8</salvage>
@@ -176,9 +176,9 @@
 		<pctOmni>13,13,18,92,100</pctOmni>
 		<pctClan>74,74,89,100,100</pctClan>
 		<pctSL>26,26,11,0,0</pctSL>
-		<pctOmni unitType='Aero'>18,18,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>18,18,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,50,50</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:1,CIH:5,CSV:2,CFM:10,CCO:4,CGS:3,CDS:4,CW:2,CBS:1,CJF:6,CGB:1</salvage>
@@ -270,7 +270,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3067' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3067' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3067' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3067' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='KP'>
 		<salvage pct='7'>CC:1,WOB:10,FS:2</salvage>
@@ -313,9 +313,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,6,15,21</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,5</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>0,0,5,20,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,5</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0,0,5,20,40</pctSL>
 		<salvage pct='5'>CSR:2,FS:1,DC:7</salvage>
 		<weightDistribution era='3067' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3067' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -323,7 +323,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3067' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3067' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3067' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3067' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,BAN:4,DC:2</salvage>
@@ -342,7 +342,7 @@
 		<pctClan>0,0,0,0,2</pctClan>
 		<pctSL>0,0,5,12,21</pctSL>
 		<salvage pct='5'>CC:2,CLAN:1,FS:10</salvage>
-		<weightDistribution era='3067' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3067' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TCC'>
 		<salvage pct='6'>CC:1,ST:1,CM:10</salvage>
@@ -447,7 +447,7 @@
 		<pctOmni>3</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>15</pctSL>
-		<pctSL unitType='Aero'>5</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>5</pctSL>
 		<pctSL unitType='Vehicle'>10</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -461,7 +461,7 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>4</pctClan>
 		<pctSL>60</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>50</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -497,7 +497,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>29</pctSL>
-		<pctSL unitType='Aero'>14</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>14</pctSL>
 		<pctSL unitType='Vehicle'>25</pctSL>
 		<salvage pct='5'>CLAN:2,CM:4,FWL:6,WOB:1,FS:10</salvage>
 	</faction>
@@ -598,9 +598,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -675,7 +675,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>23</pctSL>
-		<pctSL unitType='Aero'>20</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>20</pctSL>
 		<pctSL unitType='Vehicle'>15</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -866,7 +866,7 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>87</pctSL>
-		<pctSL unitType='Aero'>55</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>55</pctSL>
 		<pctSL unitType='Vehicle'>40</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -880,7 +880,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>48</pctSL>
-		<pctSL unitType='Aero'>30</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>30</pctSL>
 		<pctSL unitType='Vehicle'>20</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -919,7 +919,7 @@
 		<pctOmni>14</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>26</pctSL>
-		<pctSL unitType='Aero'>24</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>24</pctSL>
 		<pctSL unitType='Vehicle'>20</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -1055,7 +1055,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:1,FWL:4,NIOPS:7,WOB:7,DC:3</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1133,7 +1133,7 @@
 			<availability>IS:2,Periphery:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:4,CIH:5,CDS:6,CW:4,CNC:4,CGS:5,CCO:5,CGB:5,CB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1714,7 +1714,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:5,CLAN:3,CNC:5,BAN:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -2093,7 +2093,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:6,CLAN:5,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -2304,7 +2304,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,SOC:6,CSV:8,CFM:7,CGS:6,CCO:4,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CJF:7,CGB:6,DC:3+,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -3155,7 +3155,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3274,7 +3274,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3405,7 +3405,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:2</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -3466,7 +3466,7 @@
 			<availability>:0,IS:4+,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:4,DC:2</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:4-,CDP:4,TC:4,Periphery:3-</availability>
@@ -3922,7 +3922,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>OA:3+,CSR:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -3959,7 +3959,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:7,FWL:1,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,BAN:4,Periphery:5-</availability>
@@ -4309,13 +4309,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB:4,FS:6+</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -4508,13 +4508,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:2</availability>
 		<model name='F-77A'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4+,WOB:5+</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -4872,7 +4872,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -4901,13 +4901,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>LA:5,FRR:3+,CNC:3,MERC:3+</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:3+,MERC:2+</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -6190,7 +6190,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6-</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:5-,FWL:5-,MH:5-,MERC:5-</availability>
@@ -6682,7 +6682,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:3,NIOPS:7,WOB:7,DC:4</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -7028,7 +7028,7 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:3,CNC:3,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -7044,7 +7044,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,OA:4,FVC:2,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:2-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
@@ -7545,7 +7545,7 @@
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
 		<availability>CS:1</availability>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CS:3+,FRR:5+,CNC:3</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -7591,7 +7591,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:5,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -7803,7 +7803,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-,DC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:4</availability>
@@ -7826,7 +7826,7 @@
 			<availability>CHH:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -7930,7 +7930,7 @@
 			<availability>WOB:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8036,7 +8036,7 @@
 			<availability>FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8448,7 +8448,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8756,7 +8756,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>FWL:4,WOB:3</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -8929,7 +8929,7 @@
 			<availability>CS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:6-</availability>
@@ -9262,7 +9262,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -9271,7 +9271,7 @@
 			<availability>FRR:6,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,HL:4,LA:8,FRR:4,Periphery.MW:3,FS:5-,MERC:3,CIR:3,TC:2,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:2-,General:2-,Periphery.Deep:4,MERC:8-,Periphery:2-</availability>
@@ -10848,7 +10848,7 @@
 			<availability>CLAN:1,IS:1+,WOB:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>FRR:2,CNC:2,DC:3</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -12137,7 +12137,7 @@
 			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:4,CLAN:3,NIOPS:6,WOB:6</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:5,NIOPS:8,WOB:8</availability>
@@ -12311,7 +12311,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,FVC:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:4-,FVC:5-,HL:3-,LA:2,FRR:2,FWL:5-,Periphery.Deep:8,MERC:5-,DC:2,Periphery:5-</availability>
@@ -12480,7 +12480,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
@@ -12548,7 +12548,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rusalka' unitType='Aero' omni='IS'>
+	<chassis name='Rusalka' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:5</availability>
 		<model name='S-RSL-O Invictus'>
 			<roles>interceptor</roles>
@@ -12684,7 +12684,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:2,MERC:2,Periphery:3-,OA:2-,LA:2,FWL:2-,DC:4</availability>
 		<model name='SB-27'>
 			<availability>General:6-</availability>
@@ -12699,7 +12699,7 @@
 			<availability>MERC:4,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -12737,7 +12737,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,FRR:6,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:3-</availability>
@@ -12811,7 +12811,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,WOB:4,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -13065,7 +13065,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:3,CCC:4,CIH:3,CSR:4,CSV:4,CLAN:3,CFM:3,CGS:3,CCO:5,CWIE:5,CSA:3,CW:5,CNC:4,CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13182,7 +13182,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:3-,MH:2,DC:4-</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -13227,7 +13227,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shade' unitType='Aero' omni='IS'>
+	<chassis name='Shade' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:4</availability>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
@@ -13378,7 +13378,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
@@ -13393,7 +13393,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FWL:4+,WOB:3+,FWL.KIS:6+,FWL.FWG:5+</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -13433,7 +13433,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:7,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>HL:5,LA:6,Periphery.Deep:7,MERC:7,DC:7,Periphery:7</availability>
@@ -13549,7 +13549,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:2,DC:7</availability>
 		<model name='SL-15'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
@@ -13638,7 +13638,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -13650,7 +13650,7 @@
 			<availability>WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3,DC:2-</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,FRR:5,PIR:2+,FS:8,MERC:5,CDP:2+,TC:2+</availability>
@@ -13882,7 +13882,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -13981,7 +13981,7 @@
 			<availability>LA:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:4-,LA:3-,IS:4-,FS:4-,Periphery:4-</availability>
@@ -14069,7 +14069,7 @@
 			<availability>CLAN:6,General:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Striga' unitType='Aero' omni='IS'>
+	<chassis name='Striga' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6</availability>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
@@ -14130,7 +14130,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:5,Periphery.HR:2,DC:1</availability>
 		<model name='STU-D6'>
 			<availability>LA:6,FS:8,MERC:6</availability>
@@ -14200,7 +14200,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:6,General:2,CGB:7,CB:6</availability>
@@ -14309,7 +14309,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -14384,7 +14384,7 @@
 			<availability>FVC:4,IS:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FRR:4+,CNC:4,DC:5+</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -14603,7 +14603,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -14693,7 +14693,7 @@
 			<availability>CC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -14830,7 +14830,7 @@
 			<availability>FRR:6-,DC:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:4</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6,CLAN:4</availability>
@@ -14949,7 +14949,7 @@
 			<availability>General:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,PIR:2,FWL:3,MERC:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:5-,HL:3-,IS:4-,MERC:5-,Periphery:5-</availability>
@@ -14967,7 +14967,7 @@
 			<availability>CC:7,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:4,Periphery.CM:3,Periphery.ME:3,FWL:3,TC:4</availability>
 		<model name='TR-10'>
 			<availability>CC:6,MOC:6,General:6,TC:6</availability>
@@ -15013,7 +15013,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -15076,7 +15076,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:4,Periphery.CM:2,Periphery.ME:2,TC:5</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
@@ -15159,7 +15159,7 @@
 			<availability>DC:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15223,7 +15223,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:3</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -15240,7 +15240,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -15486,7 +15486,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -15706,7 +15706,7 @@
 			<availability>CSR:8,CSV:8,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15792,7 +15792,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,CDP:2,TC:2</availability>
 		<model name='VLC-5N'>
 			<availability>General:3</availability>
@@ -16307,7 +16307,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CIH:5,CSR:6,CLAN:5,CFM:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -16409,7 +16409,7 @@
 			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>

--- a/MekHQ/data/forcegenerator/3075.xml
+++ b/MekHQ/data/forcegenerator/3075.xml
@@ -25,7 +25,7 @@
 		<pctOmni>0,3,7,10,20</pctOmni>
 		<pctClan>0,0,3,6,10</pctClan>
 		<pctSL>10,20,40,50,75</pctSL>
-		<pctSL unitType='Aero'>7,18,32,40,62</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>7,18,32,40,62</pctSL>
 		<pctSL unitType='Vehicle'>7,15,28,30,50</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -56,7 +56,7 @@
 		<techMargin>1</techMargin>
 		<weightDistribution era='3075' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3075' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3075' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3075' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -71,9 +71,9 @@
 		<pctOmni>0,0,35,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<techMargin>1</techMargin>
@@ -105,9 +105,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>60,60,80,90,100</pctClan>
 		<pctSL>40,40,20,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,35,35,35</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>1</techMargin>
@@ -153,9 +153,9 @@
 		<pctOmni>40,40,75,95,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,55,55</pctSL>
 		<techMargin>1</techMargin>
@@ -165,9 +165,9 @@
 		<pctOmni>15,15,20,95,100</pctOmni>
 		<pctClan>75,75,90,100,100</pctClan>
 		<pctSL>25,25,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>80,20,95,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,20,95,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>15,85,45,50,50</pctSL>
 		<techMargin>1</techMargin>
@@ -294,7 +294,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3075' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3075' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3075' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3075' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='KP'>
 		<omniMargin>1</omniMargin>
@@ -355,9 +355,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,18,35,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,2,8</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>6,10,20,30,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,2,8</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>6,10,20,30,60</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
 		<salvage pct='5'>FS:10,DC:6</salvage>
@@ -369,7 +369,7 @@
 		<techMargin>1</techMargin>
 		<weightDistribution era='3075' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3075' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3075' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3075' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>1</omniMargin>
@@ -401,7 +401,7 @@
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3075' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3075' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='SOC'>
 		<techMargin>1</techMargin>
@@ -535,7 +535,7 @@
 		<pctOmni>3</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>55</pctSL>
-		<pctSL unitType='Aero'>22</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>22</pctSL>
 		<pctSL unitType='Vehicle'>32</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -553,7 +553,7 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>80</pctSL>
-		<pctSL unitType='Aero'>80</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>80</pctSL>
 		<pctSL unitType='Vehicle'>75</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -605,7 +605,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>55</pctSL>
-		<pctSL unitType='Aero'>30</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>30</pctSL>
 		<pctSL unitType='Vehicle'>37</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -747,9 +747,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>1</techMargin>
@@ -794,7 +794,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>44</pctSL>
-		<pctSL unitType='Aero'>37</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>37</pctSL>
 		<pctSL unitType='Vehicle'>28</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -1080,7 +1080,7 @@
 		<pctOmni>15</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>87</pctSL>
-		<pctSL unitType='Aero'>55</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>55</pctSL>
 		<pctSL unitType='Vehicle'>40</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -1098,7 +1098,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>65</pctSL>
-		<pctSL unitType='Aero'>40</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>40</pctSL>
 		<pctSL unitType='Vehicle'>29</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -1152,7 +1152,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>4</pctClan>
 		<pctSL>62</pctSL>
-		<pctSL unitType='Aero'>48</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>48</pctSL>
 		<pctSL unitType='Vehicle'>40</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -1304,7 +1304,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:1,FWL:2,NIOPS:7,WOB:7,DC:2</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1392,7 +1392,7 @@
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CGS:5,CCO:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2018,7 +2018,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:4,CLAN:3,CNC:4,BAN:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -2423,7 +2423,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:7,CNC:6,CLAN:4,IS:2+,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
@@ -2643,7 +2643,7 @@
 			<availability>DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,SOC:6,CSV:8,CGS:6,CCO:4,CWIE:4,CSA:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CGB:6,DC:2+</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -3547,7 +3547,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3644,7 +3644,7 @@
 			<availability>LA:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3782,7 +3782,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,OA:4,FVC:2,LA:2-,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,RCM:10,DC:2-</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -3843,7 +3843,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:3,DC:1,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:2-,CDP:4,TC:4,Periphery:2-</availability>
@@ -4314,7 +4314,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>OA:3+,CSR:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4354,7 +4354,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:5,FWL:1,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,BAN:4,Periphery:4-</availability>
@@ -4742,13 +4742,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB:4,FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -4946,13 +4946,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4+,MOC:3+,WOB:5+</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5316,7 +5316,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -5366,13 +5366,13 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FRR:3,CNC:3,MERC:3,CGB:3</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:3,MERC:2+</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -6768,7 +6768,7 @@
 			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,DTA:7,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5-</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
@@ -7278,7 +7278,7 @@
 			<availability>General:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:3,NIOPS:7,WOB:7,DC:2</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -7663,7 +7663,7 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:2,CNC:3,NIOPS:6,WOB:6,FS:2,DC:2</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -7679,7 +7679,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,OA:5,FVC:3,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
@@ -8213,7 +8213,7 @@
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
 		<availability>CS:1</availability>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CS:3,FRR:5,CNC:4,CGB:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8259,7 +8259,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:5,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8485,7 +8485,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,DC:1</availability>
 		<model name='CX-19'>
 			<availability>CS:2</availability>
@@ -8511,7 +8511,7 @@
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8621,7 +8621,7 @@
 			<availability>WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8727,7 +8727,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9161,7 +9161,7 @@
 			<availability>DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CGS:7,BAN:7,CWIE:6,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9482,7 +9482,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>DTA:5,FWL:5,WOB:3,RCM:5</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -9674,7 +9674,7 @@
 			<availability>CS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:5-</availability>
@@ -10021,7 +10021,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10030,7 +10030,7 @@
 			<availability>FRR:6,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:3,FS:3,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:2,FVC:2,LA:8,Periphery.MW:3</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:6-,Periphery:2-</availability>
@@ -11700,7 +11700,7 @@
 			<availability>CLAN:1,IS:2+,WOB:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>FRR:3,CNC:3,DC:4</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13040,7 +13040,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:4,CLAN:3,NIOPS:6,WOB:6</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
@@ -13227,7 +13227,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,RCM:8,DC:4</availability>
 		<model name='F-100'>
 			<availability>CC:2-,FVC:4-,HL:2-,LA:1,FRR:1,FWL:4-,Periphery.Deep:8,MERC:4-,DC:1,Periphery:4-</availability>
@@ -13390,7 +13390,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
@@ -13473,7 +13473,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rusalka' unitType='Aero' omni='IS'>
+	<chassis name='Rusalka' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6</availability>
 		<model name='S-RSL-O Invictus'>
 			<roles>interceptor</roles>
@@ -13621,7 +13621,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:5-</availability>
@@ -13636,7 +13636,7 @@
 			<availability>MERC:5,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -13674,7 +13674,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,FRR:6,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:2-</availability>
@@ -13748,7 +13748,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,WOB:4,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -14006,13 +14006,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter'>
 		<availability>CSR:2</availability>
 		<model name='XR'>
 			<availability>CSR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:5,CW:5,CSV:5,CLAN:4,CNC:5,CGS:4,CJF:7,CCO:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14142,7 +14142,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:2,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,FWL:3-,MH:2,DC:3-</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14190,7 +14190,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shade' unitType='Aero' omni='IS'>
+	<chassis name='Shade' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:5</availability>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
@@ -14359,7 +14359,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
@@ -14374,7 +14374,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FWL:4,WOB:4,FWL.KIS:6,FWL.FWG:5</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14411,7 +14411,7 @@
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:6,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>HL:4,LA:4,Periphery.Deep:6,MERC:5,DC:5,Periphery:6</availability>
@@ -14523,7 +14523,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,DC:7</availability>
 		<model name='SL-15'>
 			<availability>HL:2-,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
@@ -14611,7 +14611,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -14623,7 +14623,7 @@
 			<availability>WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:2,FRR:5,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
@@ -14846,7 +14846,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:4</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -14864,7 +14864,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -14981,7 +14981,7 @@
 			<availability>LA:4,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,DTA:6,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,RCM:6,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:3-,LA:2-,IS:4-,FS:3-,Periphery:4-</availability>
@@ -15072,7 +15072,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Striga' unitType='Aero' omni='IS'>
+	<chassis name='Striga' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
@@ -15136,7 +15136,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:4,Periphery.HR:2,DC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,FS:6,MERC:6</availability>
@@ -15210,7 +15210,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:6,General:2,CGB:7</availability>
@@ -15319,7 +15319,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -15400,7 +15400,7 @@
 			<availability>DTA:6,FVC:4,IS:4,MERC:5,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FRR:4,CNC:4,DC:5</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -15637,7 +15637,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -15733,7 +15733,7 @@
 			<availability>CC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -15888,7 +15888,7 @@
 			<availability>FRR:5-,DC:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:5</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6,CLAN:3</availability>
@@ -16017,7 +16017,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,PIR:2,FWL:3,MERC:3,RCM:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:3-,HL:2-,IS:2-,MERC:3-,Periphery:4-</availability>
@@ -16035,7 +16035,7 @@
 			<availability>CC:7,MOC:5,MERC:5,RCM:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:5,MOC:5,General:6,TC:5</availability>
@@ -16084,7 +16084,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -16147,7 +16147,7 @@
 			<availability>IS:2,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,FVC:2,Periphery.CM:3,Periphery.ME:3,MERC:2,TC:6,Periphery:2</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
@@ -16249,7 +16249,7 @@
 			<availability>DC:4-</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16325,7 +16325,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -16342,7 +16342,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -16598,7 +16598,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -16833,7 +16833,7 @@
 			<availability>CSR:8,CSV:8,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16919,7 +16919,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:5,CDP:2,Periphery:2,TC:2</availability>
 		<model name='VLC-5N'>
 			<availability>General:2</availability>
@@ -17482,7 +17482,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CSR:6,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -17590,7 +17590,7 @@
 			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:3-,CLAN:1,NIOPS:3-,WOB:3-</availability>

--- a/MekHQ/data/forcegenerator/3078.xml
+++ b/MekHQ/data/forcegenerator/3078.xml
@@ -25,7 +25,7 @@
 		<pctOmni>0,3,7,10,20</pctOmni>
 		<pctClan>0,0,3,6,11</pctClan>
 		<pctSL>13,27,47,56,76</pctSL>
-		<pctSL unitType='Aero'>9,21,37,46,68</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>9,21,37,46,68</pctSL>
 		<pctSL unitType='Vehicle'>9,21,31,34,56</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -56,7 +56,7 @@
 		<techMargin>2</techMargin>
 		<weightDistribution era='3078' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3078' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3078' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3078' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -71,9 +71,9 @@
 		<pctOmni>0,0,36,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<techMargin>2</techMargin>
@@ -105,9 +105,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>2</techMargin>
@@ -153,9 +153,9 @@
 		<pctOmni>30,30,60,90,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,60,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,60,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,55,55</pctSL>
 		<techMargin>2</techMargin>
@@ -165,9 +165,9 @@
 		<pctOmni>15,15,20,96,100</pctOmni>
 		<pctClan>75,75,91,100,100</pctClan>
 		<pctSL>25,25,8,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>80,20,95,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,20,95,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>15,85,45,50,50</pctSL>
 		<techMargin>2</techMargin>
@@ -320,7 +320,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3078' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3078' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3078' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3078' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='KP'>
 		<omniMargin>2</omniMargin>
@@ -394,9 +394,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,6,22,38,43</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,2,8</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>8,14,26,36,63</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,2,8</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>8,14,26,36,63</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
 		<salvage pct='5'>FS:9,DC:7</salvage>
@@ -408,7 +408,7 @@
 		<techMargin>2</techMargin>
 		<weightDistribution era='3078' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3078' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3078' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3078' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>2</omniMargin>
@@ -485,7 +485,7 @@
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3078' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3078' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TP'>
 		<pctOmni>0,3,10,14,20</pctOmni>
@@ -624,7 +624,7 @@
 		<pctOmni>3</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>63</pctSL>
-		<pctSL unitType='Aero'>26</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>26</pctSL>
 		<pctSL unitType='Vehicle'>38</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -642,8 +642,8 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>82</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>83</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>83</pctSL>
 		<pctClan unitType='Vehicle'>5</pctClan>
 		<pctSL unitType='Vehicle'>79</pctSL>
 		<omniMargin>2</omniMargin>
@@ -704,7 +704,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>62</pctSL>
-		<pctSL unitType='Aero'>34</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>34</pctSL>
 		<pctSL unitType='Vehicle'>40</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -846,9 +846,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>2</techMargin>
@@ -900,7 +900,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>50</pctSL>
-		<pctSL unitType='Aero'>41</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>41</pctSL>
 		<pctSL unitType='Vehicle'>31</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -966,8 +966,8 @@
 		<pctOmni>24</pctOmni>
 		<pctClan>9</pctClan>
 		<pctSL>73</pctSL>
-		<pctClan unitType='Aero'>8</pctClan>
-		<pctSL unitType='Aero'>92</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>8</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92</pctSL>
 		<pctClan unitType='Vehicle'>6</pctClan>
 		<pctSL unitType='Vehicle'>100</pctSL>
 		<omniMargin>2</omniMargin>
@@ -1214,7 +1214,7 @@
 		<pctOmni>13</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>53</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>53</pctSL>
 		<pctSL unitType='Vehicle'>39</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -1232,7 +1232,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>68</pctSL>
-		<pctSL unitType='Aero'>43</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>43</pctSL>
 		<pctSL unitType='Vehicle'>31</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -1286,7 +1286,7 @@
 		<pctOmni>11</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>71</pctSL>
-		<pctSL unitType='Aero'>55</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>55</pctSL>
 		<pctSL unitType='Vehicle'>46</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -1438,7 +1438,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:1,FWL:1,NIOPS:4,WOB:7,DC:1</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1542,7 +1542,7 @@
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CGS:5,CCO:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2193,7 +2193,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:2,CW:4,CLAN:3,CNC:4,BAN:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,General:6</availability>
@@ -2624,7 +2624,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:4,CNC:6,CLAN:4,IS:2+,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
@@ -2844,7 +2844,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CGS:6,CCO:4,CJF:7,CWIE:4,CGB:6,DC:1+</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -3787,7 +3787,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3884,7 +3884,7 @@
 			<availability>LA:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4025,7 +4025,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>PR:8,HL:2,DoO:10,FRR:3,DO:10,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,RFS:8,MOC:5,CC:3,WOB:6,DGM:10,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,FVC:2,LA:1-,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10,DC:1-</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4090,7 +4090,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,FWL:2,DC:1,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:1-,CDP:4,TC:4,Periphery:1-</availability>
@@ -4564,13 +4564,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>CSR:2-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>OA:3+,CSR:2</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4610,7 +4610,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:4,CGB.FRR:2,ROS:4,DC:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:4</availability>
@@ -5001,13 +5001,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB:4,FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5205,7 +5205,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:3,DA:4</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5214,7 +5214,7 @@
 			<availability>DA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4+,MOC:3+,WOB:5+</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5613,7 +5613,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -5681,13 +5681,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FRR:3,CGB.FRR:3,CNC:2,MERC:3,CGB:3</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:4,MERC:2+</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7141,7 +7141,7 @@
 			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>DoO:7,CLAN:4,WOB:9,DO:7,DGM:7,MERC:4-,CS:8,DTA:7,SC:7,CDS:5,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,TP:7</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
@@ -7677,7 +7677,7 @@
 			<availability>General:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,ROS:6,CLAN:3,CNC:4,FWL:2,NIOPS:7,WOB:7,DC:1</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -8068,7 +8068,7 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:1,ROS:4,CNC:2,NIOPS:6,WOB:6,FS:1,DC:1</availability>
 		<model name='HCT-212'>
 			<availability>LA:5,FS:5</availability>
@@ -8084,7 +8084,7 @@
 			<availability>CS:4,ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,OA:5,FVC:3,CSR:2,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
@@ -8628,7 +8628,7 @@
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
 		<availability>CS:1</availability>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CS:3,FRR:5,CGB.FRR:5,CNC:4,CGB:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8684,7 +8684,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:3,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8914,7 +8914,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:1,NIOPS:3,WOB:6,DC:1</availability>
 		<model name='CX-19'>
 			<availability>CS:2</availability>
@@ -8940,7 +8940,7 @@
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:4,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9068,7 +9068,7 @@
 			<availability>WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9174,7 +9174,7 @@
 			<availability>FS:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9637,7 +9637,7 @@
 			<availability>DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CGS:7,BAN:7,CWIE:6,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9961,7 +9961,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>PR:5,DoO:5,WOB:3,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,DA:5,RCM:5,RFS:5</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10163,7 +10163,7 @@
 			<availability>CS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:5-</availability>
@@ -10524,7 +10524,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:4,CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10533,7 +10533,7 @@
 			<availability>FRR:6,CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:3,FS:2,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:1,FVC:2,LA:7,Periphery.MW:3</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
@@ -10746,7 +10746,7 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Malaika' unitType='Aero'>
+	<chassis name='Malaika' unitType='AeroSpaceFighter'>
 		<availability>FWL:4-</availability>
 		<model name='BAM-1A1'>
 			<availability>General:8</availability>
@@ -12307,7 +12307,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>FRR:3,CGB.FRR:3,CNC:3,DC:4</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -12477,7 +12477,7 @@
 			<availability>FS:2-,DC:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CGB:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13761,7 +13761,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:4,ROS:5,CLAN:3,NIOPS:6,WOB:6</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
@@ -13954,7 +13954,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>PR:7,DoO:8,FRR:5,DO:8,FS:3,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,RFS:7,MOC:3,CC:3,WOB:6,DGM:8,MERC:2,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:1,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:4</availability>
 		<model name='F-100'>
 			<availability>CC:1-,FVC:4-,HL:1-,LA:1,FRR:1,CGB.FRR:1,FWL:3-,Periphery.Deep:8,MERC:3-,DC:1,Periphery:4-</availability>
@@ -14130,7 +14130,7 @@
 			<availability>CGB:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:1,NIOPS:2,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
@@ -14213,7 +14213,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rusalka' unitType='Aero' omni='IS'>
+	<chassis name='Rusalka' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6</availability>
 		<model name='S-RSL-O Invictus'>
 			<roles>interceptor</roles>
@@ -14361,7 +14361,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:5-</availability>
@@ -14380,7 +14380,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -14418,7 +14418,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,FRR:6,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:2-</availability>
@@ -14492,7 +14492,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,CGB.FRR:4,ROS:5,WOB:4,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -14766,13 +14766,13 @@
 			<availability>CHH:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter'>
 		<availability>CSR:1</availability>
 		<model name='XR'>
 			<availability>CSR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:3,CW:5,CLAN:4,CNC:5,CGS:4,CJF:7,CCO:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14905,7 +14905,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,CGB.FRR:2,ROS:4,FWL:3-,MH:2,DC:3-</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14953,7 +14953,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shade' unitType='Aero' omni='IS'>
+	<chassis name='Shade' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:5</availability>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
@@ -15134,7 +15134,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
@@ -15149,13 +15149,13 @@
 			<availability>ROS:6,DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FWL:4,WOB:4,FWL.KIS:6,FWL.FWG:5</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -15192,7 +15192,7 @@
 			<availability>MERC.WD:8,CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:6,CGB.FRR:6,ROS:3,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>HL:4,LA:2,Periphery.Deep:7,MERC:4,DC:4,Periphery:6</availability>
@@ -15308,7 +15308,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,CGB.FRR:7,ROS:4,DC:7</availability>
 		<model name='SL-15'>
 			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
@@ -15399,7 +15399,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,ROS:5,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -15411,7 +15411,7 @@
 			<availability>ROS:4,WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:3,FRR:5,CGB.FRR:5,ROS:3,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
@@ -15652,7 +15652,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:5</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -15670,7 +15670,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -15787,7 +15787,7 @@
 			<availability>LA:4,ROS:4,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:2,RFS:5,MOC:2,CC:5,IS:3,WOB:3,DGM:6,MERC:5,CIR:2,Periphery:1,TC:2,CS:3,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:2-,LA:2-,IS:4-,FS:2-,Periphery:4-</availability>
@@ -15874,7 +15874,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Striga' unitType='Aero' omni='IS'>
+	<chassis name='Striga' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
@@ -15938,7 +15938,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:1,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:3,CGB.FRR:2,Periphery.HR:2,ROS:5,DC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:6,MERC:6</availability>
@@ -16012,7 +16012,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,CBS:6,General:2,CGB:7</availability>
@@ -16121,7 +16121,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,ROS:6,CLAN:5,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:5,CLAN:8</availability>
@@ -16209,7 +16209,7 @@
 			<availability>DTA:7,SC:6,FVC:2,DoO:6,MCM:6,ROS:6,IS:2,DO:6,DGM:6,TP:6,MERC:5,DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FRR:4,CGB.FRR:4,CNC:4,DC:5</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -16461,7 +16461,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -16560,7 +16560,7 @@
 			<availability>CC:2,MOC:2,CC.LCC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:1,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -16727,7 +16727,7 @@
 			<availability>FRR:5-,CGB.FRR:5-,DC:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:4,ROS:7,CLAN:3,NIOPS:9,WOB:8,DC:5</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6,CLAN:2</availability>
@@ -16859,7 +16859,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,PR:3,Periphery.CM:2,PG:3,PIR:1,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:3-,HL:1-,IS:1-,MERC:3-,Periphery:4-</availability>
@@ -16877,7 +16877,7 @@
 			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:4,MOC:5,General:6,TC:5</availability>
@@ -16943,7 +16943,7 @@
 			<availability>TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -17006,7 +17006,7 @@
 			<availability>IS:3,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,FVC:2,Periphery.CM:3,Periphery.ME:3,MERC:2,DA:2,TC:6,Periphery:2</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
@@ -17118,7 +17118,7 @@
 			<availability>DC:3-</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -17194,7 +17194,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -17211,7 +17211,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -17482,7 +17482,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -17721,7 +17721,7 @@
 			<availability>CSR:8,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -17811,7 +17811,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:5,CDP:2,Periphery:3,TC:2</availability>
 		<model name='VLC-5N'>
 			<availability>General:1</availability>
@@ -18411,7 +18411,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CSR:3,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18525,7 +18525,7 @@
 			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,ROS:4,CLAN:1,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:3-,CLAN:1,NIOPS:2-,WOB:3-</availability>

--- a/MekHQ/data/forcegenerator/3082.xml
+++ b/MekHQ/data/forcegenerator/3082.xml
@@ -20,7 +20,7 @@
 		<pctOmni>0,4,9,11,20</pctOmni>
 		<pctClan>0,0,3,7,14</pctClan>
 		<pctSL>17,38,58,65,78</pctSL>
-		<pctSL unitType='Aero'>12,26,44,54,78</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>12,26,44,54,78</pctSL>
 		<pctSL unitType='Vehicle'>12,29,36,40,65</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -35,7 +35,7 @@
 		<techMargin>3</techMargin>
 		<weightDistribution era='3082' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3082' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3082' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3082' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -50,9 +50,9 @@
 		<pctOmni>0,0,38,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<techMargin>3</techMargin>
@@ -120,9 +120,9 @@
 		<pctOmni>20,20,30,88,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,40,95,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,40,95,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,55,55</pctSL>
 		<techMargin>3</techMargin>
@@ -132,9 +132,9 @@
 		<pctOmni>15,15,20,98,100</pctOmni>
 		<pctClan>75,75,93,100,100</pctClan>
 		<pctSL>25,25,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>80,20,95,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,20,95,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>15,85,45,50,50</pctSL>
 		<techMargin>3</techMargin>
@@ -221,9 +221,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>3</techMargin>
@@ -288,7 +288,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3082' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3082' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3082' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3082' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<pctOmni>0,11,14,17,19</pctOmni>
@@ -355,9 +355,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,14,29,42,47</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,3,9</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>12,20,34,44,67</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,3,9</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>12,20,34,44,67</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
 		<salvage pct='5'>FS:9,DC:10</salvage>
@@ -369,7 +369,7 @@
 		<techMargin>3</techMargin>
 		<weightDistribution era='3082' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3082' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3082' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3082' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>3</omniMargin>
@@ -396,9 +396,9 @@
 		<pctOmni>10,10,20,88,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,95,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,95,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>3</techMargin>
@@ -453,7 +453,7 @@
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3082' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3082' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TP'>
 		<pctOmni>0,4,11,15,22</pctOmni>
@@ -496,9 +496,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,20,35,45,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,4,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>15,25,40,50,70</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,4,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>15,25,40,50,70</pctSL>
 		<techMargin>3</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3082' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -588,7 +588,7 @@
 		<pctOmni>3</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>74</pctSL>
-		<pctSL unitType='Aero'>33</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>33</pctSL>
 		<pctSL unitType='Vehicle'>48</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -606,8 +606,8 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>10</pctClan>
 		<pctSL>85</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>87</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>87</pctSL>
 		<pctClan unitType='Vehicle'>5</pctClan>
 		<pctSL unitType='Vehicle'>86</pctSL>
 		<omniMargin>3</omniMargin>
@@ -668,7 +668,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>73</pctSL>
-		<pctSL unitType='Aero'>40</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>40</pctSL>
 		<pctSL unitType='Vehicle'>46</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -778,9 +778,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>3</techMargin>
@@ -824,7 +824,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>58</pctSL>
-		<pctSL unitType='Aero'>48</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>48</pctSL>
 		<pctSL unitType='Vehicle'>37</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -882,8 +882,8 @@
 		<pctOmni>24</pctOmni>
 		<pctClan>11</pctClan>
 		<pctSL>79</pctSL>
-		<pctClan unitType='Aero'>8</pctClan>
-		<pctSL unitType='Aero'>92</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>8</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92</pctSL>
 		<pctClan unitType='Vehicle'>6</pctClan>
 		<pctSL unitType='Vehicle'>100</pctSL>
 		<omniMargin>3</omniMargin>
@@ -1062,7 +1062,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>84</pctSL>
-		<pctSL unitType='Aero'>52</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>52</pctSL>
 		<pctSL unitType='Vehicle'>38</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1072,7 +1072,7 @@
 		<pctOmni>11</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>74</pctSL>
-		<pctSL unitType='Aero'>48</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>48</pctSL>
 		<pctSL unitType='Vehicle'>35</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1118,7 +1118,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>65</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>65</pctSL>
 		<pctSL unitType='Vehicle'>55</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1351,7 +1351,7 @@
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CCO:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1978,7 +1978,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:2,CCC:2,CSR:2,CW:4,CLAN:2,CNC:4,RA:1,BAN:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,General:6,RA:7</availability>
@@ -2410,7 +2410,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:4,ROS:2+,CNC:5,CLAN:4,IS:2+,RA:5,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
@@ -2598,7 +2598,7 @@
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CCO:3,CGB:6,CWIE:4</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
@@ -3502,7 +3502,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3593,7 +3593,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3730,7 +3730,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>PR:8,HL:2,DoO:10,DO:10,FS:2,RA.OA:4,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:7,RFS:8,MOC:5,CC:2,DGM:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -3795,7 +3795,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,RA.OA:2,FVC:5,OA:2,LA:8,CGB.FRR:2,ROS:5,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:3,CDP:3,TC:3</availability>
@@ -4259,13 +4259,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:2,CSR:2-,RA:3-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:3,OA:3+,CSR:2,RA:2</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4305,7 +4305,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:3,OA:3,LA:4,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
 		<model name='CSR-12D'>
 			<availability>FS:5</availability>
@@ -4674,13 +4674,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -4891,7 +4891,7 @@
 			<availability>CLAN:6,IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,PR:2,MERC:2,FS:2,DTA:2,ROS:2,PG:2,FWL:3,DA:5,RCM:2,RFS:2,DC:2</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -4900,7 +4900,7 @@
 			<availability>DA:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,MOC:4,SC:3,MCM:3,DGM:3,MSC:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5256,7 +5256,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>PR:6,LA:5,ROS:6,PG:6,MERC:5,FS:3,RFS:6</availability>
@@ -5308,13 +5308,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>PR:1,LA:3,CGB.FRR:3,ROS:1,PG:1,MERC:3,FS:1,RFS:1,CGB:3</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:4,ROS:3,MERC:3</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -6701,7 +6701,7 @@
 			<availability>RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>DoO:7,CLAN:3,DO:7,DGM:7,MERC:3,DTA:7,SC:7,CDS:4,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:5,TP:7</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
@@ -7161,7 +7161,7 @@
 			<availability>General:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:6,CLAN:2,CNC:3,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -7543,13 +7543,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,CSR:2,HL:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:3,TC:2-,Periphery:3-,RA.OA:5,FVC:4,OA:5,LA:2-</availability>
 		<model name='HCT-213'>
 			<availability>General:3</availability>
@@ -8042,7 +8042,7 @@
 			<availability>CC:8,MOC:8,FWL:4,MERC:6,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:3,CGB.FRR:5,ROS:4,CNC:4,MERC:3,FS:3,CGB:5,DC:3</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8080,7 +8080,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:3,CLAN:4,RA:4</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8302,7 +8302,7 @@
 			<availability>CHH:7,CW:3,ROS:3,CJF:4,CWIE:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:4,CLAN:4,RA:5,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8425,7 +8425,7 @@
 			<availability>DTA:5,SC:5,MCM:5,ROS:5,DGM:5,MSC:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8531,7 +8531,7 @@
 			<availability>FS:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8989,7 +8989,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,BAN:7,CWIE:5,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9275,7 +9275,7 @@
 			<availability>CGB.FRR:2-,DC:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>PR:6,DoO:6,DO:6,FS:2,SC:6,Periphery.MW:2,Periphery.CM:2,FWL:6,MH:2,MSC:4,RFS:6,CC:2,MOC:2,DGM:6,MERC:2,DTA:6,FVC:2,LA:2,MCM:6,ROS:2,PG:6,Periphery.ME:2,TP:6,DA:6,RCM:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -9446,7 +9446,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:4-</availability>
@@ -9765,7 +9765,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -9774,7 +9774,7 @@
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,OA:1,HL:4,LA:7,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
@@ -9980,7 +9980,7 @@
 			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Malaika' unitType='Aero'>
+	<chassis name='Malaika' unitType='AeroSpaceFighter'>
 		<availability>FWL:3-</availability>
 		<model name='BAM-1A1'>
 			<availability>General:8</availability>
@@ -10627,7 +10627,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,MERC:2</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -11473,7 +11473,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,CNC:4,DC:5</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -11644,7 +11644,7 @@
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA:1,CGB:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -12145,7 +12145,7 @@
 			<availability>CSR:5,CBS:7,RA:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:4</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -12493,7 +12493,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,SC:5,MCM:5,ROS:3,FWL:3,DGM:5,MSC:4,RCM:3,MERC:2</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -12852,7 +12852,7 @@
 			<availability>LA:1,ROS:1,FS:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5,CLAN:2,NIOPS:6</availability>
 		<model name='RPR-100'>
 			<availability>General:3,NIOPS:8</availability>
@@ -13034,7 +13034,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>PR:7,DoO:8,DO:8,FS:2,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:6,RFS:7,MOC:2,CC:3,DGM:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
 		<model name='F-100'>
 			<availability>FVC:3-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
@@ -13359,7 +13359,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,OA:2-,LA:4,ROS:3,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:4-</availability>
@@ -13378,7 +13378,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -13416,7 +13416,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -13425,7 +13425,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:1-</availability>
@@ -13496,7 +13496,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,CGB.FRR:4,ROS:5,DC:1</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -13760,13 +13760,13 @@
 			<availability>CJF:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter'>
 		<availability>CSR:1,RA:1</availability>
 		<model name='XR'>
 			<availability>CSR:8,RA:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:3,CW:4,CNC:5,CLAN:4,CJF:6,CCO:4,RA:4,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13856,7 +13856,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,OA:7,LA:7,CGB.FRR:2,ROS:6,FWL:2-,MH:2,DC:2-</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14038,7 +14038,7 @@
 			<availability>CHH:4,CDS:4,CSR:2,CW:4,ROS:8,CNC:4,CJF:4,RA:4,CGB:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,OA:4,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:3,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
@@ -14050,13 +14050,13 @@
 			<availability>ROS:6,MERC:3,DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>PR:4,DoO:6,DO:6,DGM:6,DTA:4,SC:6,MCM:6,ROS:3,PG:4,FWL:5,MSC:4,TP:6,RCM:4,DA:4,RFS:4</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14096,7 +14096,7 @@
 			<availability>CDS:2,CW:6,ROS:4,CNC:6,CJF:6,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:1,OA:3,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,HL:3,Periphery.Deep:7,MERC:4,DC:4,Periphery:5</availability>
@@ -14209,7 +14209,7 @@
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,OA:5,CGB.FRR:7,ROS:4,DC:7,CGB:4</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
@@ -14308,7 +14308,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:2,OA:2,ROS:4,NIOPS:6,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -14320,7 +14320,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,OA:2,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:3,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
@@ -14554,7 +14554,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:6,TC:4-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -14675,7 +14675,7 @@
 			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:4,RFS:5,MOC:3,CC:5,IS:3,DGM:6,MERC:5,TC:2,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:3-,Periphery:3-</availability>
@@ -14801,7 +14801,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,OA:2,LA:3,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
@@ -14860,7 +14860,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,CBS:6,General:2,RA:7,CGB:7</availability>
@@ -14934,7 +14934,7 @@
 			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:5,DC:3</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -14990,7 +14990,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:4,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:5,CLAN:8,RA:9</availability>
@@ -15089,7 +15089,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CGB.FRR:5,ROS:3,CNC:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -15289,7 +15289,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -15389,7 +15389,7 @@
 			<availability>CC:3,MOC:3,CC.LCC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -15553,7 +15553,7 @@
 			<availability>CGB.FRR:4-,DC:4-</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CW:3,ROS:7,CLAN:2,NIOPS:9,MERC:3,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
@@ -15651,7 +15651,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,PR:3,Periphery.CM:2,PG:3,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
@@ -15669,7 +15669,7 @@
 			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:1,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:4,MOC:4,General:6,TC:4</availability>
@@ -15738,7 +15738,7 @@
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,OA:6,NIOPS:7,RA:2</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,OA:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -15798,7 +15798,7 @@
 			<availability>IS:3,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:6,FVC:3,HL:1,Periphery.CM:4,Periphery.ME:4,MERC:3,DA:3,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:5,DA:5,TC:8</availability>
@@ -15913,7 +15913,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15981,7 +15981,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>PR:2,LA:5,ROS:2,PG:2,MERC:2,RFS:2,DC:2</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -15998,7 +15998,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -16051,7 +16051,7 @@
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -16273,7 +16273,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -16488,7 +16488,7 @@
 			<availability>CSR:8,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:8,BAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16566,7 +16566,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>HL:2,MERC:6,FS:4,CDP:3,Periphery:3,TC:1</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -17046,7 +17046,7 @@
 			<availability>DoO:8,DO:8,TP:8,DA:8,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -17112,7 +17112,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CSR:3,CLAN:5,RA:4</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -17211,7 +17211,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/MekHQ/data/forcegenerator/3085.xml
+++ b/MekHQ/data/forcegenerator/3085.xml
@@ -20,7 +20,7 @@
 		<pctOmni>0,5,10,12,20</pctOmni>
 		<pctClan>0,0,4,8,16</pctClan>
 		<pctSL>20,46,66,72,80</pctSL>
-		<pctSL unitType='Aero'>15,30,50,60,85</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>15,30,50,60,85</pctSL>
 		<pctSL unitType='Vehicle'>15,35,40,45,72</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -35,15 +35,15 @@
 		<techMargin>3</techMargin>
 		<weightDistribution era='3085' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3085' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3085' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3085' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CCC'>
 		<pctOmni>0,0,40,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<techMargin>3</techMargin>
@@ -111,9 +111,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>75,75,95,100,100</pctClan>
 		<pctSL>25,25,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>80,20,95,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,20,95,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>15,85,45,50,50</pctSL>
 		<techMargin>3</techMargin>
@@ -192,9 +192,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>3</techMargin>
@@ -259,7 +259,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3085' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3085' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3085' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3085' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>3</omniMargin>
@@ -331,7 +331,7 @@
 		<techMargin>3</techMargin>
 		<weightDistribution era='3085' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3085' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3085' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3085' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>3</omniMargin>
@@ -358,9 +358,9 @@
 		<pctOmni>0,0,0,86,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,95,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,95,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>3</techMargin>
@@ -415,7 +415,7 @@
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3085' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3085' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TP'>
 		<pctOmni>0,5,12,16,24</pctOmni>
@@ -458,9 +458,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,20,35,45,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,4,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>15,25,40,50,70</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,4,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>15,25,40,50,70</pctSL>
 		<techMargin>3</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3085' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -550,7 +550,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>83</pctSL>
-		<pctSL unitType='Aero'>39</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>39</pctSL>
 		<pctSL unitType='Vehicle'>55</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -568,8 +568,8 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>12</pctClan>
 		<pctSL>88</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>5</pctClan>
 		<pctSL unitType='Vehicle'>91</pctSL>
 		<omniMargin>3</omniMargin>
@@ -630,7 +630,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>81</pctSL>
-		<pctSL unitType='Aero'>45</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>45</pctSL>
 		<pctSL unitType='Vehicle'>50</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -748,9 +748,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>3</techMargin>
@@ -794,7 +794,7 @@
 		<pctOmni>5</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>65</pctSL>
-		<pctSL unitType='Aero'>54</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>54</pctSL>
 		<pctSL unitType='Vehicle'>41</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -852,8 +852,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>12</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>8</pctClan>
-		<pctSL unitType='Aero'>92</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>8</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92</pctSL>
 		<pctClan unitType='Vehicle'>6</pctClan>
 		<pctSL unitType='Vehicle'>100</pctSL>
 		<omniMargin>3</omniMargin>
@@ -1044,7 +1044,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>83</pctSL>
-		<pctSL unitType='Aero'>52</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>52</pctSL>
 		<pctSL unitType='Vehicle'>38</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1054,7 +1054,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>78</pctSL>
-		<pctSL unitType='Aero'>52</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>52</pctSL>
 		<pctSL unitType='Vehicle'>38</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1100,7 +1100,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>95</pctSL>
-		<pctSL unitType='Aero'>73</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>73</pctSL>
 		<pctSL unitType='Vehicle'>62</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1345,7 +1345,7 @@
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CCO:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2002,7 +2002,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:2,CCC:2,CW:4,CLAN:2,CNC:4,RA:2,BAN:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>CSA:7,General:6,RA:7</availability>
@@ -2440,7 +2440,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CNC:5,CLAN:4,IS:2+,RA:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
@@ -2622,7 +2622,7 @@
 			<availability>DC:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CCO:3,CGB:6,CWIE:4</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
@@ -3581,7 +3581,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3672,7 +3672,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CW:5,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3812,7 +3812,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>PR:8,HL:2,DoO:10,DO:10,FS:3,RA.OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:10,RFS:8,MOC:5,CC:2,OP:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,RF:8,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -3877,7 +3877,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:3,CDP:3,TC:3</availability>
@@ -4374,13 +4374,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:3,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4420,7 +4420,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:3,LA:3,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
 		<model name='CSR-12D'>
 			<availability>FS:6</availability>
@@ -4826,13 +4826,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5043,7 +5043,7 @@
 			<availability>CLAN:6,IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,PR:3,MERC:3,FS:3,DTA:3,RF:3,ROS:3,PG:3,FWL:4,DA:5,RCM:3,RFS:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5058,7 +5058,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,MOC:4,MSC:3</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5459,7 +5459,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:5,FS:6,RFS:6</availability>
@@ -5511,13 +5511,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>PR:2,RF:2,LA:3,CGB.FRR:3,ROS:2,PG:2,MERC:3,FS:2,RFS:2,CGB:3</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:5,ROS:4,MERC:3</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -6964,7 +6964,7 @@
 			<availability>RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>OP:7,DoO:7,CLAN:3,DO:7,MERC:4,DTA:7,CDS:4,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:7,TP:7</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
@@ -7440,7 +7440,7 @@
 			<availability>General:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:6,CLAN:2,CNC:3,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -7833,13 +7833,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,HL:2-,LA:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:3</availability>
@@ -8347,7 +8347,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:4,CGB.FRR:5,ROS:6,CNC:4,MERC:4,FS:4,CGB:5,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8385,7 +8385,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8608,7 +8608,7 @@
 			<availability>CHH:7,CW:3,ROS:3,CJF:4,CWIE:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CLAN:4,RA:7,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8742,7 +8742,7 @@
 			<availability>DTA:5,ROS:5,MSC:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8848,7 +8848,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9308,7 +9308,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,BAN:7,CWIE:5,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9633,7 +9633,7 @@
 			<availability>CGB.FRR:2-,DC:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:3,MERC:3,DTA:6,FVC:3,RF:6,LA:3,ROS:3,Periphery.MW:3,Periphery.CM:3,PG:6,Periphery.ME:3,FWL:6,MH:3,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -9810,7 +9810,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:4-</availability>
@@ -10129,13 +10129,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:4,ROS:4</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10144,7 +10144,7 @@
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,HL:4,LA:6,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:4-,Periphery:2-</availability>
@@ -10378,7 +10378,7 @@
 			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Malaika' unitType='Aero'>
+	<chassis name='Malaika' unitType='AeroSpaceFighter'>
 		<availability>FWL:2-</availability>
 		<model name='BAM-1A1'>
 			<availability>General:8</availability>
@@ -11037,7 +11037,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,MERC:3</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -11303,7 +11303,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:4,LA:5,CWIE:4</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -11951,7 +11951,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,CNC:4,DC:5</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -12125,7 +12125,7 @@
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA:2,CGB:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -12632,7 +12632,7 @@
 			<availability>RA:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:5</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -12819,7 +12819,7 @@
 	<chassis name='Phoenix' unitType='Mek'>
 		<availability>LA:1-,MERC:2-,TC:2-,Periphery:2-</availability>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:3,MERC:3</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -12995,7 +12995,7 @@
 			<availability>CC:3,MOC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>DTA:4,ROS:4,FWL:4,MSC:5,RCM:4,MERC:3</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -13407,7 +13407,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5,CLAN:2,NIOPS:6</availability>
 		<model name='RPR-100'>
 			<availability>General:3,NIOPS:8</availability>
@@ -13586,7 +13586,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>PR:7,DoO:8,DO:8,FS:2,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:8,RFS:7,MOC:2,CC:2,OP:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,RF:7,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
 		<model name='F-100'>
 			<availability>FVC:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
@@ -13758,7 +13758,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -13926,7 +13926,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:4-</availability>
@@ -13945,7 +13945,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -13983,7 +13983,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:5</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -13992,7 +13992,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:1-</availability>
@@ -14063,7 +14063,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,CGB.FRR:4,ROS:5,DC:1</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -14236,7 +14236,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:5</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -14358,13 +14358,13 @@
 			<availability>CJF:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter'>
 		<availability>RA:1</availability>
 		<model name='XR'>
 			<availability>RA:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CW:4,CNC:5,CLAN:4,CJF:6,CCO:4,RA:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14454,7 +14454,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,LA:7,CGB.FRR:2,ROS:7,MH:2,CGB:0</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14693,7 +14693,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
@@ -14705,13 +14705,13 @@
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>OP:6,PR:6,DoO:6,DO:6,DTA:6,RF:6,ROS:4,PG:6,FWL:5,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14751,7 +14751,7 @@
 			<availability>CDS:4,CW:6,ROS:4,CNC:6,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,HL:3,Periphery.Deep:8,MERC:3,DC:3,Periphery:5</availability>
@@ -14868,7 +14868,7 @@
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,CGB.FRR:7,ROS:4,DC:7,CGB:5</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
@@ -14980,7 +14980,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:2,ROS:4,NIOPS:6,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -14992,7 +14992,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:4,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
@@ -15219,7 +15219,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:6-,TC:4-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -15274,7 +15274,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:4,LA:4</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -15358,7 +15358,7 @@
 			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:6,RFS:5,MOC:3,CC:5,OP:6,IS:3,MERC:5,TC:3,DTA:6,RF:5,LA:5,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:3-,Periphery:3-</availability>
@@ -15499,7 +15499,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,LA:2,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
@@ -15552,7 +15552,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,General:2,RA:7,CGB:7</availability>
@@ -15626,7 +15626,7 @@
 			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:7,DC:5</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -15691,7 +15691,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:4,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CLAN:8,RA:9</availability>
@@ -15793,7 +15793,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:1,CGB.FRR:5,ROS:4,CNC:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -16029,7 +16029,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -16141,7 +16141,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -16353,7 +16353,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CW:3,ROS:7,CLAN:2,NIOPS:9,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
@@ -16451,7 +16451,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,PR:3,RF:3,Periphery.CM:2,PG:3,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
@@ -16469,7 +16469,7 @@
 			<availability>CC:7,MOC:5,PR:8,RF:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:1,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:3,MOC:4,General:6,TC:4</availability>
@@ -16541,7 +16541,7 @@
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,NIOPS:7,RA:3</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -16611,7 +16611,7 @@
 			<availability>IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:6,FVC:3,HL:2,Periphery.CM:4,Periphery.ME:4,MERC:3,DA:3,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -16726,7 +16726,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16794,7 +16794,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>PR:3,RF:3,LA:5,ROS:3,PG:3,MERC:3,RFS:3,DC:3</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -16811,7 +16811,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -16868,7 +16868,7 @@
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:5</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -17093,7 +17093,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -17329,7 +17329,7 @@
 			<availability>CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:8,BAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -17407,7 +17407,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>HL:3,Periphery.Deep:1,MERC:6,FS:4,CDP:3,Periphery:4,TC:1</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -17791,7 +17791,7 @@
 			<availability>CNC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:5</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -17931,7 +17931,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -18000,7 +18000,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18135,7 +18135,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/MekHQ/data/forcegenerator/3100.xml
+++ b/MekHQ/data/forcegenerator/3100.xml
@@ -41,7 +41,7 @@
 		<techMargin>6</techMargin>
 		<weightDistribution era='3100' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3100' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3100' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CGB'>
 		<pctOmni>16,5,24,68,100</pctOmni>
@@ -141,9 +141,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>6</techMargin>
@@ -208,7 +208,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3100' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3100' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3100' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>6</omniMargin>
@@ -289,7 +289,7 @@
 		<upgradeMargin>3</upgradeMargin>
 		<weightDistribution era='3100' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3100' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3100' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>6</omniMargin>
@@ -312,9 +312,9 @@
 		<pctOmni>0,0,0,77,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,15,90,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,15,90,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>6</techMargin>
@@ -339,7 +339,7 @@
 		<salvage pct='6'>CC:9,LA:10,MSC:3,FS:10,DC:6</salvage>
 		<weightDistribution era='3100' unitType='Mek'>4,3,2,1</weightDistribution>
 		<weightDistribution era='3100' unitType='Tank'>3,2,1,4</weightDistribution>
-		<weightDistribution era='3100' unitType='Aero'>2,1,3,4</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>2,1,3,4</weightDistribution>
 	</faction>
 	<faction key='RIM'>
 		<omniMargin>6</omniMargin>
@@ -370,7 +370,7 @@
 		<techMargin>6</techMargin>
 		<upgradeMargin>3</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3100' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>6</omniMargin>
@@ -415,9 +415,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>10,30,40,55,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,4,8,12</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>20,30,50,60,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,4,8,12</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,30,50,60,80</pctSL>
 		<techMargin>6</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3100' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -517,7 +517,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>45</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>45</pctSL>
 		<pctSL unitType='Vehicle'>75</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -537,8 +537,8 @@
 		<pctOmni>22</pctOmni>
 		<pctClan>14</pctClan>
 		<pctSL>86</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>8</pctClan>
 		<pctSL unitType='Vehicle'>92</pctSL>
 		<omniMargin>6</omniMargin>
@@ -603,7 +603,7 @@
 		<pctOmni>5</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>84</pctSL>
-		<pctSL unitType='Aero'>48</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>48</pctSL>
 		<pctSL unitType='Vehicle'>60</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -737,9 +737,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>6</techMargin>
@@ -787,7 +787,7 @@
 		<pctOmni>6</pctOmni>
 		<pctClan>2</pctClan>
 		<pctSL>70</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>50</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -858,8 +858,8 @@
 		<pctOmni>28</pctOmni>
 		<pctClan>14</pctClan>
 		<pctSL>86</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>6</omniMargin>
@@ -1082,7 +1082,7 @@
 		<pctOmni>15</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>48</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -1093,7 +1093,7 @@
 		<pctOmni>14</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>80</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>45</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -1145,7 +1145,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>95</pctSL>
-		<pctSL unitType='Aero'>80</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>80</pctSL>
 		<pctSL unitType='Vehicle'>70</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -1419,7 +1419,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,RD:5,CDS:6,CW:5,CNC:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1586,7 +1586,7 @@
 			<availability>DTA:6,OP:6,RF:6,FWL:6,MSC:6,DA:6,RCM:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>OP:4,ROS:3,RCM:4,MERC:3,DA:3</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2101,7 +2101,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CLAN:2,CNC:3,RA:2,BAN:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2552,7 +2552,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CNC:5,CLAN:3,IS:3+,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7,CGB:8</availability>
@@ -2724,7 +2724,7 @@
 			<availability>DC:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:5,RD:5,CDS:5,CW:6,CNC:5,CJF:6,CGB:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
@@ -3747,7 +3747,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -3854,7 +3854,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>RD:5,CW:5,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3997,7 +3997,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4059,7 +4059,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4550,13 +4550,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:4,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4593,7 +4593,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -4910,7 +4910,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:5</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5026,13 +5026,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5253,7 +5253,7 @@
 			<availability>CLAN:8,IS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,CC:4,MOC:4,RF:3,ROS:3,FWL:4,DA:6,MERC:3,RCM:3,FS:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5265,7 +5265,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:5,MOC:5,MSC:4</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5688,7 +5688,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
@@ -5744,13 +5744,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,ROS:2,MERC:2,FS:2,CGB:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7281,7 +7281,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>DTA:7,OP:7,CDS:4,ROS:7,Periphery.MW:5,PIR:5,Periphery.ME:5,CLAN:3,CNC:4,FWL:7,MSC:7,MERC:4</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:2-,FWL:2-,MH:2-,MERC:2-</availability>
@@ -7798,7 +7798,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:6,CLAN:2,CNC:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -8209,13 +8209,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -8729,7 +8729,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,CNC:4,MERC:4,FS:4,CGB:5,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8767,7 +8767,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8977,7 +8977,7 @@
 			<availability>CHH:8,CW:4,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9107,7 +9107,7 @@
 			<availability>DTA:5,ROS:5,MSC:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9223,7 +9223,7 @@
 			<availability>FVC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:9,CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9708,7 +9708,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:5,CGB:6</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9868,7 +9868,7 @@
 			<availability>OP:4,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:4</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10078,7 +10078,7 @@
 			<availability>ROS:3,CLAN:8,MERC.SI:4,BAN:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10272,7 +10272,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:3-</availability>
@@ -10605,13 +10605,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10620,7 +10620,7 @@
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:5,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:1-,MERC:2-,Periphery:2-</availability>
@@ -11500,7 +11500,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:7,MOC:6,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -11761,7 +11761,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:5,LA:7,CWIE:5</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -12443,7 +12443,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CNC:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -12610,7 +12610,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:3,RA:2,CGB:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13120,7 +13120,7 @@
 			<availability>RD:8,CGB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:8</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -13306,7 +13306,7 @@
 	<chassis name='Phoenix' unitType='Mek'>
 		<availability>MERC:1-,TC:1-,Periphery:1-</availability>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,RF:5,LA:4,MERC:4,DA:3</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -13482,7 +13482,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>DTA:5,ROS:5,FWL:5,MSC:6,RCM:5,MERC:4</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -13895,7 +13895,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:4,CLAN:2</availability>
 		<model name='RPR-100'>
 			<availability>General:2</availability>
@@ -14101,7 +14101,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,OP:8,FS:2,MERC:1,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8,DC:2</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -14282,7 +14282,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:4,MERC:2</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -14450,7 +14450,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RA.OA:2-,LA:4,ROS:4,CLAN:2,IS:3-,FWL:2-,FS:3,MERC:4,Periphery:3-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:2-</availability>
@@ -14469,7 +14469,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -14507,7 +14507,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:7</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -14516,7 +14516,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>RD:4,CDS:4,CW:4,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
@@ -14585,7 +14585,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -14812,7 +14812,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:5</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -14935,7 +14935,7 @@
 			<availability>CJF:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:2,CW:4,CNC:5,CLAN:4,CJF:6,RA:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -15044,7 +15044,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2,CGB:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -15288,7 +15288,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:3,FWL:4,DA:4,MERC:3</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -15300,7 +15300,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,CGB.FRR:7,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
@@ -15312,13 +15312,13 @@
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:6,MSC:6,RCM:6,DA:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -15361,7 +15361,7 @@
 			<availability>CDS:4,CW:6,ROS:4,CNC:6,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:3,ROS:3,CGB.FRR:4,MERC:3,Periphery.OS:3,FS:1-,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,MERC:1,Periphery:4</availability>
@@ -15429,7 +15429,7 @@
 			<availability>LA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Simurgh' unitType='Aero' omni='IS'>
+	<chassis name='Simurgh' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:5</availability>
 		<model name='SMG-O'>
 			<roles>assault</roles>
@@ -15501,7 +15501,7 @@
 			<availability>FVC:3,IS.pm:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7,CGB:6</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,FS:0,Periphery:2-</availability>
@@ -15617,7 +15617,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,ROS:4,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -15629,7 +15629,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
@@ -15851,7 +15851,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:5-,TC:3-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -15906,7 +15906,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:5,LA:6,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -15999,7 +15999,7 @@
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -16147,7 +16147,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
@@ -16200,7 +16200,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6,CGB:5</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7,CGB:7</availability>
@@ -16271,7 +16271,7 @@
 			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:7</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -16336,7 +16336,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -16449,7 +16449,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -16721,7 +16721,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3,FS:4,MERC:3,Periphery:3,TC:5</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -16833,7 +16833,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,CGB.FRR:4,IS:4,FWL:4,FS:5,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -17060,7 +17060,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CW:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
@@ -17154,7 +17154,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,RCM:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -17169,7 +17169,7 @@
 			<availability>CC:7,MOC:5,RF:8,MERC:5,RCM:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -17237,7 +17237,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -17307,7 +17307,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -17425,7 +17425,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -17493,7 +17493,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,ROS:4,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -17510,7 +17510,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -17567,7 +17567,7 @@
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:6</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -17813,7 +17813,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -18037,7 +18037,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18115,7 +18115,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -18510,7 +18510,7 @@
 			<availability>CNC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:7</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -18676,7 +18676,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -18748,7 +18748,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18849,7 +18849,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>
@@ -18909,7 +18909,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/MekHQ/data/forcegenerator/3131.xml
+++ b/MekHQ/data/forcegenerator/3131.xml
@@ -47,7 +47,7 @@
 		<techMargin>12</techMargin>
 		<weightDistribution era='3131' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3131' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3131' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3131' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CHH'>
 		<pctOmni>0,0,10,82,95</pctOmni>
@@ -151,9 +151,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>12</techMargin>
@@ -218,7 +218,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3131' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3131' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3131' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3131' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>12</omniMargin>
@@ -305,7 +305,7 @@
 		<upgradeMargin>9</upgradeMargin>
 		<weightDistribution era='3131' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3131' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3131' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3131' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>12</omniMargin>
@@ -334,9 +334,9 @@
 		<pctOmni>0,0,0,60,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,80,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,80,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>12</techMargin>
@@ -425,7 +425,7 @@
 		<techMargin>12</techMargin>
 		<upgradeMargin>9</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3131' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3131' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>12</omniMargin>
@@ -479,9 +479,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>20,40,50,65,70</pctSL>
-		<pctOmni unitType='Aero'>0,4,8,10,15</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>30,40,60,70,90</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,4,8,10,15</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>30,40,60,70,90</pctSL>
 		<techMargin>12</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3131' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -599,7 +599,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>87</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -619,8 +619,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>12</omniMargin>
@@ -688,7 +688,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>72</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -850,9 +850,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>12</techMargin>
@@ -893,7 +893,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>4</pctClan>
 		<pctSL>72</pctSL>
-		<pctSL unitType='Aero'>64</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>64</pctSL>
 		<pctSL unitType='Vehicle'>60</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -973,8 +973,8 @@
 		<pctOmni>30</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>12</omniMargin>
@@ -1238,7 +1238,7 @@
 		<pctOmni>16</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>88</pctSL>
-		<pctSL unitType='Aero'>65</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>65</pctSL>
 		<pctSL unitType='Vehicle'>64</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -1249,7 +1249,7 @@
 		<pctOmni>15</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>68</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>68</pctSL>
 		<pctSL unitType='Vehicle'>60</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -1319,7 +1319,7 @@
 		<pctOmni>15</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>93</pctSL>
-		<pctSL unitType='Aero'>85</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>85</pctSL>
 		<pctSL unitType='Vehicle'>76</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -1599,7 +1599,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CW:5,CNC:5,CP:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1766,7 +1766,7 @@
 			<availability>DTA:6,OP:6,RF:6,FWL:6,MSC:6,DA:6,RCM:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>OP:7,ROS:4,FWL:5:3139,RCM:7,MERC:4,DA:4,CP:5</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2319,7 +2319,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CW:3,CLAN:2,CNC:3,CP:3,RA:2,BAN:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2782,7 +2782,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CNC:4,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
@@ -2960,7 +2960,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CW:6,CNC:5,CP:5,CJF:6,CWIE:3</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
@@ -4096,7 +4096,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -4203,7 +4203,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,RD:5,CW:5,CLAN:6,CJF:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4346,7 +4346,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,CP:10,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4408,7 +4408,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4902,13 +4902,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:5,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4945,7 +4945,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -5297,7 +5297,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:7</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5422,7 +5422,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5661,7 +5661,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,CC:4,MOC:4,RF:3,ROS:3,FWL:4,DA:6,MERC:3,RCM:3,FS:3,CP:2,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5673,7 +5673,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2:3139,MSC:4,CP:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -6100,7 +6100,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
@@ -6160,13 +6160,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,ROS:2,MERC:2,FS:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7748,7 +7748,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>DTA:7,OP:7,CDS:4,ROS:7,CLAN:3,CNC:4,FWL:7,MSC:7,CP:5,MERC:4</availability>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,CNC:4,FWL:4,CP:4,MERC:4,BAN:2,Periphery:4</availability>
@@ -8321,7 +8321,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:2,CNC:3,CP:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4,CP:4</availability>
@@ -8746,13 +8746,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -9275,7 +9275,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,CNC:4,MERC:4,FS:4,CP:4,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -9313,7 +9313,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9523,7 +9523,7 @@
 			<availability>CWE:4,CHH:8,CW:4,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9687,7 +9687,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,CW:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9803,7 +9803,7 @@
 			<availability>FVC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,RD:9,CW:8,CLAN:6,CWIE:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10309,7 +10309,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10472,7 +10472,7 @@
 			<availability>OP:4,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:5</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10706,7 +10706,7 @@
 			<availability>ROS:3,CLAN:8,MERC.SI:4,BAN:6,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,CP:6,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10907,7 +10907,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
@@ -11251,13 +11251,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:6</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -11266,7 +11266,7 @@
 			<availability>ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:4,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
@@ -12221,7 +12221,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:7,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -12474,7 +12474,7 @@
 			<availability>RR:1,ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,CWIE:6</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -13207,7 +13207,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CNC:4,CP:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13380,7 +13380,7 @@
 			<availability>CC:4,CDS:2-,FWL:4,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13902,7 +13902,7 @@
 			<availability>RD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:7</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -14085,7 +14085,7 @@
 			<availability>RD:4,ROS:2,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,RF:6,LA:4,MERC:4,DA:4</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -14265,7 +14265,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>DTA:5,ROS:5,FWL:5,MSC:6,RCM:5,MERC:4,CP:5</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -14528,7 +14528,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Qasar' unitType='Aero'>
+	<chassis name='Qasar' unitType='AeroSpaceFighter'>
 		<availability>CNC:5</availability>
 		<model name='C'>
 			<availability>General:8</availability>
@@ -14723,7 +14723,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
@@ -14958,7 +14958,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,OP:8,FS:2,CP:8,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -15145,7 +15145,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:5,MERC:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -15331,7 +15331,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:1-</availability>
@@ -15350,7 +15350,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15391,7 +15391,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:8</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -15403,7 +15403,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CWE:4,RD:4,CDS:4,CW:4,ROS:5,CNC:5,FS:4,CP:4,BAN:1,DC:7,CWIE:4</availability>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
@@ -15478,7 +15478,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -15703,7 +15703,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:7</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -15838,7 +15838,7 @@
 			<availability>CJF:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CHH:2,CW:3,CNC:5,CLAN:4,CP:5,CJF:5,RA:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -15949,7 +15949,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -16207,7 +16207,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:4,FWL:5,DA:5,MERC:4,CP:5</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -16219,7 +16219,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
@@ -16240,13 +16240,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2,CP:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:6,MSC:6,RCM:6,DA:6,CP:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -16293,7 +16293,7 @@
 			<availability>CWE:6,CDS:4,CW:6,ROS:4,CNC:6,CP:5,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:2,ROS:3,MERC:3,Periphery.OS:3,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -16372,7 +16372,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Simurgh' unitType='Aero' omni='IS'>
+	<chassis name='Simurgh' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:7</availability>
 		<model name='SMG-O'>
 			<roles>assault</roles>
@@ -16444,7 +16444,7 @@
 			<availability>FVC:3,IS.pm:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,FS:0,Periphery:2-</availability>
@@ -16560,7 +16560,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,ROS:3,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -16572,7 +16572,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
@@ -16799,7 +16799,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:4-,TC:2-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -16854,7 +16854,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:7,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -16947,7 +16947,7 @@
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,CP:6,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -17105,7 +17105,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
@@ -17158,7 +17158,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
@@ -17238,7 +17238,7 @@
 			<availability>ROS:5,CNC:5,CP:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:8</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -17303,7 +17303,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -17413,7 +17413,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,CP:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -17698,7 +17698,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -17831,7 +17831,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -18062,7 +18062,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CWE:3,CW:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6,CW:6</availability>
@@ -18171,7 +18171,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,RCM:3,CP:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -18186,7 +18186,7 @@
 			<availability>CC:7,MOC:5,RF:8,FWL:5:3139,MERC:5,RCM:8,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -18258,7 +18258,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -18328,7 +18328,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -18449,7 +18449,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:2,CW:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18520,7 +18520,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,ROS:4,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -18537,7 +18537,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18600,7 +18600,7 @@
 			<availability>CWE:3,CW:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:6</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -18851,7 +18851,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CW:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -19083,7 +19083,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -19167,7 +19167,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -19637,7 +19637,7 @@
 			<availability>CNC:8,CP:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -19836,7 +19836,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -19911,7 +19911,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -20020,7 +20020,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>
@@ -20080,7 +20080,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/MekHQ/data/forcegenerator/3145.xml
+++ b/MekHQ/data/forcegenerator/3145.xml
@@ -42,7 +42,7 @@
 		<techMargin>15</techMargin>
 		<weightDistribution era='3145' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3145' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3145' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3145' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CHH'>
 		<pctOmni>0,0,0,80,95</pctOmni>
@@ -169,7 +169,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3145' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3145' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3145' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3145' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>15</omniMargin>
@@ -233,7 +233,7 @@
 		<upgradeMargin>12</upgradeMargin>
 		<weightDistribution era='3145' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3145' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3145' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3145' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>15</omniMargin>
@@ -256,9 +256,9 @@
 		<pctOmni>0,0,0,48,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,75,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,75,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>15</techMargin>
@@ -307,9 +307,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>15</techMargin>
@@ -323,7 +323,7 @@
 		<techMargin>15</techMargin>
 		<upgradeMargin>12</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3145' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3145' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>15</omniMargin>
@@ -377,9 +377,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>30,50,60,75,80</pctSL>
-		<pctOmni unitType='Aero'>0,8,10,12,18</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>40,50,70,85,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,8,10,12,18</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>40,50,70,85,100</pctSL>
 		<techMargin>15</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3145' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -479,7 +479,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -499,8 +499,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>15</omniMargin>
@@ -568,7 +568,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -703,9 +703,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>15</techMargin>
@@ -746,7 +746,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>75</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>70</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -817,8 +817,8 @@
 		<pctOmni>32</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>15</omniMargin>
@@ -1049,7 +1049,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>76</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -1060,7 +1060,7 @@
 		<pctOmni>16</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>72</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>72</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -1130,7 +1130,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>92</pctSL>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctSL unitType='Vehicle'>84</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -1416,7 +1416,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CP:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1583,7 +1583,7 @@
 			<availability>RF:6,FWL:6,DA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,FWL:7,MERC:5,DA:4,CP:7</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2148,7 +2148,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CP:3,RA:2,BAN:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2614,7 +2614,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
@@ -2792,7 +2792,7 @@
 			<availability>DC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CP:5,CJF:6,CWIE:3</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
@@ -3965,7 +3965,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -4072,7 +4072,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,RD:5,CLAN:6,CJF:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4215,7 +4215,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4277,7 +4277,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4774,13 +4774,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:5,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4817,7 +4817,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -5179,7 +5179,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:8</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5304,7 +5304,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5549,7 +5549,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RF:3,ROS:3,FWL:4,DA:6,MERC:3,FS:3,CP:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5561,7 +5561,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2,CP:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -6013,7 +6013,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
@@ -6073,13 +6073,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,ROS:2,MERC:2,FS:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7667,7 +7667,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,ROS:7,CLAN:3,FWL:7,CP:5,MERC:4</availability>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,FWL:3,CP:3,MERC:3,BAN:2,Periphery:3</availability>
@@ -8237,7 +8237,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:2,CP:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CP:4</availability>
@@ -8671,13 +8671,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -9210,7 +9210,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,MERC:4,FS:4,CP:4,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -9248,7 +9248,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9477,7 +9477,7 @@
 			<availability>CWE:4,CHH:8,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>MERC:3:3146,Periphery:3:3146</availability>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -9496,7 +9496,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9681,7 +9681,7 @@
 			<availability>CJF:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9797,7 +9797,7 @@
 			<availability>FVC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,RD:9,CLAN:6,CWIE:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10297,7 +10297,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10446,7 +10446,7 @@
 			<availability>FWL:4,MERC:3,CP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:5</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10686,7 +10686,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10887,7 +10887,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
@@ -11234,13 +11234,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:6</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -11249,7 +11249,7 @@
 			<availability>ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:3,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
@@ -12222,7 +12222,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:7,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -12486,7 +12486,7 @@
 			<availability>RR:1,ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,CWIE:6</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -13252,7 +13252,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CP:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13425,7 +13425,7 @@
 			<availability>CC:4,CDS:2-,FWL:4,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13965,7 +13965,7 @@
 			<availability>RD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:7</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -14144,7 +14144,7 @@
 			<availability>RD:4,ROS:2,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>RF:6,LA:4,MERC:4,DA:4</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -14320,7 +14320,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -14775,7 +14775,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
@@ -15028,7 +15028,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -15240,7 +15240,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:5,MERC:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -15453,7 +15453,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:1-</availability>
@@ -15472,7 +15472,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15513,7 +15513,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:8</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -15525,7 +15525,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CWE:4,RD:4,CDS:4,ROS:5,FS:4,CP:4,BAN:1,DC:7,CWIE:4</availability>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
@@ -15600,7 +15600,7 @@
 			<availability>LA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -15825,7 +15825,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:8</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -15960,7 +15960,7 @@
 			<availability>CJF:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CHH:2,CLAN:4,CP:5,CJF:5,RA:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -16071,7 +16071,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
@@ -16322,7 +16322,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -16334,7 +16334,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
@@ -16355,13 +16355,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2,CP:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RF:6,ROS:4,FWL:6,DA:6,CP:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -16408,7 +16408,7 @@
 			<availability>CWE:6,CDS:4,ROS:4,CP:5,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:2,ROS:3,MERC:3,Periphery.OS:3,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -16487,7 +16487,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Simurgh' unitType='Aero' omni='IS'>
+	<chassis name='Simurgh' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:8</availability>
 		<model name='SMG-O'>
 			<roles>assault</roles>
@@ -16559,7 +16559,7 @@
 			<availability>FVC:3,IS.pm:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,FS:0,Periphery:2-</availability>
@@ -16693,7 +16693,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,ROS:3,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -16705,7 +16705,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
@@ -16947,7 +16947,7 @@
 			<availability>SE:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:2-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -17002,7 +17002,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -17082,7 +17082,7 @@
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -17261,7 +17261,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
@@ -17314,7 +17314,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
@@ -17394,7 +17394,7 @@
 			<availability>ROS:5,CP:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:8</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -17459,7 +17459,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -17569,7 +17569,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,ROS:4,CP:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -17854,7 +17854,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -17987,7 +17987,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -18215,7 +18215,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CWE:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6</availability>
@@ -18317,7 +18317,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,CP:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -18332,7 +18332,7 @@
 			<availability>CC:7,MOC:5,RF:8,FWL:5,MERC:5,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -18404,7 +18404,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -18458,7 +18458,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -18579,7 +18579,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18650,7 +18650,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,ROS:4,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -18667,7 +18667,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18730,7 +18730,7 @@
 			<availability>CWE:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:6</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -18984,7 +18984,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -19216,7 +19216,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -19300,7 +19300,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -19795,7 +19795,7 @@
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -20009,7 +20009,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -20084,7 +20084,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -20193,7 +20193,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>
@@ -20253,7 +20253,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/MekHQ/data/forcegenerator/3150.xml
+++ b/MekHQ/data/forcegenerator/3150.xml
@@ -45,7 +45,7 @@
 		<techMargin>16</techMargin>
 		<weightDistribution era='3150' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3150' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3150' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3150' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CHH'>
 		<pctOmni>0,0,0,80,95</pctOmni>
@@ -172,7 +172,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3150' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3150' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3150' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3150' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>16</omniMargin>
@@ -241,7 +241,7 @@
 		<upgradeMargin>13</upgradeMargin>
 		<weightDistribution era='3150' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3150' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3150' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3150' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>16</omniMargin>
@@ -264,9 +264,9 @@
 		<pctOmni>0,0,0,48,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,75,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,75,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>16</techMargin>
@@ -315,9 +315,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>16</techMargin>
@@ -341,7 +341,7 @@
 		<techMargin>16</techMargin>
 		<upgradeMargin>13</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3150' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3150' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>16</omniMargin>
@@ -400,9 +400,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>30,50,60,75,80</pctSL>
-		<pctOmni unitType='Aero'>0,8,10,12,18</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>40,50,70,85,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,8,10,12,18</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>40,50,70,85,100</pctSL>
 		<techMargin>16</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3150' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -502,7 +502,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -522,8 +522,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>16</omniMargin>
@@ -591,7 +591,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -726,9 +726,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>16</techMargin>
@@ -769,7 +769,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>75</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>70</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -840,8 +840,8 @@
 		<pctOmni>32</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>16</omniMargin>
@@ -1072,7 +1072,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>76</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -1083,7 +1083,7 @@
 		<pctOmni>16</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>72</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>72</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -1159,7 +1159,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>92</pctSL>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctSL unitType='Vehicle'>84</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -1466,7 +1466,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CP:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1633,7 +1633,7 @@
 			<availability>RF:6,FWL:6,DA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,FWL:7,MERC:5,DA:4,CP:7</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2198,7 +2198,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CP:3,RA:2,BAN:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2664,7 +2664,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
@@ -2842,7 +2842,7 @@
 			<availability>DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CP:5,CJF:6,CWIE:3</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
@@ -4009,7 +4009,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -4116,7 +4116,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,RD:5,CLAN:6,CJF:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4259,7 +4259,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4321,7 +4321,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4818,13 +4818,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:5,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4861,7 +4861,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -5223,7 +5223,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:8</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5348,7 +5348,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5593,7 +5593,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RF:3,ROS:3,FWL:4,DA:6,MERC:3,FS:3,CP:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5605,7 +5605,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2,CP:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -6057,7 +6057,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
@@ -6117,13 +6117,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,ROS:2,MERC:2,FS:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7726,7 +7726,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,ROS:7,CLAN:3,FWL:7,CP:5,MERC:4</availability>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,FWL:3,CP:3,MERC:3,BAN:2,Periphery:3</availability>
@@ -8305,7 +8305,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:2,CP:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CP:4</availability>
@@ -8739,13 +8739,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -9281,7 +9281,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,MERC:4,FS:4,CP:4,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -9319,7 +9319,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9557,7 +9557,7 @@
 			<availability>CWE:4,CHH:8,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>MERC:3:3146,Periphery:3:3146</availability>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -9576,7 +9576,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9761,7 +9761,7 @@
 			<availability>CJF:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9877,7 +9877,7 @@
 			<availability>FVC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,RD:9,CLAN:6,CWIE:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10377,7 +10377,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10526,7 +10526,7 @@
 			<availability>FWL:4,MERC:3,CP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:5</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10763,7 +10763,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10964,7 +10964,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
@@ -11308,13 +11308,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:6</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -11323,7 +11323,7 @@
 			<availability>ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:3,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
@@ -12299,7 +12299,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:7,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -12563,7 +12563,7 @@
 			<availability>RR:1,ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,CWIE:6</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -13329,7 +13329,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CP:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13502,7 +13502,7 @@
 			<availability>CC:4,CDS:2-,FWL:4,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14042,7 +14042,7 @@
 			<availability>RD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:7</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -14221,7 +14221,7 @@
 			<availability>RD:4,ROS:2,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>RF:6,LA:4,MERC:4,DA:4</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -14401,7 +14401,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -14856,7 +14856,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
@@ -15109,7 +15109,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -15321,7 +15321,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:5,MERC:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -15534,7 +15534,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:1-</availability>
@@ -15553,7 +15553,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15594,7 +15594,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:8</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -15606,7 +15606,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CWE:4,RD:4,CDS:4,ROS:5,FS:4,CP:4,BAN:1,DC:7,CWIE:4</availability>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
@@ -15681,7 +15681,7 @@
 			<availability>LA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -15906,7 +15906,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:8</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -16041,7 +16041,7 @@
 			<availability>CJF:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CHH:2,CLAN:4,CP:5,CJF:5,RA:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -16152,7 +16152,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
@@ -16403,7 +16403,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -16415,7 +16415,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
@@ -16436,13 +16436,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2,CP:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RF:6,ROS:4,FWL:6,DA:6,CP:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -16489,7 +16489,7 @@
 			<availability>CWE:6,CDS:4,ROS:4,CP:5,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:2,ROS:3,MERC:3,Periphery.OS:3,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -16568,7 +16568,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Simurgh' unitType='Aero' omni='IS'>
+	<chassis name='Simurgh' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:8</availability>
 		<model name='SMG-O'>
 			<roles>assault</roles>
@@ -16640,7 +16640,7 @@
 			<availability>FVC:3,IS.pm:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,FS:0,Periphery:2-</availability>
@@ -16774,7 +16774,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,ROS:3,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -16786,7 +16786,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
@@ -17028,7 +17028,7 @@
 			<availability>SE:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:2-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -17089,7 +17089,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -17182,7 +17182,7 @@
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -17361,7 +17361,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
@@ -17414,7 +17414,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
@@ -17494,7 +17494,7 @@
 			<availability>ROS:5,CP:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:8</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -17559,7 +17559,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -17669,7 +17669,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,ROS:4,CP:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -17957,7 +17957,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -18090,7 +18090,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -18315,7 +18315,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CWE:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6</availability>
@@ -18417,7 +18417,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,CP:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -18432,7 +18432,7 @@
 			<availability>CC:7,MOC:5,RF:8,FWL:5,MERC:5,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -18504,7 +18504,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -18558,7 +18558,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -18679,7 +18679,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18750,7 +18750,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,ROS:4,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -18767,7 +18767,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18830,7 +18830,7 @@
 			<availability>CWE:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:6</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -19084,7 +19084,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -19316,7 +19316,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -19400,7 +19400,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -19901,7 +19901,7 @@
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -20115,7 +20115,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -20190,7 +20190,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -20299,7 +20299,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>
@@ -20359,7 +20359,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/MekHQ/data/forcegenerator/3160.xml
+++ b/MekHQ/data/forcegenerator/3160.xml
@@ -45,7 +45,7 @@
 		<techMargin>18</techMargin>
 		<weightDistribution era='3160' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3160' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3160' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3160' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CHH'>
 		<pctOmni>0,0,0,80,95</pctOmni>
@@ -163,7 +163,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3160' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3160' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3160' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3160' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>18</omniMargin>
@@ -232,7 +232,7 @@
 		<upgradeMargin>15</upgradeMargin>
 		<weightDistribution era='3160' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3160' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3160' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3160' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>18</omniMargin>
@@ -255,9 +255,9 @@
 		<pctOmni>0,0,0,48,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,75,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,75,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>18</techMargin>
@@ -288,9 +288,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>18</techMargin>
@@ -314,7 +314,7 @@
 		<techMargin>18</techMargin>
 		<upgradeMargin>15</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3160' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3160' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>18</omniMargin>
@@ -373,9 +373,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>30,50,60,75,80</pctSL>
-		<pctOmni unitType='Aero'>0,8,10,12,18</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>40,50,70,85,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,8,10,12,18</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>40,50,70,85,100</pctSL>
 		<techMargin>18</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3160' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -475,7 +475,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -495,8 +495,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>18</omniMargin>
@@ -564,7 +564,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -699,9 +699,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>18</techMargin>
@@ -742,7 +742,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>75</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>70</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -813,8 +813,8 @@
 		<pctOmni>32</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>18</omniMargin>
@@ -1045,7 +1045,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>76</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -1056,7 +1056,7 @@
 		<pctOmni>16</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>72</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>72</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -1129,7 +1129,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>92</pctSL>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctSL unitType='Vehicle'>84</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -1430,7 +1430,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CP:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1587,7 +1587,7 @@
 			<availability>RF:6,FWL:6,DA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>FWL:7,MERC:5,DA:4,CP:7</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2112,7 +2112,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CP:3,RA:2,BAN:5</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2578,7 +2578,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
@@ -2756,7 +2756,7 @@
 			<availability>DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CP:5,CJF:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
@@ -3837,7 +3837,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -3944,7 +3944,7 @@
 			<availability>LA:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,RD:5,CLAN:6,CJF:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4084,7 +4084,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,Periphery.ME:4,FWL:10,DA:8</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4138,7 +4138,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4626,13 +4626,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:5,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4669,7 +4669,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -5019,7 +5019,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:8</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5144,7 +5144,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5389,7 +5389,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RF:3,FWL:4,DA:6,MERC:3,FS:3,CP:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5401,7 +5401,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2,CP:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5812,7 +5812,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,MERC:6,FS:6</availability>
@@ -5872,13 +5872,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,MERC:2,FS:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7461,7 +7461,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CLAN:3,FWL:7,CP:5,MERC:4</availability>
 		<model name='GTHA-500'>
 			<availability>CDS:4,FWL:3,CP:3,MERC:3,BAN:2,Periphery:3</availability>
@@ -8036,7 +8036,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CLAN:2,CP:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CP:4</availability>
@@ -8464,7 +8464,7 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -8990,7 +8990,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,MERC:4,FS:4,CP:4,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -9028,7 +9028,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9258,7 +9258,7 @@
 			<availability>CWE:4,CHH:8,CJF:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,Periphery:3</availability>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -9277,7 +9277,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9462,7 +9462,7 @@
 			<availability>CJF:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9578,7 +9578,7 @@
 			<availability>FVC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,RD:9,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10069,7 +10069,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10218,7 +10218,7 @@
 			<availability>FWL:4,MERC:3,CP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:5</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10437,7 +10437,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10624,7 +10624,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
@@ -10968,13 +10968,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:6</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10983,7 +10983,7 @@
 			<availability>MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:3,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
@@ -11953,7 +11953,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:7,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -12206,7 +12206,7 @@
 			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -12942,7 +12942,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CP:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13112,7 +13112,7 @@
 			<availability>CC:4,CDS:2-,FWL:4,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13636,7 +13636,7 @@
 			<availability>RD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:7</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -13815,7 +13815,7 @@
 			<availability>RD:4,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>RF:6,LA:4,MERC:4,DA:4</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -13989,7 +13989,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>FWL:6,MERC:4,CP:6</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -14391,7 +14391,7 @@
 			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,CLAN:1</availability>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
@@ -14595,7 +14595,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -14797,7 +14797,7 @@
 			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:5,MERC:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -15002,7 +15002,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RA.OA:2-,LA:4,CLAN:2,IS:3-,FWL:2-,FS:3,MERC:4,CP:2-,Periphery:3-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:1-</availability>
@@ -15021,7 +15021,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15062,7 +15062,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CWE:4,RD:4,CDS:4,FS:4,CP:4,BAN:1,DC:7</availability>
 		<model name='S-4'>
 			<availability>FS:5,DC:6</availability>
@@ -15137,7 +15137,7 @@
 			<availability>LA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -15444,7 +15444,7 @@
 			<availability>CJF:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CHH:2,CLAN:4,CP:5,CJF:5,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -15552,7 +15552,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,MH:2</availability>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
@@ -15800,7 +15800,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -15812,7 +15812,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>Periphery:2-</availability>
@@ -15833,13 +15833,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2,CP:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RF:6,FWL:6,DA:6,CP:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -15886,7 +15886,7 @@
 			<availability>CWE:6,CDS:4,CP:5,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:2,MERC:3,Periphery.OS:3,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -16001,7 +16001,7 @@
 			<availability>FVC:3,IS.pm:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:5,Periphery.DD:3,FVC:4,RD:6,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,DC:7</availability>
 		<model name='SL-15'>
 			<availability>FS:0,Periphery:2-</availability>
@@ -16135,7 +16135,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -16144,7 +16144,7 @@
 			<availability>BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,FS:8,MERC:5</availability>
@@ -16386,7 +16386,7 @@
 			<availability>SE:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:2-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -16447,7 +16447,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -16540,7 +16540,7 @@
 			<availability>LA:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -16719,7 +16719,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,FS:4,MERC:6,CDP:4</availability>
@@ -16772,7 +16772,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
@@ -16852,7 +16852,7 @@
 			<availability>CP:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:8</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -16917,7 +16917,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -17010,7 +17010,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,CP:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -17285,7 +17285,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -17418,7 +17418,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -17622,7 +17622,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CWE:3,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6</availability>
@@ -17696,7 +17696,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,CP:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -17711,7 +17711,7 @@
 			<availability>CC:7,MOC:5,RF:8,FWL:5,MERC:5,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -17780,7 +17780,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -17824,7 +17824,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -17945,7 +17945,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:2,CLAN:3,CJF:2,BAN:1</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18016,7 +18016,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -18033,7 +18033,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18334,7 +18334,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CJF:3,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -18566,7 +18566,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18650,7 +18650,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -19136,7 +19136,7 @@
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -19347,7 +19347,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -19418,7 +19418,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -19527,7 +19527,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>

--- a/MekHQ/data/forcegenerator/faction_rules/CB.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CB.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3061,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3060">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3061,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3060">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>

--- a/MekHQ/data/forcegenerator/faction_rules/CBS.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CBS.xml
@@ -10,16 +10,16 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%TOUMAN%,%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="Warship">%GALAXY%</option>
 			<option ifUnitType="Dropship|Jumpship">%STAR%</option>
-			<option ifUnitType="Aero">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
+			<option ifUnitType="AeroSpaceFighter">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -96,19 +96,19 @@
 		<attachedForces>
 			<subforceOption>
 				<option num="3" ifDateBetween="3061,"
-					rating="FL" unitType="Aero">%CLUSTER%</option>
+					rating="FL" unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option num="4" rating="FL"
-					unitType="Aero">%CLUSTER%</option>
+					unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option num="5" ifDateBetween=",3060"
-					rating="FL" unitType="Aero">%CLUSTER%</option>
+					rating="FL" unitType="AeroSpaceFighter">%CLUSTER%</option>
 			</subforceOption>
 			<subforceOption>
 				<option num="2" ifDateBetween="3061,"
-					rating="SL" unitType="Aero">%CLUSTER%</option>
+					rating="SL" unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option num="3" rating="SL"
-					unitType="Aero">%CLUSTER%</option>
+					unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option num="4" ifDateBetween=",3060"
-					rating="SL" unitType="Aero">%CLUSTER%</option>
+					rating="SL" unitType="AeroSpaceFighter">%CLUSTER%</option>
 			</subforceOption>
 		</attachedForces>
 	</force>
@@ -136,7 +136,7 @@
 	one BA/infantry, and one vehicle. ASFs are attached to the naval
 	reserve.-->
 	
-	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="AeroSpaceFighter">
 		<name>Aerospace Cluster</name>
 		<co>%STAR_COL%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CC.SIJ.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CC.SIJ.xml
@@ -14,14 +14,14 @@ with a wing of aerospace support and a battalion of BattleArmor. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,BattleArmor,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Mek|Tank|VTOL">%COMPANY%,%LANCE%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -37,7 +37,7 @@ with a wing of aerospace support and a battalion of BattleArmor. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero" name="Aerospace Support">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter" name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="BattleArmor" name="Infantry Support">%BATTALION%</subforce>			
 		</attachedForces>
 	</force>

--- a/MekHQ/data/forcegenerator/faction_rules/CC.WHO.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CC.WHO.xml
@@ -26,7 +26,7 @@ had been upgraded to BA by that date. -->
 			<option ifUnitType="Mek">%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -72,7 +72,7 @@ had been upgraded to BA by that date. -->
 			<subforce unitType="Infantry"
 					name="Infantry Support">%BATTALION%</subforce>
 			<subforceOption>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					name="Aerospace Support">%FLIGHT%</option>
 				<option weight="3"/>
 			</subforceOption>
@@ -203,7 +203,7 @@ had been upgraded to BA by that date. -->
 		<attachedForces ifUnitType="Mek">
 			<subforce unitType="BattleArmor" augmented="1" name="Infantry Support">%BATTALION%</subforce>
 			<subforceOption>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					name="Aerospace Support">%FLIGHT%</option>
 				<option weight="3"/>
 			</subforceOption>

--- a/MekHQ/data/forcegenerator/faction_rules/CC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CC.xml
@@ -20,9 +20,9 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2472,">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2472,">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -33,7 +33,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%REGIMENT%,%WING%+,%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%^,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%REGIMENT%,%WING%+,%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%^,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -141,11 +141,11 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		
 		<attachedForces ifUnitType="Mek">
 			<subforceOption>
-				<option unitType="Aero" weight="2"
+				<option unitType="AeroSpaceFighter" weight="2"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero" weight="2" num="2"
+				<option unitType="AeroSpaceFighter" weight="2" num="2"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero" num="2"
+				<option unitType="AeroSpaceFighter" num="2"
 					name="Aerospace Support">%FLIGHT%</option>
 			</subforceOption>
 			<subforceOption ifDateBetween=",3080">
@@ -165,11 +165,11 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2540">
 			<subforceOption>
-				<option unitType="Aero" weight="2"
+				<option unitType="AeroSpaceFighter" weight="2"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero" weight="2" num="2"
+				<option unitType="AeroSpaceFighter" weight="2" num="2"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero" num="2"
+				<option unitType="AeroSpaceFighter" num="2"
 					name="Aerospace Support">%FLIGHT%</option>
 			</subforceOption>
 			<subforceOption ifDateBetween="2472,">
@@ -911,7 +911,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%REGIMENT%" eschName="Fleet Regiment" ifUnitType="Aero">
+	<force eschelon="%REGIMENT%" eschName="Fleet Regiment" ifUnitType="AeroSpaceFighter">
 		<co>%COLONEL%</co>
 
 		<weightClass>
@@ -923,18 +923,18 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		<subforces>
 			<subforce role="command" augmented="1" num="2">%FLIGHT%</subforce>
 			
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%WING%</option>
 				<option weightClass="H,H,M">%WING%</option>
 				<option weightClass="H,H,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%WING%</option>
 				<option weightClass="M,M,M">%WING%</option>
 				<option weightClass="H,M,L">%WING%</option>
 				<option weightClass="M,M,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%WING%</option>
 				<option weightClass="M,L,L">%WING%</option>
 				<option weightClass="L,L,L">%WING%</option>
@@ -942,7 +942,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT_COLONEL%</co>
 		
 		<weightClass>
@@ -954,18 +954,18 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		<subforces>
 			<subforce role="command" augmented="1">%FLIGHT%</subforce>
 			
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H" augmented="1">%SQUADRON%</option>
 				<option weightClass="H,H,M" augmented="1">%SQUADRON%</option>
 				<option weightClass="H,H,L" augmented="1">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M" augmented="1">%SQUADRON%</option>
 				<option weightClass="M,M,M" augmented="1">%SQUADRON%</option>
 				<option weightClass="H,M,L" augmented="1">%SQUADRON%</option>
 				<option weightClass="M,M,L" augmented="1">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L" augmented="1">%SQUADRON%</option>
 				<option weightClass="M,L,L" augmented="1">%SQUADRON%</option>
 				<option weightClass="L,L,L" augmented="1">%SQUADRON%</option>
@@ -974,7 +974,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Flight" ifAugmented="1" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Flight" ifAugmented="1" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -986,16 +986,16 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		<subforces>
 			<subforce role="command" augmented="1">%FLIGHT%</subforce>
 			
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" augmented="0" weight="2">%SQUADRON%</option>
 				<option weightClass="H,M" augmented="0">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M" augmented="0">%SQUADRON%</option>
 				<option weightClass="M,L" augmented="0">%SQUADRON%</option>
 				<option weightClass="H,L" augmented="0">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L" augmented="0">%SQUADRON%</option>
 				<option weightClass="L,L" augmented="0" weight="2">%SQUADRON%</option>
 			</subforceOption>
@@ -1011,7 +1011,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifAugmented="0" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifAugmented="0" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{formation} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -1031,7 +1031,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%</option>
 				<option weightClass="H,H,M">%FLIGHT%</option>
 				<option weightClass="H,H,L">%FLIGHT%</option>
@@ -1040,7 +1040,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 				<option weightClass="H,M"
 					augmented="1">%FLIGHT%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%</option>
 				<option weightClass="M,M,M">%FLIGHT%</option>
 				<option weightClass="H,M,L">%FLIGHT%</option>
@@ -1052,7 +1052,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 				<option weightClass="H,L"
 					augmented="1">%FLIGHT%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%</option>
 				<option weightClass="M,L,L">%FLIGHT%</option>
 				<option weightClass="L,L,L">%FLIGHT%</option>
@@ -1068,7 +1068,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Triple" ifAugmented="1" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Triple" ifAugmented="1" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name ifRole="command">Command Element</name>
 		<name>Element {cardinal}</name>
 		<co>%LT%</co>
@@ -1084,7 +1084,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</subforces>
 	</force>
 
-	<force eschelon="%FLIGHT%" eschName="Element" ifAugmented="0" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Element" ifAugmented="0" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>Element {cardinal}</name>
 		<co>%LT%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CCC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CCC.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -155,7 +155,7 @@
 		
 		<subforces>
 			<subforce unitType="Mek" augmented="1">%TRINARY%</subforce>
-			<subforce unitType="Aero" num="2">%BINARY%</subforce>
+			<subforce unitType="AeroSpaceFighter" num="2">%BINARY%</subforce>
 		</subforces>
 	</force>
 
@@ -165,7 +165,7 @@
 		
 		<subforces>
 			<subforce unitType="Mek" augmented="1">%TRINARY%</subforce>
-			<subforce unitType="Aero">%TRINARY%</subforce>
+			<subforce unitType="AeroSpaceFighter">%TRINARY%</subforce>
 		</subforces>
 	</force>
 
@@ -207,44 +207,44 @@
 			<subforce ifDateBetween="2872," unitType="BattleArmor"
 				>%TRINARY%</subforce>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
 		
 		<subforces ifFlags="coil">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H,H" unitType="Aero"
+				<option weightClass="H,H,H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,H,M" unitType="Aero"
+				<option weightClass="H,H,M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="H,H,L" unitType="Aero"
+				<option weightClass="H,H,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,M,M" unitType="Aero"
+				<option weightClass="H,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,M,M" unitType="Aero"
+				<option weightClass="H,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,M,L" unitType="Aero"
+				<option weightClass="H,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,M" unitType="Aero"
+				<option weightClass="M,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero"
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L,L" unitType="Aero"
+				<option weightClass="H,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero"
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,L,L" unitType="Aero"
+				<option weightClass="M,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="L,L,L" unitType="Aero"
+				<option weightClass="L,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			
@@ -292,64 +292,64 @@
 					augmented="1">%TRINARY%</option>
 			</subforceOption>
 			<subforce weightClass="M,M"
-				unitType="Aero">%TRINARY%</subforce>
+				unitType="AeroSpaceFighter">%TRINARY%</subforce>
 		</subforces>
 		
 		<subforces ifFlags="fang">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H,H" unitType="Aero"
+				<option weightClass="H,H,H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,H,M" unitType="Aero"
+				<option weightClass="H,H,M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="H,H,L" unitType="Aero"
+				<option weightClass="H,H,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,M,M" unitType="Aero"
+				<option weightClass="H,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,M,M" unitType="Aero"
+				<option weightClass="H,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,M,L" unitType="Aero"
+				<option weightClass="H,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,M" unitType="Aero"
+				<option weightClass="M,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero"
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L,L" unitType="Aero"
+				<option weightClass="H,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero"
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,L,L" unitType="Aero"
+				<option weightClass="M,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="L,L,L" unitType="Aero"
+				<option weightClass="L,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -374,55 +374,55 @@
 			<subforce ifDateBetween="2870," unitType="BattleArmor"
 				>%TRINARY%</subforce>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -459,37 +459,37 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -504,55 +504,55 @@
 				<option num="2" unitType="BattleArmor">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>

--- a/MekHQ/data/forcegenerator/faction_rules/CCO.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CCO.xml
@@ -21,9 +21,9 @@ ranked SL units.-->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3062,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3061">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3062,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3061">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -412,27 +412,27 @@ ranked SL units.-->
 			</subforceOption>		
 				
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -591,29 +591,29 @@ ranked SL units.-->
 			</subforceOption>		
 				
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>

--- a/MekHQ/data/forcegenerator/faction_rules/CDS.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CDS.xml
@@ -26,9 +26,9 @@ but with more independence.-->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3100,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3099">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3100,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3099">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -171,18 +171,18 @@ but with more independence.-->
 				
 		<subforces>
 			<subforceOption ifWeightClass="H">
-				<option weightClass="H,H,H" unitType="Aero">%TRINARY%</option>
-				<option weightClass="H,H,M" unitType="Aero">%TRINARY%</option>
+				<option weightClass="H,H,H" unitType="AeroSpaceFighter">%TRINARY%</option>
+				<option weightClass="H,H,M" unitType="AeroSpaceFighter">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,M,L" unitType="Aero" weight="3">%TRINARY%</option>
-				<option weightClass="H,L,L" unitType="Aero">%TRINARY%</option>
-				<option weightClass="M,M,M" unitType="Aero" weight="2">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero" weight="2">%TRINARY%</option>
+				<option weightClass="H,M,L" unitType="AeroSpaceFighter" weight="3">%TRINARY%</option>
+				<option weightClass="H,L,L" unitType="AeroSpaceFighter">%TRINARY%</option>
+				<option weightClass="M,M,M" unitType="AeroSpaceFighter" weight="2">%TRINARY%</option>
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="M,L,L" unitType="Aero">%TRINARY%</option>
-				<option weightClass="L,L,L" unitType="Aero">%TRINARY%</option>
+				<option weightClass="M,L,L" unitType="AeroSpaceFighter">%TRINARY%</option>
+				<option weightClass="L,L,L" unitType="AeroSpaceFighter">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
 
@@ -398,27 +398,27 @@ but with more independence.-->
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -432,17 +432,17 @@ but with more independence.-->
 					weight="4">%TRINARY%</option>
 				<option weightClass="H" unitType="Mek"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -452,17 +452,17 @@ but with more independence.-->
 					weight="3">%TRINARY%</option>
 				<option weightClass="M" unitType="Mek"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -472,17 +472,17 @@ but with more independence.-->
 					weight="3">%TRINARY%</option>
 				<option weightClass="L" unitType="Mek"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -490,17 +490,17 @@ but with more independence.-->
 					weight="2">%TRINARY%</option>
 				<option weightClass="L" unitType="Mek"
 					weight="4">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -518,11 +518,11 @@ but with more independence.-->
 					ifRating="SL" weight="6">%TRINARY%</option>
 				<option ifRating="SL" unitType="Infantry"
 					ifDateBetween=",2950" weight="6">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -538,11 +538,11 @@ but with more independence.-->
 					ifRating="SL" weight="14">%TRINARY%</option>
 				<option ifRating="SL" unitType="Infantry"
 					ifDateBetween=",2950" weight="14">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -558,11 +558,11 @@ but with more independence.-->
 					ifRating="SL" weight="14">%TRINARY%</option>
 				<option ifRating="SL" unitType="Infantry"
 					ifDateBetween=",2950" weight="14">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -576,11 +576,11 @@ but with more independence.-->
 					ifRating="SL" weight="6">%TRINARY%</option>
 				<option ifRating="SL" unitType="Infantry"
 					ifDateBetween=",2950" weight="6">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -633,9 +633,9 @@ but with more independence.-->
 					weightClass="H" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="4">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -651,11 +651,11 @@ but with more independence.-->
 					weightClass="H" weight="2">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -671,11 +671,11 @@ but with more independence.-->
 					weightClass="M" weight="4">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="4">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -689,11 +689,11 @@ but with more independence.-->
 					weightClass="M" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 			
@@ -708,9 +708,9 @@ but with more independence.-->
 					weightClass="H" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="4">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -726,11 +726,11 @@ but with more independence.-->
 					weightClass="H" weight="2">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -746,11 +746,11 @@ but with more independence.-->
 					weightClass="M" weight="4">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="4">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -764,11 +764,11 @@ but with more independence.-->
 					weightClass="M" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -829,27 +829,27 @@ but with more independence.-->
 		
 		<subforces generate="group">
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="3">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="1">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="3">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="2">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="1">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="3">%ELEMENT%</option>
 			</subforceOption>
 		</subforces>

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.BG.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.BG.xml
@@ -10,14 +10,14 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%GALAXY%,%CLUSTER%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -39,13 +39,13 @@
 		
 		<subforces>
 			<subforce role="command" rating="Keshik"
-				unitType="Aero">%BINARY%</subforce>
+				unitType="AeroSpaceFighter">%BINARY%</subforce>
 			<subforceOption>
 				<option num="1" rating="FL">%CLUSTER%</option>
 				<option num="2" rating="FL">%CLUSTER%</option>
 			</subforceOption>
 			<subforce num="1" rating="FL"
-				unitType="Aero">%CLUSTER%</subforce>
+				unitType="AeroSpaceFighter">%CLUSTER%</subforce>
 			<subforce num="1" rating="SL">%CLUSTER%</subforce>
 			<subforce num="1" rating="SL"
 				flags="binary">%CLUSTER%</subforce>
@@ -62,7 +62,7 @@
 	
 	<!--One cluster has three binaries of ASF, one Mek, and one BA.-->
 	
-	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="AeroSpaceFighter">
 		<name>Mandrill Airborne</name>
 		<co>%STAR_COL%</co>
 		
@@ -220,27 +220,27 @@
 		
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					role="command" weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					role="command" weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					role="command" weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					role="command" weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					role="command" weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					role="command" weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					role="command" weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					role="command" weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					role="command" weight="3">%BINARY%</option>
 			</subforceOption>
 
@@ -261,27 +261,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 			
@@ -353,27 +353,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -390,7 +390,7 @@
 	<!--SL command binary is one star of ASF and one nova of ASF+BA.-->
 	
 	<force eschelon="%BINARY%" eschName="Binary" ifRating="SL|PG" ifRole="command"
-			ifUnitType="Aero">
+			ifUnitType="AeroSpaceFighter">
 		<name>Binary [Command]</name>
 		<co>%STAR_COL%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.FT.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.FT.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -139,27 +139,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 			

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.Kl.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.Kl.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -31,7 +31,7 @@
 		
 		<flags>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%STAR%|STAR^">mekAeroNova:Mek+Aero Nova</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%STAR%|STAR^">mekAeroNova:Mek+Aero Nova</option>
 		</flags>
 	</toc>
 	
@@ -224,19 +224,19 @@
 				<option weightClass="L,L" unitType="Mek">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="A|H|M">

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.MaC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.MaC.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -30,10 +30,10 @@
 		</rating>
 		
 		<flags>
-			<option ifUnitType="null|Mek|BattleArmor|Aero" ifEschelon="%BINARY%">kindraa_command:Kindraa Command Binary</option>
+			<option ifUnitType="null|Mek|BattleArmor|AeroSpaceFighter" ifEschelon="%BINARY%">kindraa_command:Kindraa Command Binary</option>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%BINARY%">mixed:Combined Mek/Aero unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%STAR%">mekAeroNova:Mek+Aero Nova</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%BINARY%">mixed:Combined Mek/Aero unit</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%STAR%">mekAeroNova:Mek+Aero Nova</option>
 		</flags>
 	</toc>
 	
@@ -162,27 +162,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 			
@@ -297,27 +297,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="3">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="2">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -383,33 +383,33 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option ifRole="!command" weightClass="H" unitType="Aero"
+				<option ifRole="!command" weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option ifRole="!command" weightClass="M" unitType="Aero"
+				<option ifRole="!command" weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option ifRole="!command" weightClass="L" unitType="Aero"
+				<option ifRole="!command" weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
 				<option ifDateBetween="2870,"
 					ifAugmented="0" unitType="BattleArmor"
 					weight="6">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option ifRole="!command" weightClass="H" unitType="Aero"
+				<option ifRole="!command" weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option ifRole="!command" weightClass="M" unitType="Aero"
+				<option ifRole="!command" weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option ifRole="!command" weightClass="L" unitType="Aero"
+				<option ifRole="!command" weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 				<option ifDateBetween="2870,"
 					ifAugmented="0" unitType="BattleArmor"
 					weight="6">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option ifRole="!command" weightClass="H" unitType="Aero"
+				<option ifRole="!command" weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option ifRole="!command" weightClass="M" unitType="Aero"
+				<option ifRole="!command" weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option ifRole="!command" weightClass="L" unitType="Aero"
+				<option ifRole="!command" weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 				<option ifDateBetween="2870,"
 					ifAugmented="0" unitType="BattleArmor"

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.MiKr.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.MiKr.xml
@@ -10,15 +10,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="BattleArmor">%CLUSTER%,%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -32,7 +32,7 @@
 		
 		<flags>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%TRINARY%|%BINARY%">mixedMekAero:Combined Mek/Aero unit</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%TRINARY%|%BINARY%">mixedMekAero:Combined Mek/Aero unit</option>
 		</flags>
 	</toc>
 	
@@ -40,7 +40,7 @@
 		<co>%GALAXY_CMDR%</co>
 		
 		<subforces>
-			<subforce role="command" rating="Keshik" unitType="Aero"
+			<subforce role="command" rating="Keshik" unitType="AeroSpaceFighter"
 				name="Kindraa Command Binary">%BINARY%</subforce>
 			<subforceOption>
 				<option weight="3" rating="FL">%CLUSTER%</option>
@@ -53,7 +53,7 @@
 			</subforceOption>
 			<subforceOption>
 				<option weight="3" rating="FL"
-					unitType="Aero">%CLUSTER%</option>
+					unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option />
 			</subforceOption>
 			<subforceOption>
@@ -85,29 +85,29 @@
 
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option unitType="Aero" augmented="1" weightClass="A"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="A"
 					role="command" weight="2">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="H"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="H"
 					role="command" weight="3">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="M"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="M"
 					role="command" weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero" augmented="1" weightClass="A"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="A"
 					role="command" weight="1">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="H"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="H"
 					role="command" weight="3">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="M"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="M"
 					role="command" weight="3">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="L"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="L"
 					role="command" weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero" augmented="1" weightClass="H"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="H"
 					role="command" weight="4">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="M"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="M"
 					role="command" weight="3">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="L"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="L"
 					role="command" weight="2">%BINARY%</option>
 			</subforceOption>
 			
@@ -161,7 +161,7 @@
 	
 	<!--Aerospace cluster includes two ASF trinaries and one Mek/BA
 	 trinary.-->
-	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="AeroSpaceFighter">
 		<name ifWeightClass="H|A">Air Assault Cluster</name>
 		<name ifWeightClass="M">Air Battle Cluster</name>
 		<name ifWeightClass="L">Air Striker Cluster</name>
@@ -340,18 +340,18 @@
 			</subforceOption>			
 						
 			<subforceOption ifWeightClass="H">
-				<option unitType="Aero" weightClass="H,H"
+				<option unitType="AeroSpaceFighter" weightClass="H,H"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="H,M">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H,M">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero" weightClass="H,M">%BINARY%</option>
-				<option unitType="Aero" weightClass="M,M">%BINARY%</option>
-				<option unitType="Aero" weightClass="M,L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H,M">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="M,M">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="M,L">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero" weightClass="M,L">%BINARY%</option>
-				<option unitType="Aero" weightClass="L,L"
+				<option unitType="AeroSpaceFighter" weightClass="M,L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="L,L"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -382,29 +382,29 @@
 
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option unitType="Mek" weightClass="A" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="A" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="2">%TRINARY%</option>
-				<option unitType="Mek" weightClass="H" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="H" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="3">%TRINARY%</option>
-				<option unitType="Mek" weightClass="M" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="M" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Mek" weightClass="A" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="A" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="1">%TRINARY%</option>
-				<option unitType="Mek" weightClass="H" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="H" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="3">%TRINARY%</option>
-				<option unitType="Mek" weightClass="M" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="M" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="3">%TRINARY%</option>
-				<option unitType="Mek" weightClass="L" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="L" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Mek" weightClass="H" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="H" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="4">%TRINARY%</option>
-				<option unitType="Mek" weightClass="M" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="M" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="3">%TRINARY%</option>
-				<option unitType="Mek" weightClass="L" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="L" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="2">%TRINARY%</option>
 			</subforceOption>
 
@@ -501,7 +501,7 @@
 	<!--Command trinary used for SL clusters, consisting of two
 	Mek stars and one ASF star.-->
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifFlags="mixedMekAero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifFlags="mixedMekAeroSpaceFighter">
 		<name>Trinary Command</name>
 		<co>%STAR_COL%</co>
 		
@@ -545,27 +545,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="2">%STAR%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="2">%STAR%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="1">%STAR%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.MiKrKl.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.MiKrKl.xml
@@ -10,15 +10,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="BattleArmor">%CLUSTER%,%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -32,8 +32,8 @@
 		
 		<flags>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%TRINARY%|%BINARY%">mixedMekAero:Combined Mek/Aero unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%STAR%|STAR^">mekAeroNova:Mek+Aero Nova</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%TRINARY%|%BINARY%">mixedMekAero:Combined Mek/Aero unit</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%STAR%|STAR^">mekAeroNova:Mek+Aero Nova</option>
 		</flags>
 	</toc>
 	
@@ -50,7 +50,7 @@
 					faction="CFM.MiKr">%CLUSTER%</option>
 			</subforceOption>
 			<subforce num="1" rating="FL" faction="CFM.MiKr"
-				unitType="Aero">%CLUSTER%</subforce>
+				unitType="AeroSpaceFighter">%CLUSTER%</subforce>
 			<subforce num="1" rating="FL" faction="CFM.MiKr"
 				unitType="BattleArmor">%CLUSTER%</subforce>
 			<subforceOption>

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.P.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.P.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -121,26 +121,26 @@
 					unitType="Mek">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="1">%BINARY%</option>
 				<option weight="12" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero" weightClass="H">%BINARY%</option>
-				<option unitType="Aero" weightClass="M">%BINARY%</option>
-				<option unitType="Aero" weightClass="L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="M">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="L">%BINARY%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="1">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="3">%BINARY%</option>
 				<option weight="12" />
 			</subforceOption>
@@ -164,29 +164,29 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 				<option weight="12" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 				<option weight="14" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 				<option weight="12" />
 			</subforceOption>
@@ -257,11 +257,11 @@
 		
 		<attachedForces>
 			<subforceOption>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					name="Support Aero Star" weight="3">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					name="Support Aero Star" weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					name="Support Aero Star" weight="1">%STAR%</option>
 			</subforceOption>
 		</attachedForces>

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.PBG.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.PBG.xml
@@ -10,14 +10,14 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%GALAXY%,%CLUSTER%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -47,7 +47,7 @@
 					faction="CFM.P">%CLUSTER%</option>
 			</subforceOption>
 			<subforce num="1" rating="FL" faction="CFM.BG"
-				unitType="Aero">%CLUSTER%</subforce>
+				unitType="AeroSpaceFighter">%CLUSTER%</subforce>
 			<subforce num="1" rating="SL"
 				faction="CFM.BG">%CLUSTER%</subforce>
 			<subforce num="1" rating="SL" flags="binary"

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.S.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.S.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -51,7 +51,7 @@
 		</subforces>
 	</force>
 	
-	<!-- Standard cluster includes one trinary each of Mek, Aero, BA
+	<!-- Standard cluster includes one trinary each of Mek, AeroSpaceFighter, BA
 	and an additional cluster of mixed Mek/BA-->
 	<force eschelon="%CLUSTER%" eschName="Cluster">
 		<name ifRating="FL" ifWeightClass="A|H">Assault Cluster</name>
@@ -94,27 +94,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 			

--- a/MekHQ/data/forcegenerator/faction_rules/CFM.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CFM.xml
@@ -15,15 +15,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%TOUMAN%,%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="Dropship|Jumpship">%STAR%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -38,7 +38,7 @@
 		
 		<flags>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%TRINARY%|%BINARY%">mekAeroNova:Mek+Aero Nova</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%TRINARY%|%BINARY%">mekAeroNova:Mek+Aero Nova</option>
 		</flags>
 	</toc>
 	
@@ -132,27 +132,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -235,7 +235,7 @@
 	fighters and a star of battlearmor. There is no indication in the FM of how they
 	work together, but the Nova formation rules in Campaign Operations say the ASFs must
 	be omni, which suggests that they ride the fighters into battle and make a hot drop. -->
-	<force eschelon="%STAR%" eschName="Nova" ifAugmented="1" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Nova" ifAugmented="1" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic} Aero Nova</name>
 		<co>%STAR_CMDR%</co>
 		
@@ -328,8 +328,8 @@
 		
 		<subforces>
 			<subforce flags="-mekAeroNova" augmented="0" unitType="Mek">%STAR%</subforce>
-			<subforce flags="-mekAeroNova" augmented="0" unitType="Aero" ifWeightClass="A" weightClass="H">%STAR%</subforce>
-			<subforce flags="-mekAeroNova" augmented="0" unitType="Aero" ifWeightClass="H|M|L">%STAR%</subforce>
+			<subforce flags="-mekAeroNova" augmented="0" unitType="AeroSpaceFighter" ifWeightClass="A" weightClass="H">%STAR%</subforce>
+			<subforce flags="-mekAeroNova" augmented="0" unitType="AeroSpaceFighter" ifWeightClass="H|M|L">%STAR%</subforce>
 		</subforces>
 	</force>
 

--- a/MekHQ/data/forcegenerator/faction_rules/CGB.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CGB.xml
@@ -14,15 +14,15 @@ but have a smaller aerospace arm than most other Clans. -->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%TOUMAN%,%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="Warship">%CLUSTER%</option>
 			<option ifUnitType="Mek" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
-			<option ifUnitType="Aero" ifDateBetween="3069,">%GALAXY%,%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
+			<option ifUnitType="AeroSpaceFighter" ifDateBetween="3069,">%GALAXY%,%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
 			<option ifUnitType="BattleArmor">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
@@ -78,7 +78,7 @@ but have a smaller aerospace arm than most other Clans. -->
 			<subforce rating="SL" ifDateBetween="3068,"
 				name="Rasalhague Galaxy">%GALAXY%</subforce>
 			<subforce rating="SL" ifDateBetween="3069,"
-			    unitType="Aero"
+			    unitType="AeroSpaceFighter"
 				name="Valkyrie Galaxy">%GALAXY%</subforce>
 			<subforce rating="SL" ifDateBetween="2950,3075"
 			    flags="zeta"
@@ -92,7 +92,7 @@ but have a smaller aerospace arm than most other Clans. -->
 	to have been reduced to two in the drive to Terra (FR:C). The two-
 	cluster size is kept in later TO&E listings.-->
 	
-	<force eschelon="%GALAXY%" eschName="Valkyrie Galaxy" ifUnitType="Aero">
+	<force eschelon="%GALAXY%" eschName="Valkyrie Galaxy" ifUnitType="AeroSpaceFighter">
 	    <name>{greek} Galaxy</name>
 	    <co>%GALAXY_CMDR%</co>
 	    
@@ -229,7 +229,7 @@ but have a smaller aerospace arm than most other Clans. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="AeroSpaceFighter">
 	    <name>{ordinal} Valkyrie</name>
 	    <co>%STAR_COL%</co>
 	    
@@ -376,31 +376,31 @@ but have a smaller aerospace arm than most other Clans. -->
             resulting in many clusters having no support of their own.-->
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 				<option weight="3"/>
 				<option ifRating="SL|PG|Sol" weight="3"/>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 				<option weight="3"/>
 				<option ifRating="SL|PG|Sol" weight="3"/>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 				<option weight="3"/>
 				<option ifRating="SL|PG|Sol" weight="3"/>
@@ -474,7 +474,7 @@ but have a smaller aerospace arm than most other Clans. -->
 		
 		<attachedForces ifRating="FL">
 		    <subforceOption>
-		        <option unitType="Aero" name="Tango Fighter Star"
+		        <option unitType="AeroSpaceFighter" name="Tango Fighter Star"
 		            weight="1">%STAR%</option>
 		        <option weight="5"/>
 		    </subforceOption>
@@ -482,7 +482,7 @@ but have a smaller aerospace arm than most other Clans. -->
 
 		<attachedForces ifRating="Keshik">
 		    <subforceOption>
-		        <option unitType="Aero" name="Tango Fighter Star"
+		        <option unitType="AeroSpaceFighter" name="Tango Fighter Star"
 		            weight="2">%STAR%</option>
 		        <option unitType="Mek" name="Tango Support Star"
 		            weight="1">%STAR%</option>
@@ -535,7 +535,7 @@ but have a smaller aerospace arm than most other Clans. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name>Fighter Trinary</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -585,7 +585,7 @@ but have a smaller aerospace arm than most other Clans. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name>Fighter Binary</name>
 		<co>%STAR_CAPTAIN%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CGS.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CGS.xml
@@ -17,9 +17,9 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -487,27 +487,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>		
@@ -621,8 +621,8 @@
 			</subforceOption>
 			
 			<subforceOption>
-				<option unitType="Aero" role="cargo" ifDateBetween=",2900">%STAR%</option>
-				<option weightClass="H" unitType="Aero" model="Kirghiz C" ifDateBetween="2874,">%STAR%</option>
+				<option unitType="AeroSpaceFighter" role="cargo" ifDateBetween=",2900">%STAR%</option>
+				<option weightClass="H" unitType="AeroSpaceFighter" model="Kirghiz C" ifDateBetween="2874,">%STAR%</option>
 			</subforceOption>
 		</subforces>
 	</force>		
@@ -657,21 +657,21 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="M" unitType="Aero">%STAR%</option>
-				<option weightClass="L" unitType="Aero">%STAR%</option>
+				<option weightClass="M" unitType="AeroSpaceFighter">%STAR%</option>
+				<option weightClass="L" unitType="AeroSpaceFighter">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>			
@@ -745,27 +745,27 @@
 		
 		<subforces generate="group">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="3">%ELEMENT%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%ELEMENT%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="1">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="2">%ELEMENT%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="3">%ELEMENT%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="2">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="1">%ELEMENT%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%ELEMENT%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="3">%ELEMENT%</option>
 			</subforceOption>
 		</subforces>		
@@ -847,7 +847,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{ordinal} {phonetic:parent} {name:parent} Star</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CHH.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CHH.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -100,9 +100,9 @@
 			</subforceOption>
 
 			<subforceOption>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="2">%TRINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 
@@ -293,27 +293,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -1232,7 +1232,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Trinary Delta</name>
 		<name>Trinary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1456,7 +1456,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Binary Delta</name>
 		<name>Binary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>

--- a/MekHQ/data/forcegenerator/faction_rules/CIH.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CIH.xml
@@ -18,9 +18,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -239,7 +239,7 @@
 		
 		<!-- Assume each cluster contains two Mek trinaries, and
 		optionally up to three additional trinaries which could be
-		Mek, Tank (SL/Sol only), Aero, or infantry.-->
+		Mek, Tank (SL/Sol only), AeroSpaceFighter, or infantry.-->
 
 		<subforces>
 			<subforceOption ifWeightClass="A">
@@ -350,40 +350,40 @@
 
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary"
 					ifDateBetween="2850,">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary"
 					ifDateBetween="2950,">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option ifRating="FL" weight="1" />
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary"
 					ifDateBetween="2950,">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary"
 					ifDateBetween="2950,">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -758,7 +758,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command" ifRating="!Keshik">Trinary [Command]</name>
 		<name>{ordinal:distinct} Trinary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1036,7 +1036,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Binary [Command]</name>
 		<name>{ordinal:distinct} Binary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1409,7 +1409,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CJF.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CJF.xml
@@ -17,9 +17,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,3072">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,3072">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -406,15 +406,15 @@
 					ifAugmented="0" />
 			</subforceOption>
 
-			<!--The final trinary is usually Aero, but may rarely
+			<!--The final trinary is usually AeroSpaceFighter, but may rarely
 			be Mek (1/15)-->
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="21">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="14">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="7">%TRINARY%</option>
 				<option weightClass="H"
 					unitType="Mek" weight="2">%TRINARY%</option>
@@ -422,11 +422,11 @@
 					unitType="Mek">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="16">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="21">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="16">%TRINARY%</option>
 				<option weightClass="H"
 					unitType="Mek" weight="1">%TRINARY%</option>
@@ -436,11 +436,11 @@
 					unitType="Mek" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="7">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="14">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="21">%TRINARY%</option>
 				<option weightClass="M"
 					unitType="Mek" weight="1">%TRINARY%</option>
@@ -566,29 +566,29 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -920,7 +920,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Trinary Command</name>
 		<name>Trinary {phonetic}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1178,7 +1178,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Binary Command</name>
 		<name>Binary {phonetic}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1751,7 +1751,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic:parent} Wing {cardinal:distinct}</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CLAN.GC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CLAN.GC.xml
@@ -94,9 +94,9 @@
 			</subforceOption>
 
 			<subforceOption>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="2">%TRINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 
@@ -287,27 +287,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -1226,7 +1226,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Trinary Delta</name>
 		<name>Trinary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1450,7 +1450,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Binary Delta</name>
 		<name>Binary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>

--- a/MekHQ/data/forcegenerator/faction_rules/CLAN.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CLAN.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -251,29 +251,29 @@
 		<!-- Possibly add trinary each of aero and battlearmor-->
 		<subforces ifRating="FL|Keshik">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option ifRating="FL" weight="1" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option ifRating="FL" weight="1" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option ifRating="FL" weight="1" />
 			</subforceOption>
@@ -289,33 +289,33 @@
 		
 		<subforces ifRating="SL|Sol|PG">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option weight="3" />
 				<option ifRating="Sol" weight="3" />
 				<option ifRating="PG" weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="3" />
 				<option ifRating="Sol" weight="3" />
 				<option ifRating="PG" weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="3" />
 				<option ifRating="Sol" weight="3" />
@@ -672,7 +672,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Trinary Command</name>
 		<name>{ordinal:distinct} Trinary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -994,7 +994,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Binary [Command]</name>
 		<name>{ordinal:distinct} Binary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1364,7 +1364,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>
 		
@@ -1514,7 +1514,7 @@
 			<option weight="2">L</option>
 		</weightClass>
 		
-		<weightClass ifUnitType="Aero">
+		<weightClass ifUnitType="AeroSpaceFighter">
 			<option>H</option>
 			<option>M</option>
 			<option>L</option>
@@ -1527,7 +1527,7 @@
 			</unitType>
 		</ruleGroup>
 		
-		<subforces generate="group" ifUnitType="Tank|VTOL|Aero">
+		<subforces generate="group" ifUnitType="Tank|VTOL|AeroSpaceFighter">
 			<subforce num="2">%ELEMENT%</subforce>
 		</subforces>
 

--- a/MekHQ/data/forcegenerator/faction_rules/CNC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CNC.xml
@@ -22,9 +22,9 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -356,27 +356,27 @@
 		
 		<subforces ifRating="FL" ifFlags="!lancer">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>			
 		</subforces>
@@ -420,27 +420,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 			</subforceOption>						
 		</subforces>
@@ -734,7 +734,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name ifRating="Keshik">{ordinal} Fighter {phonetic:parent} Command</name>
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>

--- a/MekHQ/data/forcegenerator/faction_rules/CS.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CS.xml
@@ -1613,66 +1613,66 @@
 		<subforces generate="group" ifFlags="4002|0402|0042|2202|2022|0222">
 		    <subforceOption ifWeightClass="A">
 		        <option weightClass="H,H" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="H">
 		        <option weightClass="H,H" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L" weight="1"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="M">
 		        <option weightClass="H,H" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="L">
 		        <option weightClass="H,H" weight="1"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		</subforces>
 
 		<subforces generate="group" ifFlags="3003">
 		    <subforceOption ifWeightClass="A">
 		        <option weightClass="H,H,H" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M,M"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="H">
 		        <option weightClass="H,H,H" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M,M" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L,L" weight="1"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="M">
 		        <option weightClass="H,H,H" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M,M" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L,L" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="L">
 		        <option weightClass="H,H,H" weight="1"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M,M" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L,L" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		</subforces>
 	</force>

--- a/MekHQ/data/forcegenerator/faction_rules/CSA.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CSA.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -262,11 +262,11 @@
 			</subforceOption>
 			
 			<subforceOption>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="L">%BINARY%</option>
 			</subforceOption>		
 		</subforces>
 	</force>
@@ -336,9 +336,9 @@
 					unitType="Mek">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption>
-				<option unitType="Aero" weightClass="H">%TRINARY%+</option>
-				<option unitType="Aero" weightClass="M">%TRINARY%+</option>
-				<option unitType="Aero" weightClass="L">%TRINARY%+</option>
+				<option unitType="AeroSpaceFighter" weightClass="H">%TRINARY%+</option>
+				<option unitType="AeroSpaceFighter" weightClass="M">%TRINARY%+</option>
+				<option unitType="AeroSpaceFighter" weightClass="L">%TRINARY%+</option>
 			</subforceOption>		
 		</subforces>
 		
@@ -456,21 +456,21 @@
 				<option ifFlags="guards|sentinels" weight="8" />
 			</subforceOption>
 			<subforceOption ifFlags="!cavalry">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%TRINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%TRINARY%</option>
-				<option unitType="Aero" weightClass="L">%TRINARY%</option>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="L">%TRINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L">%BINARY%</option>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%STAR%</option>
-				<option unitType="Aero" weightClass="L">%STAR%</option>
+				<option unitType="AeroSpaceFighter" weightClass="L">%STAR%</option>
 			</subforceOption>		
 		</subforces>
 
@@ -572,16 +572,16 @@
 				<option unitType="Infantry">%BINARY%</option>
 			</subforceOption>
 			<subforceOption>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L">%BINARY%</option>
-				<option unitType="Aero" weightClass="H" ifRating="SL"
+				<option unitType="AeroSpaceFighter" weightClass="L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H" ifRating="SL"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="M" ifRating="SL"
+				<option unitType="AeroSpaceFighter" weightClass="M" ifRating="SL"
 					weight="2">%STAR%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					ifRating="SL">%STAR%</option>
 			</subforceOption>		
 		</subforces>

--- a/MekHQ/data/forcegenerator/faction_rules/CSJ.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CSJ.xml
@@ -13,9 +13,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3059,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3059,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -408,29 +408,29 @@
 		
 		<subforces ifRating="!Sol">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -485,11 +485,11 @@
 					weightClass="H" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -499,11 +499,11 @@
 					weightClass="H" weight="2">%STAR%</option>
 				<option unitType="BattleArmor" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -513,11 +513,11 @@
 					weightClass="M" weight="2">%STAR%</option>
 				<option unitType="BattleArmor" augmented="0"
 					weightClass="L" weight="1">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -527,11 +527,11 @@
 					weightClass="M" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" augmented="0"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -576,29 +576,29 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="1">%STAR%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="2">%STAR%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="3">%STAR%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -691,7 +691,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Trinary Command</name>
 		<name>{ordinal:distinct} Trinary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -819,7 +819,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Binary [Command]</name>
 		<name>{ordinal:distinct} Binary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1033,7 +1033,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CSL.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CSL.xml
@@ -18,7 +18,7 @@
 	
 	<toc>
 		<unitType>
-			<option>null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Dropship,Jumpship</option>
+			<option>null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -138,31 +138,31 @@
 			
 			<!-- Half the FL and 1/3 the SL units get aerospace support -->
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option weight="6"/>
 				<option weight="6" ifRating="SL"/>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="7"/>
 				<option weight="7" ifRating="SL"/>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="6"/>
 				<option weight="6" ifRating="SL"/>
@@ -941,7 +941,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Trinary Delta</name>
 		<name>Trinary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1165,7 +1165,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Binary Delta</name>
 		<name>Binary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>

--- a/MekHQ/data/forcegenerator/faction_rules/CSR.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CSR.xml
@@ -10,16 +10,16 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%TOUMAN%,%GALAXY%,%CLUSTER%,%TRINARY%</option>
 			<option ifUnitType="Warship">%STAR%</option>
 			<option ifUnitType="Mek" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
-			<option ifUnitType="Aero">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
+			<option ifUnitType="AeroSpaceFighter">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -35,7 +35,7 @@
 		
 		<flags>
 			<option ifEschelon="%GALAXY%">proto:Zeta Galaxy (ProtoMek heavy)</option>
-			<option ifUnitType="!Aero" ifEschelon="%CLUSTER%">phalanx:Phalanx Cluster,stoop:Stoop Cluster,proto:Chausseurs Cluster</option>
+			<option ifUnitType="!AeroSpaceFighter" ifEschelon="%CLUSTER%">phalanx:Phalanx Cluster,stoop:Stoop Cluster,proto:Chausseurs Cluster</option>
 		</flags>
 	</toc>
 	
@@ -103,10 +103,10 @@
 		
 		<subforces ifRating="FL">
 			<subforce num="2">%CLUSTER%</subforce>
-			<subforce unitType="Aero">%CLUSTER%</subforce>
+			<subforce unitType="AeroSpaceFighter">%CLUSTER%</subforce>
 			<subforceOption>
 				<option flags="phalanx">%CLUSTER%</option>
-				<option unitType="Aero">%CLUSTER%</option>
+				<option unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option flags="stoop">%CLUSTER%</option>
 				<option>%CLUSTER%</option>
 			</subforceOption>
@@ -135,7 +135,7 @@
 	
 	<!-- Wing clusters have four ASF trinaries. -->
 	
-	<force eschelon="%CLUSTER%" eschName="Wing Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Wing Cluster" ifUnitType="AeroSpaceFighter">
 		<name>Raven Wing</name>
 		<co>%STAR_COL%</co>
 		
@@ -244,27 +244,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -397,21 +397,21 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="M" unitType="Aero">%STAR%</option>
-				<option weightClass="L" unitType="Aero">%STAR%</option>
+				<option weightClass="M" unitType="AeroSpaceFighter">%STAR%</option>
+				<option weightClass="L" unitType="AeroSpaceFighter">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -506,7 +506,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name>Trinary [Fighter] {phonetic:distinct}</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -744,7 +744,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{ordinal} {name:parent}</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/CSV.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CSV.xml
@@ -10,8 +10,8 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -373,27 +373,27 @@
 
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -472,7 +472,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name>Trinary {phonetic}</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -845,7 +845,7 @@
 	distinctive. Four of the five ASFs in the star are paired as is standard in
 	ASF deployment, with one generated alone. -->
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{ordinal:distinct} {phonetic:parent} Adder</name>
 		<co>%STAR_CMDR%</co>
 		
@@ -866,7 +866,7 @@
 			</formation>
 		</ruleGroup>
 
-		<subforces generate="group" ifUnitType="Aero">
+		<subforces generate="group" ifUnitType="AeroSpaceFighter">
 			<subforceOption ifWeightClass="H">
 				<option weightClass="H" weight="2">%ELEMENT%</option>
 				<option weightClass="M">%ELEMENT%</option>

--- a/MekHQ/data/forcegenerator/faction_rules/CW.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CW.xml
@@ -14,8 +14,8 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -360,27 +360,27 @@
 		
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -468,27 +468,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -585,27 +585,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 		</attachedForces>
@@ -706,7 +706,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Trinary Command</name>
 		<name>{ordinal:distinct} Trinary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -875,27 +875,27 @@
 		
 		<subforces generate="group">
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="3">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="1">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="3">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="2">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="1">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="3">%ELEMENT%</option>
 			</subforceOption>
 		</subforces>

--- a/MekHQ/data/forcegenerator/faction_rules/CWIE.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/CWIE.xml
@@ -15,9 +15,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocat
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,3084">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,3084">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>

--- a/MekHQ/data/forcegenerator/faction_rules/DC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/DC.xml
@@ -12,9 +12,9 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2468,">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2468,">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -22,7 +22,7 @@
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -69,7 +69,7 @@
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%BATTALION%</subforce>
@@ -78,7 +78,7 @@
 		</attachedForces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2515">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2468,">
 				<option ifRating="D|F"/>
@@ -436,7 +436,7 @@
 		<co>%SGT%</co>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT_COLONEL%</co>
 		
 		<weightClass>
@@ -446,7 +446,7 @@
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,H,H">%SQUADRON%</option>
 				<option augmented="1"
@@ -454,7 +454,7 @@
 				<option augmented="1"
 					weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,M,M">%SQUADRON%</option>
 				<option augmented="1"
@@ -464,7 +464,7 @@
 				<option augmented="1"
 					weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,L,L">%SQUADRON%</option>
 				<option augmented="1"
@@ -485,7 +485,7 @@
 	</force>
 	
 	<force eschelon="%SQUADRON%" eschName="Company" ifAugmented="1"
-			ifUnitType="Aero|Conventional Fighter">
+			ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{phonetic} Company</name>
 		<co>%MAJOR%</co>
 		
@@ -496,13 +496,13 @@
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="H,H" weight="2">%SQUADRON%</option>
 				<option augmented="0"
 					weightClass="H,M">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="H,M">%SQUADRON%</option>
 				<option augmented="0"
@@ -512,7 +512,7 @@
 				<option augmented="0"
 					weightClass="M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="M,L">%SQUADRON%</option>
 				<option augmented="0"
@@ -524,7 +524,7 @@
 	</force>
 	
 	<force eschelon="%SQUADRON%" eschName="Flight" ifAugmented="0"
-			ifUnitType="Aero|Conventional Fighter">
+			ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{formation} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -544,7 +544,7 @@
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%
 					</option>
 				<option weightClass="H,H,M">%FLIGHT%
@@ -552,7 +552,7 @@
 				<option weightClass="H,H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M,M">%FLIGHT%
@@ -562,7 +562,7 @@
 				<option weightClass="M,M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%
 					</option>
 				<option weightClass="M,L,L">%FLIGHT%
@@ -575,7 +575,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT%</co>
 		
 		<weightClass>

--- a/MekHQ/data/forcegenerator/faction_rules/FC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/FC.xml
@@ -11,8 +11,8 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -21,7 +21,7 @@
 			<option ifUnitType="Tank">%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 			<option ifUnitType="Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/FRR.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/FRR.xml
@@ -16,9 +16,9 @@
     
 	<toc>
 		<unitType>
-			<option ifDateBetween="3076,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="3051,3075">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3076,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="3051,3075">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -29,7 +29,7 @@
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -64,7 +64,7 @@
     	</subforces>
     	
     	<attachedForces>
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%BATTALION%</subforce>
@@ -155,7 +155,7 @@
     chosen to follow DC organization. This gives a FRR wing 36 fighters, which puts it
     between DC (54) and standard IS (18). -->
     
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter" ifDateBetween=",3075">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween=",3075">
 		<co>%LT_COLONEL%</co>
 		
 		<weightClass>
@@ -165,7 +165,7 @@
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,H,H">%SQUADRON%</option>
 				<option augmented="1"
@@ -173,7 +173,7 @@
 				<option augmented="1"
 					weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,M,M">%SQUADRON%</option>
 				<option augmented="1"
@@ -183,7 +183,7 @@
 				<option augmented="1"
 					weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,L,L">%SQUADRON%</option>
 				<option augmented="1"
@@ -204,7 +204,7 @@
 	</force>
 	
 	<force eschelon="%SQUADRON%" eschName="Company" ifAugmented="1"
-	        ifDateBetween=",3075" ifUnitType="Aero|Conventional Fighter">
+	        ifDateBetween=",3075" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -214,13 +214,13 @@
 		</weightClass>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="H,H" weight="2">%SQUADRON%</option>
 				<option augmented="0"
 					weightClass="H,M">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="H,M">%SQUADRON%</option>
 				<option augmented="0"
@@ -230,7 +230,7 @@
 				<option augmented="0"
 					weightClass="M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="M,L">%SQUADRON%</option>
 				<option augmented="0"
@@ -242,7 +242,7 @@
 	</force>
 	
 	<force eschelon="%SQUADRON%" eschName="Flight" ifAugmented="0"
-	        ifDateBetween=",3075" ifUnitType="Aero|Conventional Fighter">
+	        ifDateBetween=",3075" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 	    <name>{formation} Flight</name>
 		<co>%CAPTAIN%</co>
 		
@@ -262,17 +262,17 @@
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" weight="2">%FLIGHT%</option>
 				<option weightClass="H,M">%FLIGHT%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M">%FLIGHT%</option>
 				<option weightClass="M,M">%FLIGHT%</option>
 				<option weightClass="H,L">%FLIGHT%</option>
 				<option weightClass="M,L">%FLIGHT%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L">%FLIGHT%</option>
 				<option weightClass="L,L" weight="2">%FLIGHT%</option>
 			</subforceOption>
@@ -281,7 +281,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="Aero|Conventional Fighter" ifDateBetween=",3075">
+	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween=",3075">
 		<name>Lance {cardinal}</name>
 		<co>%LT%</co>
 		
@@ -396,27 +396,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -469,7 +469,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero|Conventional Fighter" ifDateBetween="3076,">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="3076,">
 		<name>Fighter Binary</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -484,7 +484,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero|Conventional Fighter" ifDateBetween="3076,">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="3076,">
 		<name>Fighter Binary</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -719,7 +719,7 @@
 		</subforces>
 	</force>
 		
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero|Conventional Fighter" ifDateBetween="3076,">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="3076,">
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>
 		
@@ -756,7 +756,7 @@
 			<option weight="2">L</option>
 		</weightClass>
 		
-		<weightClass ifUnitType="Aero">
+		<weightClass ifUnitType="AeroSpaceFighter">
 			<option>H</option>
 			<option>M</option>
 			<option>L</option>
@@ -770,7 +770,7 @@
 			</unitType>
 		</ruleGroup>
 		
-		<subforces generate="group" ifUnitType="Tank|VTOL|Aero|Conventional Fighter">
+		<subforces generate="group" ifUnitType="Tank|VTOL|AeroSpaceFighter|Conventional Fighter">
 			<subforce num="2">%ELEMENT%</subforce>
 		</subforces>
 	</force>

--- a/MekHQ/data/forcegenerator/faction_rules/FS.CH.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/FS.CH.xml
@@ -15,7 +15,7 @@ are often combined down to the company level. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,BattleArmor,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -23,7 +23,7 @@ are often combined down to the company level. -->
 			<option ifUnitType="Mek|Tank|VTOL">%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -43,7 +43,7 @@ are often combined down to the company level. -->
 				<option num="2" unitType="Tank" role="artillery" name="Artillery Support">%BATTALION%</option>
 				<option num="3" unitType="Tank" role="artillery" name="Artillery Support">%BATTALION%</option>
 			</subforceOption>
-			<subforce num="2" unitType="Aero">%WING%</subforce>
+			<subforce num="2" unitType="AeroSpaceFighter">%WING%</subforce>
 		</subforces>
 	</force>
 	

--- a/MekHQ/data/forcegenerator/faction_rules/FS.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/FS.xml
@@ -15,10 +15,10 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2881,3050">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2459,2880">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2881,3050">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2459,2880">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -30,7 +30,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 			<option ifUnitType="Tank">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 			<option ifUnitType="Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
@@ -59,7 +59,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 			<subforce unitType="Mek" ifFlags="lct">%BATTALION%</subforce>
 			<subforce unitType="Tank">%BRIGADE%</subforce>
 			<subforce unitType="Infantry">%BRIGADE%</subforce>
-			<subforce unitType="Aero" num="2">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter" num="2">%WING%</subforce>
 		</subforces>
 	</force>
 
@@ -171,7 +171,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</subforces>
 		
 		<attachedForces ifTopLevel="1" ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption>
 				<option unitType="Tank" weight="4"
@@ -184,7 +184,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</attachedForces>		
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2510">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2459,">
 				<option ifRating="D|F"/>
@@ -784,7 +784,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</subforces>
 	</force>
 	
-	<force eschelon="%GROUP%" eschName="Aero Regiment" ifUnitType="Aero">
+	<force eschelon="%GROUP%" eschName="Aero Regiment" ifUnitType="AeroSpaceFighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -794,18 +794,18 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%WING%</option>
 				<option weightClass="H,H,M">%WING%</option>
 				<option weightClass="H,H,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%WING%</option>
 				<option weightClass="M,M,M">%WING%</option>
 				<option weightClass="H,M,L">%WING%</option>
 				<option weightClass="M,M,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%WING%</option>
 				<option weightClass="M,L,L">%WING%</option>
 				<option weightClass="L,L,L">%WING%</option>
@@ -813,7 +813,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -825,18 +825,18 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		<subforces>
 			<subforce role="command">%FLIGHT%</subforce>
 		
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>

--- a/MekHQ/data/forcegenerator/faction_rules/FWL.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/FWL.xml
@@ -12,16 +12,16 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2470,3050">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2470,3050">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%GROUP%,%WING%+,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%GROUP%,%WING%+,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -65,7 +65,7 @@
 		</subforces>
 		
 		<attachedForces ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%REGIMENT%</subforce>
@@ -74,7 +74,7 @@
 		</attachedForces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2520">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2470,">
 				<option ifRating="D|F"/>
@@ -604,7 +604,7 @@
 		<co>%SGT%</co>
 	</force>
 
-	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="Aero">
+	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="AeroSpaceFighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -618,7 +618,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>Lance {cardinal}</name>
 		<co>%LT%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/HL.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/HL.xml
@@ -25,7 +25,7 @@ would have none so I've attached a wing to each RDF. -->
 	
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -33,7 +33,7 @@ would have none so I've attached a wing to each RDF. -->
 			<option ifUnitType="Mek">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Tank|VTOL">%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%COMPANY%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -54,7 +54,7 @@ would have none so I've attached a wing to each RDF. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 	

--- a/MekHQ/data/forcegenerator/faction_rules/IS.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/IS.xml
@@ -11,15 +11,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -64,7 +64,7 @@
 		</subforces>
 		
 		<attachedForces ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%BATTALION%</subforce>
@@ -73,7 +73,7 @@
 		</attachedForces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2550">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2481,">
 				<option ifRating="D|F"/>
@@ -698,7 +698,7 @@
 		<co>%SGT%</co>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -708,18 +708,18 @@
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -736,7 +736,7 @@
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{formation} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -756,7 +756,7 @@
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%
 					</option>
 				<option weightClass="H,H,M">%FLIGHT%
@@ -764,7 +764,7 @@
 				<option weightClass="H,H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M,M">%FLIGHT%
@@ -774,7 +774,7 @@
 				<option weightClass="M,M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%
 					</option>
 				<option weightClass="M,L,L">%FLIGHT%
@@ -787,7 +787,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name ifRole="command">Command Flight</name>
 		<name>Flight {cardinal}</name>
 		<co>%LT%</co>

--- a/MekHQ/data/forcegenerator/faction_rules/LA.AlJ.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/LA.AlJ.xml
@@ -17,14 +17,14 @@ that all infantry units are BattleArmor. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,BattleArmor,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%REGIMENT%,%BATTALION%</option>
 			<option ifUnitType="Mek|Tank|VTOL">%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -57,7 +57,7 @@ that all infantry units are BattleArmor. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 	

--- a/MekHQ/data/forcegenerator/faction_rules/LA.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/LA.xml
@@ -19,10 +19,10 @@ each Mek regiment. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="3040,3050">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2462,3039">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="3040,3050">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2462,3039">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -32,7 +32,7 @@ each Mek regiment. -->
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 			<option ifUnitType="Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
@@ -55,7 +55,7 @@ each Mek regiment. -->
 			<subforce unitType="Mek">%REGIMENT%</subforce>
 			<subforce unitType="Tank">%BRIGADE%</subforce>
 			<subforce unitType="Infantry">%BRIGADE%</subforce>
-			<subforce unitType="Aero" num="2">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter" num="2">%WING%</subforce>
 		</subforces>
 	</force>
 
@@ -114,7 +114,7 @@ each Mek regiment. -->
 		</subforces>
 		
 		<attachedForces ifTopLevel="1" ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption>
 				<option unitType="Tank" weight="8"
@@ -129,7 +129,7 @@ each Mek regiment. -->
 		</attachedForces>		
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2510">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2462,">
 				<option ifRating="D|F"/>
@@ -717,7 +717,7 @@ each Mek regiment. -->
 		</subforces>
 	</force>
 
-	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="Aero">
+	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="AeroSpaceFighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -727,18 +727,18 @@ each Mek regiment. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%WING%</option>
 				<option weightClass="H,H,M">%WING%</option>
 				<option weightClass="H,H,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%WING%</option>
 				<option weightClass="M,M,M">%WING%</option>
 				<option weightClass="H,M,L">%WING%</option>
 				<option weightClass="M,M,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%WING%</option>
 				<option weightClass="M,L,L">%WING%</option>
 				<option weightClass="L,L,L">%WING%</option>
@@ -746,7 +746,7 @@ each Mek regiment. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -756,18 +756,18 @@ each Mek regiment. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>

--- a/MekHQ/data/forcegenerator/faction_rules/MH.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/MH.xml
@@ -16,8 +16,8 @@ support wing (cohort). -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -25,7 +25,7 @@ support wing (cohort). -->
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -74,7 +74,7 @@ support wing (cohort). -->
 				<option num="1" flags="+auxiliary" unitType="">%REGIMENT%</option>
 			</subforceOption>
 			<subforceOption>
-				<option weight="2" unitType="Aero">%BATTALION%</option>
+				<option weight="2" unitType="AeroSpaceFighter">%BATTALION%</option>
 				<option/>
 			</subforceOption>
 		</attachedForces>
@@ -157,7 +157,7 @@ support wing (cohort). -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{latin:distinct} Ala</name>
 		<co>%MAJOR%</co>
 		
@@ -168,18 +168,18 @@ support wing (cohort). -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -382,7 +382,7 @@ support wing (cohort). -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Maniple" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Maniple" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{latin} Manipulus</name>
 		<co>%CAPTAIN%</co>
 		
@@ -393,13 +393,13 @@ support wing (cohort). -->
 		</weightClass>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" weight="2">%FLIGHT%
 					</option>
 				<option weightClass="H,M">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M">%FLIGHT%
@@ -409,7 +409,7 @@ support wing (cohort). -->
 				<option weightClass="M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L">%FLIGHT%
 					</option>
 				<option weightClass="L,L" weight="2">%FLIGHT%
@@ -693,7 +693,7 @@ support wing (cohort). -->
 	still fit the requirements of the capital fighter squadron rule in StratOps,
 	allowing the maniple to be split 5/5. -->
 	
-	<force eschelon="%FLIGHT%" eschName="Century" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Century" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{latin:parent} Centuria {roman}</name>
 		<co>%LT%</co>
 		
@@ -712,7 +712,7 @@ support wing (cohort). -->
 			</formation>
 		</ruleGroup>
 
-		<subforces generate="group" ifUnitType="Aero">
+		<subforces generate="group" ifUnitType="AeroSpaceFighter">
 			<subforceOption ifWeightClass="H">
 				<option weightClass="H" weight="2">%ELEMENT%</option>
 				<option weightClass="M">%ELEMENT%</option>

--- a/MekHQ/data/forcegenerator/faction_rules/MOC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/MOC.xml
@@ -21,15 +21,15 @@ expanding to a full wing per regiment by the Dark Age. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -82,28 +82,28 @@ expanding to a full wing per regiment by the Dark Age. -->
 
 		<attachedForces>
 			<subforceOption ifFaction="MOC.MRG">
-				<option unitType="Aero" ifDateBetween=",3070"
+				<option unitType="AeroSpaceFighter" ifDateBetween=",3070"
 					name="Air Guard">%FLIGHT%</option>
-				<option unitType="Aero" ifDateBetween="3056,3080"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3056,3080"
 					name="Air Guard">%SQUADRON%-</option>
-				<option unitType="Aero" ifDateBetween="3060,3090"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3060,3090"
 					name="Air Guard">%SQUADRON%</option>
-				<option unitType="Aero" ifDateBetween="3065,3110"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3065,3110"
 					name="Air Guard">%WING%-</option>
-				<option unitType="Aero" ifDateBetween="3080,"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3080,"
 					name="Air Guard">%WING%</option>
 			</subforceOption>
 			<subforceOption ifFaction="MOC.CC">
 				<option ifDateBetween=",3070"/>
-				<option unitType="Aero" ifDateBetween="3060,3075"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3060,3075"
 					name="Air Guard">%FLIGHT%</option>
-				<option unitType="Aero" ifDateBetween="3066,3085"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3066,3085"
 					name="Air Guard">%SQUADRON%-</option>
-				<option unitType="Aero" ifDateBetween="3071,3100"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3071,3100"
 					name="Air Guard">%SQUADRON%</option>
-				<option unitType="Aero" ifDateBetween="3076,"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3076,"
 					name="Air Guard">%WING%-</option>
-				<option unitType="Aero" ifDateBetween="3080,"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3080,"
 					name="Air Guard">%WING%</option>
 			</subforceOption>
 			<subforceOption ifFaction="!MOC.MH">
@@ -200,7 +200,7 @@ expanding to a full wing per regiment by the Dark Age. -->
 		</subforces>
 	</force>
 
-	<force eschelon="%FLIGHT%" eschName="Air Lance" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Air Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT%</co>
 		
 		<weightClass>

--- a/MekHQ/data/forcegenerator/faction_rules/NC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/NC.xml
@@ -23,14 +23,14 @@ brigada seems reasonable. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="Mek|Tank|VTOL">%LANCE%</option>
 			<option ifUnitType="Infantry">%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -46,7 +46,7 @@ brigada seems reasonable. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce num="2" unitType="Aero">%WING%</subforce>
+			<subforce num="2" unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 

--- a/MekHQ/data/forcegenerator/faction_rules/OA.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/OA.xml
@@ -30,10 +30,10 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">null,Aero,Mek,Tank,VTOL,Infantry,BattleArmor,Conventional Fighter</option>
-			<option ifDateBetween="2840,3050">null,Aero,Mek,Tank,VTOL,Infantry,Conventional Fighter</option>
-			<option ifDateBetween="2600,2839">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2599">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">null,AeroSpaceFighter,Mek,Tank,VTOL,Infantry,BattleArmor,Conventional Fighter</option>
+			<option ifDateBetween="2840,3050">null,AeroSpaceFighter,Mek,Tank,VTOL,Infantry,Conventional Fighter</option>
+			<option ifDateBetween="2600,2839">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2599">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -44,7 +44,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 			<option ifUnitType="Mek|Tank|VTOL">%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -52,7 +52,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</rating>
 	</toc>
 	
-	<force eschelon="%GROUP%" eschName="Wing" ifUnitType="Aero|Conventional Fighter" ifDateBetween="2840,">
+	<force eschelon="%GROUP%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="2840,">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -88,7 +88,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Regiment" ifUnitType="Aero|Conventional Fighter" ifDateBetween="2840,">
+	<force eschelon="%WING%" eschName="Regiment" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="2840,">
 		<name>{ordinal} Regiment</name>
 		<co>%MAJOR%</co>
 		
@@ -99,18 +99,18 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -127,7 +127,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{phonetic} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -147,7 +147,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%
 					</option>
 				<option weightClass="H,H,M">%FLIGHT%
@@ -155,7 +155,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 				<option weightClass="H,H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M,M">%FLIGHT%
@@ -165,7 +165,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 				<option weightClass="M,M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%
 					</option>
 				<option weightClass="M,L,L">%FLIGHT%
@@ -178,7 +178,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>Flight {cardinal}</name>
 		<co>%LT%</co>
 		
@@ -257,7 +257,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%GROUP%</subforce>
+			<subforce unitType="AeroSpaceFighter">%GROUP%</subforce>
 		</attachedForces>
 	</force>
 	

--- a/MekHQ/data/forcegenerator/faction_rules/Periphery.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/Periphery.xml
@@ -17,16 +17,16 @@ Infantry are poorly trained and equipped. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2500,3050">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2500,3050">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -73,7 +73,7 @@ Infantry are poorly trained and equipped. -->
 		</subforces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2575">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2500,">
 				<option ifRating="D|F"/>
@@ -122,7 +122,7 @@ Infantry are poorly trained and equipped. -->
 		</subforces>
 
 		<attachedForces ifTopLevel="1">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%SQUADRON%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%REGIMENT%</subforce>
@@ -733,7 +733,7 @@ Infantry are poorly trained and equipped. -->
 		<co>%SGT%</co>
 	</force>
 	
-	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -762,7 +762,7 @@ Infantry are poorly trained and equipped. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -772,18 +772,18 @@ Infantry are poorly trained and equipped. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -800,7 +800,7 @@ Infantry are poorly trained and equipped. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{phonetic} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -820,7 +820,7 @@ Infantry are poorly trained and equipped. -->
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%
 					</option>
 				<option weightClass="H,H,M">%FLIGHT%
@@ -828,7 +828,7 @@ Infantry are poorly trained and equipped. -->
 				<option weightClass="H,H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M,M">%FLIGHT%
@@ -838,7 +838,7 @@ Infantry are poorly trained and equipped. -->
 				<option weightClass="M,M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%
 					</option>
 				<option weightClass="M,L,L">%FLIGHT%
@@ -851,7 +851,7 @@ Infantry are poorly trained and equipped. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>Flight {cardinal}</name>
 		<co>%LT%</co>
 		

--- a/MekHQ/data/forcegenerator/faction_rules/RD.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/RD.xml
@@ -34,7 +34,7 @@
 			<subforce rating="SL"
 				name="Rasalhague Galaxy">%GALAXY%</subforce>
 			<subforce rating="SL"
-			    unitType="Aero"
+			    unitType="AeroSpaceFighter"
 				name="Valkyrie Galaxy">%GALAXY%</subforce>
 			<subforce rating="SL" faction="FRR" weightClass="H"
 				name="Tundra Galaxy">%GALAXY%</subforce>

--- a/MekHQ/data/forcegenerator/faction_rules/ROS.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/ROS.xml
@@ -15,14 +15,14 @@
 
 	<toc>
 		<unitType>
-			<option>Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%REGIMENT%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%REGIMENT%,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -71,13 +71,13 @@
 		<attachedForces ifUnitType="Mek" ifRating="!SB">
 			<subforce unitType="Tank">%BRIGADE%</subforce>
 			<subforce unitType="Infantry">%BRIGADE%</subforce>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 		
 		<attachedForces ifUnitType="Mek" ifRating="SB">
 			<subforce unitType="Tank">%REGIMENT%</subforce>
 			<subforce unitType="BattleArmor">%BATTALION%</subforce>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 	
@@ -131,7 +131,7 @@
 		<attachedForces>
 			<subforce unitType="Tank">%BRIGADE%</subforce>
 			<subforce unitType="Infantry">%BRIGADE%</subforce>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 </ruleset>

--- a/MekHQ/data/forcegenerator/faction_rules/RWR.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/RWR.xml
@@ -32,9 +32,9 @@ nations this ruleset sets IS as the parent rather than Periphery. -->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="2760,">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2600,2759">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2474,2599">null,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="2760,">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2600,2759">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2474,2599">null,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -45,7 +45,7 @@ nations this ruleset sets IS as the parent rather than Periphery. -->
 			<option ifUnitType="Mek|Tank|VTOL">%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -156,7 +156,7 @@ nations this ruleset sets IS as the parent rather than Periphery. -->
 		</subforces>
 
 		<attachedForces>
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Infantry"
 				name="Infantry Support">%REGIMENT%</subforce>			
@@ -211,7 +211,7 @@ nations this ruleset sets IS as the parent rather than Periphery. -->
 		</subforces>
 
 		<attachedForces>
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%REGIMENT%</subforce>

--- a/MekHQ/data/forcegenerator/faction_rules/SL.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/SL.xml
@@ -13,7 +13,7 @@ division where most factions organize around a regiment. -->
 	
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship</option>
 		</unitType>
 		
 		<eschelon>
@@ -22,7 +22,7 @@ division where most factions organize around a regiment. -->
 			<option ifUnitType="Mek">%DIVISION%,%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%DIVISION%,%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%AIR_REGIMENT%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%AIR_REGIMENT%,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -163,7 +163,7 @@ division where most factions organize around a regiment. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%AIR_REGIMENT%</subforce>
+			<subforce unitType="AeroSpaceFighter">%AIR_REGIMENT%</subforce>
 			<subforceOption>
 				<option unitType="Tank" role="artillery" name="Artillery Regiment"
 					weight="2">%REGIMENT%</option>
@@ -425,7 +425,7 @@ division where most factions organize around a regiment. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero" generate="group">%FLIGHT%</subforce>
+			<subforce unitType="AeroSpaceFighter" generate="group">%FLIGHT%</subforce>
 		</attachedForces>		
 	</force>
 	
@@ -775,8 +775,8 @@ division where most factions organize around a regiment. -->
 		</subforces>
 	</force>
 
-	<force eschelon="%AIR_REGIMENT%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
-		<name ifUnitType="Aero">Ground Aero Wing</name>
+	<force eschelon="%AIR_REGIMENT%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
+		<name ifUnitType="AeroSpaceFighter">Ground Aero Wing</name>
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -786,18 +786,18 @@ division where most factions organize around a regiment. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%WING%</option>
 				<option weightClass="H,H,M">%WING%</option>
 				<option weightClass="H,H,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%WING%</option>
 				<option weightClass="M,M,M">%WING%</option>
 				<option weightClass="H,M,L">%WING%</option>
 				<option weightClass="M,M,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%WING%</option>
 				<option weightClass="M,L,L">%WING%</option>
 				<option weightClass="L,L,L">%WING%</option>
@@ -805,14 +805,14 @@ division where most factions organize around a regiment. -->
 			<subforce ifUnitType="Conventional Fighter" num="3">%WING%</subforce>
 		</subforces>
 		
-		<attachedForces ifUnitType="Aero">
+		<attachedForces ifUnitType="AeroSpaceFighter">
 			<subforce unitType="Conventional Fighter">%AIR_REGIMENT%</subforce>
 			<subforce unitType="Infantry" name="Engineers"
 					role="engineer">%BATTALION%</subforce>
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Group" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Group" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -822,18 +822,18 @@ division where most factions organize around a regiment. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -842,7 +842,7 @@ division where most factions organize around a regiment. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%CAPTAIN%</co>
 		
 		<weightClass>
@@ -865,7 +865,7 @@ division where most factions organize around a regiment. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT%</co>
 		
 		<weightClass>

--- a/MekHQ/data/forcegenerator/faction_rules/SOC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/SOC.xml
@@ -10,7 +10,7 @@
 	
 	<toc>
 		<unitType>
-			<option>Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
+			<option>Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -84,7 +84,7 @@
 		</weightClass>
 
 		<ruleGroup>
-			<formation ifIndex="0" ifUnitType="!Aero|Conventional Fighter">
+			<formation ifIndex="0" ifUnitType="!AeroSpaceFighter|Conventional Fighter">
 				<option weight="30">Battle</option>
 				<option weight="12" ifWeightClass="H|A">Heavy Battle</option>
 				<option weight="8" ifWeightClass="M">Medium Battle</option>
@@ -97,7 +97,7 @@
 				<option weight="1" role="+urban">Urban</option>
 			</formation>
 
-			<formation ifIndex="!0" ifUnitType="!Aero|Conventional Fighter">
+			<formation ifIndex="!0" ifUnitType="!AeroSpaceFighter|Conventional Fighter">
 				<option weight="20">Fire</option>
 				<option weight="3">Fire Support</option>
 				<option weight="2">Direct Fire</option>
@@ -211,7 +211,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%POINT%" eschName="Un" ifUnitType="Infantry|ProtoMek|Aero|Conventional Fighter">
+	<force eschelon="%POINT%" eschName="Un" ifUnitType="Infantry|ProtoMek|AeroSpaceFighter|Conventional Fighter">
 		<co>%POINT_CMDR%</co>
 		
 		<weightClass>

--- a/MekHQ/data/forcegenerator/faction_rules/TC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/TC.xml
@@ -16,9 +16,9 @@ types of support units attached to Mek regiments can vary widely. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2481,3050">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2480">Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2481,3050">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2480">Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -26,7 +26,7 @@ types of support units attached to Mek regiments can vary widely. -->
 			<option ifUnitType="Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%,%POINT%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -49,11 +49,11 @@ types of support units attached to Mek regiments can vary widely. -->
 
 		<attachedForces>
 			<subforceOption>
-				<option unitType="Aero" weight="7"
+				<option unitType="AeroSpaceFighter" weight="7"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					name="Aerospace Support">%SQUADRON%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					name="Aerospace Support">%GROUP%</option>
 				<option weight="3"/>
 			</subforceOption>
@@ -262,7 +262,7 @@ types of support units attached to Mek regiments can vary widely. -->
 		</subforces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2550">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2481,">
 				<option ifRating="D|F"/>
@@ -305,7 +305,7 @@ types of support units attached to Mek regiments can vary widely. -->
 	of bringing in trainers from the Outworlds Alliance, Taurian air forces are largely
 	heavy fighters in order to protect the investment in the pilot. -->
 	
-	<force eschelon="%GROUP%" eschName="Air Division" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%GROUP%" eschName="Air Division" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -348,7 +348,7 @@ types of support units attached to Mek regiments can vary widely. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{ordinal} Wing</name>
 		<co>%MAJOR%</co>
 		
@@ -359,13 +359,13 @@ types of support units attached to Mek regiments can vary widely. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" weight="2">%SQUADRON%
 					</option>
 				<option weightClass="H,M">%SQUADRON%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M" weight="3">%SQUADRON%
 					</option>
 				<option weightClass="M,M" weight="2">%SQUADRON%
@@ -373,7 +373,7 @@ types of support units attached to Mek regiments can vary widely. -->
 				<option weightClass="H,L">%SQUADRON%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L" weight="2">%SQUADRON%
 					</option>
 				<option weightClass="L,L">%SQUADRON%
@@ -392,7 +392,7 @@ types of support units attached to Mek regiments can vary widely. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{phonetic} Company</name>
 		<co>%CAPTAIN%</co>
 		
@@ -403,13 +403,13 @@ types of support units attached to Mek regiments can vary widely. -->
 		</weightClass>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" weight="2">%FLIGHT%
 					</option>
 				<option weightClass="H,M">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M" weight="3">%FLIGHT%
 					</option>
 				<option weightClass="M,M" weight="2">%FLIGHT%
@@ -417,7 +417,7 @@ types of support units attached to Mek regiments can vary widely. -->
 				<option weightClass="H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L" weight="2">%FLIGHT%
 					</option>
 				<option weightClass="L,L">%FLIGHT%
@@ -428,7 +428,7 @@ types of support units attached to Mek regiments can vary widely. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Air Lance" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Air Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT%</co>
 		
 		<weightClass>

--- a/MekHQ/data/forcegenerator/faction_rules/TH.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/TH.xml
@@ -12,15 +12,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="2442,">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="2442,">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -65,7 +65,7 @@
 		</subforces>
 		
 		<attachedForces ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%BATTALION%</subforce>
@@ -74,7 +74,7 @@
 		</attachedForces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2500">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2442,">
 				<option ifRating="D|F"/>

--- a/MekHQ/data/forcegenerator/faction_rules/UC.xml
+++ b/MekHQ/data/forcegenerator/faction_rules/UC.xml
@@ -23,14 +23,14 @@ but a wing per corps seemed reasonable. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="Mek|Tank|VTOL">%LANCE%</option>
 			<option ifUnitType="Infantry">%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -49,7 +49,7 @@ but a wing per corps seemed reasonable. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 

--- a/MekHQ/data/mechfiles/smallcraft/Gheist GST-17A.blk
+++ b/MekHQ/data/mechfiles/smallcraft/Gheist GST-17A.blk
@@ -1,0 +1,151 @@
+#Saved from version 0.49.16-SNAPSHOT on 2023-12-18
+<BlockVersion>
+1
+</BlockVersion>
+
+<UnitType>
+SmallCraft
+</UnitType>
+
+<Name>
+Gheist
+</Name>
+
+<Model>
+GST-17A
+</Model>
+
+<year>
+3025
+</year>
+
+<originalBuildYear>
+3025
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<quirks>
+internal_bomb
+</quirks>
+
+<motion_type>
+Aerodyne
+</motion_type>
+
+<transporters>
+cargobay:30.0:1:1::-1:0
+steeragequarters:20.0:0:-1::-1:0
+cargobay:6.0:1:3::-1:0
+</transporters>
+
+<SafeThrust>
+5
+</SafeThrust>
+
+<heatsinks>
+1
+</heatsinks>
+
+<sink_type>
+0
+</sink_type>
+
+<fuel>
+600
+</fuel>
+
+<engine_type>
+1
+</engine_type>
+
+<armor_type>
+41
+</armor_type>
+
+<armor_tech>
+1
+</armor_tech>
+
+<internal_type>
+-1
+</internal_type>
+
+<armor>
+212
+180
+180
+148
+</armor>
+
+<Nose Equipment>
+</Nose Equipment>
+
+<Left Side Equipment>
+Medium Laser
+Medium Laser
+</Left Side Equipment>
+
+<Right Side Equipment>
+Medium Laser
+Medium Laser
+</Right Side Equipment>
+
+<Aft Equipment>
+Large Laser
+</Aft Equipment>
+
+<Hull Equipment>
+ISReconCamera
+</Hull Equipment>
+
+<structural_integrity>
+20
+</structural_integrity>
+
+<tonnage>
+200.0
+</tonnage>
+
+<designtype>
+1
+</designtype>
+
+<crew>
+4
+</crew>
+
+<officers>
+1
+</officers>
+
+<gunners>
+1
+</gunners>
+
+<passengers>
+0
+</passengers>
+
+<marines>
+0
+</marines>
+
+<battlearmor>
+0
+</battlearmor>
+
+<otherpassenger>
+0
+</otherpassenger>
+
+<life_boat>
+0
+</life_boat>
+
+<escape_pod>
+0
+</escape_pod>
+

--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -123,7 +123,6 @@ public class CampaignSummary {
                     veeCount++;
                     break;
                 case UnitType.AEROSPACEFIGHTER:
-                case UnitType.AERO:
                 case UnitType.CONV_FIGHTER:
                     aeroCount++;
                     break;

--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBStaticWeightGenerator.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBStaticWeightGenerator.java
@@ -44,7 +44,7 @@ public class AtBStaticWeightGenerator {
      */
     private static int getRandomWeight(final int unitType, final Faction faction,
                                        final boolean regionVariations) {
-        if (unitType == UnitType.AERO) {
+        if (unitType == UnitType.AEROSPACEFIGHTER) {
             return getRandomAerospaceWeight();
         } else if ((unitType == UnitType.MEK) && regionVariations) {
             return getRegionalMechWeight(faction);

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -74,7 +74,7 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
                 null, IUnitRating.DRAGOON_F, 7);
         addOffers(campaign, Compute.d6() - 1, UnitMarketType.OPEN, UnitType.TANK,
                 null, IUnitRating.DRAGOON_F, 7);
-        addOffers(campaign, Compute.d6() - 2, UnitMarketType.OPEN, UnitType.AERO,
+        addOffers(campaign, Compute.d6() - 2, UnitMarketType.OPEN, UnitType.AEROSPACEFIGHTER,
                 null, IUnitRating.DRAGOON_F, 7);
         addOffers(campaign, Compute.d6() - 2, UnitMarketType.OPEN, UnitType.CONV_FIGHTER,
                 null, IUnitRating.DRAGOON_F, 7);
@@ -85,7 +85,7 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
                     employer, IUnitRating.DRAGOON_D, 7);
             addOffers(campaign, Compute.d6() - 2, UnitMarketType.EMPLOYER, UnitType.TANK,
                     employer, IUnitRating.DRAGOON_D, 7);
-            addOffers(campaign, Compute.d6() - 3, UnitMarketType.EMPLOYER, UnitType.AERO,
+            addOffers(campaign, Compute.d6() - 3, UnitMarketType.EMPLOYER, UnitType.AEROSPACEFIGHTER,
                     employer, IUnitRating.DRAGOON_D, 7);
             addOffers(campaign, Compute.d6() - 3, UnitMarketType.EMPLOYER, UnitType.CONV_FIGHTER,
                     employer, IUnitRating.DRAGOON_D, 7);
@@ -98,7 +98,7 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
             addOffers(campaign, Compute.d6(3) - 6, UnitMarketType.MERCENARY,
                     UnitType.TANK, mercenaryFaction, IUnitRating.DRAGOON_C, 5);
             addOffers(campaign, Compute.d6(3) - 9, UnitMarketType.MERCENARY,
-                    UnitType.AERO, mercenaryFaction, IUnitRating.DRAGOON_C, 5);
+                    UnitType.AEROSPACEFIGHTER, mercenaryFaction, IUnitRating.DRAGOON_C, 5);
             addOffers(campaign, Compute.d6(3) - 9, UnitMarketType.MERCENARY,
                     UnitType.CONV_FIGHTER, mercenaryFaction, IUnitRating.DRAGOON_C, 5);
         }
@@ -111,7 +111,7 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
                         faction, IUnitRating.DRAGOON_A, 6);
                 addOffers(campaign, Compute.d6() - 2, UnitMarketType.FACTORY, UnitType.TANK,
                         faction, IUnitRating.DRAGOON_A, 6);
-                addOffers(campaign, Compute.d6() - 3, UnitMarketType.FACTORY, UnitType.AERO,
+                addOffers(campaign, Compute.d6() - 3, UnitMarketType.FACTORY, UnitType.AEROSPACEFIGHTER,
                         faction, IUnitRating.DRAGOON_A, 6);
                 addOffers(campaign, Compute.d6() - 3, UnitMarketType.FACTORY, UnitType.CONV_FIGHTER,
                         faction, IUnitRating.DRAGOON_A, 6);
@@ -123,7 +123,7 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
                     null, IUnitRating.DRAGOON_C, 6);
             addOffers(campaign, Compute.d6(2) - 4, UnitMarketType.BLACK_MARKET, UnitType.TANK,
                     null, IUnitRating.DRAGOON_C, 6);
-            addOffers(campaign, Compute.d6(2) - 6, UnitMarketType.BLACK_MARKET, UnitType.AERO,
+            addOffers(campaign, Compute.d6(2) - 6, UnitMarketType.BLACK_MARKET, UnitType.AEROSPACEFIGHTER,
                     null, IUnitRating.DRAGOON_C, 6);
             addOffers(campaign, Compute.d6(2) - 6, UnitMarketType.BLACK_MARKET, UnitType.CONV_FIGHTER,
                     null, IUnitRating.DRAGOON_C, 6);

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -200,7 +200,7 @@ public class AtBContract extends Contract {
                     numUnits += campaign.getFaction().isClan() ? 0.5 : 1;
                     break;
                 case UnitType.CONV_FIGHTER:
-                case UnitType.AERO:
+                case UnitType.AEROSPACEFIGHTER:
                     if (campaign.getCampaignOptions().isUseAero()) {
                         numUnits += campaign.getFaction().isClan() ? 0.5 : 1;
                     }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -146,7 +146,7 @@ public class AtBDynamicScenarioFactory {
             if (template.mapParameters.getMapLocation() == MapLocation.LowAtmosphere) {
                 defaultReinforcements.setAllowedUnitType(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX);
             } else if (template.mapParameters.getMapLocation() == MapLocation.Space) {
-                defaultReinforcements.setAllowedUnitType(UnitType.AERO);
+                defaultReinforcements.setAllowedUnitType(UnitType.AEROSPACEFIGHTER);
             }
 
 
@@ -362,7 +362,7 @@ public class AtBDynamicScenarioFactory {
         boolean isPlanetOwner = isPlanetOwner(contract, currentDate, factionCode);
         boolean usingAerospace = forceTemplate.getAllowedUnitType() == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX ||
                 forceTemplate.getAllowedUnitType() == UnitType.CONV_FIGHTER ||
-                forceTemplate.getAllowedUnitType() == UnitType.AERO;
+                forceTemplate.getAllowedUnitType() == UnitType.AEROSPACEFIGHTER;
 
         // here we determine the "lance size". Aircraft almost always come in pairs, mechs and tanks, not so much.
         int lanceSize = usingAerospace ? getAeroLanceSize(forceTemplate.getAllowedUnitType(), isPlanetOwner, factionCode) :
@@ -404,9 +404,9 @@ public class AtBDynamicScenarioFactory {
             int actualUnitType = forceTemplate.getAllowedUnitType();
             if (isPlanetOwner && actualUnitType == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX &&
                     scenario.getTemplate().mapParameters.getMapLocation() != MapLocation.Space) {
-                actualUnitType = Compute.d6() > 3 ? UnitType.AERO : UnitType.CONV_FIGHTER;
+                actualUnitType = Compute.d6() > 3 ? UnitType.AEROSPACEFIGHTER : UnitType.CONV_FIGHTER;
             } else if (actualUnitType == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX) {
-                actualUnitType = UnitType.AERO;
+                actualUnitType = UnitType.AEROSPACEFIGHTER;
             }
 
             // some special cases that don't fit into the regular RAT generation mechanism
@@ -1362,7 +1362,7 @@ public class AtBDynamicScenarioFactory {
                 case UnitType.BATTLE_ARMOR:
                     phenotype = Phenotype.ELEMENTAL;
                     break;
-                case UnitType.AERO:
+                case UnitType.AEROSPACEFIGHTER:
                 case UnitType.CONV_FIGHTER:
                     phenotype = Phenotype.AEROSPACE;
                     break;
@@ -2324,7 +2324,7 @@ public class AtBDynamicScenarioFactory {
         // TODO: except maybe clans?
         int numFightersPerFlight = factionCode.equals("CC") ? 3 : 2;
 
-        if (unitTypeCode == UnitType.AERO) {
+        if (unitTypeCode == UnitType.AEROSPACEFIGHTER) {
             return numFightersPerFlight;
         } else if (unitTypeCode == UnitType.CONV_FIGHTER) {
             return (Compute.randomInt(3) + 1) * numFightersPerFlight;

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2315,23 +2315,35 @@ public class AtBDynamicScenarioFactory {
 
     /**
      * Worker function to determine the "lance size" of a group of aircraft.
-     * Either 2 for ASF
+     * Either 2 for ASF, 3 for CC ASF,
+     * @param unitTypeCode
      * @param isPlanetOwner
+     * @param factionCode
      * @return
      */
     public static int getAeroLanceSize(int unitTypeCode, boolean isPlanetOwner, String factionCode) {
         // capellans use units of three aircraft at a time, others use two
         // TODO: except maybe clans?
         int numFightersPerFlight = factionCode.equals("CC") ? 3 : 2;
+        int weightCountRoll = (Compute.randomInt(3) + 1) * numFightersPerFlight;
+        int useASFRoll = isPlanetOwner ? Compute.d6() : 6;
+        return getAeroLanceSize(unitTypeCode, numFightersPerFlight, weightCountRoll, useASFRoll);
+    }
 
+    /**
+     * Unwrapped inner logic of above function to be deterministic, for testing purposes.
+     * @param unitTypeCode
+     * @param numFightersPerFlight
+     * @param weightCountRoll
+     * @param useASFRoll
+     * @return
+     */
+    public static int getAeroLanceSize(int unitTypeCode, int numFightersPerFlight, int weightCountRoll, int useASFRoll) {
         if (unitTypeCode == UnitType.AEROSPACEFIGHTER) {
             return numFightersPerFlight;
         } else if (unitTypeCode == UnitType.CONV_FIGHTER) {
-            return (Compute.randomInt(3) + 1) * numFightersPerFlight;
+            return weightCountRoll;
         } else {
-            int useASFRoll = isPlanetOwner ? Compute.d6() : 6;
-            int weightCountRoll = (Compute.randomInt(3) + 1) * numFightersPerFlight; // # of conventional fighters, just in case
-
             // if we are the planet owner, we may use ASF or conventional fighters
             boolean useASF = useASFRoll >= 4;
             // if we are using ASF, we "always" use 2 at a time, otherwise, use the # of conventional fighters

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -1138,7 +1138,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         int unitsPerPoint;
         switch (unitType) {
             case UnitType.TANK:
-            case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
                 unitsPerPoint = 2;
                 break;
             case UnitType.PROTOMEK:
@@ -1318,7 +1318,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 int weightClass = randomAeroWeights[Compute.d6() - 1];
 
                 aero = getEntity(contract.getEnemyCode(), contract.getEnemySkill(), contract.getEnemyQuality(),
-                        UnitType.AERO, weightClass, campaign);
+                        UnitType.AEROSPACEFIGHTER, weightClass, campaign);
                 if (aero != null) {
                     aircraft.add(aero);
                 }

--- a/MekHQ/src/mekhq/campaign/mission/BotForceRandomizer.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForceRandomizer.java
@@ -173,7 +173,7 @@ public class BotForceRandomizer {
             if ((unitType == UnitType.MEK) && (percentConventional > 0)
                     && (Compute.randomInt(100) <= percentConventional)) {
                 uType = UnitType.TANK;
-            } else if ((unitType == UnitType.AERO) && (percentConventional > 0)
+            } else if ((unitType == UnitType.AEROSPACEFIGHTER) && (percentConventional > 0)
                     && (Compute.randomInt(100) <= percentConventional)) {
                 uType = UnitType.CONV_FIGHTER;
             }
@@ -313,7 +313,7 @@ public class BotForceRandomizer {
                 case UnitType.BATTLE_ARMOR:
                     phenotype = Phenotype.ELEMENTAL;
                     break;
-                case UnitType.AERO:
+                case UnitType.AEROSPACEFIGHTER:
                 case UnitType.CONV_FIGHTER:
                     phenotype = Phenotype.AEROSPACE;
                     break;
@@ -420,7 +420,7 @@ public class BotForceRandomizer {
         double multiplier;
         switch (e.getUnitType()) {
             case UnitType.MEK:
-            case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
             case UnitType.PROTOMEK:
                 multiplier = 1.0;
                 break;

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifier.java
@@ -427,7 +427,7 @@ public class AtBScenarioModifier implements Cloneable {
         copy.linkedModifiers = linkedModifiers == null ? new HashMap<>() : new HashMap<>(linkedModifiers);
         copy.objectives = objectives == null ? new ArrayList<>() : new ArrayList<>(objectives);
         copy.bvBudgetAdditiveMultiplier = bvBudgetAdditiveMultiplier;
-        copy .reinforcementDelayReduction = reinforcementDelayReduction;
+        copy.reinforcementDelayReduction = reinforcementDelayReduction;
         return copy;
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillPrereq.java
@@ -94,6 +94,7 @@ public class SkillPrereq {
     public boolean qualifies(int unitType) {
         switch (unitType) {
             case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
                 return skillSet.containsKey(SkillType.S_PILOT_AERO) ||
                         skillSet.containsKey(SkillType.S_GUN_AERO);
             case UnitType.BATTLE_ARMOR:

--- a/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
@@ -921,7 +921,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
             case UnitType.JUMPSHIP:
                 incrementJumpShipCount();
                 break;
-            case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
             case UnitType.CONV_FIGHTER:
                 incrementFighterCount();
                 break;

--- a/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
+++ b/MekHQ/src/mekhq/campaign/rating/CampaignOpsReputation.java
@@ -185,6 +185,7 @@ public class CampaignOpsReputation extends AbstractUnitRating {
             case UnitType.DROPSHIP:
             case UnitType.CONV_FIGHTER:
             case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
             case UnitType.VTOL:
             case UnitType.TANK:
                 gunnery = crew.getGunnery();

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -893,6 +893,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             case UnitType.PROTOMEK:
             case UnitType.CONV_FIGHTER:
             case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
             case UnitType.TANK:
             case UnitType.VTOL:
             case UnitType.BATTLE_ARMOR:

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -213,7 +213,7 @@ public class StratconRulesManager {
         } else {
             terrainType = track.getTerrainTile(coords);
         }
-        
+
         var mapTypes = biomeManifest.getBiomeMapTypes();
 
         // don't have a map list for the given terrain, leave it alone
@@ -697,7 +697,7 @@ public class StratconRulesManager {
                 case UnitType.VTOL:
                     retVal.get(MapLocation.AllGroundTerrain).add(forceID);
                     break;
-                case UnitType.AERO:
+                case UnitType.AEROSPACEFIGHTER:
                     retVal.get(MapLocation.Space).add(forceID);
                     // intentional fallthrough here, ASFs can go to atmospheric maps too
                 case UnitType.CONV_FIGHTER:
@@ -980,7 +980,7 @@ public class StratconRulesManager {
     private static boolean unitTypeIsAirborne(ScenarioForceTemplate template) {
         int unitType = template.getAllowedUnitType();
 
-        return ((unitType == UnitType.AERO) ||
+        return ((unitType == UnitType.AEROSPACEFIGHTER) ||
                 (unitType == UnitType.CONV_FIGHTER) ||
                 (unitType == UnitType.DROPSHIP) ||
                 (unitType == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX)) &&
@@ -1002,10 +1002,10 @@ public class StratconRulesManager {
                     || (primaryUnitType == UnitType.BATTLE_ARMOR)
                     || (primaryUnitType == UnitType.PROTOMEK)
                     || (primaryUnitType == UnitType.VTOL)
-                    || (primaryUnitType == UnitType.AERO) && reinforcements
+                    || (primaryUnitType == UnitType.AEROSPACEFIGHTER) && reinforcements
                     || (primaryUnitType == UnitType.CONV_FIGHTER) && reinforcements;
         } else if (unitType == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX) {
-            return (primaryUnitType == UnitType.AERO) || (primaryUnitType == UnitType.CONV_FIGHTER);
+            return (primaryUnitType == UnitType.AEROSPACEFIGHTER) || (primaryUnitType == UnitType.CONV_FIGHTER);
         } else {
             return primaryUnitType == unitType;
         }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenarioFactory.java
@@ -173,6 +173,7 @@ public class StratconScenarioFactory {
     public static int convertSpecificUnitTypeToGeneral(int unitType) {
         switch (unitType) {
             case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
             case UnitType.CONV_FIGHTER:
             case UnitType.DROPSHIP:
             case UnitType.JUMPSHIP:

--- a/MekHQ/src/mekhq/campaign/universe/IUnitGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/IUnitGenerator.java
@@ -79,7 +79,7 @@ public interface IUnitGenerator {
      * @return Whether or not the unit type supports weight class selection.
      */
     static boolean unitTypeSupportsWeightClass(final int unitType) {
-        return (unitType == UnitType.AERO) || (unitType == UnitType.MEK) || (unitType == UnitType.TANK);
+        return (unitType == UnitType.AEROSPACEFIGHTER) || (unitType == UnitType.MEK) || (unitType == UnitType.TANK);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/universe/RATManager.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATManager.java
@@ -333,7 +333,7 @@ public class RATManager extends AbstractUnitGenerator {
     public boolean isSupportedUnitType(final int unitType) {
         return (unitType == UnitType.MEK)
                 || (unitType == UnitType.TANK)
-                || (unitType == UnitType.AERO)
+                || (unitType == UnitType.AEROSPACEFIGHTER)
                 || (unitType == UnitType.DROPSHIP)
                 || (unitType == UnitType.INFANTRY)
                 || (unitType == UnitType.BATTLE_ARMOR)
@@ -490,7 +490,7 @@ public class RATManager extends AbstractUnitGenerator {
                                     retVal.unitTypes.add(UnitType.CONV_FIGHTER);
                                     break;
                                 case "Aero":
-                                    retVal.unitTypes.add(UnitType.AERO);
+                                    retVal.unitTypes.add(UnitType.AEROSPACEFIGHTER);
                                     break;
                                 case "Small Craft":
                                     retVal.unitTypes.add(UnitType.SMALL_CRAFT);

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -666,7 +666,7 @@ public class GMToolsDialog extends AbstractMHQDialog {
         getComboUnitType().addItemListener(ev -> {
             final int unitType = getComboUnitType().getSelectedIndex();
             getComboUnitWeight().setEnabled((unitType == UnitType.MEK) || (unitType == UnitType.TANK)
-                    || (unitType == UnitType.AERO));
+                    || (unitType == UnitType.AEROSPACEFIGHTER));
         });
         gbc.gridx++;
         panel.add(getComboUnitType(), gbc);
@@ -1272,6 +1272,7 @@ public class GMToolsDialog extends AbstractMHQDialog {
     private boolean doesPersonPrimarilyDriveUnitType(final int unitType) {
         switch (unitType) {
             case UnitType.AERO:
+            case UnitType.AEROSPACEFIGHTER:
                 return getPerson().getPrimaryRole().isAerospacePilot();
             case UnitType.BATTLE_ARMOR:
                 return getPerson().getPrimaryRole().isBattleArmour();

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -486,7 +486,7 @@ public class RetirementDefectionDialog extends JDialog {
                     unassignedMechs.add(u.getId());
                 }
             }
-            if (UnitType.AERO == u.getEntity().getUnitType()) {
+            if (UnitType.AEROSPACEFIGHTER == u.getEntity().getUnitType()) {
                 if (null == u.getCommander()) {
                     unassignedASF.add(u.getId());
                 }
@@ -844,7 +844,7 @@ public class RetirementDefectionDialog extends JDialog {
                     cbUnitCategory.setSelectedIndex(UnitType.VTOL + 1);
                     break;
                 case AEROSPACE_PILOT:
-                    cbUnitCategory.setSelectedIndex(UnitType.AERO + 1);
+                    cbUnitCategory.setSelectedIndex(UnitType.AEROSPACEFIGHTER + 1);
                     break;
                 case CONVENTIONAL_AIRCRAFT_PILOT:
                     cbUnitCategory.setSelectedIndex(UnitType.CONV_FIGHTER + 1);

--- a/MekHQ/src/mekhq/gui/dialog/ScenarioTemplateEditorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ScenarioTemplateEditorDialog.java
@@ -437,17 +437,17 @@ public class ScenarioTemplateEditorDialog extends JDialog implements ActionListe
         gbc.gridy++;
         gbc.gridx = 1;
         forcedPanel.add(cboSyncForceName, gbc);
-        
+
         JLabel lblFixedMul = new JLabel("Fixed MUL:");
         gbc.gridx = 0;
         gbc.gridy++;
-        forcedPanel.add(lblFixedMul, gbc);        
-        
+        forcedPanel.add(lblFixedMul, gbc);
+
         lstMuls = new JList<>();
         DefaultListModel<String> mulModel = new DefaultListModel<>();
         JScrollPane scrMulList = new JScrollPane(lstMuls);
         File mulDir = new File(MHQConstants.STRATCON_MUL_FILES_DIRECTORY);
-        
+
         if (mulDir.exists() && mulDir.isDirectory()) {
             for (String mul : mulDir.list((d, s) -> {
                         return s.toLowerCase().endsWith(".mul");
@@ -455,8 +455,8 @@ public class ScenarioTemplateEditorDialog extends JDialog implements ActionListe
                 mulModel.addElement(mul);
             }
         }
-        
-        lstMuls.setModel(mulModel);    
+
+        lstMuls.setModel(mulModel);
         lstMuls.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         gbc.gridx = 1;
         forcedPanel.add(scrMulList, gbc);
@@ -1149,7 +1149,7 @@ public class ScenarioTemplateEditorDialog extends JDialog implements ActionListe
         sft.setDeployOffboard(chkOffBoard.isSelected());
 
         sft.setSyncDeploymentType(SynchronizedDeploymentType.values()[cboSyncDeploymentType.getSelectedIndex()]);
-        
+
         sft.setFixedMul(lstMuls.getSelectedValue());
 
         // if we have picked "None" for synchronization, then set explicit deployment zones.
@@ -1332,7 +1332,7 @@ public class ScenarioTemplateEditorDialog extends JDialog implements ActionListe
         int selectedItem = cboUnitType.getSelectedIndex() - ScenarioForceTemplate.SPECIAL_UNIT_TYPES.size();
         boolean isAero = selectedItem == ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX ||
                         selectedItem == UnitType.CONV_FIGHTER ||
-                        selectedItem == UnitType.AERO;
+                        selectedItem == UnitType.AEROSPACEFIGHTER;
 
         chkAllowAeroBombs.setEnabled(isAero);
     }

--- a/MekHQ/src/mekhq/gui/panes/UnitMarketPane.java
+++ b/MekHQ/src/mekhq/gui/panes/UnitMarketPane.java
@@ -499,7 +499,7 @@ public class UnitMarketPane extends AbstractMHQSplitPane {
                         return getChkShowMechs().isSelected();
                     case UnitType.TANK:
                         return getChkShowVehicles().isSelected();
-                    case UnitType.AERO:
+                    case UnitType.AEROSPACEFIGHTER:
                         return getChkShowAerospace().isSelected();
                     case UnitType.CONV_FIGHTER:
                         return getChkShowConvAero().isSelected();

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -102,7 +102,7 @@ public class StaticChecks {
                 return "    Selection of Units includes a large spacecraft. \n";
             } else if (unit.getEntity().getUnitType() == UnitType.SMALL_CRAFT) {
                 numberSC++;
-            } else if (unit.getEntity().getUnitType() == UnitType.AERO
+            } else if (unit.getEntity().getUnitType() == UnitType.AEROSPACEFIGHTER
                         || unit.getEntity().getUnitType() == UnitType.CONV_FIGHTER) {
                 // Includes conventional fighters
                 numberASF++;

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -150,7 +150,7 @@ public class AtBEventProcessor {
                 if (!campaign.getCampaignOptions().isAeroRecruitsHaveUnits()) {
                     return;
                 }
-                unitType = UnitType.AERO;
+                unitType = UnitType.AEROSPACEFIGHTER;
                 break;
             case PROTOMECH_PILOT:
                 unitType = UnitType.PROTOMEK;
@@ -173,7 +173,7 @@ public class AtBEventProcessor {
         int weight = -1;
         if (unitType == UnitType.MEK
                 || unitType == UnitType.TANK
-                || unitType == UnitType.AERO) {
+                || unitType == UnitType.AEROSPACEFIGHTER) {
             int roll = Compute.d6(2);
             if (roll < 8) {
                 return;

--- a/MekHQ/unittests/mekhq/campaign/mission/DynamicScenarioFactoryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/DynamicScenarioFactoryTest.java
@@ -19,6 +19,7 @@
 package mekhq.campaign.mission;
 
 import megamek.common.Board;
+import megamek.common.Compute;
 import megamek.common.UnitType;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,24 @@ public class DynamicScenarioFactoryTest {
         assertEquals(Board.START_SE, AtBDynamicScenarioFactory.getOppositeEdge(startingEdge));
     }
 
-    @Disabled // This Test relies on randomness, and thus doesn't work properly.
+    private void testAeroLanceSizeInner(int unitTypeCode, int numFightersPerFlight, boolean isPlanetOwner){
+        int weightCountRoll = (Compute.randomInt(3) + 1) * numFightersPerFlight;
+        int useASFRoll = isPlanetOwner ? Compute.d6() : 6;
+        int expected;
+        switch(unitTypeCode){
+            case UnitType.AEROSPACEFIGHTER:
+                expected = numFightersPerFlight;
+                break;
+            case UnitType.CONV_FIGHTER:
+                expected = weightCountRoll;
+                break;
+            default:
+                expected = (useASFRoll >= 4) ? numFightersPerFlight : weightCountRoll;
+        }
+
+        assertEquals(expected,AtBDynamicScenarioFactory.getAeroLanceSize(unitTypeCode, numFightersPerFlight, weightCountRoll, useASFRoll));
+    }
+
     @Test
     public void testAeroLanceSize() {
         assertEquals(2, AtBDynamicScenarioFactory.getAeroLanceSize(UnitType.AEROSPACEFIGHTER, true, "FC"));
@@ -68,25 +86,30 @@ public class DynamicScenarioFactoryTest {
         assertEquals(3,
                 AtBDynamicScenarioFactory.getAeroLanceSize(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX, false, "CC"));
 
-        // the number of conv fighters is randomly generated, but should be between 2 and 6, inclusively
-        // we run it a bunch of times, all but guaranteeing that we hit the extremes
-        for (int x = 0; x < 40; x++) {
-            int numConvFighters = AtBDynamicScenarioFactory.getAeroLanceSize(UnitType.CONV_FIGHTER, true, "FC");
-            assertTrue((numConvFighters >= 2) && (numConvFighters <= 6),
-                    String.format("Conv Fighter count: %d for FC faction not between 2 and 6 inclusive", numConvFighters));
+        // Roll some "random" values and check inner function return values
+        int unitTypeCode = UnitType.AEROSPACEFIGHTER;
+        int numFightersPerFlight = 2;
+        boolean isPlanetOwner = false;
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
+        isPlanetOwner = true;
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
+        numFightersPerFlight = 3;
+        isPlanetOwner = false;
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
+        isPlanetOwner = true;
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
 
-            // for Capellans, between 3 and 9
-            numConvFighters = AtBDynamicScenarioFactory.getAeroLanceSize(UnitType.CONV_FIGHTER, true, "CC");
-            assertTrue((numConvFighters >= 3) && (numConvFighters <= 9),
-                    String.format("Conv Fighter count: %d for CC faction not between 3 and 9 inclusive", numConvFighters));
-
-            numConvFighters = AtBDynamicScenarioFactory.getAeroLanceSize(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX, true, "FC");
-            assertTrue((numConvFighters >= 2) && (numConvFighters <= 6),
-                    String.format("Conv Fighter count: %d for FC faction not between 2 and 6 inclusive", numConvFighters));
-
-            numConvFighters = AtBDynamicScenarioFactory.getAeroLanceSize(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX, true, "CC");
-            assertTrue((numConvFighters >= 3) && (numConvFighters <= 9),
-                    String.format("Conv Fighter count: %d for CC faction not between 3 and 9 inclusive", numConvFighters));
-        }
+        unitTypeCode = UnitType.CONV_FIGHTER;
+        numFightersPerFlight = 2;
+        isPlanetOwner = false;
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
+        isPlanetOwner = true;
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
+        numFightersPerFlight = 3;
+        isPlanetOwner = false;
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
+        isPlanetOwner = true;
+        testAeroLanceSizeInner(unitTypeCode,numFightersPerFlight, isPlanetOwner);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/DynamicScenarioFactoryTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/DynamicScenarioFactoryTest.java
@@ -35,10 +35,10 @@ public class DynamicScenarioFactoryTest {
     public void testGetOppositeEdge() {
         int startingEdge = Board.START_EDGE;
         assertEquals(Board.START_CENTER, AtBDynamicScenarioFactory.getOppositeEdge(startingEdge));
-        
+
         startingEdge = Board.START_CENTER;
         assertEquals(Board.START_EDGE, AtBDynamicScenarioFactory.getOppositeEdge(startingEdge));
-        
+
         startingEdge = Board.START_ANY;
         assertEquals(Board.START_ANY, AtBDynamicScenarioFactory.getOppositeEdge(startingEdge));
 
@@ -61,8 +61,8 @@ public class DynamicScenarioFactoryTest {
     @Disabled // This Test relies on randomness, and thus doesn't work properly.
     @Test
     public void testAeroLanceSize() {
-        assertEquals(2, AtBDynamicScenarioFactory.getAeroLanceSize(UnitType.AERO, true, "FC"));
-        assertEquals(3, AtBDynamicScenarioFactory.getAeroLanceSize(UnitType.AERO, true, "CC"));
+        assertEquals(2, AtBDynamicScenarioFactory.getAeroLanceSize(UnitType.AEROSPACEFIGHTER, true, "FC"));
+        assertEquals(3, AtBDynamicScenarioFactory.getAeroLanceSize(UnitType.AEROSPACEFIGHTER, true, "CC"));
         assertEquals(2,
                 AtBDynamicScenarioFactory.getAeroLanceSize(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX, false, "FC"));
         assertEquals(3,

--- a/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CampaignOpsReputationTest.java
@@ -153,11 +153,11 @@ public class CampaignOpsReputationTest {
     // Fighters
     private Skill mockAeroGunnery;
     private Skill mockAeroPilot;
-    private Aero mockCorsair1;
+    private AeroSpaceFighter mockCorsair1;
     private Unit mockCorsairUnit1;
     private Person mockCorsair1Pilot;
     private Person mockCorsair1Tech;
-    private Aero mockCorsair2;
+    private AeroSpaceFighter mockCorsair2;
     private Unit mockCorsairUnit2;
     private Person mockCorsair2Pilot;
     private Person mockCorsair2Tech;
@@ -1378,7 +1378,7 @@ public class CampaignOpsReputationTest {
     }
 
     private int mockCorsair1() {
-        mockCorsair1 = mock(Aero.class);
+        mockCorsair1 = mock(AeroSpaceFighter.class);
         mockCorsairUnit1 = mock(Unit.class);
         mockCorsair1Pilot = mock(Person.class);
         mockCorsair1Tech = mock(Person.class);
@@ -1414,7 +1414,7 @@ public class CampaignOpsReputationTest {
     }
 
     private int mockCorsair2() {
-        mockCorsair2 = mock(Aero.class);
+        mockCorsair2 = mock(AeroSpaceFighter.class);
         mockCorsairUnit2 = mock(Unit.class);
         mockCorsair2Pilot = mock(Person.class);
         mockCorsair2Tech = mock(Person.class);


### PR DESCRIPTION
This fix cleans up the last extraneous UnitType.AERO case and comparison locations, excepting one or two that look to be useful for backward compatibility.

This will alleviate the issue seen in #3882 where ASF units are not properly accounted for in the Unit Rating Report, as well as preventing generation of _new_ missions containing ASF forces as "ground" units (although existing missions in save files will not be affected).

Testing:
1. ran all three projects' unit tests,
2. updated failing MHQ unit tests to mock AeroSpaceFighter class instances instead of bare Aero instances.
3. ran the previously-failing Unit Rating report with saves provided by @Thom293 for issue #3882.

Note: testing for this fix uncovered further issues in the RandomUnitGenerator and RATManager when dealing with ASFs; those will be fixed in a separate MM-only PR.

Close #3882 