### PR TITLE
Prevent advancing day with pending vanilla scenarios

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -218,3 +218,6 @@ lblRepairStatus.text=<html><nobr><b>Unit Damage Status:</b></nobr></html>;
 lblTransportCapacity.text=<html><nobr><b>Transport Capacity:</b></nobr></html>;
 lblCargoSummary.text=<html><nobr><b>Cargo Summary:</b></nobr></html>;
 panLog.title=Daily Activity Log
+
+dialogCheckDueScenarios.text=You must complete scenarios with a date of today or earlier before advancing the day.
+dialogCheckDueScenarios.title=Scenarios Must Be Completed

--- a/MekHQ/resources/mekhq/resources/CustomizeScenarioDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CustomizeScenarioDialog.properties
@@ -1,6 +1,7 @@
 btnCancel.text=Cancel
 btnOkay.text=OK
-lblName.text=Scenario Name
-lblStatus.text=Status
+lblName.text=Scenario Name:
+lblStatus.text=Status:
 title=Customize Scenario
 title.new=New Scenario
+lblDate.text=Date:

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6770,6 +6770,19 @@ public class Campaign implements ITechManager {
         return false;
     }
 
+    public boolean checkScenariosDue() {
+        for(Mission m : getActiveMissions(true)) {
+            for(Scenario s : m.getCurrentScenarios()) {
+                if((s.getDate() != null)
+                        && !(s instanceof AtBScenario)
+                        && !getLocalDate().isBefore(s.getDate())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /**
      * Sets the type of rating method used.
      */

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2366,6 +2366,13 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
+        if(getCampaign().checkScenariosDue()) {
+            JOptionPane.showMessageDialog(null, getResourceMap().getString("dialogCheckDueScenarios.text"),
+                    getResourceMap().getString("dialogCheckDueScenarios.title"), JOptionPane.WARNING_MESSAGE);
+            evt.cancel();
+            return;
+        }
+
         if (new UnmaintainedUnitsNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
             evt.cancel();
             return;

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -76,6 +76,7 @@ public class CustomizeScenarioDialog extends JDialog {
     private JComboBox<ScenarioStatus> choiceStatus;
     private JLabel lblStatus;
     private JButton btnDate;
+    private JLabel lblDate;
 
     public CustomizeScenarioDialog(JFrame parent, boolean modal, Scenario s, Mission m, Campaign c) {
         super(parent, modal);
@@ -174,20 +175,21 @@ public class CustomizeScenarioDialog extends JDialog {
             panMain.add(choiceStatus, gridBagConstraints);
         }
 
-        if (!scenario.getStatus().isCurrent() || (campaign.getCampaignOptions().isUseAtB() && (scenario instanceof AtBScenario))) {
-            btnDate = new JButton();
-            btnDate.setText(MekHQ.getMHQOptions().getDisplayFormattedDate(date));
-            btnDate.addActionListener(evt -> changeDate());
-            gridBagConstraints.gridx = 0;
-            gridBagConstraints.gridy++;
-            gridBagConstraints.gridwidth = 2;
-            gridBagConstraints.weightx = 1.0;
-            gridBagConstraints.weighty = 0.0;
-            gridBagConstraints.fill = GridBagConstraints.BOTH;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            gridBagConstraints.insets = new Insets(5, 5, 0, 0);
-            panMain.add(btnDate, gridBagConstraints);
-        }
+        lblDate = new JLabel(resourceMap.getString("lblDate.text"));
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy++;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 5, 5);
+        panMain.add(lblDate, gridBagConstraints);
+
+        btnDate = new JButton();
+        btnDate.setText(MekHQ.getMHQOptions().getDisplayFormattedDate(date));
+        btnDate.addActionListener(evt -> changeDate());
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
+        panMain.add(btnDate, gridBagConstraints);
 
         if (scenario.getStatus().isCurrent()) {
             initLootPanel();
@@ -318,9 +320,8 @@ public class CustomizeScenarioDialog extends JDialog {
             if (choiceStatus.getSelectedItem() != null) {
                 scenario.setStatus((ScenarioStatus) choiceStatus.getSelectedItem());
             }
-
-            scenario.setDate(date);
         }
+        scenario.setDate(date);
         scenario.resetLoot();
         for (Loot loot : lootModel.getAllLoot()) {
             scenario.addLoot(loot);


### PR DESCRIPTION
This PR addresses issue #3929. It will prevent advancing the day when a scenario is due (is pending and has a due date of today or earlier). This only affects vanilla scenarios not AtB scenarios. This will make story arcs where scenarios are created by the arc easier to manage because players will be alerted when there is a scenario that requires attention. 

This is ready to go ~~but I am going to leave it in a draft state because I do not want to add this code until we give players a way to edit the date of a pending scenario, which I plan to do as part of addressing issue #3927.~~