### PR TITLE
Clamped Unit Rating Mod for CamOps (redux)

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5571,7 +5571,7 @@ public class Campaign implements ITechManager {
         }
         IUnitRating rating = getUnitRating();
         return getCampaignOptions().getUnitRatingMethod().isFMMR() ? rating.getUnitRatingAsInteger()
-                : rating.getModifier();
+                : MathUtility.clamp(rating.getModifier(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3187,7 +3187,7 @@ public class Campaign implements ITechManager {
                 }
             }
 
-            final int roll = MathUtility.clamp(Compute.d6(2) + getUnitRatingMod() - 2, 2, 12);
+            final int roll = MathUtility.clamp(Compute.d6(2) + getUnitRatingMod() -  2, 2, 12);
 
             int change = numPersonnel * (roll - 5) / 100;
             if (change < 0) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3187,7 +3187,7 @@ public class Campaign implements ITechManager {
                 }
             }
 
-            final int roll = MathUtility.clamp(Compute.d6(2) + getUnitRatingMod() -  2, 2, 12);
+            final int roll = MathUtility.clamp(Compute.d6(2) + getUnitRatingMod() - 2, 2, 12);
 
             int change = numPersonnel * (roll - 5) / 100;
             if (change < 0) {


### PR DESCRIPTION
### Current Implementation
Currently, CamOps Unit Rating is uncapped. AtB relies on Unit Rating to generate TN modifiers to a number of different functions.

### Problem
With CamOps being uncapped, there is no upper or lower boundary to the modifiers which can create undesirable effects. Such as...

- Only generating Relief missions
- Making Retirement checks impossible to pass/fail.
- Making Ship Search checks impossible to pass/fail.
- Influencing what large craft are found, through the Ship Search.
- Influencing the arrival/departure of Dependents.
- Influencing enemy Morale Checks, causing enemy morale to snowball towards Invincible/Rout.
- Influencing part availability, during contracts. Potentially making the availability of parts much easier/harder than intended.
- Influencing where units are placed, after scenarios (Field Repair, Repair Bay, etc).
- Influencing the hiring hall, making better pilots more/less common than intended.

### Solution
Using `MathUtility.clamp()` I have bound `UnitRating` so fit within the lower/upper bounds of the FM:M Dragoon Rating System (F-A*). This is only limited to the above instances, so things like `Unit Report` are unaffected.

All issues listed under 'Problems' have been closed by this PR.

### Credit
Credit for this solution goes to https://github.com/SuperStucco. All I did was edit the `getUnitRatingMod` to ensure it applied to all uses of `getUnitRatingMod`. This approach was suggested by Nick and replaces my earlier approach of editing on a case-by-case basis.

### Closes
Closes #3729
Closes #3817
Closes #3753