### PR TITLE
Adjust Retirement Payouts for 49.19

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RetirementDefectionTracker.java
@@ -403,14 +403,14 @@ public class RetirementDefectionTracker {
                 person.getPrimaryRole()).isMechWarrior();
         switch (person.getExperienceLevel(campaign, false)) {
             case SkillType.EXP_ELITE:
-                return Money.of(isMechWarriorProfession ? 9600 : 5920);
+                return Money.of(isMechWarriorProfession ? 115200 : 71520);
             case SkillType.EXP_VETERAN:
-                return Money.of(isMechWarriorProfession ? 4800 : 2960);
+                return Money.of(isMechWarriorProfession ? 57600 : 35520);
             case SkillType.EXP_REGULAR:
-                return Money.of(isMechWarriorProfession ? 3000 : 1850);
+                return Money.of(isMechWarriorProfession ? 3600 : 22200);
             case SkillType.EXP_GREEN:
             default:
-                return Money.of(isMechWarriorProfession ? 1800 : 1110);
+                return Money.of(isMechWarriorProfession ? 21600 : 13320);
         }
     }
 


### PR DESCRIPTION
As discussed on Discord, this tweak adjusts payout values. It will be fully replaced by #3921 and should only be merged if 3921 is _not_ going to be merged into 49.19.