### PR TITLE
Added Nag Dialog for Prisoners of War Outside of Contracts

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -285,6 +285,10 @@ ShortDeploymentNagDialog.text=You have not met the deployment levels required by
 UnmaintainedUnitsNagDialog.title=Unmaintained Units
 UnmaintainedUnitsNagDialog.text=You have unmaintained units. Do you really wish to advance the day?
 
+### PrisonersNagDialog Class
+PrisonersNagDialog.title=Prisoners of War
+PrisonersNagDialog.text=You still have prisoners of war. Do you really wish to advance the day?
+
 ### UnresolvedStratConContactsNagDialog Class
 UnresolvedStratConContactsNagDialog.title=Unresolved StratCon Contacts
 UnresolvedStratConContactsNagDialog.text=You have unresolved contacts on the StratCon interface:\n%s\nAdvance day anyway?
@@ -634,6 +638,8 @@ optionSaveMothballState.toolTipText=This option allows you to disable saving of 
 nagTab.title=Nag Options
 optionUnmaintainedUnitsNag.text=Hide Unmaintained Units Nag
 optionUnmaintainedUnitsNag.toolTipText=This allows you to ignore the daily warning for when you have unmaintained units.
+optionPrisonersNag.text=Hide Prisoners of War Nag
+optionPrisonersNag.toolTipText=This allows you to ignore the daily warning for when you have prisoners of war outside of a contract.
 optionInsufficientAstechsNag.text=Hide Insufficient Astechs Nag
 optionInsufficientAstechsNag.toolTipText=This allows you to ignore the daily warning for when you don't have enough astechs to support your techs.
 optionInsufficientAstechTimeNag.text=Hide Insufficient Astech Time Nag

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -161,6 +161,7 @@ public final class MHQConstants extends SuiteConstants {
     //region Nag Tab
     public static final String NAG_NODE = "mekhq/prefs/nags";
     public static final String NAG_UNMAINTAINED_UNITS = "nagUnmaintainedUnits";
+    public static final String NAG_PRISONERS = "nagPrisoners";
     public static final String NAG_INSUFFICIENT_ASTECHS = "nagInsufficientAstechs";
     public static final String NAG_INSUFFICIENT_ASTECH_TIME = "nagInsufficientAstechTime";
     public static final String NAG_INSUFFICIENT_MEDICS = "nagInsufficientMedics";

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2371,6 +2371,11 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
+        if (new PrisonersNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+            evt.cancel();
+            return;
+        }
+
         if (new InsufficientAstechsNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
             evt.cancel();
             return;

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -144,6 +144,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
 
     //region Nag Tab
     private JCheckBox optionUnmaintainedUnitsNag;
+    private JCheckBox optionPrisonersNag;
     private JCheckBox optionInsufficientAstechsNag;
     private JCheckBox optionInsufficientAstechTimeNag;
     private JCheckBox optionInsufficientMedicsNag;
@@ -842,6 +843,10 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionUnmaintainedUnitsNag.setToolTipText(resources.getString("optionUnmaintainedUnitsNag.toolTipText"));
         optionUnmaintainedUnitsNag.setName("optionUnmaintainedUnitsNag");
 
+        optionPrisonersNag = new JCheckBox(resources.getString("optionPrisonersNag.text"));
+        optionPrisonersNag.setToolTipText(resources.getString("optionPrisonersNag.toolTipText"));
+        optionPrisonersNag.setName("optionPrisonersNag");
+
         optionInsufficientAstechsNag = new JCheckBox(resources.getString("optionInsufficientAstechsNag.text"));
         optionInsufficientAstechsNag.setToolTipText(resources.getString("optionInsufficientAstechsNag.toolTipText"));
         optionInsufficientAstechsNag.setName("optionInsufficientAstechsNag");
@@ -877,6 +882,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         layout.setVerticalGroup(
                 layout.createSequentialGroup()
                         .addComponent(optionUnmaintainedUnitsNag)
+                        .addComponent(optionPrisonersNag)
                         .addComponent(optionInsufficientAstechsNag)
                         .addComponent(optionInsufficientAstechTimeNag)
                         .addComponent(optionInsufficientMedicsNag)
@@ -888,6 +894,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         layout.setHorizontalGroup(
                 layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                         .addComponent(optionUnmaintainedUnitsNag)
+                        .addComponent(optionPrisonersNag)
                         .addComponent(optionInsufficientAstechsNag)
                         .addComponent(optionInsufficientAstechTimeNag)
                         .addComponent(optionInsufficientMedicsNag)
@@ -1140,6 +1147,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         MekHQ.getMHQOptions().setSaveMothballState(optionSaveMothballState.isSelected());
 
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNMAINTAINED_UNITS, optionUnmaintainedUnitsNag.isSelected());
+        MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_PRISONERS, optionPrisonersNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECHS, optionInsufficientAstechsNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME, optionInsufficientAstechTimeNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_MEDICS, optionInsufficientMedicsNag.isSelected());
@@ -1248,6 +1256,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionSaveMothballState.setSelected(MekHQ.getMHQOptions().getSaveMothballState());
 
         optionUnmaintainedUnitsNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNMAINTAINED_UNITS));
+        optionPrisonersNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_PRISONERS));
         optionInsufficientAstechsNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECHS));
         optionInsufficientAstechTimeNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME));
         optionInsufficientMedicsNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_MEDICS));

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
@@ -30,7 +30,7 @@ public class PrisonersNagDialog extends AbstractMHQNagDialog {
     public static boolean hasPrisoners (Campaign campaign) {
         if (!campaign.hasActiveContract()) {
             for (Person p : campaign.getActivePersonnel()) {
-                if ((p.getPrisonerStatus().isCurrentPrisoner()) || (p.getPrisonerStatus().isBondsman())) {
+                if ((p.getPrisonerStatus().isCurrentPrisoner())) {
                     return true;
                 }
             }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
@@ -27,10 +27,10 @@ import mekhq.gui.baseComponents.AbstractMHQNagDialog;
 import javax.swing.*;
 
 public class PrisonersNagDialog extends AbstractMHQNagDialog {
-    public static boolean hasPrisoners (Campaign campaign) {
+    private static boolean hasPrisoners (Campaign campaign) {
         if (!campaign.hasActiveContract()) {
             for (Person p : campaign.getActivePersonnel()) {
-                if ((p.getPrisonerStatus().isCurrentPrisoner())) {
+                if (p.getPrisonerStatus().isCurrentPrisoner()) {
                     return true;
                 }
             }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
@@ -21,22 +21,31 @@ package mekhq.gui.dialog.nagDialogs;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.unit.Unit;
+import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.AbstractMHQNagDialog;
 
 import javax.swing.*;
 
 public class PrisonersNagDialog extends AbstractMHQNagDialog {
+    public static boolean hasPrisoners (Campaign campaign) {
+        if (!campaign.hasActiveContract()) {
+            for (Person p : campaign.getActivePersonnel()) {
+                if ((p.getPrisonerStatus().isCurrentPrisoner()) || (p.getPrisonerStatus().isBondsman())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
     //region Constructors
     public PrisonersNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "PrisonersNagDialog", "PrisonersNagDialog.title",
                 "PrisonersNagDialog.text", campaign, MHQConstants.NAG_PRISONERS);
     }
-    //endregion Constructors
 
+    //endregion Constructors
     @Override
     protected boolean checkNag() {
-        return !MekHQ.getMHQOptions().getNagDialogIgnore(getKey())
-                && getCampaign().getHangar().getUnitsStream().anyMatch(Unit::isUnmaintained);
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(getKey()) && hasPrisoners(getCampaign());
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog.nagDialogs;
+
+import mekhq.MHQConstants;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class PrisonersNagDialog extends AbstractMHQNagDialog {
+    //region Constructors
+    public PrisonersNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "PrisonersNagDialog", "PrisonersNagDialog.title",
+                "PrisonersNagDialog.text", campaign, MHQConstants.NAG_PRISONERS);
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag() {
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(getKey())
+                && getCampaign().getHangar().getUnitsStream().anyMatch(Unit::isUnmaintained);
+    }
+}


### PR DESCRIPTION
### Current Implementation
None

### Problem
I am definitely not the only person who has done this: end the contract, enjoy the spoils of war, get halfway to Galatea only to remember you have a couple hundred prisoners of war still hanging about. You're not about to return to the contract planet so you just dump them out into space. Everyone is sad.

### Solution
On a new day, if not on a contract, the system will check whether any of the users' active personnel are prisoners. If any prisoners are found the nag dialog is triggered.

<p align=center>
<img width="435" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/38290a8c-f1ee-44d8-8e15-86df5116211b">
<img width="213" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/1a1377f0-d385-46f9-b38a-9adc14b7353b">
</p>

### Update
I removed the check for Bondsmen, as these can still be assigned to roles they don't really have the same issue as Prisoners.