### PR TITLE
Unmaintained Unit Nag Dialog Suppressed for Units set to Salvage

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
@@ -29,10 +29,8 @@ import javax.swing.*;
 public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
     private boolean checkHanger() {
         for (Unit u : getCampaign().getHangar().getUnits()) {
-            if(u.isUnmaintained()) {
-                if(!u.isSalvage()) {
+            if((u.isUnmaintained()) && (!u.isSalvage())) {
                     return true;
-                }
             }
         }
         return false;

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
@@ -28,16 +28,14 @@ import javax.swing.*;
 
 public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
     private boolean checkHanger() {
-        int countUnmaintained = 0;
-
         for (Unit u : getCampaign().getHangar().getUnits()) {
             if(u.isUnmaintained()) {
                 if(!u.isSalvage()) {
-                    countUnmaintained += 1;
+                    return true;
                 }
             }
         }
-        return countUnmaintained > 0;
+        return false;
     }
 
     //region Constructors

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
@@ -27,6 +27,19 @@ import mekhq.gui.baseComponents.AbstractMHQNagDialog;
 import javax.swing.*;
 
 public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
+    private boolean checkHanger() {
+        int countUnmaintained = 0;
+
+        for (Unit u : getCampaign().getHangar().getUnits()) {
+            if(u.isUnmaintained()) {
+                if(!u.isSalvage()) {
+                    countUnmaintained += 1;
+                }
+            }
+        }
+        return countUnmaintained > 0;
+    }
+
     //region Constructors
     public UnmaintainedUnitsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "UnmaintainedUnitsNagDialog", "UnmaintainedUnitsNagDialog.title",
@@ -37,6 +50,6 @@ public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
     @Override
     protected boolean checkNag() {
         return !MekHQ.getMHQOptions().getNagDialogIgnore(getKey())
-                && getCampaign().getHangar().getUnitsStream().anyMatch(Unit::isUnmaintained);
+                && checkHanger();
     }
 }


### PR DESCRIPTION
### Current Implementation
When users trigger `Advance Day`, while there are unmaintained units in their hanger, they are presented with a nag dialog asking for confirmation.

### Problem
This triggers even for units set to salvage.

### Solution
The nag now only triggers if there are unmaintained units that are _not_ set to salvage.

### Closes
Closes #646 (only 6 years old! :D)