### PR TITLE
MekHQ fix for WOB.pm/.PM mismatch and missing parent faction check

### DIFF
--- a/MekHQ/data/forcegenerator/factions.xml
+++ b/MekHQ/data/forcegenerator/factions.xml
@@ -67,7 +67,7 @@
 	<faction key='CIR' name='Circinus Federation' minor='false' clan='false' periphery='true'>
 		<years>2785-3081</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
-		<parentFaction>Periphery.MW,WOB.pm</parentFaction>
+		<parentFaction>Periphery.MW,WOB.PM</parentFaction>
 	</faction>
 	<faction key='CLAN' name='Clan - General' minor='false' clan='true' periphery='false'>
 		<years>2807-</years>

--- a/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
+++ b/MekHQ/src/mekhq/campaign/universe/RATGeneratorConnector.java
@@ -152,6 +152,12 @@ public class RATGeneratorConnector extends AbstractUnitGenerator {
                 final Set<String> parentFactions = new HashSet<>();
                 for (final String factionCode : factions) {
                     // Use the current Parent Faction
+                    FactionRecord newFaction = RATGenerator.getInstance().getFaction(factionCode);
+                    if (newFaction == null) {
+                        // No parent faction found
+                        LogManager.getLogger().warn("Failed lookup of faction code '" + factionCode + "', skipping...");
+                        continue;
+                    }
                     parameters.setFaction(RATGenerator.getInstance().getFaction(factionCode));
 
                     // Get the table for the new Parent Faction


### PR DESCRIPTION
Fix case error in Circinus Federation parent faction "WOB.pm" (should be "WOB.PM").

Safety part of the lookup which can cause NPE.

Testing:

- Ran all 3 projects' unit tests
- Ran MekHQ with campaign save and custom units from #3803 and confirmed proper operation.

Close #3803 