### PR TITLE
StratCon Air & Arty Modifiers

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedASFAce01.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedASFAce01.xml
@@ -1,0 +1,36 @@
+<AtBScenarioModifier>
+	<additionalBriefingText>One of your employer's ASF Aces is close and is moving to support.  Watch and learn.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
+	<benefitsPlayer>true</benefitsPlayer>
+	<eventTiming>PreForceGeneration</eventTiming>
+	<forceDefinition>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>-2</allowedUnitType>
+		<arrivalTurn>2</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>true</contributesToBV>
+		<contributesToMapSize>true</contributesToMapSize>
+		<contributesToUnitCount>true</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+		<deploymentZones/>
+		<destinationZone>5</destinationZone>
+		<fixedUnitCount>-1</fixedUnitCount>
+		<forceAlignment>1</forceAlignment>
+		<forceMultiplier>1.0</forceMultiplier>
+		<fixedUnitCount>4</fixedUnitCount>
+		<forceName>Allied ASF Ace</forceName>
+		<generationMethod>5</generationMethod>
+			<fixedMul>AlliedASFAceHvy.mul</fixedMul>	
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>
+		<retreatThreshold>0</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<syncDeploymentType>SameEdge</syncDeploymentType>
+		<syncedForceName>Player</syncedForceName>
+		<useArtillery>false</useArtillery>
+	</forceDefinition>
+</AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/EnemyASFAce01.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyASFAce01.xml
@@ -1,0 +1,37 @@
+<AtBScenarioModifier>
+	<additionalBriefingText>An enemy ASF Ace has been spotted.  Beware.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
+	<benefitsPlayer>false</benefitsPlayer>
+	<eventTiming>PreForceGeneration</eventTiming>
+	<forceDefinition>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>-3</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>false</contributesToBV>
+		<contributesToMapSize>true</contributesToMapSize>
+		<contributesToUnitCount>false</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+        <deploymentZones/>
+		<destinationZone>5</destinationZone>
+		<fixedUnitCount>0</fixedUnitCount>
+		<forceAlignment>2</forceAlignment>
+		<forceName>Enemy ASF Ace</forceName>
+		<generationMethod>5</generationMethod>
+			<fixedMul>EnemyASFAceHvy.mul</fixedMul>		
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>		
+		<retreatThreshold>75</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<objectiveLinkedForces>
+			<objectiveLinkedForce>Primary Opfor</objectiveLinkedForce>
+		</objectiveLinkedForces>
+		<syncDeploymentType>SameEdge</syncDeploymentType>
+		<syncedForceName>Primary Opfor</syncedForceName>
+		<useArtillery>false</useArtillery>
+	</forceDefinition>
+</AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/EnemyASFAce02.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyASFAce02.xml
@@ -1,0 +1,37 @@
+<AtBScenarioModifier>
+	<additionalBriefingText>An enemy ASF Ace has been spotted.  Beware.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
+	<benefitsPlayer>false</benefitsPlayer>
+	<eventTiming>PreForceGeneration</eventTiming>
+	<forceDefinition>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>-3</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>false</contributesToBV>
+		<contributesToMapSize>true</contributesToMapSize>
+		<contributesToUnitCount>false</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+        <deploymentZones/>
+		<destinationZone>5</destinationZone>
+		<fixedUnitCount>0</fixedUnitCount>
+		<forceAlignment>2</forceAlignment>
+		<forceName>Enemy ASF Ace</forceName>
+		<generationMethod>5</generationMethod>
+			<fixedMul>EnemyASFAceMed.mul</fixedMul>		
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>		
+		<retreatThreshold>75</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<objectiveLinkedForces>
+			<objectiveLinkedForce>Primary Opfor</objectiveLinkedForce>
+		</objectiveLinkedForces>
+		<syncDeploymentType>SameEdge</syncDeploymentType>
+		<syncedForceName>Primary Opfor</syncedForceName>
+		<useArtillery>false</useArtillery>
+	</forceDefinition>
+</AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/EnemyFieldArtyCrack.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyFieldArtyCrack.xml
@@ -1,0 +1,37 @@
+<AtBScenarioModifier>
+	<additionalBriefingText>An enemy Crack Field Artillery Unit has been spotted in the area.  Beware.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
+	<benefitsPlayer>false</benefitsPlayer>
+	<eventTiming>PreForceGeneration</eventTiming>
+	<forceDefinition>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>1</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>false</contributesToBV>
+		<contributesToMapSize>true</contributesToMapSize>
+		<contributesToUnitCount>false</contributesToUnitCount>
+		<deployOffboard>false</deployOffboard>
+        <deploymentZones/>
+		<destinationZone>5</destinationZone>
+		<fixedUnitCount>8</fixedUnitCount>
+		<forceAlignment>2</forceAlignment>
+		<forceName>Enemy Crack Field Arty</forceName>
+		<generationMethod>5</generationMethod>
+			<fixedMul>EnemyCrackFieldArty.mul</fixedMul>		
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>		
+		<retreatThreshold>75</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<objectiveLinkedForces>
+			<objectiveLinkedForce>Primary Opfor</objectiveLinkedForce>
+		</objectiveLinkedForces>
+		<syncDeploymentType>SameEdge</syncDeploymentType>
+		<syncedForceName>Primary Opfor</syncedForceName>
+		<useArtillery>false</useArtillery>
+	</forceDefinition>
+</AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/EnemyFieldArtyOffboard.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyFieldArtyOffboard.xml
@@ -1,0 +1,37 @@
+<AtBScenarioModifier>
+	<additionalBriefingText>An enemy Field Artillery Unit has been spotted in the area.  Beware.</additionalBriefingText>
+	<allowedMapLocations>
+		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
+		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
+	</allowedMapLocations>
+	<benefitsPlayer>false</benefitsPlayer>
+	<eventTiming>PreForceGeneration</eventTiming>
+	<forceDefinition>
+		<actualDeploymentZone>-1</actualDeploymentZone>
+		<allowAeroBombs>false</allowAeroBombs>
+		<allowedUnitType>0</allowedUnitType>
+		<arrivalTurn>0</arrivalTurn>
+		<canReinforceLinked>false</canReinforceLinked>
+		<contributesToBV>false</contributesToBV>
+		<contributesToMapSize>true</contributesToMapSize>
+		<contributesToUnitCount>false</contributesToUnitCount>
+		<deployOffboard>true</deployOffboard>
+        <deploymentZones/>
+		<destinationZone>5</destinationZone>
+		<fixedUnitCount>4</fixedUnitCount>
+		<forceAlignment>2</forceAlignment>
+		<forceName>Enemy Offboard Field Arty</forceName>
+		<generationMethod>5</generationMethod>
+			<fixedMul>EnemyOffFieldArty.mul</fixedMul>		
+		<generationOrder>1</generationOrder>
+		<maxWeightClass>4</maxWeightClass>		
+		<retreatThreshold>75</retreatThreshold>
+		<startingAltitude>0</startingAltitude>
+		<objectiveLinkedForces>
+			<objectiveLinkedForce>Primary Opfor</objectiveLinkedForce>
+		</objectiveLinkedForces>
+		<syncDeploymentType>SameEdge</syncDeploymentType>
+		<syncedForceName>Primary Opfor</syncedForceName>
+		<useArtillery>false</useArtillery>
+	</forceDefinition>
+</AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/airBattleModifiers.xml
+++ b/MekHQ/data/scenariomodifiers/airBattleModifiers.xml
@@ -73,6 +73,15 @@
 		</modifier>
 		<modifier>		
 			EnemyAirPatrol.xml
+		</modifier>
+		<modifier>
+			AlliedASFAce01.xml
 		</modifier>	
+		<modifier>
+			EnemyASFAce01.xml
+		</modifier>	
+		<modifier>
+			EnemyASFAce02.xml
+		</modifier>		
 	</modifiers>
 </scenarioModifierManifest>

--- a/MekHQ/data/scenariomodifiers/groundBattleModifiers.xml
+++ b/MekHQ/data/scenariomodifiers/groundBattleModifiers.xml
@@ -230,6 +230,21 @@
 		</modifier>	
 		<modifier>
 			AlliedHorseCav.xml
+		</modifier>	
+		<modifier>
+			AlliedASFAce01.xml
+		</modifier>	
+		<modifier>
+			EnemyFieldArtyCrack.xml
+		</modifier>	
+		<modifier>
+			EnemyFieldArtyOffboard.xml
+		</modifier>	
+		<modifier>
+			EnemyASFAce01.xml
+		</modifier>	
+		<modifier>
+			EnemyASFAce02.xml
 		</modifier>		
 	</modifiers>
 </scenarioModifierManifest>

--- a/MekHQ/data/scenariomodifiers/modifiermanifest.xml
+++ b/MekHQ/data/scenariomodifiers/modifiermanifest.xml
@@ -244,6 +244,22 @@
 		<modifier>
 			AlliedHorseCav.xml
 		</modifier>
+		<modifier>
+			AlliedASFAce01.xml
+		</modifier>	
+		<modifier>
+			EnemyFieldArtyCrack.xml
+		</modifier>	
+		<modifier>
+			EnemyFieldArtyOffboard.xml
+		</modifier>	
+		<modifier>
+			EnemyASFAce01.xml
+		</modifier>	
+		<modifier>
+			EnemyASFAce02.xml
+		</modifier>
+
 		
 		<!-- Fixed scenario modifiers suitable for specific scenario types go here -->
 		<modifier>

--- a/MekHQ/data/scenariotemplates/fixedmuls/AlliedASFAceHvy.mul
+++ b/MekHQ/data/scenariotemplates/fixedmuls/AlliedASFAceHvy.mul
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<unit version="0.49.19-SNAPSHOT" >
+
+		<entity chassis="Thunderbird" model="TRB-D36" type="Aerodyne" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" velocity="0" altitude="5" externalId="5d79591a-e4cb-4cae-ae70-6896c5b646a3">
+			<pilot size="1" name="Tarvo Guzmán" nick="Wedge" gender="MALE" gunnery="3" piloting="2" externalId="d9e8decb-4abb-4f37-bd4c-fbaaaa6cf261" ejected="false" advantages="maneuvering_ace::shaky_stick::golden_goose" edge="edge 3::edge_when_aero_alt_loss::edge_when_aero_explosion::edge_when_aero_ko::edge_when_aero_lucky_crit::edge_when_aero_nuke_crit::edge_when_aero_unit_cargo_lost"/>
+			<fuel left="400"/>
+			<bombs>
+				<bomb type="HEBomb" load="7" Internal="false"/>
+				<bomb type="ClusterBomb" load="7" Internal="false"/>
+				<bomb type="FABombSmall Ammo" load="4" Internal="false"/>
+			</bombs>
+			<structural integrity="10"/>
+			<heat sinks="25"/>
+      The first slot in a location is at index="1".
+			<location index="5"> Fuselage
+				<slot index="1" type="IS Ammo LRM-20" shots="6"/>
+				<slot index="2" type="IS Ammo LRM-20" shots="6"/>
+				<slot index="3" type="IS Ammo LRM-20" shots="6"/>
+				<slot index="4" type="IS Ammo LRM-20" shots="6"/>
+			</location>
+			<Game id="11"/>
+		</entity>
+
+</unit>

--- a/MekHQ/data/scenariotemplates/fixedmuls/EnemyASFAceHvy.mul
+++ b/MekHQ/data/scenariotemplates/fixedmuls/EnemyASFAceHvy.mul
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<unit version="0.49.19-SNAPSHOT" >
+
+		<entity chassis="Slayer" model="SL-15" type="Aerodyne" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" velocity="0" altitude="5" externalId="6a5344dd-dce9-4a70-812f-cc360a9e8aba">
+			<pilot size="1" name="Lewis Sturgeon" nick="Maverick" gender="MALE" gunnery="2" piloting="3" externalId="71b72d48-3045-42fd-83e9-a7c1521bf4ea" ejected="false" advantages="aptitude_piloting::shaky_stick" edge="edge 2::edge_when_aero_alt_loss::edge_when_aero_explosion::edge_when_aero_ko::edge_when_aero_lucky_crit"/>
+			<fuel left="800"/>
+			<bombs>
+				<bomb type="HEBomb" load="6" Internal="false"/>
+				<bomb type="ClusterBomb" load="6" Internal="false"/>
+			</bombs>
+			<structural integrity="8"/>
+			<heat sinks="20"/>
+      The first slot in a location is at index="1".
+			<location index="5"> Fuselage
+				<slot index="1" type="IS Ammo AC/10" shots="10"/>
+				<slot index="2" type="IS Ammo AC/10" shots="10"/>
+			</location>
+			<Game id="9"/>
+		</entity>
+
+</unit>

--- a/MekHQ/data/scenariotemplates/fixedmuls/EnemyASFAceMed.mul
+++ b/MekHQ/data/scenariotemplates/fixedmuls/EnemyASFAceMed.mul
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<unit version="0.49.19-SNAPSHOT" >
+
+		<entity chassis="Samurai" model="SL-25" type="Aerodyne" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" velocity="0" altitude="5" externalId="eab96f32-c155-4e14-b2a1-0791fd067ac5">
+			<pilot size="1" name="Ilmari Juutilainen" nick="Illu" gender="MALE" gunnery="3" piloting="2" externalId="f7ba9a8e-83a9-4de1-8b46-0c379ff9bfed" ejected="false" advantages="hot_dog::maneuvering_ace::golden_goose" edge="edge 2::edge_when_aero_alt_loss::edge_when_aero_explosion::edge_when_aero_ko::edge_when_aero_lucky_crit::edge_when_aero_unit_cargo_lost"/>
+			<fuel left="640"/>
+			<bombs>
+				<bomb type="HEBomb" load="4" Internal="false"/>
+				<bomb type="ClusterBomb" load="4" Internal="false"/>
+			</bombs>
+			<structural integrity="7"/>
+			<heat sinks="19"/>
+			<Game id="10"/>
+		</entity>
+
+</unit>

--- a/MekHQ/data/scenariotemplates/fixedmuls/EnemyCrackFieldArty.mul
+++ b/MekHQ/data/scenariotemplates/fixedmuls/EnemyCrackFieldArty.mul
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<unit version="0.49.19-SNAPSHOT" >
+
+		<entity chassis="Field Artillery" model="(Sniper)" type="Tracked" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="d793b194-a284-43c8-af46-b75532439f52">
+			<pilot size="1" name="Finnian Stainer" nick="" gender="MALE" gunnery="2" piloting="8" externalId="d74eee27-2094-4354-bd4b-2605b8b87830" ejected="false" advantages="oblique_artillery"/>
+      The first slot in a location is at index="1".
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+				<slot index="2" type="ISSniperAmmo" shots="10"/>
+			</location>
+			<Game id="1"/>
+		</entity>
+
+		<entity chassis="Field Artillery" model="(Sniper)" type="Tracked" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="aae3add7-c409-48dc-82eb-44cb6a3f4b9d">
+			<pilot size="1" name="Zak Uthman" nick="" gender="MALE" gunnery="3" piloting="8" externalId="e830ce22-0ef6-4973-b4f6-f03f70adccc3" ejected="false" advantages="oblique_artillery"/>
+      The first slot in a location is at index="1".
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+				<slot index="2" type="ISSniperAmmo" shots="10"/>
+			</location>
+			<Game id="2"/>
+		</entity>
+
+		<entity chassis="Field Artillery" model="(Thumper)" type="Tracked" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="18ac1d76-cb6b-4ee8-ac0e-72998016026c">
+			<pilot size="1" name="Greta Kluge" nick="" gender="FEMALE" gunnery="3" piloting="8" externalId="115e242f-0654-4f36-ac26-c955930a7c17" ejected="false" advantages="oblique_attacker"/>
+      The first slot in a location is at index="1".
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+				<slot index="2" type="ISThumperAmmo" shots="20"/>
+			</location>
+			<Game id="3"/>
+		</entity>
+
+		<entity chassis="Field Artillery" model="(Thumper)" type="Tracked" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="00d96377-7e06-4117-aea4-aa29fa52d5bf">
+			<pilot size="1" name="Robbie Berger" nick="" gender="MALE" gunnery="3" piloting="8" externalId="a1af0625-a18b-4039-a7af-0c9c2e516ede" ejected="false" advantages="oblique_attacker"/>
+      The first slot in a location is at index="1".
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+				<slot index="2" type="ISThumperAmmo" shots="20"/>
+			</location>
+			<Game id="4"/>
+		</entity>
+
+		<entity chassis="Foot Platoon" model="(Laser)" type="Leg" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="ba256ab8-9e6a-449c-a7e8-9f49bb34d700">
+			<pilot size="1" name="Mirvat Chandio" nick="" gender="FEMALE" gunnery="3" piloting="6" externalId="f0989378-ccc4-499d-9e50-7b01e35be162" ejected="false" advantages="forward_observer"/>
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+			</location>
+			<Game id="5"/>
+		</entity>
+
+		<entity chassis="Foot Platoon" model="(Rifle)" type="Leg" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="aa6baf0b-d0e2-4bce-92f7-3e128a431325">
+			<pilot size="1" name="Jerry Pilipo" nick="" gender="MALE" gunnery="3" piloting="6" externalId="2ea5e52a-3c35-407d-a113-d852a781eff6" ejected="false" advantages="forward_observer"/>
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+			</location>
+			<Game id="6"/>
+		</entity>
+
+		<entity chassis="Foot Platoon" model="(SRM)" type="Leg" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="dc70321a-f7ce-4452-b970-5f1cf3f65714">
+			<pilot size="1" name="Aimee Gilkes" nick="" gender="FEMALE" gunnery="3" piloting="6" externalId="cfbb62c7-cfca-42a8-ba00-e80c20f2b88e" ejected="false" advantages="forward_observer::foot_cav"/>
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+			</location>
+			<Game id="7"/>
+		</entity>
+
+		<entity chassis="Jump Platoon" model="(Rifle)" type="Jump" commander="false" offboard="false" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="b8b7b6aa-576d-4335-b756-35aadccd6b5c">
+			<pilot size="1" name="Bill Bates" nick="" gender="MALE" gunnery="3" piloting="4" externalId="eee3cc75-a957-41bc-bb4e-1fc1a84b966f" ejected="false" advantages="forward_observer"/>
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+			</location>
+			<Game id="8"/>
+		</entity>
+
+</unit>

--- a/MekHQ/data/scenariotemplates/fixedmuls/EnemyOffFieldArty.mul
+++ b/MekHQ/data/scenariotemplates/fixedmuls/EnemyOffFieldArty.mul
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<unit version="0.49.19-SNAPSHOT" >
+
+		<entity chassis="Field Artillery" model="(Sniper)" type="Tracked" commander="false" offboard="true" offboard_distance="17" offboard_direction="0" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="d793b194-a284-43c8-af46-b75532439f52">
+			<pilot size="1" name="Finnian Stainer" nick="" gender="MALE" gunnery="4" piloting="8" externalId="d74eee27-2094-4354-bd4b-2605b8b87830" ejected="false"/>
+      The first slot in a location is at index="1".
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+				<slot index="2" type="ISSniperAmmo" shots="10"/>
+			</location>
+			<Game id="1"/>
+		</entity>
+
+		<entity chassis="Field Artillery" model="(Sniper)" type="Tracked" commander="false" offboard="true" offboard_distance="17" offboard_direction="0" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="aae3add7-c409-48dc-82eb-44cb6a3f4b9d">
+			<pilot size="1" name="Zak Uthman" nick="" gender="MALE" gunnery="3" piloting="8" externalId="e830ce22-0ef6-4973-b4f6-f03f70adccc3" ejected="false"/>
+      The first slot in a location is at index="1".
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+				<slot index="2" type="ISSniperAmmo" shots="10"/>
+			</location>
+			<Game id="2"/>
+		</entity>
+
+		<entity chassis="Field Artillery" model="(Thumper)" type="Tracked" commander="false" offboard="true" offboard_distance="17" offboard_direction="0" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="18ac1d76-cb6b-4ee8-ac0e-72998016026c">
+			<pilot size="1" name="Greta Kluge" nick="" gender="FEMALE" gunnery="3" piloting="8" externalId="115e242f-0654-4f36-ac26-c955930a7c17" ejected="false"/>
+      The first slot in a location is at index="1".
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+				<slot index="2" type="ISThumperAmmo" shots="20"/>
+			</location>
+			<Game id="3"/>
+		</entity>
+
+		<entity chassis="Field Artillery" model="(Thumper)" type="Tracked" commander="false" offboard="true" offboard_distance="17" offboard_direction="0" hidden="false" deployment="0" deploymentZone="-1" deploymentZoneWidth="3" deploymentZoneOffset="0" deploymentZoneAnyNWx="-1" deploymentZoneAnyNWy="-1" deploymentZoneAnySEx="-1" deploymentZoneAnySEy="-1" neverDeployed="true" externalId="00d96377-7e06-4117-aea4-aa29fa52d5bf">
+			<pilot size="1" name="Robbie Berger" nick="" gender="MALE" gunnery="3" piloting="8" externalId="a1af0625-a18b-4039-a7af-0c9c2e516ede" ejected="false"/>
+      The first slot in a location is at index="1".
+			<location index="1"> Field Guns
+				<armor points="0" type="Internal"/>
+				<slot index="2" type="ISThumperAmmo" shots="20"/>
+			</location>
+			<Game id="4"/>
+		</entity>
+
+</unit>


### PR DESCRIPTION
This PR addresses a recent RFE to add infantry field guns.  Its also adds ASF aces to fill the last hole of the most commonly used units.  I dont plan on adding any more at this time unless the ability to sort them by date happens.

Regardless, later I plan on updating all of the current .mul modifiers to have one for each era.  Even without date sorting, they can be added to the repo to their own folder with instructions that users can copy over depending on the era they are playing, or I can just put them in the files forum for people that want to use them.

Closes #3894 