### PR TITLE
Fix #3949: Custom ScenarioObjectives do not change ScenarioStatus in ResolveScenarioWizardDialog

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
@@ -281,9 +281,9 @@ public class ScenarioObjectiveProcessor {
         }
 
         for (ScenarioObjective objective : scenario.getScenarioObjectives()) {
-            // some objectives aren't associated with units and their completion is set manually
-            // in that case, we continue on
-            if (!objectiveUnitCounts.containsKey(objective)) {
+
+            // if the scenario is not in our objectiveUnitCounts or objectiveOverrides, skip it
+            if (!(objectiveUnitCounts.containsKey(objective) || objectiveOverrides.containsKey(objective))) {
                 continue;
             }
 

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -816,7 +816,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
 
         // dynamically update victory/defeat dropdown based on objective checkboxes
         ScenarioStatus scenarioStatus = objectiveProcessor.determineScenarioStatus(tracker.getScenario(),
-                new HashMap<>(), getObjectiveUnitCounts());
+                getObjectiveOverridesStatus(), getObjectiveUnitCounts());
         choiceStatus.setSelectedItem(scenarioStatus);
 
         pnlStatus.setLayout(new FlowLayout(FlowLayout.LEADING, 5, 5));
@@ -1452,6 +1452,24 @@ public class ResolveScenarioWizardDialog extends JDialog {
         return objectiveUnitCounts;
     }
 
+    /**
+     * Determine the status of each custom objective checkbox
+     * @return the true/false condition of custom objective checkboxes
+     */
+    private Map<ScenarioObjective, Boolean> getObjectiveOverridesStatus() {
+        Map<ScenarioObjective, Boolean> objectiveOverrides = new HashMap<>();
+
+        if (objectiveOverrideCheckboxes == null) {
+            return objectiveOverrides;
+        }
+
+        for (ScenarioObjective objective : objectiveOverrideCheckboxes.keySet()) {
+            objectiveOverrides.put(objective, objectiveOverrideCheckboxes.get(objective).isSelected());
+        }
+
+        return objectiveOverrides;
+    }
+
     private void checkPrisonerStatus() {
         for (int i = 0; i < prisonerCapturedBtns.size(); i++) {
             JCheckBox captured = prisonerCapturedBtns.get(i);
@@ -1565,7 +1583,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
     private void updatePreviewPanel() {
         // set victory/defeat status based on scenario objectives
         ScenarioStatus scenarioStatus = objectiveProcessor.determineScenarioStatus(tracker.getScenario(),
-                new HashMap<>(), getObjectiveUnitCounts());
+                getObjectiveOverridesStatus(), getObjectiveUnitCounts());
         choiceStatus.setSelectedItem(scenarioStatus);
 
         // do a "dry run" of the scenario objectives to output a report


### PR DESCRIPTION
These fixes will enable checking custom ScenarioObjectives to affect the victory conditions. 