### PR TITLE
Variable OperationalVP Added to CommonObjectiveFactory.java

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
@@ -71,7 +71,7 @@ public class CommonObjectiveFactory {
     /**
      * Generates a "keep at least X% or X of [force] units" objective from the bot force with the specified name
      */
-    public static ScenarioObjective getPreserveSpecificFriendlies(String forceName, int number, boolean fixedAmount) {
+    public static ScenarioObjective getPreserveSpecificFriendlies(String forceName, int OperationalVP, int number, boolean fixedAmount) {
         ScenarioObjective keepFriendliesAlive = new ScenarioObjective();
         if (fixedAmount) {
             keepFriendliesAlive.setDescription(String.format(resourceMap.getString("commonObjectives.preserveFriendlyUnits.text"), number, ""));
@@ -85,12 +85,12 @@ public class CommonObjectiveFactory {
 
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
-        successEffect.howMuch = 1;
+        successEffect.howMuch = OperationalVP;
         keepFriendliesAlive.addSuccessEffect(successEffect);
 
         ObjectiveEffect friendlyFailureEffect = new ObjectiveEffect();
         friendlyFailureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
-        friendlyFailureEffect.howMuch = 1;
+        friendlyFailureEffect.howMuch = OperationalVP;
         keepFriendliesAlive.addFailureEffect(friendlyFailureEffect);
 
         return keepFriendliesAlive;

--- a/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
@@ -101,7 +101,7 @@ public class CommonObjectiveFactory {
      * as well as any attached allies, alive
      */
     public static ScenarioObjective getKeepFriendliesAlive(Campaign campaign, AtBContract contract,
-                                                           AtBScenario scenario, int number,
+                                                           AtBScenario scenario, int OperationalVP, int number,
                                                            boolean fixedAmount) {
         ScenarioObjective keepFriendliesAlive = new ScenarioObjective();
         if (fixedAmount) {
@@ -119,12 +119,12 @@ public class CommonObjectiveFactory {
 
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
-        successEffect.howMuch = 1;
+        successEffect.howMuch = OperationalVP;
         keepFriendliesAlive.addSuccessEffect(successEffect);
 
         ObjectiveEffect friendlyFailureEffect = new ObjectiveEffect();
         friendlyFailureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
-        friendlyFailureEffect.howMuch = 1;
+        friendlyFailureEffect.howMuch = OperationalVP;
         keepFriendliesAlive.addFailureEffect(friendlyFailureEffect);
 
         return keepFriendliesAlive;
@@ -134,7 +134,7 @@ public class CommonObjectiveFactory {
      * Generates a "destroy x% of all units" from the given force name objective
      * @param forcename Explicit enemy force name
      */
-    public static ScenarioObjective getDestroyEnemies(String forcename, int percentage) {
+    public static ScenarioObjective getDestroyEnemies(String forcename, int OperationalVP, int percentage) {
         ScenarioObjective destroyHostiles = new ScenarioObjective();
         destroyHostiles.setDescription(String.format(resourceMap.getString("commonObjectives.forceWithdraw.text"), percentage));
         destroyHostiles.setObjectiveCriterion(ObjectiveCriterion.ForceWithdraw);
@@ -143,12 +143,12 @@ public class CommonObjectiveFactory {
 
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
-        successEffect.howMuch = 1;
+        successEffect.howMuch = OperationalVP;
         destroyHostiles.addSuccessEffect(successEffect);
 
         ObjectiveEffect failureEffect = new ObjectiveEffect();
         failureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
-        failureEffect.howMuch = 1;
+        failureEffect.howMuch = OperationalVP;
         destroyHostiles.addFailureEffect(failureEffect);
 
         return destroyHostiles;
@@ -158,14 +158,14 @@ public class CommonObjectiveFactory {
      * Generates a "destroy x% of all units" objective from the primary opposing force
      * @param contract Contract to examine for enemy force name.
      */
-    public static ScenarioObjective getDestroyEnemies(AtBContract contract, int percentage) {
-        return getDestroyEnemies(contract.getEnemyBotName(), percentage);
+    public static ScenarioObjective getDestroyEnemies(AtBContract contract, int OperationalVP, int percentage) {
+        return getDestroyEnemies(contract.getEnemyBotName(), OperationalVP, percentage);
     }
 
     /**
      * Generates a "prevent x% of all units from reaching given edge" objective from the primary opposing force
      */
-    public static ScenarioObjective getPreventEnemyBreakthrough(AtBContract contract, int percentage, OffBoardDirection direction) {
+    public static ScenarioObjective getPreventEnemyBreakthrough(AtBContract contract, int OperationalVP, int percentage, OffBoardDirection direction) {
         ScenarioObjective destroyHostiles = new ScenarioObjective();
         destroyHostiles.setDescription(
                 String.format(resourceMap.getString("commonObjectives.preventBreakthrough.text"), percentage, direction));
@@ -176,12 +176,12 @@ public class CommonObjectiveFactory {
 
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
-        successEffect.howMuch = 1;
+        successEffect.howMuch = OperationalVP;
         destroyHostiles.addSuccessEffect(successEffect);
 
         ObjectiveEffect failureEffect = new ObjectiveEffect();
         failureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
-        failureEffect.howMuch = 1;
+        failureEffect.howMuch = OperationalVP;
         destroyHostiles.addFailureEffect(failureEffect);
 
         return destroyHostiles;
@@ -190,7 +190,7 @@ public class CommonObjectiveFactory {
     /**
      * Generates a "reach X edge with x% of all allied + player units" objective
      */
-    public static ScenarioObjective getBreakthrough(AtBContract contract, AtBScenario scenario, Campaign campaign,
+    public static ScenarioObjective getBreakthrough(AtBContract contract, AtBScenario scenario, Campaign campaign, int OperationalVP,
                                                     int percentage, OffBoardDirection direction) {
         ScenarioObjective breakthrough = new ScenarioObjective();
         breakthrough.setDescription(
@@ -204,12 +204,12 @@ public class CommonObjectiveFactory {
 
         ObjectiveEffect successEffect = new ObjectiveEffect();
         successEffect.effectType = ObjectiveEffectType.ScenarioVictory;
-        successEffect.howMuch = 1;
+        successEffect.howMuch = OperationalVP;
         breakthrough.addSuccessEffect(successEffect);
 
         ObjectiveEffect failureEffect = new ObjectiveEffect();
         failureEffect.effectType = ObjectiveEffectType.ScenarioDefeat;
-        failureEffect.howMuch = 1;
+        failureEffect.howMuch = OperationalVP;
         breakthrough.addFailureEffect(failureEffect);
 
         return breakthrough;

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
@@ -142,7 +142,7 @@ public class AceDuelBuiltInScenario extends AtBScenario {
         super.setObjectives(campaign, contract);
 
         ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract,1, 100);
-        ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 100, false);
+        ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 1, 100, false);
 
         getScenarioObjectives().add(destroyHostiles);
         getScenarioObjectives().add(keepFriendliesAlive);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
@@ -141,7 +141,7 @@ public class AceDuelBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 100);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract,1, 100);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 100, false);
 
         getScenarioObjectives().add(destroyHostiles);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
@@ -141,7 +141,7 @@ public class AceDuelBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract,1, 100);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 100);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 1, 100, false);
 
         getScenarioObjectives().add(destroyHostiles);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AlliedTraitorsBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AlliedTraitorsBuiltInScenario.java
@@ -81,11 +81,11 @@ public class AlliedTraitorsBuiltInScenario extends AtBScenario {
 
         String allyBotName = getContract(campaign).getAllyBotName();
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 100);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1,100);
         // this is a special case where the target is actually the "allied" bot.
         destroyHostiles.clearForces();
         destroyHostiles.addForce(allyBotName);
-        ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 100, false);
+        ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 1, 100, false);
         keepFriendliesAlive.removeForce(allyBotName);
 
         getScenarioObjectives().add(destroyHostiles);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AlliedTraitorsBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AlliedTraitorsBuiltInScenario.java
@@ -81,7 +81,7 @@ public class AlliedTraitorsBuiltInScenario extends AtBScenario {
 
         String allyBotName = getContract(campaign).getAllyBotName();
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1,100);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 100);
         // this is a special case where the target is actually the "allied" bot.
         destroyHostiles.clearForces();
         destroyHostiles.addForce(allyBotName);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AllyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AllyRescueBuiltInScenario.java
@@ -122,9 +122,9 @@ public class AllyRescueBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 50);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 50);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                50, false);
+                1, 50, false);
 
         // in addition to the standard destroy 50/preserve 50, you need to keep
         // at least 3/8 of the "allied" units alive.

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AmbushBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AmbushBuiltInScenario.java
@@ -92,9 +92,9 @@ public class AmbushBuiltInScenario extends AtBScenario {
     @Override
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 66);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 66);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                100, false);
+                1, 100, false);
 
         getScenarioObjectives().add(destroyHostiles);
         getScenarioObjectives().add(keepFriendliesAlive);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -162,10 +162,10 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 50);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 50);
         destroyHostiles.addForce(String.format("%s%s", contract.getEnemyBotName(), SECOND_ENEMY_FORCE_SUFFIX));
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                50, false);
+                1, 50, false);
 
         ScenarioObjective preserveBaseUnits = null;
         if (!isAttacker()) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -169,7 +169,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
 
         ScenarioObjective preserveBaseUnits = null;
         if (!isAttacker()) {
-            preserveBaseUnits = CommonObjectiveFactory.getPreserveSpecificFriendlies(BASE_CIVILIAN_FORCE_ID, 1,3, true);
+            preserveBaseUnits = CommonObjectiveFactory.getPreserveSpecificFriendlies(BASE_CIVILIAN_FORCE_ID, 1, 3, true);
             preserveBaseUnits.addForce(BASE_TURRET_FORCE_ID);
 
             ObjectiveEffect defeatEffect = new ObjectiveEffect();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -169,7 +169,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
 
         ScenarioObjective preserveBaseUnits = null;
         if (!isAttacker()) {
-            preserveBaseUnits = CommonObjectiveFactory.getPreserveSpecificFriendlies(BASE_CIVILIAN_FORCE_ID, 3, true);
+            preserveBaseUnits = CommonObjectiveFactory.getPreserveSpecificFriendlies(BASE_CIVILIAN_FORCE_ID, 1,3, true);
             preserveBaseUnits.addForce(BASE_TURRET_FORCE_ID);
 
             ObjectiveEffect defeatEffect = new ObjectiveEffect();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
@@ -120,7 +120,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
         super.setObjectives(campaign, contract);
 
         ScenarioObjective destroyHostiles = isAttacker()
-                ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 66,
+                ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 1, 66,
                         OffBoardDirection.getOpposite(OffBoardDirection.translateBoardStart(getStart())))
                 : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 1, 50,
                         OffBoardDirection.translateBoardStart(getEnemyHome()));

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
@@ -122,7 +122,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
         ScenarioObjective destroyHostiles = isAttacker()
                 ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 66,
                         OffBoardDirection.getOpposite(OffBoardDirection.translateBoardStart(getStart())))
-                : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 50,
+                : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 1, 50,
                         OffBoardDirection.translateBoardStart(getEnemyHome()));
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,
                 this);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -142,7 +142,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
         ScenarioObjective destroyHostiles = isAttacker()
                 ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 50,
                         OffBoardDirection.translateBoardStart(AtBDynamicScenarioFactory.getOppositeEdge(getStart())))
-                : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 50,
+                : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 1, 50,
                         OffBoardDirection.translateBoardStart(getEnemyHome()));
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,
                 this);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -140,7 +140,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
         super.setObjectives(campaign, contract);
 
         ScenarioObjective destroyHostiles = isAttacker()
-                ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 1,50,
+                ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 1, 50,
                         OffBoardDirection.translateBoardStart(AtBDynamicScenarioFactory.getOppositeEdge(getStart())))
                 : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 1, 50,
                         OffBoardDirection.translateBoardStart(getEnemyHome()));

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -140,7 +140,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
         super.setObjectives(campaign, contract);
 
         ScenarioObjective destroyHostiles = isAttacker()
-                ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 50,
+                ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 1,50,
                         OffBoardDirection.translateBoardStart(AtBDynamicScenarioFactory.getOppositeEdge(getStart())))
                 : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 1, 50,
                         OffBoardDirection.translateBoardStart(getEnemyHome()));

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianHelpBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianHelpBuiltInScenario.java
@@ -102,9 +102,9 @@ public class CivilianHelpBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 66);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 66);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                1, true);
+                1, 1, true);
         ScenarioObjective keepCiviliansAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(CIVILIAN_FORCE_ID,
                 1, 1, true);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianHelpBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianHelpBuiltInScenario.java
@@ -106,7 +106,7 @@ public class CivilianHelpBuiltInScenario extends AtBScenario {
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
                 1, true);
         ScenarioObjective keepCiviliansAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(CIVILIAN_FORCE_ID,
-                1, true);
+                1, 1, true);
 
         // not losing the scenario also gets you a "bonus"
         ObjectiveEffect bonusEffect = new ObjectiveEffect();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianRiotBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianRiotBuiltInScenario.java
@@ -135,7 +135,7 @@ public class CivilianRiotBuiltInScenario extends AtBScenario {
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
                 50, false);
         ScenarioObjective keepLoyalistsAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(LOYALIST_FORCE_ID,
-                1, true);
+                1, 1, true);
 
         // not losing the scenario also gets you a "bonus"
         ObjectiveEffect bonusEffect = new ObjectiveEffect();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianRiotBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianRiotBuiltInScenario.java
@@ -130,10 +130,10 @@ public class CivilianRiotBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyRioters = CommonObjectiveFactory.getDestroyEnemies(RIOTER_FORCE_ID, 100);
-        ScenarioObjective destroyRebels = CommonObjectiveFactory.getDestroyEnemies(REBEL_FORCE_ID, 50);
+        ScenarioObjective destroyRioters = CommonObjectiveFactory.getDestroyEnemies(RIOTER_FORCE_ID, 1, 100);
+        ScenarioObjective destroyRebels = CommonObjectiveFactory.getDestroyEnemies(REBEL_FORCE_ID, 1, 50);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                50, false);
+                1, 50, false);
         ScenarioObjective keepLoyalistsAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(LOYALIST_FORCE_ID,
                 1, 1, true);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyAttackBuiltInScenario.java
@@ -110,9 +110,9 @@ public class ConvoyAttackBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyConvoy = CommonObjectiveFactory.getDestroyEnemies(CONVOY_FORCE_ID, 100);
+        ScenarioObjective destroyConvoy = CommonObjectiveFactory.getDestroyEnemies(CONVOY_FORCE_ID, 1, 100);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                50, false);
+                1, 50, false);
 
         getScenarioObjectives().add(destroyConvoy);
         getScenarioObjectives().add(keepFriendliesAlive);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
@@ -121,7 +121,7 @@ public class ConvoyRescueBuiltInScenario extends AtBScenario {
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
                 50, false);
         ScenarioObjective keepConvoyAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(CONVOY_FORCE_ID, 1,
-                true);
+                1, true);
 
         // not losing the scenario also gets you a "bonus"
         ObjectiveEffect bonusEffect = new ObjectiveEffect();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
@@ -117,9 +117,9 @@ public class ConvoyRescueBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 50);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 50);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                50, false);
+                1, 50, false);
         ScenarioObjective keepConvoyAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(CONVOY_FORCE_ID, 1,
                 1, true);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
@@ -136,7 +136,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
         ScenarioObjective civilianObjective;
 
         if (isAttacker()) {
-            civilianObjective = CommonObjectiveFactory.getPreserveSpecificFriendlies(CIVILIAN_FORCE_ID, 50, false);
+            civilianObjective = CommonObjectiveFactory.getPreserveSpecificFriendlies(CIVILIAN_FORCE_ID, 50, 1, false);
             keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 66, false);
 
             civilianObjective.setTimeLimit(12);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
@@ -136,8 +136,8 @@ public class ExtractionBuiltInScenario extends AtBScenario {
         ScenarioObjective civilianObjective;
 
         if (isAttacker()) {
-            civilianObjective = CommonObjectiveFactory.getPreserveSpecificFriendlies(CIVILIAN_FORCE_ID, 50, 1, false);
-            keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 66, false);
+            civilianObjective = CommonObjectiveFactory.getPreserveSpecificFriendlies(CIVILIAN_FORCE_ID, 1, 50, false);
+            keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 1, 66, false);
 
             civilianObjective.setTimeLimit(12);
             civilianObjective.setTimeLimitAtMost(false);
@@ -156,11 +156,11 @@ public class ExtractionBuiltInScenario extends AtBScenario {
             civilianObjective.addDetail(String
                     .format(defaultResourceBundle.getString("commonObjectives.bonusRolls.text"), bonusEffect.howMuch));
         } else {
-            civilianObjective = CommonObjectiveFactory.getDestroyEnemies(CIVILIAN_FORCE_ID, 100);
+            civilianObjective = CommonObjectiveFactory.getDestroyEnemies(CIVILIAN_FORCE_ID, 1, 100);
             civilianObjective.setTimeLimit(10);
             civilianObjective.setTimeLimitAtMost(true);
             civilianObjective.setTimeLimitType(TimeLimitType.Fixed);
-            destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 33);
+            destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 33);
             destroyHostiles.setTimeLimit(10);
             destroyHostiles.setTimeLimitAtMost(true);
             destroyHostiles.setTimeLimitType(TimeLimitType.Fixed);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/HideAndSeekBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/HideAndSeekBuiltInScenario.java
@@ -123,10 +123,10 @@ public class HideAndSeekBuiltInScenario extends AtBScenario {
 
         // Attacker must destroy 50% and keep 66% alive
         // Defender must destroy 33% and keep 50% alive
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract,
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1,
                 isAttacker() ? 50 : 33);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(
-                campaign, contract, this, isAttacker() ? 66 : 50, false);
+                campaign, contract, this, 1, isAttacker() ? 66 : 50, false);
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,
                 this);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/HoldTheLineBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/HoldTheLineBuiltInScenario.java
@@ -96,10 +96,10 @@ public class HoldTheLineBuiltInScenario extends AtBScenario {
 
         // Attacker must destroy 50% and keep 66% alive
         // Defender must destroy 33% and keep 50% alive
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract,
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1,
                 isAttacker() ? 50 : 33);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(
-                campaign, contract, this, isAttacker() ? 66 : 50, false);
+                campaign, contract, this, 1, isAttacker() ? 66 : 50,false);
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,
                 this);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
@@ -144,9 +144,9 @@ public class OfficerDuelBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 100);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 100);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign,
-                contract, this, 100, false);
+                contract, this, 1,100, false);
 
         getScenarioObjectives().add(destroyHostiles);
         getScenarioObjectives().add(keepFriendliesAlive);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/PirateFreeForAllBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/PirateFreeForAllBuiltInScenario.java
@@ -113,10 +113,10 @@ public class PirateFreeForAllBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 50);
-        ScenarioObjective destroyPirates = CommonObjectiveFactory.getDestroyEnemies(PIRATE_FORCE_ID, 50);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 50);
+        ScenarioObjective destroyPirates = CommonObjectiveFactory.getDestroyEnemies(PIRATE_FORCE_ID, 1, 50);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                50, false);
+                1, 50, false);
 
         getScenarioObjectives().add(destroyHostiles);
         getScenarioObjectives().add(destroyPirates);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/PrisonBreakBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/PrisonBreakBuiltInScenario.java
@@ -119,7 +119,7 @@ public class PrisonBreakBuiltInScenario extends AtBScenario {
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
                 1, true);
         ScenarioObjective keepPrisonersAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(PRISONER_FORCE_ID,
-                1, true);
+                1, 1, true);
         ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(GUARD_FORCE_ID, 100);
         destroyHostiles.getSuccessEffects().clear();
         destroyHostiles.addDetail(getResourceBundle().getString("commonObjectives.battlefieldControl"));

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/PrisonBreakBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/PrisonBreakBuiltInScenario.java
@@ -117,10 +117,10 @@ public class PrisonBreakBuiltInScenario extends AtBScenario {
         super.setObjectives(campaign, contract);
 
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                1, true);
+                1, 1, true);
         ScenarioObjective keepPrisonersAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(PRISONER_FORCE_ID,
                 1, 1, true);
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(GUARD_FORCE_ID, 100);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(GUARD_FORCE_ID, 1, 100);
         destroyHostiles.getSuccessEffects().clear();
         destroyHostiles.addDetail(getResourceBundle().getString("commonObjectives.battlefieldControl"));
         destroyHostiles.setTimeLimit(8);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ProbeBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ProbeBuiltInScenario.java
@@ -88,9 +88,9 @@ public class ProbeBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 25);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 25);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                75, false);
+                1, 75, false);
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,
                 this);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ReconRaidBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ReconRaidBuiltInScenario.java
@@ -100,7 +100,7 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 50);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 50);
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,
                 this);
 
@@ -110,7 +110,7 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
 
         if (isAttacker()) {
             ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract,
-                    this, 75, false);
+                    this, 1, 75, false);
             getScenarioObjectives().add(keepFriendliesAlive);
 
             ScenarioObjective raidObjective = new ScenarioObjective();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StandUpBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StandUpBuiltInScenario.java
@@ -77,9 +77,9 @@ public class StandUpBuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 50);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 50);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                50, false);
+                1, 50, false);
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,
                 this);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
@@ -141,7 +141,7 @@ public class StarLeagueCache1BuiltInScenario extends AtBScenario {
         ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 100);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
                 1, true);
-        ScenarioObjective keepTechAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(TECH_FORCE_ID, 1, true);
+        ScenarioObjective keepTechAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(TECH_FORCE_ID, 1, 1, true);
 
         getScenarioObjectives().add(destroyHostiles);
         getScenarioObjectives().add(keepFriendliesAlive);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
@@ -138,8 +138,8 @@ public class StarLeagueCache1BuiltInScenario extends AtBScenario {
     public void setObjectives(Campaign campaign, AtBContract contract) {
         super.setObjectives(campaign, contract);
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 100);
-        ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1, 100);
+        ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this, 1,
                 1, true);
         ScenarioObjective keepTechAlive = CommonObjectiveFactory.getPreserveSpecificFriendlies(TECH_FORCE_ID, 1, 1, true);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache2BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache2BuiltInScenario.java
@@ -79,9 +79,9 @@ public class StarLeagueCache2BuiltInScenario extends StarLeagueCache1BuiltInScen
     public void setObjectives(Campaign campaign, AtBContract contract) {
         getScenarioObjectives().clear();
 
-        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 100);
+        ScenarioObjective destroyHostiles = CommonObjectiveFactory.getDestroyEnemies(contract, 1,100);
         ScenarioObjective keepFriendliesAlive = CommonObjectiveFactory.getKeepFriendliesAlive(campaign, contract, this,
-                100, false);
+                1, 100, false);
 
         getScenarioObjectives().add(destroyHostiles);
         getScenarioObjectives().add(keepFriendliesAlive);


### PR DESCRIPTION
### Current Implementation
`MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java` details the victory conditions (objectives) for the various built in AtB scenarios. All objectives have a fixed Operational Victory Point value of 1.

### Problem
This means that it is not possible to edit the value of objectives when compared to each other. For example, in one scenario you might have three objectives: 1 primary, 2 secondary. All objectives are valued identically, meaning completing both secondary objectives but losing the primary is still considered a victory.

### Solution
I added the integer `OperationalVP` to objective functions, where applicable. I updated all calls from the various objectives to include this variable. All instances default to 1, so nothing has been changed insofar as rewarding Operational VPs. This isn't an update to Operation VP rewards, but preparatory work for a future review.

### Examples of Use
The below is an example of use. `OperationalVP` for the below is actually set to 1 in this PR (as per current implementation), not 99.
<p align =center>
<img width="321" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/6617ed72-057b-487d-8649-c965f8b49938">
<img width="939" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/26a5d741-dedc-4346-ac68-6937c7d02cf1">
</p>

### A Note on StratCon
With the exception of the base attacks scenario (the one you get when the enemy is Invincible), StratCon doesn't appear to use AtB's scenarios and already has this functionality. The focus of this PR is to bring that functionality to AtB scenarios, as this allows a holistic review of Operational VPs, rather than restricting any review to StratCon only. 