### PR TITLE
Add disabled option for Personnel Market

### DIFF
--- a/MekHQ/resources/META-INF/services/mekhq.module.api.PersonnelMarketMethod
+++ b/MekHQ/resources/META-INF/services/mekhq.module.api.PersonnelMarketMethod
@@ -2,4 +2,5 @@ mekhq.campaign.market.PersonnelMarketRandom
 mekhq.campaign.market.PersonnelMarketFMMr
 mekhq.campaign.market.PersonnelMarketStratOps
 mekhq.campaign.market.PersonnelMarketDylan
+mekhq.campaign.market.PersonnelMarketDisabled
 mekhq.module.atb.PersonnelMarketAtB

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -893,7 +893,7 @@ public class CampaignOptions {
 
         //region Markets Tab
         // Personnel Market
-        setPersonnelMarketName(PersonnelMarket.getTypeName(PersonnelMarket.TYPE_STRAT_OPS));
+        setPersonnelMarketName(PersonnelMarket.getTypeName(PersonnelMarket.TYPE_NONE));
         setPersonnelMarketReportRefresh(true);
         setPersonnelMarketRandomRemovalTargets(new HashMap<>());
         getPersonnelMarketRandomRemovalTargets().put(SkillLevel.NONE, 3);

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -45,12 +45,14 @@ public class PersonnelMarket {
     private List<Person> personnel = new ArrayList<>();
     private PersonnelMarketMethod method;
 
+
     public static final int TYPE_RANDOM = 0;
     public static final int TYPE_DYLANS = 1;
     public static final int TYPE_FMMR = 2;
     public static final int TYPE_STRAT_OPS = 3;
     public static final int TYPE_ATB = 4;
-    public static final int TYPE_NUM = 5;
+    public static final int TYPE_NONE = 5;
+    public static final int TYPE_NUM = 6;
 
     /* Used by AtB to track Units assigned to recruits; the key
      * is the person UUID. */
@@ -60,7 +62,7 @@ public class PersonnelMarket {
     private PersonnelRole paidRecruitRole = PersonnelRole.MECHWARRIOR;
 
     public PersonnelMarket() {
-        method = new PersonnelMarketRandom();
+        method = new PersonnelMarketDisabled();
         MekHQ.registerHandler(this);
     }
 
@@ -77,7 +79,7 @@ public class PersonnelMarket {
     public void setType(String key) {
         method = PersonnelMarketServiceManager.getInstance().getService(key);
         if (null == method) {
-            method = new PersonnelMarketRandom();
+            method = new PersonnelMarketDisabled();
         }
     }
 
@@ -301,9 +303,15 @@ public class PersonnelMarket {
                 return "Strat Ops";
             case TYPE_ATB:
                 return "Against the Bot";
+            case TYPE_NONE:
+                return "Disabled";
             default:
                 return "ERROR: Default case reached in PersonnelMarket.getTypeName()";
         }
+    }
+
+    public boolean isNone() {
+        return null == method || method instanceof PersonnelMarketDisabled;
     }
 
     public static long getUnitMainForceType(Campaign c) {

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarketDisabled.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarketDisabled.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+*/
+package mekhq.campaign.market;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.module.api.PersonnelMarketMethod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PersonnelMarketDisabled implements PersonnelMarketMethod {
+
+
+    @Override
+    public String getModuleName() {
+        return "Disabled";
+    }
+
+    @Override
+    public List<Person> generatePersonnelForDay(Campaign c) {
+        return new ArrayList<Person>();
+    }
+
+    @Override
+    public List<Person> removePersonnelForDay(Campaign c, List<Person> current) {
+        return new ArrayList<Person>();
+    }
+}

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -116,6 +116,7 @@ public class CampaignGUI extends JPanel {
     /* For the menu bar */
     private JMenuBar menuBar;
     private JMenu menuThemes;
+    private JMenuItem miPersonnelMarket;
     private JMenuItem miContractMarket;
     private JMenuItem miUnitMarket;
     private JMenuItem miShipSearch;
@@ -673,10 +674,11 @@ public class CampaignGUI extends JPanel {
         JMenu menuMarket = new JMenu(resourceMap.getString("menuMarket.text"));
         menuMarket.setMnemonic(KeyEvent.VK_M);
 
-        JMenuItem miPersonnelMarket = new JMenuItem(resourceMap.getString("miPersonnelMarket.text"));
+        miPersonnelMarket = new JMenuItem(resourceMap.getString("miPersonnelMarket.text"));
         miPersonnelMarket.setMnemonic(KeyEvent.VK_P);
         miPersonnelMarket.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.ALT_DOWN_MASK));
         miPersonnelMarket.addActionListener(evt -> hirePersonMarket());
+        miPersonnelMarket.setVisible(!getCampaign().getPersonnelMarket().isNone());
         menuMarket.add(miPersonnelMarket);
 
         miContractMarket = new JMenuItem(resourceMap.getString("miContractMarket.text"));
@@ -1503,6 +1505,8 @@ public class CampaignGUI extends JPanel {
                 }
             }
         }
+
+        miPersonnelMarket.setVisible(!getCampaign().getPersonnelMarket().isNone());
 
         final AbstractUnitMarket unitMarket = getCampaign().getUnitMarket();
         if (unitMarket.getMethod() != newOptions.getUnitMarketMethod()) {


### PR DESCRIPTION
For **years**, even aeons, MekHQ has included a personnel market that the user had no ability to disable, creating enormous frustration and breaking of immersion among those of who had no use for it. The unit market - you can disable it. The contract market - you can disable it. The personnel market - apparently it has been ordained by God.

But no longer! I bring good tidings. Despite an absolute byzantine coding scheme, I have managed against all odds in this PR to add a disabled option to the personnel market choices, without disrupting people's existing choices in saved games. Furthermore, if you choose disabled, you will not even be forced to look at the personnel market menu item. Hallelujah!