### PR TITLE
Added ATOW Salaries & Rank Multipliers

### DIFF
--- a/MekHQ/data/universe/ranks.xml
+++ b/MekHQ/data/universe/ranks.xml
@@ -11,7 +11,7 @@ Rank:
 	Officer: Whether the rank is considered to be an officer.
 	Pay Multiplier: The pay bonus paid to those of this rank.
 -->
-<rankSystems version="0.49.0">
+<rankSystems version="0.49.19">
 	<rankSystem>
 		<code>SSLDF</code>
 		<name>Second Star League Defense Force</name>
@@ -19,52 +19,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Recruit,-,-,Spaceman Recruit,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Private,-,-,Spaceman,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Corporal,-,-,Petty Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -74,67 +74,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Sergeant,-,-,Chief Petty Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Master Sergeant,-,-,Master Chief PO,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -144,47 +144,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>Lieutenant JG,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Lieutenant SG,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Captain,-,-,Commander,-,-,-,-,-</rankNames>
@@ -194,82 +194,82 @@ Rank:
 		<rank>
 			<rankNames>Major,-,-,Captain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Commodore,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>Lieutenant General,-,-,Rear Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>Major General,-,-,Vice Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>General,-,-,Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Commanding General,-,-,Commanding Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>Star Lord,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -279,52 +279,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Recruit,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Private,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>Private 1st Class,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Corporal,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -334,67 +334,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Sergeant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>Sergeant Major,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Cmd Sergeant Major,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -404,47 +404,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>Cadet,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>Subaltern,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Leftenant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Captain,-,-,--MW,-,-,-,-,-</rankNames>
@@ -454,82 +454,82 @@ Rank:
 		<rank>
 			<rankNames>Major,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Leftenant Colonel,-,-,Light Commodore,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Commodore,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>Leftenant General,-,-,Rear Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>Major General,-,-,Vice Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>General,-,-,Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>Marshal,-,-,Fleet Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>Field Marshal,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Marshal of the Armies,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Prince,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -539,52 +539,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Recruit,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Private,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>Private 1st Class,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Corporal,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -594,67 +594,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Sergeant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>Sergeant Major,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Cmd Sergeant Major,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -664,47 +664,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>Cadet,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>Subaltern,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Leftenant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Hauptmann,-,-,-,-,-,-,-,-</rankNames>
@@ -714,82 +714,82 @@ Rank:
 		<rank>
 			<rankNames>Kommandant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Leftenant Colonel,-,-,Light Kaptain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Kaptain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>Leftenant General,-,-,Rear Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,Vice Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>Hauptmann General,-,-,Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>Marshal,-,-,Fleet Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>Field Marshal,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Marshal of the Armies,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Prince,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -799,52 +799,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Private,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>Private 1st Class,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Corporal,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>Senior Corporal,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>Sergeant,-,-,-,-,-,-,-,-</rankNames>
@@ -854,67 +854,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Staff Sergeant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>Sergeant Major,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>Staff Sergeant Major,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>Sr Sergeant Major,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>Warrant Officer,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>Warrant Officer 1st Class,-,-,-,-,-,-,-,-</rankNames>
@@ -924,47 +924,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>Sr. Warrant Officer,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>Chief Warrant Officer,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>Leutnant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>First Leutnant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Hauptmann,-,-,-,-,-,-,-,-</rankNames>
@@ -974,82 +974,82 @@ Rank:
 		<rank>
 			<rankNames>Kommandant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>Hauptmann-Kommandant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Letnant-Colonel,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>Leutnant-General,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>Hauptmann-General,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>Kommandant-General,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>General,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>General of the Armies,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Archon,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -1059,52 +1059,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Recruit,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Private,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>Private 1st Class,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Corporal,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>Senior Corporal,-,-,-,-,-,-,-,-</rankNames>
@@ -1114,67 +1114,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Sergeant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>Staff Sergeant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>Sergeant Major,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>Staff Sergeant Major,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Senior Sergeant Major,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -1184,47 +1184,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>Cadet,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>Leutnant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>First Leutnant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Hauptmann,-,-,-,-,-,-,-,-</rankNames>
@@ -1234,82 +1234,82 @@ Rank:
 		<rank>
 			<rankNames>Kommandant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>Hauptmann-Kommandant,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Leutnant Colonel,-,-,Leutnant-Kaptain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Kaptain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>Leutnant General,-,-,Leutnant Kommodore,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>Hauptmann General,-,-,Kommodore,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>General,-,-,Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>General of the Armies,-,-,Fleet Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Archon,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -1319,52 +1319,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Recruit,-,-,Spaceman Recruit,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Private,-,-,Spaceman,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>Private 1st Class,-,-,Able Spaceman,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Corporal,-,-,Petty Officer 2nd Class,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -1374,67 +1374,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Sergeant,-,-,Petty Officer 1st Class,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>Staff Sergeant,-,-,Chief Petty Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>Master Sergeant,-,-,Senior Chief Petty Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Sergeant Major,-,-,Master Chief Petty Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -1444,47 +1444,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>Lieutenant JG,-,-,Ensign,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Lieutenant,-,-,Lieutenant,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Captain,-,-,Lieutenant Commander,-,-,-,-,-</rankNames>
@@ -1494,82 +1494,82 @@ Rank:
 		<rank>
 			<rankNames>Force Commander,-,-,Commander,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,Captain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Lieutenant Colonel,-,-,Flag Captain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Commodore,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>General,-,-,Vice Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Marshal,-,-,Fleet Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Captain-General,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -1579,52 +1579,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Shia-ben-bing,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>San-ben-bing,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -1634,67 +1634,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Si-ben-bing,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Yi-si-ben-bing,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -1704,47 +1704,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Sao-wei,-,-,Kong-sao-wei,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Sang-wei,-,-,Kong-sang-wei,-,-,-,-,-</rankNames>
@@ -1754,82 +1754,82 @@ Rank:
 		<rank>
 			<rankNames>Sao-shao,-,-,Kong-sao-shao,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Zhong-shao,-,-,Kong-zhong-shao,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Sang-shao,-,-,Kong-sang-shao,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>Jiang-jun,-,-,Kong-jiang-jun,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Sang-jiang-jun,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Chancellor,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -1839,52 +1839,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -1894,67 +1894,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Zhang-si,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -1964,47 +1964,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Ban-zhang,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Pai-zhang,-,-,-,-,-,-,-,-</rankNames>
@@ -2014,82 +2014,82 @@ Rank:
 		<rank>
 			<rankNames>Lien-zhang,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Ying-zhang,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Shiao-zhang,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>Gao-shiao-zhang,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -2099,52 +2099,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Heishi,-,-,Heishi,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>Gunjin,-,-,Gunjin,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Go-cho,-,-,Go-cho,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -2154,67 +2154,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Gunsho,-,-,Gunsho,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>Shujin,-,-,Shujin,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>Kashira,-,-,Kashira,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Sho-ko,-,-,Sho-ko,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -2224,47 +2224,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Chu-i,-,-,Sho-i,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Tai-i,-,-,Chu-i,-,-,-,-,-</rankNames>
@@ -2274,82 +2274,82 @@ Rank:
 		<rank>
 			<rankNames>Sho-sa,-,-,Dai-i,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Chu-sa,-,-,Sho-sa,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Tai-sa,-,-,Captain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>Sho-sho,-,-,Cho-sho,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>Tai-sho,-,-,Tai-Sho,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>Tai-shu,-,-,Tai-shu,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Gunji-no-Kanrei,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Coordinator,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -2359,52 +2359,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Warrior,Pilot,Warrior Crewman,Naval Warrior,Warrior,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>Point 1,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>Point 2,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Point 3,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>Point 4,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>Point 5,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
@@ -2414,67 +2414,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>Point Commander,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -2484,47 +2484,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>Star Commander,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Nova Commander,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Star Captain,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
@@ -2534,82 +2534,82 @@ Rank:
 		<rank>
 			<rankNames>Nova Captain,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Star Colonel,--MW,--MW,Star Commodore,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>Galaxy Commander,--MW,--MW,Star Admiral,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>Oathmaster,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>Loremaster,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>saKhan,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>Khan,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>ilKhan,--MW,--MW,--MW,--MW,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -2620,52 +2620,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Acolyte:25,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -2675,67 +2675,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -2745,47 +2745,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Adept:25,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Demi-Precentor:25,-,-,-,-,-,-,-,-</rankNames>
@@ -2795,82 +2795,82 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Precentor:25,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>Precentor Martial,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Primus,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -2882,52 +2882,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Acolyte:25,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -2937,67 +2937,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -3007,47 +3007,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Adept:25,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Demi-Precentor:25,-,-,-,-,-,-,-,-</rankNames>
@@ -3057,82 +3057,82 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Precentor:25,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>Precentor Martial,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Conclave Member,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -3142,52 +3142,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Volunteer,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>First Ranker,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -3197,67 +3197,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Lance Corporal,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>Star Corporal,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>Command Sergeant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Banner Sergeant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -3267,47 +3267,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Ensign,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Commander,-,-,--MW,-,-,-,-,-</rankNames>
@@ -3317,82 +3317,82 @@ Rank:
 		<rank>
 			<rankNames>Major,-,-,Comcapt,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Force Major,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Rearad,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>General,-,-,Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Senior General,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Magestrix,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -3402,52 +3402,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Recruit,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Corporal,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Section Leader,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -3457,67 +3457,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Force Sergeant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>Lance Sergeant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Battalion Chief Sergeant,-,-,Air Chief,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -3527,47 +3527,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Cornet,-,-,Ensign,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Subaltern,-,-,Air Master JG,-,-,-,-,-</rankNames>
@@ -3577,82 +3577,82 @@ Rank:
 		<rank>
 			<rankNames>Brigadier,-,-,Air Master SG,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Space Master,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>Comptroller,-,-,Commodore,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>Marshal,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Protector,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -3662,52 +3662,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Miles,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Miles probatus,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -3717,67 +3717,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Miles gregarius,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -3787,47 +3787,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>Legionnaire,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Centurion,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Principes,-,-,-,-,-,-,-,-</rankNames>
@@ -3837,82 +3837,82 @@ Rank:
 		<rank>
 			<rankNames>Legatus,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Prefect,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>General,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>Imperator,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Ceasar,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -3922,52 +3922,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Defender,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Protector,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -3977,67 +3977,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Guardian,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Preceptor,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -4047,47 +4047,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Supervisor,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Section Leader,-,-,-,-,-,-,-,-</rankNames>
@@ -4097,82 +4097,82 @@ Rank:
 		<rank>
 			<rankNames>Director,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Chairman,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Senior Chairman,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>President,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -4182,52 +4182,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Menig,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Kavellrist,Korpral,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -4237,67 +4237,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Sergeant,--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Fanjunkare,--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -4307,47 +4307,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Löjtnant,--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Kapten,--MW,-,-,-,-,-,-,-</rankNames>
@@ -4357,82 +4357,82 @@ Rank:
 		<rank>
 			<rankNames>Major,--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>Överste-Löjtnant,--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Överste,--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>Generalmajor,--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>General,--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Överbefälhavare (Elected Prince),--MW,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -4442,52 +4442,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Recruit,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Corporal,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Section Leader,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -4497,67 +4497,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Force Sergeant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>Lance Sergeant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Battalion Chief Sergeant,-,-,Air Chief,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -4567,47 +4567,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Cornet,-,-,Ensign,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Subaltern,-,-,Air Master JG,-,-,-,-,-</rankNames>
@@ -4617,82 +4617,82 @@ Rank:
 		<rank>
 			<rankNames>Brigadier,-,-,Air Master SG,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>Captain,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Space Master,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>General,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>Commander-in-Chief,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 	<rankSystem>
@@ -4702,52 +4702,52 @@ Rank:
 		<rank>
 			<rankNames>None,--NAVAL,--MW,--MW,--MW,--MW,--TECH,--TECH,--ADMIN</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.0</payMultiplier>
 		</rank> <!-- E0 "None" -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.08</payMultiplier>
 		</rank> <!-- E1 -->
 		<rank>
 			<rankNames>Recruit,-,-,Spaceman Recruit,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- E2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.25</payMultiplier>
 		</rank> <!-- E3 -->
 		<rank>
 			<rankNames>Private,-,-,Spaceman,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- E4 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.42</payMultiplier>
 		</rank> <!-- E5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.5</payMultiplier>
 		</rank> <!-- E6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.58</payMultiplier>
 		</rank> <!-- E7 -->
 		<rank>
 			<rankNames>Corporal,-,-,Petty Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- E8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.83</payMultiplier>
 		</rank> <!-- E9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -4757,67 +4757,67 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.17</payMultiplier>
 		</rank> <!-- E11 -->
 		<rank>
 			<rankNames>Sergeant,-,-,Chief Petty Officer,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- E12 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.38</payMultiplier>
 		</rank> <!-- E13 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.42</payMultiplier>
 		</rank> <!-- E14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.46</payMultiplier>
 		</rank> <!-- E15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.5</payMultiplier>
 		</rank> <!-- E16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.54</payMultiplier>
 		</rank> <!-- E17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.58</payMultiplier>
 		</rank> <!-- E18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.63</payMultiplier>
 		</rank> <!-- E19 -->
 		<rank>
 			<rankNames>Master Sergeant,-,-,Master Chief PO,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- E20 -->
 		<rank>
 			<rankNames>Warrant Officer,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- WO1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- WO2 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- WO3 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
@@ -4827,47 +4827,47 @@ Rank:
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- WO5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- WO6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- WO7 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- WO8 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- WO9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>false</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- WO10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.17</payMultiplier>
 		</rank> <!-- O1 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.33</payMultiplier>
 		</rank> <!-- O2 -->
 		<rank>
 			<rankNames>Lieutenant,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>0.67</payMultiplier>
 		</rank> <!-- O3 -->
 		<rank>
 			<rankNames>Captain,-,-,Commander,-,-,-,-,-</rankNames>
@@ -4877,82 +4877,82 @@ Rank:
 		<rank>
 			<rankNames>Major,-,-,Captain,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.33</payMultiplier>
 		</rank> <!-- O5 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>1.67</payMultiplier>
 		</rank> <!-- O6 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.0</payMultiplier>
 		</rank> <!-- O7 -->
 		<rank>
 			<rankNames>Colonel,-,-,Commodore,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.33</payMultiplier>
 		</rank> <!-- O8 -->
 		<rank>
 			<rankNames>Lieutenant General,-,-,Rear Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.67</payMultiplier>
 		</rank> <!-- O9 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.78</payMultiplier>
 		</rank> <!-- O10 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>2.89</payMultiplier>
 		</rank> <!-- O11 -->
 		<rank>
 			<rankNames>Major General,-,-,Vice Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.0</payMultiplier>
 		</rank> <!-- O12 -->
 		<rank>
 			<rankNames>General,-,-,Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>3.33</payMultiplier>
 		</rank> <!-- O13 -->
 		<rank>
 			<rankNames>Commanding General,-,-,Commanding Admiral,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.0</payMultiplier>
 		</rank> <!-- O14 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.44</payMultiplier>
 		</rank> <!-- O15 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>4.89</payMultiplier>
 		</rank> <!-- O16 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.33</payMultiplier>
 		</rank> <!-- O17 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>5.78</payMultiplier>
 		</rank> <!-- O18 -->
 		<rank>
 			<rankNames>-,-,-,-,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.22</payMultiplier>
 		</rank> <!-- O19 -->
 		<rank>
 			<rankNames>Star Lord,-,-,--MW,-,-,-,-,-</rankNames>
 			<officer>true</officer>
-			<payMultiplier>1.0</payMultiplier>
+			<payMultiplier>6.67</payMultiplier>
 		</rank> <!-- O20 -->
 	</rankSystem>
 </rankSystems>

--- a/MekHQ/mmconf/campaignPresets/AtB.xml
+++ b/MekHQ/mmconf/campaignPresets/AtB.xml
@@ -134,8 +134,6 @@
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
-		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
 		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>

--- a/MekHQ/mmconf/campaignPresets/AtB.xml
+++ b/MekHQ/mmconf/campaignPresets/AtB.xml
@@ -134,10 +134,6 @@
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
-		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
 		<useClannerMarriages>false</useClannerMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>

--- a/MekHQ/mmconf/campaignPresets/AtBStarterGuidev40.xml
+++ b/MekHQ/mmconf/campaignPresets/AtBStarterGuidev40.xml
@@ -134,8 +134,6 @@
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
-		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
 		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>

--- a/MekHQ/mmconf/campaignPresets/AtBStarterGuidev40.xml
+++ b/MekHQ/mmconf/campaignPresets/AtBStarterGuidev40.xml
@@ -134,10 +134,6 @@
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
-		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
 		<useClannerMarriages>false</useClannerMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>

--- a/MekHQ/mmconf/campaignPresets/CamOps.xml
+++ b/MekHQ/mmconf/campaignPresets/CamOps.xml
@@ -126,10 +126,6 @@
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
-		<salaryTypeBase>1500 CSB,0 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
 		<useClannerMarriages>false</useClannerMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>

--- a/MekHQ/mmconf/campaignPresets/CamOps.xml
+++ b/MekHQ/mmconf/campaignPresets/CamOps.xml
@@ -126,8 +126,6 @@
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
-		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
 		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>

--- a/MekHQ/mmconf/campaignPresets/DefaultTotalWarfare.xml
+++ b/MekHQ/mmconf/campaignPresets/DefaultTotalWarfare.xml
@@ -126,8 +126,6 @@
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
-		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
 		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>

--- a/MekHQ/mmconf/campaignPresets/DefaultTotalWarfare.xml
+++ b/MekHQ/mmconf/campaignPresets/DefaultTotalWarfare.xml
@@ -126,10 +126,6 @@
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
-		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
 		<useClannerMarriages>false</useClannerMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>

--- a/MekHQ/mmconf/campaignPresets/SimpleOptions.xml
+++ b/MekHQ/mmconf/campaignPresets/SimpleOptions.xml
@@ -126,8 +126,6 @@
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
-		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
 		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>

--- a/MekHQ/mmconf/campaignPresets/SimpleOptions.xml
+++ b/MekHQ/mmconf/campaignPresets/SimpleOptions.xml
@@ -127,9 +127,6 @@
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
-		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
 		<useClannerMarriages>false</useClannerMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>

--- a/MekHQ/mmconf/campaignPresets/StratConAlpha.xml
+++ b/MekHQ/mmconf/campaignPresets/StratConAlpha.xml
@@ -134,8 +134,6 @@
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
-		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
 		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>

--- a/MekHQ/mmconf/campaignPresets/StratConAlpha.xml
+++ b/MekHQ/mmconf/campaignPresets/StratConAlpha.xml
@@ -134,10 +134,6 @@
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
-		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
 		<useClannerMarriages>false</useClannerMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>

--- a/MekHQ/mmconf/campaignPresets/TaharqaMW2ish.xml
+++ b/MekHQ/mmconf/campaignPresets/TaharqaMW2ish.xml
@@ -126,8 +126,6 @@
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryCommissionMultiplier>1.2</salaryCommissionMultiplier>
-		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
 		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>

--- a/MekHQ/mmconf/campaignPresets/TaharqaMW2ish.xml
+++ b/MekHQ/mmconf/campaignPresets/TaharqaMW2ish.xml
@@ -126,10 +126,6 @@
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
-		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
-		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
-		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
 		<useClannerMarriages>false</useClannerMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -251,8 +251,6 @@ public class CampaignOptions {
     private boolean useRandomDependentRemoval;
 
     // Salary
-    private double salaryCommissionMultiplier;
-    private double salaryEnlistedMultiplier;
     private double salaryAntiMekMultiplier;
     private double salarySpecialistInfantryMultiplier;
     private Map<SkillLevel, Double> salaryXPMultipliers;
@@ -649,8 +647,6 @@ public class CampaignOptions {
         setUseRandomDependentRemoval(true);
 
         // Salary
-        setSalaryCommissionMultiplier(1.2);
-        setSalaryEnlistedMultiplier(1.0);
         setSalaryAntiMekMultiplier(1.5);
         setSalarySpecialistInfantryMultiplier(1.0);
         setSalaryXPMultipliers(new HashMap<>());
@@ -1598,22 +1594,6 @@ public class CampaignOptions {
     //endregion Dependent
 
     //region Salary
-    public double getSalaryCommissionMultiplier() {
-        return salaryCommissionMultiplier;
-    }
-
-    public void setSalaryCommissionMultiplier(final double salaryCommissionMultiplier) {
-        this.salaryCommissionMultiplier = salaryCommissionMultiplier;
-    }
-
-    public double getSalaryEnlistedMultiplier() {
-        return salaryEnlistedMultiplier;
-    }
-
-    public void setSalaryEnlistedMultiplier(final double salaryEnlistedMultiplier) {
-        this.salaryEnlistedMultiplier = salaryEnlistedMultiplier;
-    }
-
     public double getSalaryAntiMekMultiplier() {
         return salaryAntiMekMultiplier;
     }
@@ -3650,8 +3630,6 @@ public class CampaignOptions {
         //endregion Dependent
 
         //region Salary
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salaryCommissionMultiplier", getSalaryCommissionMultiplier());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salaryEnlistedMultiplier", getSalaryEnlistedMultiplier());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salaryAntiMekMultiplier", getSalaryAntiMekMultiplier());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salarySpecialistInfantryMultiplier", getSalarySpecialistInfantryMultiplier());
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "salaryXPMultipliers");
@@ -4234,10 +4212,6 @@ public class CampaignOptions {
                 //endregion Dependent
 
                 //region Salary
-                } else if (wn2.getNodeName().equalsIgnoreCase("salaryCommissionMultiplier")) {
-                    retVal.setSalaryCommissionMultiplier(Double.parseDouble(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("salaryEnlistedMultiplier")) {
-                    retVal.setSalaryEnlistedMultiplier(Double.parseDouble(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("salaryAntiMekMultiplier")) {
                     retVal.setSalaryAntiMekMultiplier(Double.parseDouble(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("salarySpecialistInfantryMultiplier")) {

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -648,19 +648,22 @@ public class CampaignOptions {
 
         // Salary
         setSalaryAntiMekMultiplier(1.5);
-        setSalarySpecialistInfantryMultiplier(1.0);
+        // the below multiplier will match the base pay for specialised infantry
+        setSalarySpecialistInfantryMultiplier(1.28);
         setSalaryXPMultipliers(new HashMap<>());
         getSalaryXPMultipliers().put(SkillLevel.NONE, 0.5);
         getSalaryXPMultipliers().put(SkillLevel.ULTRA_GREEN, 0.6);
-        getSalaryXPMultipliers().put(SkillLevel.GREEN, 0.6);
+        getSalaryXPMultipliers().put(SkillLevel.GREEN, 0.75);
         getSalaryXPMultipliers().put(SkillLevel.REGULAR, 1.0);
-        getSalaryXPMultipliers().put(SkillLevel.VETERAN, 1.6);
-        getSalaryXPMultipliers().put(SkillLevel.ELITE, 3.2);
-        getSalaryXPMultipliers().put(SkillLevel.HEROIC, 6.4);
-        getSalaryXPMultipliers().put(SkillLevel.LEGENDARY, 12.8);
+        getSalaryXPMultipliers().put(SkillLevel.VETERAN, 1.5);
+        getSalaryXPMultipliers().put(SkillLevel.ELITE, 2.0);
+        // Expertise >Elite doesn't appear in ATOW, so I made some numbers up
+        getSalaryXPMultipliers().put(SkillLevel.HEROIC, 3.5);
+        getSalaryXPMultipliers().put(SkillLevel.LEGENDARY, 5.0);
         setRoleBaseSalaries(new Money[personnelRoles.length]);
         setRoleBaseSalary(PersonnelRole.MECHWARRIOR, 1500);
-        setRoleBaseSalary(PersonnelRole.LAM_PILOT, 3000);
+        // LAM Pilot doesn't appear in ATOW, so I treated the Aero component as if it were a second role (i.e. halved the base salary)
+        setRoleBaseSalary(PersonnelRole.LAM_PILOT, 2250);
         setRoleBaseSalary(PersonnelRole.GROUND_VEHICLE_DRIVER, 900);
         setRoleBaseSalary(PersonnelRole.NAVAL_VEHICLE_DRIVER, 900);
         setRoleBaseSalary(PersonnelRole.VTOL_PILOT, 900);
@@ -671,21 +674,23 @@ public class CampaignOptions {
         setRoleBaseSalary(PersonnelRole.PROTOMECH_PILOT, 960);
         setRoleBaseSalary(PersonnelRole.BATTLE_ARMOUR, 960);
         setRoleBaseSalary(PersonnelRole.SOLDIER, 750);
+        // ATOW differentiates between DropShip, WarShip, and JumpShip crew, mhq doesn't.
+        // I used DropShip values as they were the closest to the median
         setRoleBaseSalary(PersonnelRole.VESSEL_PILOT, 1000);
         setRoleBaseSalary(PersonnelRole.VESSEL_GUNNER, 1000);
         setRoleBaseSalary(PersonnelRole.VESSEL_CREW, 1000);
         setRoleBaseSalary(PersonnelRole.VESSEL_NAVIGATOR, 1000);
         setRoleBaseSalary(PersonnelRole.MECH_TECH, 800);
-        setRoleBaseSalary(PersonnelRole.MECHANIC, 800);
+        setRoleBaseSalary(PersonnelRole.MECHANIC, 640);
         setRoleBaseSalary(PersonnelRole.AERO_TECH, 800);
         setRoleBaseSalary(PersonnelRole.BA_TECH, 800);
         setRoleBaseSalary(PersonnelRole.ASTECH, 400);
         setRoleBaseSalary(PersonnelRole.DOCTOR, 1500);
-        setRoleBaseSalary(PersonnelRole.MEDIC, 400);
-        setRoleBaseSalary(PersonnelRole.ADMINISTRATOR_COMMAND, 500);
-        setRoleBaseSalary(PersonnelRole.ADMINISTRATOR_LOGISTICS, 500);
-        setRoleBaseSalary(PersonnelRole.ADMINISTRATOR_TRANSPORT, 500);
-        setRoleBaseSalary(PersonnelRole.ADMINISTRATOR_HR, 500);
+        setRoleBaseSalary(PersonnelRole.MEDIC, 640);
+        setRoleBaseSalary(PersonnelRole.ADMINISTRATOR_COMMAND, 640);
+        setRoleBaseSalary(PersonnelRole.ADMINISTRATOR_LOGISTICS, 640);
+        setRoleBaseSalary(PersonnelRole.ADMINISTRATOR_TRANSPORT, 640);
+        setRoleBaseSalary(PersonnelRole.ADMINISTRATOR_HR, 640);
         setRoleBaseSalary(PersonnelRole.DEPENDENT, 0);
         setRoleBaseSalary(PersonnelRole.NONE, 0);
 

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1954,11 +1954,7 @@ public class Person {
 
         // TODO: distinguish DropShip, JumpShip, and WarShip crew
         // TODO: Add era mod to salary calc..
-        return primaryBase.plus(secondaryBase)
-                .multipliedBy(getRank().isOfficer()
-                        ? campaign.getCampaignOptions().getSalaryCommissionMultiplier()
-                        : campaign.getCampaignOptions().getSalaryEnlistedMultiplier())
-                .multipliedBy(getRank().getPayMultiplier());
+        return primaryBase.plus(secondaryBase).multipliedBy(getRank().getPayMultiplier());
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -254,8 +254,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private JCheckBox chkUseRandomDependentRemoval;
 
     // Salary
-    private JSpinner spnCommissionedSalary;
-    private JSpinner spnEnlistedSalary;
     private JSpinner spnAntiMekSalary;
     private JSpinner spnSpecialistInfantrySalary;
     private Map<SkillLevel, JSpinner> spnSalaryExperienceMultipliers;
@@ -3826,22 +3824,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
     private JPanel createSalaryMultiplierPanel() {
         // Create Panel Components
-        final JLabel lblCommissionedSalary = new JLabel(resources.getString("lblCommissionedSalary.text"));
-        lblCommissionedSalary.setToolTipText(resources.getString("lblCommissionedSalary.toolTipText"));
-        lblCommissionedSalary.setName("lblCommissionedSalary");
-
-        spnCommissionedSalary = new JSpinner(new SpinnerNumberModel(0, 0, 10, 0.05));
-        spnCommissionedSalary.setToolTipText(resources.getString("lblCommissionedSalary.toolTipText"));
-        spnCommissionedSalary.setName("spnCommissionedSalary");
-
-        final JLabel lblEnlistedSalary = new JLabel(resources.getString("lblEnlistedSalary.text"));
-        lblEnlistedSalary.setToolTipText(resources.getString("lblEnlistedSalary.toolTipText"));
-        lblEnlistedSalary.setName("lblEnlistedSalary");
-
-        spnEnlistedSalary = new JSpinner(new SpinnerNumberModel(0, 0, 10, 0.05));
-        spnEnlistedSalary.setToolTipText(resources.getString("lblEnlistedSalary.toolTipText"));
-        spnEnlistedSalary.setName("spnEnlistedSalary");
-
         final JLabel lblAntiMekSalary = new JLabel(resources.getString("lblAntiMekSalary.text"));
         lblAntiMekSalary.setToolTipText(resources.getString("lblAntiMekSalary.toolTipText"));
         lblAntiMekSalary.setName("lblAntiMekSalary");
@@ -3859,8 +3841,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnSpecialistInfantrySalary.setName("spnSpecialistInfantrySalary");
 
         // Programmatically Assign Accessibility Labels
-        lblCommissionedSalary.setLabelFor(spnCommissionedSalary);
-        lblEnlistedSalary.setLabelFor(spnEnlistedSalary);
         lblAntiMekSalary.setLabelFor(spnAntiMekSalary);
         lblSpecialistInfantrySalary.setLabelFor(spnSpecialistInfantrySalary);
 
@@ -3878,10 +3858,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         layout.setVerticalGroup(
                 layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                .addComponent(lblCommissionedSalary)
-                                .addComponent(spnCommissionedSalary)
-                                .addComponent(lblEnlistedSalary)
-                                .addComponent(spnEnlistedSalary)
                                 .addComponent(lblAntiMekSalary)
                                 .addComponent(spnAntiMekSalary)
                                 .addComponent(lblSpecialistInfantrySalary)
@@ -3891,10 +3867,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         layout.setHorizontalGroup(
                 layout.createParallelGroup(Alignment.LEADING)
                         .addGroup(layout.createSequentialGroup()
-                                .addComponent(lblCommissionedSalary)
-                                .addComponent(spnCommissionedSalary)
-                                .addComponent(lblEnlistedSalary)
-                                .addComponent(spnEnlistedSalary)
                                 .addComponent(lblAntiMekSalary)
                                 .addComponent(spnAntiMekSalary)
                                 .addComponent(lblSpecialistInfantrySalary)
@@ -6103,8 +6075,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkUseRandomDependentRemoval.setSelected(options.isUseRandomDependentRemoval());
 
         // Salary
-        spnCommissionedSalary.setValue(options.getSalaryCommissionMultiplier());
-        spnEnlistedSalary.setValue(options.getSalaryEnlistedMultiplier());
         spnAntiMekSalary.setValue(options.getSalaryAntiMekMultiplier());
         spnSpecialistInfantrySalary.setValue(options.getSalarySpecialistInfantryMultiplier());
         for (final Entry<SkillLevel, JSpinner> entry : spnSalaryExperienceMultipliers.entrySet()) {
@@ -6674,8 +6644,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             options.setUseRandomDependentRemoval(chkUseRandomDependentRemoval.isSelected());
 
             // Salary
-            options.setSalaryCommissionMultiplier((Double) spnCommissionedSalary.getValue());
-            options.setSalaryEnlistedMultiplier((Double) spnEnlistedSalary.getValue());
             options.setSalaryAntiMekMultiplier((Double) spnAntiMekSalary.getValue());
             options.setSalarySpecialistInfantryMultiplier((Double) spnSpecialistInfantrySalary.getValue());
             for (final Entry<SkillLevel, JSpinner> entry : spnSalaryExperienceMultipliers.entrySet()) {


### PR DESCRIPTION
## Current Implementation
Currently, salaries appear to be mostly based on CamOps, with rank-based salary modifiers simplified to 'is this employee an officer or not'.

## Problem
While a perfectly working system, it lacks granulality. Assuming no external modifiers, under the current system a Corporal and a Sergeant Major would both be paid identically. As would a Lieutenant and the Star Lord.

## Solutions
### Rank Based Multipliers
Using ATOW as a basis, I went through and updated `ranks.xml` to include RAW salary rank multipliers.

Our rank system invents rank tiers, to ensure parity between different rank systems, so I used the ATOW:Companion SLDF rank listing to correlate across to mhq's rank tiers (E1, E2, E3, etc). Any gaps between rank tiers (where we invented additional tiers) I based the multiplier calculations on distance from the nearest RAW rank tier.

You can see my calculations [here](https://docs.google.com/spreadsheets/d/1GktLS7eJZB_772Jg9xsWzIRaqemydwetFKS9lqugHPk/edit?usp=sharing). Any Trait Point (TP) in red is one where I've extrapolated. Decimal TP means the distance between the last & next RAW rank tier is less than 1.

### Removing Current Modifiers
After discussing it with the team on Discord (see [here](https://discord.com/channels/458705327911731231/458767762219597825/1224435561226305546), it was decided that this new system should wholly replace the old.

Therefore, I've gone through and removed the old fixed Enlisted/Commissioned rank multipliers. I tested with old saves and nothing breaks if an old save is loaded. The system will just ignore the lines where Enlisted/Commissioned ranks are defined in the save file.

### Updating Base Salary, Expertise Modifiers, & Specialization Modifiers
I went through and updated base salaries, expertise modifiers, and specialization modifiers to match the values in ATOW. Where missing, I extrapolated values based on prior implementation.

The biggest change was made to LAM pilots. Previously, they were paid the sum of MechWarrior and Aero base pays (1,500 + 1,500 by default). I changed this to treat the Aero component as if it were a secondary role (i.e. the base pay is halved). This changes the calculation to 1,500 + 750 = 2,250c-bills (default values).

I also went through and removed where salary information is defined in the existing presets. This causes the system to pull from CampaignOptions.java and use the default values, instead.

Existing, custom presets, likely will not be affected by these changes and there is no way to resolve that. This will result in existing campaigns having salaries that don't quite match ATOW. This will be most evident with Elite employees, as CamOps gave them a *3.2 multiplier, whereas ATOW only gives them a *2.0. The actual pay difference will not be prohibitively large, so I considered that to be an acceptable sacrifice.

### Salary Calculations
The old salary calculations were based on CamOps, the ATOW system is very different. I have gone through and updated the calculations so that they're as close to ATOW as I could muster.

The biggest differences between the two systems are as follows:
- CamOps applies each multiplier sequentially. So if the base pay was 1,000c-bills and they had an expertise modifier of 1.6 and a specialization modifier of 1.28 the salary would be calculated as 1,000 * 1.6 * 1.28. ATOW applies each modifier additively. So the same employee would have their salary calculated as 1,000 * (1.6 + 1.28). This required the old system to be completely replaced with new calculations.
- Currently, we check whether an employee has the 'specialized infantry' and/or 'anti-mech' specializations both for primary and secondary roles. This would allow an employee with both specialized conventional infantry and anti-mech battle armor roles to double-dip, gaining the multipliers twice. Given that ATOW applies multipliers additively, this results in larger than intended salaries. I changed the system so that it checks whether either role qualifies and then applies only once.
- ATOW bases the expertise modifier on the mean skills used by both primary and secondary roles. Our current system applies the appropriate expertise modifier to the salary of the primary role and secondary role independently. This means that a Veteran MechWarrior/Elite MechTech would have the Veteran multiplier applied to their MechWarrior salary, and the Elite multiplier applied to their MechTech salary. Due to ATOW multipliers being additive, this would have resulted in double-dipping expertise multipliers. I also couldn't use ATOW's averaging of skill rating, at least not without rebuilding `getExperienceLevel()` which would likely have knock-on problems elsewhere. Instead, if the employee has a second role the system determines the mean of the two multipliers. So, using our Veteran MechWarrior/Elite MechTech as an example, the system would generate an expertise multiplier of *1.75 ((1.5 [veteran] + 2.0 [elite]) / 2).

## Closes
Closes #3938