### PR TITLE
Adjusted Zoom Speed on Interstellar Map Panel

### DIFF
--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -374,7 +374,7 @@ public class InterstellarMapPanel extends JPanel {
         addMouseWheelListener(new MouseAdapter() {
             @Override
             public void mouseWheelMoved(MouseWheelEvent e) {
-                 zoom(Math.pow(1.5, -1 * e.getWheelRotation()), e.getPoint());
+                 zoom(Math.pow(1.015, -1 * e.getWheelRotation()), e.getPoint());
              }
         });
 

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -374,7 +374,7 @@ public class InterstellarMapPanel extends JPanel {
         addMouseWheelListener(new MouseAdapter() {
             @Override
             public void mouseWheelMoved(MouseWheelEvent e) {
-                 zoom(Math.pow(1.015, -1 * e.getWheelRotation()), e.getPoint());
+                 zoom(Math.pow(1.175, -1 * e.getWheelRotation()), e.getPoint());
              }
         });
 


### PR DESCRIPTION
### Current Implementation
The current zoom calculation, for the Interstellar Map Panel (IMP), is `1.5^(-1 * Mouse Wheel 'Clicks')`.

### Problem
This leaves the IMP feeling a little over-sensitive. Frequently I've found myself going from planetary-level to Milky Way-level in a single mouse wheel roll, as illustrated below:

<p align=center>IMP After 10 Wheel Clicks (From default starting scale)
<img width="1037" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/314f9a31-5863-443c-b163-59e24d4182c1"></p>

### Solution
I adjusted the zoom calculation to `1.175^(-1 * Mouse Wheel 'Clicks')`. This improves the feel of zooming in & out on the IMP, without excessively slowing either down.

<p align=center>IMP After 10 Wheel Clicks (From default starting scale)
<img width="1037" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/04b3002c-a2c1-4182-b138-eedd493448a7"></p>