### PR TITLE
Added Nag Dialog for Exceeding Cargo Capacity While Destination is Set

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -301,6 +301,10 @@ UntreatedPersonnelNagDialog.text=You have untreated personnel. Do you really wis
 UnresolvedStratConContactsNagDialog.title=Unresolved StratCon Contacts
 UnresolvedStratConContactsNagDialog.text=You have unresolved contacts on the StratCon interface:\n%s\nAdvance day anyway?
 
+### CargoCapacityNagDialog Class
+cargoCapacityNagDialog.title=Exceeded Cargo Capacity
+cargoCapacityNagDialog.text=You have exceeded your available cargo capacity. Do you really wish to advance the day?
+
 #### Report Dialogs
 ### CargoReportDialog Class
 CargoReportDialog.title=Cargo Report
@@ -664,6 +668,8 @@ optionUnresolvedStratConContactsNag.text=Hide StratCon Unresolved Contacts Nag
 optionUnresolvedStratConContactsNag.toolTipText=This allows you to ignore the daily warning for not having resolved all active contacts.
 optionOutstandingScenariosNag.text=Hide Outstanding Scenarios Nag
 optionOutstandingScenariosNag.toolTipText=This allows you to ignore the daily warning for having unfinished scenarios on the current day.
+optionCargoCapacityNag.text=Hide Exceeded Cargo Capacity Nag
+optionCargoCapacityNag.toolTipText=This allows you to ignore the daily warning for having exceeded your available cargo capacity.
 ## Miscellaneous Tab
 miscellaneousTab.title=Miscellaneous Options
 lblUserDir.text=User Files Directory:

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -170,6 +170,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String NAG_SHORT_DEPLOYMENT = "nagShortDeployment";
     public static final String NAG_UNRESOLVED_STRATCON_CONTACTS = "nagUnresolvedStratConContacts";
     public static final String NAG_OUTSTANDING_SCENARIOS = "nagOutstandingScenarios";
+    public static final String NAG_CARGO_CAPACITY = "nagCargoCapacity";
     //endregion Nag Tab
 
     //region Miscellaneous Options

--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -251,6 +251,14 @@ public class CampaignSummary {
         return (int) Math.round(cargoTons) + " tons (" + (int) Math.round(cargoCapacity) + " tons capacity)";
     }
 
+    public int getCargoTons() {
+        return (int) Math.round(cargoTons);
+    }
+
+    public int getCargoCapacity() {
+        return (int) Math.round(cargoCapacity);
+    }
+
     /**
      * A report that gives information about the transportation capacity
      * @return a <code>String</code> of the report

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2402,6 +2402,11 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
+        if (new CargoCapacityNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+            evt.cancel();
+            return;
+        }
+
         if (new InsufficientAstechsNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
             evt.cancel();
             return;

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -153,6 +153,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private JCheckBox optionShortDeploymentNag;
     private JCheckBox optionUnresolvedStratConContactsNag;
     private JCheckBox optionOutstandingScenariosNag;
+    private JCheckBox optionCargoCapacityNag;
     //endregion Nag Tab
 
     //region Miscellaneous
@@ -881,6 +882,10 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionOutstandingScenariosNag.setToolTipText(resources.getString("optionOutstandingScenariosNag.toolTipText"));
         optionOutstandingScenariosNag.setName("optionOutstandingScenariosNag");
 
+        optionCargoCapacityNag = new JCheckBox(resources.getString("optionCargoCapacityNag.text"));
+        optionCargoCapacityNag.setToolTipText(resources.getString("optionCargoCapacityNag.toolTipText"));
+        optionCargoCapacityNag.setName("optionCargoCapacityNag");
+
         // Layout the UI
         final JPanel panel = new JPanel();
         panel.setName("nagPanel");
@@ -901,6 +906,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                         .addComponent(optionShortDeploymentNag)
                         .addComponent(optionUnresolvedStratConContactsNag)
                         .addComponent(optionOutstandingScenariosNag)
+                        .addComponent(optionCargoCapacityNag)
         );
 
         layout.setHorizontalGroup(
@@ -915,6 +921,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                         .addComponent(optionShortDeploymentNag)
                         .addComponent(optionUnresolvedStratConContactsNag)
                         .addComponent(optionOutstandingScenariosNag)
+                        .addComponent(optionCargoCapacityNag)
         );
 
         return panel;
@@ -1170,6 +1177,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_SHORT_DEPLOYMENT, optionShortDeploymentNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS, optionUnresolvedStratConContactsNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS, optionOutstandingScenariosNag.isSelected());
+        MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_CARGO_CAPACITY, optionCargoCapacityNag.isSelected());
 
         PreferenceManager.getClientPreferences().setUserDir(txtUserDir.getText());
         PreferenceManager.getInstance().save();
@@ -1281,6 +1289,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionShortDeploymentNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_SHORT_DEPLOYMENT));
         optionUnresolvedStratConContactsNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS));
         optionOutstandingScenariosNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS));
+        optionCargoCapacityNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_CARGO_CAPACITY));
 
         txtUserDir.setText(PreferenceManager.getClientPreferences().getUserDir());
         spnStartGameDelay.setValue(MekHQ.getMHQOptions().getStartGameDelay());

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/CargoCapacityNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/CargoCapacityNagDialog.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog.nagDialogs;
+
+import mekhq.MHQConstants;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class CargoCapacityNagDialog extends AbstractMHQNagDialog {
+    private static boolean checkCargoCapacity (Campaign campaign) {
+        if (campaign.getLocation().getJumpPath() != null) {
+            return campaign.getCampaignSummary().getCargoTons() > campaign.getCampaignSummary().getCargoCapacity();
+        }
+        return false;
+    }
+
+    //region Constructors
+    public CargoCapacityNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "cargoCapacityNagDialog", "cargoCapacityNagDialog.title",
+                "cargoCapacityNagDialog.text", campaign, MHQConstants.NAG_PRISONERS);
+    }
+
+    //endregion Constructors
+    @Override
+    protected boolean checkNag() {
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(getKey()) && checkCargoCapacity(getCampaign());
+    }
+}


### PR DESCRIPTION
### Current Implementation
None

### Problem
Currently it is easy to exceed cargo capacity, unless you are watching your maximum cargo capacity like a hawk.

### Solution
If the user has set a destination on the interstellar map, this nag will trigger in the event that current cargo tonnage exceeds cargo capacity. I opted to disable the check when no destination is set, as I figured while the user is on-planet there is no need to remain within cargo capacity.

<p align=center>
<img width="545" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/e5d205c0-84fa-4fce-98cc-60cf3265d2ea">
<img width="269" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/a8e4c64f-0fdc-4efb-ad4b-c108298de4b1">
</p>

### Notes
This is definitely a nag I don't expect all users will appreciate, however the ease with which this nag can be suppressed seemed to warrant its inclusion for those users who _do_ try to keep cargo within capacity.

Ideally, this nag would start suppressed on a new campaign, however I couldn't figure out how to enable that functionality. If that functionality does exist, and someone can point me towards it, it would empower me to add more niche nags like this, in future.