### PR TITLE
Added Ability to Order Impossible TN Parts from Acquisitions Dialog.

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
@@ -269,7 +269,7 @@ public class AcquisitionsDialog extends JDialog {
                 return;
             }
 
-            if ((partCountInfo.getMissingCount() > 0) && partCountInfo.isCanBeAcquired()) {
+            if (partCountInfo.getMissingCount() > 0) {
                 campaignGUI.getCampaign().getShoppingList().addShoppingItem(part.getAcquisitionWork(),
                         partCountInfo.getMissingCount(), campaignGUI.getCampaign());
 
@@ -501,10 +501,23 @@ public class AcquisitionsDialog extends JDialog {
                 gbcActions.gridy++;
             }
 
+            if (!partCountInfo.isCanBeAcquired()) {
+                JButton btnOrderOne = new JButton("Order One (TN: Impossible)");
+                btnOrderOne.setToolTipText("Order one item");
+                btnOrderOne.setName("btnOrderOne");
+                btnOrderOne.addActionListener(ev -> {
+                    campaignGUI.getCampaign().getShoppingList().addShoppingItem(part.getAcquisitionWork(),
+                            1, campaignGUI.getCampaign());
+                    refresh();
+                });
+                actionButtons.add(btnOrderOne, gbcActions);
+                gbcActions.gridy++;
+            }
+
             btnOrderAll = new JButton("Order All (" + partCountInfo.getMissingCount() + ")");
             btnOrderAll.setToolTipText("Order all missing");
             btnOrderAll.setName("btnOrderAll");
-            btnOrderAll.setVisible(partCountInfo.isCanBeAcquired() && (partCountInfo.getMissingCount() > 1));
+            btnOrderAll.setVisible(partCountInfo.getMissingCount() > 1);
             btnOrderAll.addActionListener(ev -> orderAllMissing());
             actionButtons.add(btnOrderAll, gbcActions);
             gbcActions.gridy++;


### PR DESCRIPTION
### Current Implementation
Currently it is not possible to purchase items, from the Parts Acquisition dialog, if that part has a TN >12.

### Problem
This forces users to manually order the item from the Purchase Parts dialog. This can be a little awkward, if the part in question has multiple variants (based on weight, for example).

### Solution
It is not possible to order Impossible TN missing parts from the Parts Acquisition dialog. In instances where the TN is impossible, this is clearly labeled.

<p align=center>
<img width="917" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/232daa71-ae0f-4160-90f6-524354f0ca30">
</p>

…Closes #3359