### PR TITLE
Improved CamOps Unit Rating Handling Within Clamp

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5571,7 +5571,7 @@ public class Campaign implements ITechManager {
         }
         IUnitRating rating = getUnitRating();
         return getCampaignOptions().getUnitRatingMethod().isFMMR() ? rating.getUnitRatingAsInteger()
-                : MathUtility.clamp(rating.getModifier(), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
+                : MathUtility.clamp((rating.getModifier()/2), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5571,7 +5571,7 @@ public class Campaign implements ITechManager {
         }
         IUnitRating rating = getUnitRating();
         return getCampaignOptions().getUnitRatingMethod().isFMMR() ? rating.getUnitRatingAsInteger()
-                : MathUtility.clamp((rating.getModifier()/2), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
+                : MathUtility.clamp((rating.getModifier() / 3), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
     }
 
     /**


### PR DESCRIPTION
### Current Implementation
Currently we clamp CamOps unit rating within the bounds of the FM:F (F-A*) rating system.

### Problem
While my earlier fix addressed the issue of CamOps unit rating modifiers breaking a bunch of things (see #3933), there is still the issue of the CamOps Unit Rating method resulting reaching the maximum/minimum modifier faster than expected - from a balancing point of view.

### Solution
Dividing the CamOps unit rating by 3 produces closer results to the equivalent FM:M rating. It's not an ideal solution, but it resolves the biggest issues.