### PR TITLE
Load bot entities in the chat lounge

### DIFF
--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -206,31 +206,31 @@ class GameThread extends Thread implements CloseClientListener {
                 }
                 client.sendAddEntity(entities);
                 client.sendPlayerInfo();
-            }
 
-            // Add bots
-            for (int i = 0; i < scenario.getNumBots(); i++) {
-                BotForce bf = scenario.getBotForce(i);
-                String name = bf.getName();
-                if (swingGui.getLocalBots().containsKey(name)) {
-                    int append = 2;
-                    while (swingGui.getLocalBots().containsKey(name + append)) {
-                        append++;
+                // Add bots
+                for (int i = 0; i < scenario.getNumBots(); i++) {
+                    BotForce bf = scenario.getBotForce(i);
+                    String name = bf.getName();
+                    if (swingGui.getLocalBots().containsKey(name)) {
+                        int append = 2;
+                        while (swingGui.getLocalBots().containsKey(name + append)) {
+                            append++;
+                        }
+                        name += append;
                     }
-                    name += append;
-                }
-                Princess botClient = new Princess(name, client.getHost(), client.getPort());
-                botClient.setBehaviorSettings(bf.getBehaviorSettings());
-                try {
-                    botClient.connect();
-                } catch (Exception e) {
-                    LogManager.getLogger().error("Could not connect with Bot name " + bf.getName(), e);
-                }
-                swingGui.getLocalBots().put(name, botClient);
+                    Princess botClient = new Princess(name, client.getHost(), client.getPort());
+                    botClient.setBehaviorSettings(bf.getBehaviorSettings());
+                    try {
+                        botClient.connect();
+                    } catch (Exception e) {
+                        LogManager.getLogger().error("Could not connect with Bot name " + bf.getName(), e);
+                    }
+                    swingGui.getLocalBots().put(name, botClient);
 
-                // chill out while bot is created and connects to megamek
-                Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());
-                configureBot(botClient, bf);
+                    // chill out while bot is created and connects to megamek
+                    Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());
+                    configureBot(botClient, bf);
+                }
             }
 
             while (!stop) {


### PR DESCRIPTION
This is a correction of my own mistake when I was setting up the GameThread long ago to be able to use BotForces. I added the BotForces outside of the check for being in the chat lounge. The consequence is that you end up loading them multiple times, so that when you get to scenario resolution, you have a long list of duplicate entities. Just moving them inside the brackets for the check fixes the problem. 

I actually made this correction awhile back in my story arcs branch after noticing the problem. However, I am realizing that it would be better to make the correction as a separate PR since the bug is already present in master, both to keep the diff in story arcs as small as possible and for good record keeping.