### PR TITLE
Removed Unnecessary Error Log

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5329,7 +5329,7 @@ public class Campaign implements ITechManager {
 
     public int getAvailableAstechs(final int minutes, final boolean alreadyOvertime) {
         if (minutes == 0) {
-            LogManager.getLogger().error("Tried to getAvailableAstechs with 0 minutes. Returning 0 Astechs.");
+            // If 0 Astechs are assigned to the task, return 0 minutes used
             return 0;
         }
 
@@ -5351,7 +5351,6 @@ public class Campaign implements ITechManager {
                 }
             }
         }
-
         return Math.min(Math.min(availableHelp, MHQConstants.ASTECH_TEAM_SIZE), getNumberAstechs());
     }
 


### PR DESCRIPTION
### Current Implementation
Currently, if 0 Astechs are assigned to a task 0 Astech minutes are used and an error message is popped into the log to confirm that this has happened:

`02:50:44,277 ERROR [mekhq.campaign.Campaign] {AWT-EventQueue-0} mekhq.campaign.Campaign.getAvailableAstechs(Campaign.java:5332) - Tried to getAvailableAstechs with 0 minutes. Returning 0 Astechs.`

### Problem
Large Craft do not use Astechs, causing this error to fire for each Large Craft in the Hanger. Furthermore, this appears to be working as intended: if 0 Astechs are assigned to the task, then 0 Astech minutes should be used.

### Solution
I removed the error message, in the event that 0 Astechs are assigned to a task 0 Astech minutes will be used silently.

closes... #3981