### PR TITLE
Added Scenario & Mission Tracking to Kills, Added Ability to Assign Kills to Scenario and/or Mission

### DIFF
--- a/MekHQ/resources/mekhq/resources/AddOrEditKillEntryDialog.properties
+++ b/MekHQ/resources/mekhq/resources/AddOrEditKillEntryDialog.properties
@@ -1,10 +1,9 @@
-dialogAdd.title=Add Scenario Entry
-dialogEdit.title=Edit Scenario Entry
+dialogAdd.title=Add Kill Entry
+dialogEdit.title=Edit Kill Entry
 lblKill.text=Target:
 lblKiller.text=Killer:
 lblDate.text=Date:
 lblMissionId.text=Mission:
 lblScenarioId.text=Scenario:
-txtScenario.text=Chosen Scenario:
 btnOK.text=Done
 btnClose.text=Cancel

--- a/MekHQ/resources/mekhq/resources/AddOrEditKillEntryDialog.properties
+++ b/MekHQ/resources/mekhq/resources/AddOrEditKillEntryDialog.properties
@@ -5,5 +5,6 @@ lblKiller.text=Killer:
 lblDate.text=Date:
 lblMissionId.text=Mission:
 lblScenarioId.text=Scenario:
+txtScenario.text=Chosen Scenario:
 btnOK.text=Done
 btnClose.text=Cancel

--- a/MekHQ/resources/mekhq/resources/AddOrEditKillEntryDialog.properties
+++ b/MekHQ/resources/mekhq/resources/AddOrEditKillEntryDialog.properties
@@ -2,5 +2,7 @@ dialogAdd.title=Add Scenario Entry
 dialogEdit.title=Edit Scenario Entry
 lblKill.text=Killed What:
 lblKiller.text=Killed With:
+lblMissionId.text=Mission:
+lblScenarioId.text=Scenario:
 btnOK.text=Done
 btnClose.text=Cancel

--- a/MekHQ/resources/mekhq/resources/AddOrEditKillEntryDialog.properties
+++ b/MekHQ/resources/mekhq/resources/AddOrEditKillEntryDialog.properties
@@ -1,7 +1,8 @@
 dialogAdd.title=Add Scenario Entry
 dialogEdit.title=Edit Scenario Entry
-lblKill.text=Killed What:
-lblKiller.text=Killed With:
+lblKill.text=Target:
+lblKiller.text=Killer:
+lblDate.text=Date:
 lblMissionId.text=Mission:
 lblScenarioId.text=Scenario:
 btnOK.text=Done

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1033,6 +1033,10 @@ public class Campaign implements ITechManager {
         return scenarios.get(id);
     }
 
+    public Collection<Scenario> getScenarios() {
+        return scenarios.values();
+    }
+
     public void setLocation(CurrentLocation l) {
         location = l;
     }

--- a/MekHQ/src/mekhq/campaign/Kill.java
+++ b/MekHQ/src/mekhq/campaign/Kill.java
@@ -41,15 +41,19 @@ public class Kill {
     private LocalDate date;
     private String killed;
     private String killer;
+    private int missionId;
+    private int scenarioId;
 
     public Kill() {
     }
 
-    public Kill(UUID id, String kill, String killer, LocalDate d) {
+    public Kill(UUID id, String kill, String killer, LocalDate d, int missionId, int scenarioId) {
         pilotId = id;
         this.killed = kill;
         this.killer = killer;
         date = d;
+        this.missionId = missionId;
+        this.scenarioId = scenarioId;
     }
 
     public UUID getPilotId() {
@@ -72,6 +76,14 @@ public class Kill {
         return killer;
     }
 
+    public int getMissionId() {
+        return missionId;
+    }
+
+    public int getScenarioId() {
+        return scenarioId;
+    }
+
     public void setDate(LocalDate d) {
         date = d;
     }
@@ -82,6 +94,14 @@ public class Kill {
 
     public void setKilledByWhat(String s) {
         killer = s;
+    }
+
+    public void setMissionId(int id) {
+        missionId = id;
+    }
+
+    public void setScenarioId(int id) {
+        scenarioId = id;
     }
 
     public static Kill generateInstanceFromXML(Node wn, Version version) {
@@ -100,6 +120,10 @@ public class Kill {
                     retVal.killer = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("date")) {
                     retVal.date = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("missionId")) {
+                    retVal.missionId = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("scenarioId")) {
+                    retVal.scenarioId = Integer.parseInt(wn2.getTextContent());
                 }
             }
         } catch (Exception ex) {
@@ -117,11 +141,13 @@ public class Kill {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "killed", killed);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "killer", killer);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "date", date);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "missionId", missionId);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "scenarioId", scenarioId);
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "kill");
     }
 
     @Override
     public Kill clone() {
-        return new Kill(getPilotId(), getWhatKilled(), getKilledByWhat(), getDate());
+        return new Kill(getPilotId(), getWhatKilled(), getKilledByWhat(), getDate(), getMissionId(), getScenarioId());
     }
 }

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -485,7 +485,8 @@ public class ResolveScenarioTracker {
                                     + " when trying to assign kills");
                             continue;
                         }
-                        status.addKill(new Kill(p.getId(), killed, u.getEntity().getShortNameRaw(), campaign.getLocalDate()));
+                        status.addKill(new Kill(p.getId(), killed, u.getEntity().getShortNameRaw(), campaign.getLocalDate(),
+                                getMissionId(), getScenarioId()));
                     }
                 }
             }
@@ -1354,6 +1355,14 @@ public class ResolveScenarioTracker {
 
     public Mission getMission() {
         return campaign.getMission(scenario.getMissionId());
+    }
+
+    public int getMissionId() {
+        return campaign.getMission(scenario.getMissionId()).getId();
+    }
+
+    public int getScenarioId() {
+        return scenario.getId();
     }
 
     public Hashtable<String, String> getKillCredits() {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -769,11 +769,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 if (people.length > 1) {
                     nkd = new AddOrEditKillEntryDialog(gui.getFrame(), true, null,
                             (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
-                            gui.getCampaign().getLocalDate());
+                            gui.getCampaign().getLocalDate(), gui.getCampaign());
                 } else {
                     nkd = new AddOrEditKillEntryDialog(gui.getFrame(), true, selectedPerson.getId(),
                             (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
-                            gui.getCampaign().getLocalDate());
+                            gui.getCampaign().getLocalDate(), gui.getCampaign());
                 }
                 nkd.setVisible(true);
                 if (nkd.getKill().isPresent()) {

--- a/MekHQ/src/mekhq/gui/control/EditKillLogControl.java
+++ b/MekHQ/src/mekhq/gui/control/EditKillLogControl.java
@@ -110,7 +110,7 @@ public class EditKillLogControl extends JPanel {
 
     private void addKill() {
         AddOrEditKillEntryDialog dialog = new AddOrEditKillEntryDialog(parent, true,
-                person.getId(), "", campaign.getLocalDate());
+                person.getId(), "", campaign.getLocalDate(), campaign);
         dialog.setVisible(true);
         if (dialog.getKill().isPresent()) {
             campaign.addKill(dialog.getKill().get());
@@ -121,7 +121,7 @@ public class EditKillLogControl extends JPanel {
     private void editKill() {
         Kill kill = killModel.getKillAt(killTable.getSelectedRow());
         if (null != kill) {
-            AddOrEditKillEntryDialog dialog = new AddOrEditKillEntryDialog(parent, true, kill);
+            AddOrEditKillEntryDialog dialog = new AddOrEditKillEntryDialog(parent, true, kill, campaign);
             dialog.setVisible(true);
             refreshTable();
         }

--- a/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -54,11 +55,12 @@ public class AddOrEditKillEntryDialog extends JDialog {
     private JTextField txtKill;
     private JLabel lblKiller;
     private JTextField txtKiller;
+    private JLabel lblDate;
     private JButton btnDate;
     private JLabel lblMissionId;
     private JTextField txtMissionId;
     private JLabel lblScenarioId;
-    private JTextField txtScenarioId;
+    private JSpinner spnScenarioId;
     private Campaign campaign;
 
     public AddOrEditKillEntryDialog(JFrame parent, boolean modal, UUID killerPerson, String killerUnit, LocalDate entryDate, Campaign campaign) {
@@ -80,7 +82,7 @@ public class AddOrEditKillEntryDialog extends JDialog {
         this.missionId = this.kill.getMissionId();
         this.scenarioId = this.kill.getScenarioId();
         this.operationType = operationType;
-        initComponents();
+        initComponents(operationType, campaign);
         setLocationRelativeTo(parent);
         setUserPreferences();
     }
@@ -89,20 +91,21 @@ public class AddOrEditKillEntryDialog extends JDialog {
         return Optional.ofNullable(kill);
     }
 
-    private void initComponents() {
+    private void initComponents(int operationType, Campaign campaign) {
         GridBagConstraints gridBagConstraints;
 
-        txtKill = new JTextField();
         lblKill = new JLabel();
-        txtKiller = new JTextField();
+        txtKill = new JTextField();
         lblKiller = new JLabel();
-        txtMissionId = new JTextField();
+        txtKiller = new JTextField();
+        lblDate = new JLabel();
+        btnDate = new JButton();
         lblMissionId = new JLabel();
-        txtScenarioId = new JTextField();
+        txtMissionId = new JTextField();
         lblScenarioId = new JLabel();
+        spnScenarioId = new JSpinner (new SpinnerNumberModel(kill.getScenarioId(), 0, 9999, 1));
         btnOK = new JButton();
         btnClose = new JButton();
-        btnDate = new JButton();
 
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AddOrEditKillEntryDialog",
                 MekHQ.getMHQOptions().getLocale());
@@ -157,13 +160,22 @@ public class AddOrEditKillEntryDialog extends JDialog {
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         getContentPane().add(txtKiller, gridBagConstraints);
 
+        lblDate.setText(resourceMap.getString("lblDate.text"));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 5, 5);
+        getContentPane().add(lblDate, gridBagConstraints);
+
         btnDate.setText(MekHQ.getMHQOptions().getDisplayFormattedDate(date));
         btnDate.setName("btnDate");
         btnDate.addActionListener(evt -> changeDate());
         gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 2;
-        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.gridwidth = 1;
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         getContentPane().add(btnDate, gridBagConstraints);
@@ -198,8 +210,6 @@ public class AddOrEditKillEntryDialog extends JDialog {
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         getContentPane().add(lblScenarioId, gridBagConstraints);
 
-        txtScenarioId.setText(String.valueOf(kill.getScenarioId()));
-        txtScenarioId.setMinimumSize(new Dimension(150, 28));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 4;
@@ -208,7 +218,7 @@ public class AddOrEditKillEntryDialog extends JDialog {
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
-        getContentPane().add(txtScenarioId, gridBagConstraints);
+        getContentPane().add(spnScenarioId, gridBagConstraints);
 
         btnOK.setText(resourceMap.getString("btnOK.text"));
         btnOK.setName("btnOK");
@@ -251,7 +261,13 @@ public class AddOrEditKillEntryDialog extends JDialog {
         kill.setKilledByWhat(txtKiller.getText());
         kill.setDate(date);
         kill.setMissionId(Integer.parseInt(txtMissionId.getText()));
-        kill.setScenarioId(Integer.parseInt(txtScenarioId.getText()));
+
+        try {
+            spnScenarioId.commitEdit();
+        } catch ( Exception e ) {
+            LogManager.getLogger().error("Failed to commit user changes to spnScenarioId");
+        }
+        kill.setScenarioId((Integer) spnScenarioId.getValue());
         this.setVisible(false);
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
@@ -26,7 +26,6 @@ import megamek.client.ui.preferences.PreferencesNode;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Kill;
-import mekhq.campaign.mission.Mission;
 import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
@@ -62,17 +61,17 @@ public class AddOrEditKillEntryDialog extends JDialog {
     private JTextField txtScenarioId;
     private Campaign campaign;
 
-    public AddOrEditKillEntryDialog(JFrame parent, boolean modal, UUID killerPerson, String killerUnit, LocalDate entryDate) {
+    public AddOrEditKillEntryDialog(JFrame parent, boolean modal, UUID killerPerson, String killerUnit, LocalDate entryDate, Campaign campaign) {
         // We default to 0 for missionId and scenarioId so that we don't need to unnecessarily feed that information into...
         // ...PersonnelTableMouseAdapter.java and EditKillLogControl.java
-        this(parent, modal, ADD_OPERATION, new Kill(killerPerson, "?", killerUnit, entryDate, 0, 0));
+        this(parent, modal, ADD_OPERATION, new Kill(killerPerson, "?", killerUnit, entryDate, 0, 0), campaign);
     }
 
-    public AddOrEditKillEntryDialog(JFrame parent, boolean modal, Kill kill) {
-        this(parent, modal, EDIT_OPERATION, kill);
+    public AddOrEditKillEntryDialog(JFrame parent, boolean modal, Kill kill, Campaign campaign) {
+        this(parent, modal, EDIT_OPERATION, kill, campaign);
     }
 
-    private AddOrEditKillEntryDialog(JFrame parent, boolean modal, int operationType, Kill kill) {
+    private AddOrEditKillEntryDialog(JFrame parent, boolean modal, int operationType, Kill kill, Campaign campaign) {
         super(parent, modal);
 
         this.frame = parent;
@@ -98,7 +97,7 @@ public class AddOrEditKillEntryDialog extends JDialog {
         txtKiller = new JTextField();
         lblKiller = new JLabel();
         txtMissionId = new JTextField();
-        lblMissionId = new JLabel();;
+        lblMissionId = new JLabel();
         txtScenarioId = new JTextField();
         lblScenarioId = new JLabel();
         btnOK = new JButton();

--- a/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
@@ -24,17 +24,16 @@ package mekhq.gui.dialog;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.Kill;
+import mekhq.campaign.mission.Mission;
 import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.time.LocalDate;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.ResourceBundle;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author Taharqa
@@ -47,6 +46,8 @@ public class AddOrEditKillEntryDialog extends JDialog {
     private int operationType;
     private Kill kill;
     private LocalDate date;
+    private int missionId;
+    private int scenarioId;
 
     private JButton btnClose;
     private JButton btnOK;
@@ -55,9 +56,16 @@ public class AddOrEditKillEntryDialog extends JDialog {
     private JLabel lblKiller;
     private JTextField txtKiller;
     private JButton btnDate;
+    private JLabel lblMissionId;
+    private JTextField txtMissionId;
+    private JLabel lblScenarioId;
+    private JTextField txtScenarioId;
+    private Campaign campaign;
 
     public AddOrEditKillEntryDialog(JFrame parent, boolean modal, UUID killerPerson, String killerUnit, LocalDate entryDate) {
-        this(parent, modal, ADD_OPERATION, new Kill(killerPerson, "?", killerUnit, entryDate));
+        // We default to 0 for missionId and scenarioId so that we don't need to unnecessarily feed that information into...
+        // ...PersonnelTableMouseAdapter.java and EditKillLogControl.java
+        this(parent, modal, ADD_OPERATION, new Kill(killerPerson, "?", killerUnit, entryDate, 0, 0));
     }
 
     public AddOrEditKillEntryDialog(JFrame parent, boolean modal, Kill kill) {
@@ -70,6 +78,8 @@ public class AddOrEditKillEntryDialog extends JDialog {
         this.frame = parent;
         this.kill = Objects.requireNonNull(kill);
         this.date = this.kill.getDate();
+        this.missionId = this.kill.getMissionId();
+        this.scenarioId = this.kill.getScenarioId();
         this.operationType = operationType;
         initComponents();
         setLocationRelativeTo(parent);
@@ -81,12 +91,16 @@ public class AddOrEditKillEntryDialog extends JDialog {
     }
 
     private void initComponents() {
-         GridBagConstraints gridBagConstraints;
+        GridBagConstraints gridBagConstraints;
 
         txtKill = new JTextField();
         lblKill = new JLabel();
         txtKiller = new JTextField();
         lblKiller = new JLabel();
+        txtMissionId = new JTextField();
+        lblMissionId = new JLabel();;
+        txtScenarioId = new JTextField();
+        lblScenarioId = new JLabel();
         btnOK = new JButton();
         btnClose = new JButton();
         btnDate = new JButton();
@@ -155,12 +169,54 @@ public class AddOrEditKillEntryDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         getContentPane().add(btnDate, gridBagConstraints);
 
+        lblMissionId.setText(resourceMap.getString("lblMissionId.text"));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 5, 5);
+        getContentPane().add(lblMissionId, gridBagConstraints);
+
+        txtMissionId.setText(String.valueOf(kill.getMissionId()));
+        txtMissionId.setMinimumSize(new Dimension(150, 28));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 5, 5);
+        getContentPane().add(txtMissionId, gridBagConstraints);
+
+        lblScenarioId.setText(resourceMap.getString("lblScenarioId.text"));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 4;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 5, 5);
+        getContentPane().add(lblScenarioId, gridBagConstraints);
+
+        txtScenarioId.setText(String.valueOf(kill.getScenarioId()));
+        txtScenarioId.setMinimumSize(new Dimension(150, 28));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 4;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 5, 5);
+        getContentPane().add(txtScenarioId, gridBagConstraints);
+
         btnOK.setText(resourceMap.getString("btnOK.text"));
         btnOK.setName("btnOK");
         btnOK.addActionListener(this::btnOKActionPerformed);
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridy = 5;
         gridBagConstraints.gridwidth = 1;
         gridBagConstraints.anchor = GridBagConstraints.EAST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
@@ -171,7 +227,7 @@ public class AddOrEditKillEntryDialog extends JDialog {
         btnClose.addActionListener(this::btnCloseActionPerformed);
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridy = 5;
         gridBagConstraints.gridwidth = 1;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
@@ -195,6 +251,8 @@ public class AddOrEditKillEntryDialog extends JDialog {
         kill.setWhatKilled(txtKill.getText());
         kill.setKilledByWhat(txtKiller.getText());
         kill.setDate(date);
+        kill.setMissionId(Integer.parseInt(txtMissionId.getText()));
+        kill.setScenarioId(Integer.parseInt(txtScenarioId.getText()));
         this.setVisible(false);
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AddOrEditKillEntryDialog.java
@@ -173,7 +173,7 @@ public class AddOrEditKillEntryDialog extends JDialog {
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 2;
-        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         getContentPane().add(btnDate, gridBagConstraints);

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -516,6 +516,10 @@ public class CampaignExportWizard extends JDialog {
             destinationCampaign.getPerson(person.getId()).resetMinutesLeft();
 
             for (Kill kill : sourceCampaign.getKillsFor(person.getId())) {
+                // we don't preserve IDs to avoid conflicts with the destination campaign
+                kill.setScenarioId(0);
+                kill.setMissionId(0);
+
                 destinationCampaign.importKill(kill);
             }
         }


### PR DESCRIPTION
## Forward
Throughout this PR the term 'Mission' can be read as referring to both Missions and Contracts interchangeably. AutoMedals is the internal name for the in-dev project that will automatically prompt users to optionally assign medals to those employees that have earned them.

## Kills
### Current Functionality
Three data points are recorded for Kills: Killer, Killed, and Date.

### Problem
The in-dev AutoMedals project needs to be able to identify Kills that occurred over the course of a Mission, and those that occurred over the course of a single Scenario.

### Solution
I added functions to allow for the Scenario ID and Mission ID numbers to be baked into the stored Kill data. This information is logged and stored, alongside the existing Kill data, in the users' save file.

<p align=center>
<img width="543" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/4bd106a9-8466-47c2-a7bd-5421aefbb167">
</p>

These IDs are drawn from existing functionality, all I did was hook them into the `Kill` class. That means that any future system that calls this information (such as AutoMedals) will be able to fetch the scenario and mission data just by calling `getScenario()` or `getMission()`.

I also added the ability to fetch the internal names of all scenarios on the campaign to the `Campaign` class, (`getScenarios()`) as that functionality was missing and I needed for this PR. The `getScenarios()` function is basically identical to its Mission equivalent `getMissions()`.

### Testing
I ran a whole bunch of Human v. Princess, and Princess v. Princess scenarios. Somewhere around 20-30 and did not find any instances where kills failed to be assigned a Scenario or Mission ID. This testing was conducted with manually created scenarios, as well as AtB and StratCon scenarios. The testing also accounted for both automatically and manually assigned kills.

## Add/Edit Kills
### Current Implementation
Currently, the Add/Edit Kill dialog allows you to assign Killer, Killed, and Date. This is true, also, for the Assign Kill dialog.

<p align=center>
<img width="520" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/4bbe8ef1-6a2c-435a-b4f8-71e05024530b">
</p>

### Problem
This renders a Kill's associated Mission and Scenario IDs completely invisible to users. Furthermore, this means there is no ability for users to assign Missions and/or Scenarios to Kills obtained outside of mm. Such as kills related to RPG-focused campaigns, or any other source of Kills.

Furthermore, as shown in the above image, the dialogs are titled as if they were Scenario dialogs and not Kill.

### Solution
I updated the dialogs so that they're a little more visually streamlined. I also renamed the dialogs to 'Edit Kill Entry' and 'Add Kill Entry'.

More importantly, I added the ability to state what Scenario and/or Missions the kill occurred on. This functionality is extended to all future and prior kills. Kills that do not currently have a Scenario or Mission ID will default to the index 0 combobox option, which is blank. Kills can be saved with blank Scenario or Mission IDs, at which point the ID is saved as '0'. This ensures we're not introducing new `null` values, although as ID 0 is not a valid Scenario or Mission ID, this will need to be factored into any future code.

There was the possibility of saving the values as `null`, but that would likely break a whole bunch of things so I figured it was best avoided. The only kills which will have a Scenario/Mission ID of `null` will be those from campaigns originating from prior versions, the frequency of which will decrease with time.

When the campaign is saved, any Kills with `null` Mission/Scenario IDs will be assigned IDs of 0.

(Assign Kill/Add New Kill dialog)
<p align=center>
<img width="453" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/3157844d-77d8-4e1b-8797-745ec2826351">
</p>

(Same dialog, but with options selected)
<p align=center>
<img width="445" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/1d5fb503-cafd-4eb9-b2e2-6bcf39befbeb">
</p>

(Edit Kill dialog)
<p align=center>
<img width="449" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/139b77e9-eaf2-40a6-9950-f5bea7b226cf">
</p>

### Limitations
Currently, mhq does not track what Mission a Scenario was spawned by. This removes the ability to filter Scenarios based on what Mission was selected. Instead, I sorted the list so that the most recent scenario will always be at the top.

Potentially, this functionality could be added through a follow-up PR, but it's unlikely this is something I'll personally do. At least, I'm not adding it to my current list of projects.

### Testing
I have accounted for Missions/Scenarios being deleted, after the kill is assigned an ID tied to that  Mission/Scenario. In those events, the system recognizes it's not a valid ID and just treats it as if it were ID 0.

I also accounted for users trying to add kills before a Scenario and/or Mission has been added to the campaign. In these cases users can only select the index 0 option for Scenario and/or Mission, which sets the relevant ID to 0.

Editing a kill that has a null Mission/Scenario ID simply treats it as if the ID were 0.

### Recommendation
Once we have a release version that includes this PR, I recommend we advise users to save their campaigns immediately. This will populate all prior Kills with default Mission/Scenario IDs and reduce the amount of `null` IDs the system needs to deal with.

I'll make sure to factor into AutoMedal the possibility that it's run before these default values have been assigned, so that will catch whatever left. But saving an existing campaign to the new version, when transferring saves across versions, should probably be encouraged anyway.

## Import/Export
### Current Implementation
Currently, all kill information is exported and imported across campaigns.

### Problem
This means that Scenario/Mission IDs are also transferred across campaigns. This would cause conflicts with the destination campaign, with kills being assigned to the wrong Scenario & Mission.

### Solution
When exporting personnel information, kills have Scenario and Mission IDs reset to 0.

Any `null` IDs are also set to 0, as this is functionally identical to saving the campaign.

All this means is that the Kill is decoupled from its assigned Scenario and Mission, the Kill still remains in the employees' personnel file and can be manually reassigned, if desired.

While, when exporting, there is the option to export completed Missions, this would still result in Scenario ID conflicts, as well as conflicts with any re-used Mission IDs.

If the Active Mission's ID is ever reused (because it wouldn't have been used in the Destination Campaign), Kills from the Active Mission (in the Origin Campaign) would then be assigned to this new Mission. That functionality is undesirable, so I deemed the best approach was to wipe the slate clean.

### Testing
I tested this functionality with campaigns containing Kills both with default (0) Mission/Scenario IDs; non-zero Mission/Scenario IDs, and with `null` Mission/Scenario IDs. None caused issue.

## Reformatting
### Current Implementation
In [AddOrEditKillEntryDialog.java](https://github.com/MegaMek/mekhq/pull/3988#diff-d39cb11c2632662fccf6252558d7edf068821a328a807d45a4186cc4814266c3) all new GUI elements in `initComponents()` are placed at the top of the function.

### Problems
This forces a lot of scrolling up and down to find what elements are being created and when.

### Solution
I moved the element initialization to the top of the relevant block of Swing code.