### PR TITLE
Fixed Ship Search Overvaluing Ultra-Green Personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
@@ -326,13 +326,7 @@ public class AtBConfiguration {
         TargetRoll target = new TargetRoll(baseShipSearchTarget, "Base");
         Person adminLog = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_LOGISTICS, SkillType.S_ADMIN);
         int adminLogExp = (adminLog == null) ? SkillType.EXP_ULTRA_GREEN : adminLog.getSkill(SkillType.S_ADMIN).getExperienceLevel();
-        for (Person p : campaign.getAdmins()) {
-            if (p.getPrimaryRole().isAdministratorLogistics()
-                    || p.getSecondaryRole().isAdministratorLogistics()
-                    && (p.getSkill(SkillType.S_ADMIN).getExperienceLevel() > adminLogExp)) {
-                adminLogExp = p.getSkill(SkillType.S_ADMIN).getExperienceLevel();
-            }
-        }
+
         target.addModifier(SkillType.EXP_REGULAR - adminLogExp, "Admin/Logistics");
         target.addModifier(IUnitRating.DRAGOON_C - campaign.getUnitRatingMod(),
                 "Unit Rating");


### PR DESCRIPTION
### Current Implementation
AtB Ship Search currently uses a block of code to cycle through each logistics personnel, with a mind towards finding the best personnel skill rating among logistics personnel. It then uses this to apply a modifier to the Ship Search TN.

<p align=center>
<img width="985" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/28840ebd-c67c-4206-8503-daf27c21dd67">
<img width="549" alt="image" src="https://github.com/MegaMek/mekhq/assets/103902653/19c1cb54-256e-4bbe-bfde-fcf694f17364">
</p>

### Problem
The code already checks for highest skilled personnel using the `findBestInRole()` function. The loop that follows is unnecessary.

Furthermore, the loop includes broken logic that results in Ultra-Green personnel being rated higher than any other personnel.

### Solution
I simply removed the excess code.

### Testing
I tested personnel with both primary and secondary Admin/Logistics roles of all ranks.

...closes #3989