### PR TITLE
Add all deployment variables to BotForce

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -439,8 +439,17 @@ public class AtBGameThread extends GameThread {
                 LogManager.getLogger().error("Could not configure bot " + botClient.getName());
             } else {
                 botClient.getLocalPlayer().setTeam(botForce.getTeam());
-                botClient.getLocalPlayer().setStartingPos(botForce.getStart());
 
+                //set deployment
+                botClient.getLocalPlayer().setStartingPos(botForce.getStartingPos());
+                botClient.getLocalPlayer().setStartOffset(botForce.getStartOffset());
+                botClient.getLocalPlayer().setStartWidth(botForce.getStartWidth());
+                botClient.getLocalPlayer().setStartingAnyNWx(botForce.getStartingAnyNWx());
+                botClient.getLocalPlayer().setStartingAnyNWy(botForce.getStartingAnyNWy());
+                botClient.getLocalPlayer().setStartingAnySEx(botForce.getStartingAnySEx());
+                botClient.getLocalPlayer().setStartingAnySEy(botForce.getStartingAnySEy());
+
+                // set camo
                 botClient.getLocalPlayer().setCamouflage(botForce.getCamouflage().clone());
                 botClient.getLocalPlayer().setColour(botForce.getColour());
 

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -271,8 +271,17 @@ class GameThread extends Thread implements CloseClientListener {
                 LogManager.getLogger().error("Could not configure bot " + botClient.getName());
             } else {
                 botClient.getLocalPlayer().setTeam(botForce.getTeam());
-                botClient.getLocalPlayer().setStartingPos(botForce.getStart());
 
+                //set deployment
+                botClient.getLocalPlayer().setStartingPos(botForce.getStartingPos());
+                botClient.getLocalPlayer().setStartOffset(botForce.getStartOffset());
+                botClient.getLocalPlayer().setStartWidth(botForce.getStartWidth());
+                botClient.getLocalPlayer().setStartingAnyNWx(botForce.getStartingAnyNWx());
+                botClient.getLocalPlayer().setStartingAnyNWy(botForce.getStartingAnyNWy());
+                botClient.getLocalPlayer().setStartingAnySEx(botForce.getStartingAnySEx());
+                botClient.getLocalPlayer().setStartingAnySEy(botForce.getStartingAnySEy());
+
+                // set camo
                 botClient.getLocalPlayer().setCamouflage(botForce.getCamouflage().clone());
                 botClient.getLocalPlayer().setColour(botForce.getColour());
 
@@ -293,6 +302,13 @@ class GameThread extends Thread implements CloseClientListener {
         for (Entity entity : botForce.getFullEntityList(campaign)) {
             entity.setOwner(botClient.getLocalPlayer());
             entity.setForceString(forceName);
+            /*
+             Only overwrite deployment round for entities if they have an individual deployment round of zero.
+             Otherwise, we will overwrite entity specific deployment information.
+            */
+            if (entity.getDeployRound() == 0) {
+                entity.setDeployRound(botForce.getDeployRound());
+            }
             entities.add(entity);
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1849,7 +1849,7 @@ public class AtBDynamicScenarioFactory {
 
         for (int botIndex = 0; botIndex < scenario.getNumBots(); botIndex++) {
             BotForce botForce = scenario.getBotForce(botIndex);
-            botForce.setStart(scenario.getBotForceTemplates().get(botForce).getActualDeploymentZone());
+            botForce.setStartingPos(scenario.getBotForceTemplates().get(botForce).getActualDeploymentZone());
         }
     }
 
@@ -1924,7 +1924,7 @@ public class AtBDynamicScenarioFactory {
             // compute a random cardinal edge between 0 and 3 to avoid None
             actualDestinationEdge = Compute.randomInt(CardinalEdge.values().length - 1);
         } else if (forceTemplate.getDestinationZone() == ScenarioForceTemplate.DESTINATION_EDGE_OPPOSITE_DEPLOYMENT) {
-            actualDestinationEdge = getOppositeEdge(force.getStart());
+            actualDestinationEdge = getOppositeEdge(force.getStartingPos());
         } else {
             force.getBehaviorSettings().setDestinationEdge(CardinalEdge.getCardinalEdge(actualDestinationEdge));
             return;

--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -51,7 +51,15 @@ public class BotForce {
     private List<Entity> generatedEntityList;
     private List<UUID> traitors;
     private int team;
-    private int start;
+    // deployment settings
+    private int startingPos = Board.START_ANY;
+    private int startOffset = 0;
+    private int startWidth = 3;
+    private int startingAnyNWx = Entity.STARTING_ANY_NONE;
+    private int startingAnyNWy = Entity.STARTING_ANY_NONE;
+    private int startingAnySEx = Entity.STARTING_ANY_NONE;
+    private int startingAnySEy = Entity.STARTING_ANY_NONE;
+    private int deployRound;
     private Camouflage camouflage = new Camouflage(Camouflage.COLOUR_CAMOUFLAGE, PlayerColour.BLUE.name());
     private PlayerColour colour = PlayerColour.BLUE;
     private BehaviorSettings behaviorSettings;
@@ -86,7 +94,7 @@ public class BotForce {
                     Camouflage camouflage, PlayerColour colour) {
         this.name = name;
         this.team = team;
-        this.start = start;
+        this.startingPos = start;
         setFixedEntityList(entityList);
         setCamouflage(camouflage);
         setColour(colour);
@@ -182,13 +190,41 @@ public class BotForce {
         this.team = team;
     }
 
-    public int getStart() {
-        return start;
+    public int getStartingPos() {
+        return startingPos;
     }
 
-    public void setStart(int start) {
-        this.start = start;
+    public void setStartingPos(int start) {
+        this.startingPos = start;
     }
+
+    public int getStartOffset() { return startOffset; }
+
+    public void setStartOffset(int startOffset) { this.startOffset = startOffset; }
+
+    public int getStartWidth() { return startWidth; }
+
+    public void setStartWidth(int startWidth) { this.startWidth = startWidth; }
+
+    public int getStartingAnyNWx() { return startingAnyNWx; }
+
+    public void setStartingAnyNWx(int startingAnyNWx) { this.startingAnyNWx = startingAnyNWx; }
+
+    public int getStartingAnyNWy() { return startingAnyNWy; }
+
+    public void setStartingAnyNWy(int startingAnyNWy) { this.startingAnyNWy = startingAnyNWy; }
+
+    public int getStartingAnySEx() { return startingAnySEx; }
+
+    public void setStartingAnySEx(int startingAnySEx) { this.startingAnySEx = startingAnySEx; }
+
+    public int getStartingAnySEy() { return startingAnySEy; }
+
+    public void setStartingAnySEy(int startingAnySEy) { this.startingAnySEy = startingAnySEy; }
+
+    public int getDeployRound() { return deployRound; }
+
+    public void setDeployRound(int round) { this.deployRound = round; }
 
     public String getTemplateName() {
         return templateName;
@@ -320,7 +356,14 @@ public class BotForce {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "botForce");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", name);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "team", team);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "start", start);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingPos", startingPos);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startOffset", startOffset);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startWidth", startWidth);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnyNWx", startingAnyNWx);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnyNWy", startingAnyNWy);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnySEx", startingAnySEx);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnySEy", startingAnySEy);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "deployRound", deployRound);
         getCamouflage().writeToXML(pw, indent);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "colour", getColour().name());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "templateName", templateName);
@@ -362,8 +405,23 @@ public class BotForce {
                     name = MHQXMLUtility.unEscape(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("team")) {
                     team = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("start")) {
-                    start = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("start") // Legacy - 0.49.19 removal
+                        || wn2.getNodeName().equalsIgnoreCase("startingPos")) {
+                    startingPos = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startOffset")) {
+                    startOffset = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startWidth")) {
+                    startWidth = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startingAnyNWx")) {
+                    startingAnyNWx = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startingAnyNWy")) {
+                    startingAnyNWy = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startingAnySEx")) {
+                    startingAnySEx = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startingAnySEy")) {
+                    startingAnySEy = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("deployRound")) {
+                    deployRound = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase(Camouflage.XML_TAG)) {
                     setCamouflage(Camouflage.parseFromXML(wn2));
                 } else if (wn2.getNodeName().equalsIgnoreCase("camoCategory")) { // Legacy - 0.49.3 removal

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -518,7 +518,7 @@ public class Scenario {
         return new BotForceStub("<html>" +
                 bf.getName() + " <i>" +
                 ((bf.getTeam() == 1) ? "Allied" : "Enemy") + "</i>" +
-                " Start: " + IStartingPositions.START_LOCATION_NAMES[bf.getStart()] +
+                " Start: " + IStartingPositions.START_LOCATION_NAMES[bf.getStartingPos()] +
                 " Fixed BV: " + bf.getTotalBV(c) +
                 ((null == bf.getBotForceRandomizer()) ? "" : "<br>Random: " + bf.getBotForceRandomizer().getDescription()) +
                 "</html>", stubs);

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -68,7 +68,7 @@ public class AtBScenarioModifierApplicator {
 
         // the most recently added bot force is the one we just generated
         BotForce generatedBotForce = scenario.getBotForce(scenario.getNumBots() - 1);
-        generatedBotForce.setStart(deploymentZone);
+        generatedBotForce.setStartingPos(deploymentZone);
         AtBDynamicScenarioFactory.setDeploymentTurns(generatedBotForce, templateToApply, scenario, campaign);
         AtBDynamicScenarioFactory.setDestinationZone(generatedBotForce, templateToApply);
 


### PR DESCRIPTION
Currently, `BotForce` only tracks the starting edge with the variable `start` despite the fact that we now have several more variables that can be used to basically set up any deployment zone on a map. This PR brings in the additional deployment variables from `Player` in MegaMek to `BotForce` and assigns them in the `GameThread` and `AtBGameThread`. Given that the only place to currently set these parameters is story arcs, it doesn't have any practical use at the moment, but will be very useful to story arcs. Furthermore PR #3931 will be able to allow users to set these new variables in an updated `CustomizeScenarioDialog`.  So, this is preparatory work.

I did decide to change the name of the starting edge variable from `start` to `startingPos` to make it consistent with the variable names used in `Player` and to reduce variable name ambiguity. I refactored the get/set methods appropriately and I added a legacy check to to the XML reader for reverse compatability.

I also added a `deployRound` variable to `BotForce` that allows for setting the entire `BotForce` to deploy on a later round. This is not technically part of the deployment variables in `Player` but it is a nice convenience function. Otherwise, each individual entity in `BotForce` has to be edited for deployment round. I actually already implemented this as part of the Story Arcs PR #2997, but it made more sense to include it here for record keeping and thematically. This deployRound variable is ignored in `AtBGameThread` because there are other ways that deployment round is determined there. 