### PR TITLE
Add new player deployment variables to Scenario

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -168,7 +168,15 @@ public class AtBGameThread extends GameThread {
                 client.sendPlanetaryConditions(planetaryConditions);
                 Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());
 
-                client.getLocalPlayer().setStartingPos(scenario.getStart());
+                // set player deployment
+                client.getLocalPlayer().setStartingPos(scenario.getStartingPos());
+                client.getLocalPlayer().setStartOffset(scenario.getStartOffset());
+                client.getLocalPlayer().setStartWidth(scenario.getStartWidth());
+                client.getLocalPlayer().setStartingAnyNWx(scenario.getStartingAnyNWx());
+                client.getLocalPlayer().setStartingAnyNWy(scenario.getStartingAnyNWy());
+                client.getLocalPlayer().setStartingAnySEx(scenario.getStartingAnySEx());
+                client.getLocalPlayer().setStartingAnySEy(scenario.getStartingAnySEy());
+
                 client.getLocalPlayer().setTeam(1);
 
                 // minefields

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -191,7 +191,15 @@ class GameThread extends Thread implements CloseClientListener {
                 client.sendPlanetaryConditions(planetaryConditions);
                 Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());
 
-                client.getLocalPlayer().setStartingPos(scenario.getStart());
+                // set player deployment
+                client.getLocalPlayer().setStartingPos(scenario.getStartingPos());
+                client.getLocalPlayer().setStartOffset(scenario.getStartOffset());
+                client.getLocalPlayer().setStartWidth(scenario.getStartWidth());
+                client.getLocalPlayer().setStartingAnyNWx(scenario.getStartingAnyNWx());
+                client.getLocalPlayer().setStartingAnyNWy(scenario.getStartingAnyNWy());
+                client.getLocalPlayer().setStartingAnySEx(scenario.getStartingAnySEx());
+                client.getLocalPlayer().setStartingAnySEy(scenario.getStartingAnySEy());
+
                 client.getLocalPlayer().setTeam(1);
 
                 var entities = new ArrayList<Entity>();

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -166,7 +166,7 @@ public class AtBDynamicScenario extends AtBScenario {
      * The Board.START_X constant representing the starting zone for the player's primary force
      */
     @Override
-    public int getStart() {
+    public int getStartingPos() {
         // If we've assigned at least one force
         // and there's a player force template associated with the first force
         // then return the generated deployment zone associated with the first force
@@ -175,7 +175,7 @@ public class AtBDynamicScenario extends AtBScenario {
             return playerForceTemplates.get(getForceIDs().get(0)).getActualDeploymentZone();
         }
 
-        return super.getStart();
+        return super.getStartingPos();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -792,8 +792,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         int playerHome;
 
         playerHome = startPos[Compute.randomInt(4)];
-        setStart(playerHome);
-        enemyStart = getStart() + 4;
+        setStartingPos(playerHome);
+        enemyStart = getStartingPos() + 4;
 
         if (enemyStart > 8) {
             enemyStart -= 8;
@@ -802,7 +802,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         enemyHome = enemyStart;
 
         if (!allyEntities.isEmpty()) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
+            addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -23,6 +23,7 @@ package mekhq.campaign.mission;
 
 import megamek.Version;
 import megamek.client.ui.swing.lobby.LobbyUtility;
+import megamek.common.Board;
 import megamek.common.Entity;
 import megamek.common.IStartingPositions;
 import megamek.common.MapSettings;
@@ -112,8 +113,14 @@ public class Scenario {
     private Wind maxWindStrength;
     private Wind minWindStrength;
 
-    /** player starting position **/
-    private int start;
+    // player deployment information
+    private int startingPos;
+    private int startOffset;
+    private int startWidth;
+    private int startingAnyNWx;
+    private int startingAnyNWy;
+    private int startingAnySEx;
+    private int startingAnySEy;
 
     private boolean hasTrack;
 
@@ -153,6 +160,15 @@ public class Scenario {
         shiftWindStrength = false;
         maxWindStrength = Wind.TORNADO_F4;
         minWindStrength = Wind.CALM;
+
+        startingPos = Board.START_ANY;
+        startOffset = 0;
+        startWidth = 3;
+        startingAnyNWx = Entity.STARTING_ANY_NONE;
+        startingAnyNWy = Entity.STARTING_ANY_NONE;
+        startingAnySEx = Entity.STARTING_ANY_NONE;
+        startingAnySEy = Entity.STARTING_ANY_NONE;
+
         hasTrack = false;
     }
 
@@ -223,12 +239,60 @@ public class Scenario {
         return terrainType;
     }
 
-    public int getStart() {
-        return start;
+    public int getStartingPos() {
+        return startingPos;
     }
 
-    public void setStart(int start) {
-        this.start = start;
+    public void setStartingPos(int start) {
+        this.startingPos = start;
+    }
+
+    public int getStartOffset() {
+        return startOffset;
+    }
+
+    public void setStartOffset(int startOffset) {
+        this.startOffset = startOffset;
+    }
+
+    public int getStartWidth() {
+        return startWidth;
+    }
+
+    public void setStartWidth(int startWidth) {
+        this.startWidth = startWidth;
+    }
+
+    public int getStartingAnyNWx() {
+        return startingAnyNWx;
+    }
+
+    public void setStartingAnyNWx(int startingAnyNWx) {
+        this.startingAnyNWx = startingAnyNWx;
+    }
+
+    public int getStartingAnyNWy() {
+        return startingAnyNWy;
+    }
+
+    public void setStartingAnyNWy(int startingAnyNWy) {
+        this.startingAnyNWy = startingAnyNWy;
+    }
+
+    public int getStartingAnySEx() {
+        return startingAnySEx;
+    }
+
+    public void setStartingAnySEx(int startingAnySEx) {
+        this.startingAnySEx = startingAnySEx;
+    }
+
+    public int getStartingAnySEy() {
+        return startingAnySEy;
+    }
+
+    public void setStartingAnySEy(int startingAnySEy) {
+        this.startingAnySEy = startingAnySEy;
     }
 
     public void setTerrainType(String terrainType) {
@@ -761,7 +825,13 @@ public class Scenario {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", getName());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "desc", desc);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "report", report);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "start", start);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingPos", startingPos);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startOffset", startOffset);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startWidth", startWidth);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnyNWx", startingAnyNWx);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnyNWy", startingAnyNWy);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnySEx", startingAnySEx);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnySEy", startingAnySEy);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "status", getStatus().name());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "id", id);
         if (null != stub) {
@@ -953,8 +1023,21 @@ public class Scenario {
                     retVal.mapSizeY = Integer.parseInt(xy[1]);
                 } else if (wn2.getNodeName().equalsIgnoreCase("map")) {
                     retVal.map = wn2.getTextContent().trim();
-                }  else if (wn2.getNodeName().equalsIgnoreCase("start")) {
-                    retVal.start = Integer.parseInt(wn2.getTextContent());
+                }  else if (wn2.getNodeName().equalsIgnoreCase("start")
+                        || wn2.getNodeName().equalsIgnoreCase("startingPos")) {
+                    retVal.startingPos = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startOffset")) {
+                    retVal.startOffset = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startWidth")) {
+                    retVal.startWidth = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startingAnyNWx")) {
+                    retVal.startingAnyNWx = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startingAnyNWy")) {
+                    retVal.startingAnyNWy = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startingAnySEx")) {
+                    retVal.startingAnySEx = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("startingAnySEy")) {
+                    retVal.startingAnySEy = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("light")) {
                     retVal.light = Light.getLight(Integer.parseInt(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("weather")) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
@@ -98,8 +98,8 @@ public class AceDuelBuiltInScenario extends AtBScenario {
 
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities, ArrayList<Entity> enemyEntities) {
-        setStart(startPos[Compute.randomInt(4)]);
-        int enemyStart = getStart() + 4;
+        setStartingPos(startPos[Compute.randomInt(4)]);
+        int enemyStart = getStartingPos() + 4;
 
         if (enemyStart > 8) {
             enemyStart -= 8;

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AlliedTraitorsBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AlliedTraitorsBuiltInScenario.java
@@ -57,7 +57,7 @@ public class AlliedTraitorsBuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(Board.START_CENTER);
+        setStartingPos(Board.START_CENTER);
         int enemyStart = Board.START_CENTER;
 
         for (int weight = EntityWeightClass.WEIGHT_ULTRA_LIGHT; weight <= EntityWeightClass.WEIGHT_COLOSSAL; weight++) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AllyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AllyRescueBuiltInScenario.java
@@ -81,7 +81,7 @@ public class AllyRescueBuiltInScenario extends AtBScenario {
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
 
-        setStart(Board.START_S);
+        setStartingPos(Board.START_S);
         setDeploymentDelay(12);
 
         final AtBContract contract = getContract(campaign);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AmbushBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AmbushBuiltInScenario.java
@@ -62,7 +62,7 @@ public class AmbushBuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(Board.START_CENTER);
+        setStartingPos(Board.START_CENTER);
         int enemyStart = Board.START_CENTER;
 
         for (int weight = EntityWeightClass.WEIGHT_ULTRA_LIGHT; weight <= EntityWeightClass.WEIGHT_COLOSSAL; weight++) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -88,12 +88,12 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
         // the attacker starts on an edge, the defender starts in the center and
         // flees to the opposite edge of the attacker
         if (isAttacker()) {
-            setStart(attackerStart);
+            setStartingPos(attackerStart);
 
             setEnemyHome(defenderHome);
             enemyStart = defenderStart;
         } else {
-            setStart(defenderStart);
+            setStartingPos(defenderStart);
 
             setEnemyHome(attackerStart);
             enemyStart = attackerStart;
@@ -117,7 +117,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
         // the ally is the "second force" and will flee either in the same
         // direction as the player (in case of the player being the defender)
         // or where it came from (in case of the player being the attacker
-        addBotForce(getAllyBotForce(getContract(campaign), isAttacker() ? secondAttackerForceStart : getStart(),
+        addBotForce(getAllyBotForce(getContract(campaign), isAttacker() ? secondAttackerForceStart : getStartingPos(),
                 isAttacker() ? secondAttackerForceStart : defenderHome, allyEntities), campaign);
 
         // "base" force gets 8 civilian units and six turrets

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
@@ -71,12 +71,12 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
 
         if (isAttacker()) {
             playerHome = Compute.d6() > 3 ? Board.START_S : Board.START_N;
-            setStart(playerHome);
+            setStartingPos(playerHome);
 
             enemyStart = Board.START_CENTER;
             setEnemyHome(AtBDynamicScenarioFactory.getOppositeEdge(playerHome));
         } else {
-            setStart(Board.START_CENTER);
+            setStartingPos(Board.START_CENTER);
             playerHome = Board.START_N;
             enemyStart = Compute.d6() > 3 ? Board.START_S : Board.START_N;
 
@@ -86,7 +86,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
         BotForce allyEntitiesForce = null;
 
         if (!allyEntities.isEmpty()) {
-            allyEntitiesForce = getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities);
+            allyEntitiesForce = getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities);
             addBotForce(allyEntitiesForce, campaign);
         }
 
@@ -97,7 +97,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
             if (isAttacker()) {
                 if (null != allyEntitiesForce) {
                     allyEntitiesForce.setBehaviorSettings(BehaviorSettingsFactory.getInstance().ESCAPE_BEHAVIOR.getCopy());
-                    allyEntitiesForce.setDestinationEdge(AtBDynamicScenarioFactory.getOppositeEdge(getStart()));
+                    allyEntitiesForce.setDestinationEdge(AtBDynamicScenarioFactory.getOppositeEdge(getStartingPos()));
                 }
             } else {
                 botForce.setBehaviorSettings(BehaviorSettingsFactory.getInstance().ESCAPE_BEHAVIOR.getCopy());
@@ -121,7 +121,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
 
         ScenarioObjective destroyHostiles = isAttacker()
                 ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 1, 66,
-                        OffBoardDirection.getOpposite(OffBoardDirection.translateBoardStart(getStart())))
+                        OffBoardDirection.getOpposite(OffBoardDirection.translateBoardStart(getStartingPos())))
                 : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 1, 50,
                         OffBoardDirection.translateBoardStart(getEnemyHome()));
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -68,13 +68,13 @@ public class ChaseBuiltInScenario extends AtBScenario {
         int destinationEdge = startNorth ? Board.START_S : Board.START_N;
         int startEdge = startNorth ? Board.START_N : Board.START_S;
 
-        setStart(startEdge);
+        setStartingPos(startEdge);
         setEnemyHome(destinationEdge);
 
         BotForce allyEntitiesForce = null;
 
         if (!allyEntities.isEmpty()) {
-            allyEntitiesForce = getAllyBotForce(getContract(campaign), getStart(), destinationEdge, allyEntities);
+            allyEntitiesForce = getAllyBotForce(getContract(campaign), getStartingPos(), destinationEdge, allyEntities);
             addBotForce(allyEntitiesForce, campaign);
         }
 
@@ -141,7 +141,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
 
         ScenarioObjective destroyHostiles = isAttacker()
                 ? CommonObjectiveFactory.getBreakthrough(contract, this, campaign, 1, 50,
-                        OffBoardDirection.translateBoardStart(AtBDynamicScenarioFactory.getOppositeEdge(getStart())))
+                        OffBoardDirection.translateBoardStart(AtBDynamicScenarioFactory.getOppositeEdge(getStartingPos())))
                 : CommonObjectiveFactory.getPreventEnemyBreakthrough(contract, 1, 50,
                         OffBoardDirection.translateBoardStart(getEnemyHome()));
         ScenarioObjective keepAttachedUnitsAlive = CommonObjectiveFactory.getKeepAttachedGroundUnitsAlive(contract,

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianHelpBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianHelpBuiltInScenario.java
@@ -70,8 +70,8 @@ public class CivilianHelpBuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(startPos[Compute.randomInt(4)]);
-        int enemyStart = getStart() + 4;
+        setStartingPos(startPos[Compute.randomInt(4)]);
+        int enemyStart = getStartingPos() + 4;
 
         if (enemyStart > 8) {
             enemyStart -= 8;
@@ -95,7 +95,7 @@ public class CivilianHelpBuiltInScenario extends AtBScenario {
             getSurvivalBonusIds().add(UUID.fromString(e.getExternalIdAsString()));
         }
 
-        addBotForce(new BotForce(CIVILIAN_FORCE_ID, 1, getStart(), otherForce), campaign);
+        addBotForce(new BotForce(CIVILIAN_FORCE_ID, 1, getStartingPos(), otherForce), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianRiotBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/CivilianRiotBuiltInScenario.java
@@ -93,7 +93,7 @@ public class CivilianRiotBuiltInScenario extends AtBScenario {
                                        ArrayList<Entity> enemyEntities) {
         // north, south, east, west
         int boardEdge = (Compute.randomInt(4) + 1) * 2;
-        setStart(boardEdge);
+        setStartingPos(boardEdge);
 
         // TODO: only units with machine guns, flamers, or sm lasers
         for (int i = 0; i < 4; i++) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyAttackBuiltInScenario.java
@@ -84,7 +84,7 @@ public class ConvoyAttackBuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(Board.START_S);
+        setStartingPos(Board.START_S);
 
         for (int i = 0; i < 4; i++) {
             getAlliesPlayer().add(getEntity(getContract(campaign).getEmployerCode(),

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ConvoyRescueBuiltInScenario.java
@@ -85,7 +85,7 @@ public class ConvoyRescueBuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(Board.START_N);
+        setStartingPos(Board.START_N);
         setDeploymentDelay(7);
 
         for (int i = 0; i < 4; i++) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
@@ -63,7 +63,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
 
         if (isAttacker()) {
             playerHome = startPos[Compute.randomInt(4)];
-            setStart(playerHome);
+            setStartingPos(playerHome);
 
             enemyStart = Board.START_CENTER;
             setEnemyHome(playerHome + 4);
@@ -72,10 +72,10 @@ public class ExtractionBuiltInScenario extends AtBScenario {
                 setEnemyHome(getEnemyHome() - 8);
             }
 
-            otherStart = getStart() + 4;
+            otherStart = getStartingPos() + 4;
             otherHome = playerHome;
         } else {
-            setStart(Board.START_CENTER);
+            setStartingPos(Board.START_CENTER);
             enemyStart = startPos[Compute.randomInt(4)];
 
             setEnemyHome(enemyStart);
@@ -93,7 +93,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
         }
 
         if (!allyEntities.isEmpty()) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
+            addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/HideAndSeekBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/HideAndSeekBuiltInScenario.java
@@ -83,7 +83,7 @@ public class HideAndSeekBuiltInScenario extends AtBScenario {
 
         if (isAttacker()) {
             playerHome = startPos[Compute.randomInt(4)];
-            setStart(playerHome);
+            setStartingPos(playerHome);
 
             enemyStart = Board.START_CENTER;
             setEnemyHome(playerHome + 4);
@@ -92,7 +92,7 @@ public class HideAndSeekBuiltInScenario extends AtBScenario {
                 setEnemyHome(getEnemyHome() - 8);
             }
         } else {
-            setStart(Board.START_CENTER);
+            setStartingPos(Board.START_CENTER);
             enemyStart = startPos[Compute.randomInt(4)];
             setEnemyHome(enemyStart);
             playerHome = getEnemyHome() + 4;
@@ -103,7 +103,7 @@ public class HideAndSeekBuiltInScenario extends AtBScenario {
         }
 
         if (!allyEntities.isEmpty()) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
+            addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
         if (isAttacker()) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/HoldTheLineBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/HoldTheLineBuiltInScenario.java
@@ -56,7 +56,7 @@ public class HoldTheLineBuiltInScenario extends AtBScenario {
 
         if (isAttacker()) {
             playerHome = startPos[Compute.randomInt(4)];
-            setStart(playerHome);
+            setStartingPos(playerHome);
 
             enemyStart = Board.START_CENTER;
             setEnemyHome(playerHome + 4);
@@ -65,7 +65,7 @@ public class HoldTheLineBuiltInScenario extends AtBScenario {
                 setEnemyHome(getEnemyHome() - 8);
             }
         } else {
-            setStart(Board.START_CENTER);
+            setStartingPos(Board.START_CENTER);
             enemyStart = startPos[Compute.randomInt(4)];
             setEnemyHome(enemyStart);
             playerHome = getEnemyHome() + 4;
@@ -76,7 +76,7 @@ public class HoldTheLineBuiltInScenario extends AtBScenario {
         }
 
         if (!allyEntities.isEmpty()) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
+            addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT,

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
@@ -99,8 +99,8 @@ public class OfficerDuelBuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(startPos[Compute.randomInt(4)]);
-        int enemyStart = getStart() + 4;
+        setStartingPos(startPos[Compute.randomInt(4)]);
+        int enemyStart = getStartingPos() + 4;
 
         if (enemyStart > 8) {
             enemyStart -= 8;

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/PirateFreeForAllBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/PirateFreeForAllBuiltInScenario.java
@@ -76,7 +76,7 @@ public class PirateFreeForAllBuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(Board.START_CENTER);
+        setStartingPos(Board.START_CENTER);
 
         final AtBContract contract = getContract(campaign);
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/PrisonBreakBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/PrisonBreakBuiltInScenario.java
@@ -87,7 +87,7 @@ public class PrisonBreakBuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(Board.START_CENTER);
+        setStartingPos(Board.START_CENTER);
         int enemyStart = startPos[Compute.randomInt(4)];
 
         for (int weight = EntityWeightClass.WEIGHT_ULTRA_LIGHT; weight <= EntityWeightClass.WEIGHT_COLOSSAL; weight++) {
@@ -109,7 +109,7 @@ public class PrisonBreakBuiltInScenario extends AtBScenario {
             getSurvivalBonusIds().add(UUID.fromString(e.getExternalIdAsString()));
         }
 
-        addBotForce(new BotForce(PRISONER_FORCE_ID, 1, getStart(), otherForce), campaign);
+        addBotForce(new BotForce(PRISONER_FORCE_ID, 1, getStartingPos(), otherForce), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ProbeBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ProbeBuiltInScenario.java
@@ -64,9 +64,9 @@ public class ProbeBuiltInScenario extends AtBScenario {
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
         int playerHome = startPos[Compute.randomInt(4)];
-        setStart(playerHome);
+        setStartingPos(playerHome);
 
-        int enemyStart = getStart() + 4;
+        int enemyStart = getStartingPos() + 4;
 
         if (enemyStart > 8) {
             enemyStart -= 8;
@@ -75,7 +75,7 @@ public class ProbeBuiltInScenario extends AtBScenario {
         setEnemyHome(enemyStart);
 
         if (!allyEntities.isEmpty()) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
+            addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_MEDIUM, 0, 0,

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ReconRaidBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ReconRaidBuiltInScenario.java
@@ -62,7 +62,7 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
 
         if (isAttacker()) {
             playerHome = startPos[Compute.randomInt(4)];
-            setStart(playerHome);
+            setStartingPos(playerHome);
 
             enemyStart = Board.START_CENTER;
             setEnemyHome(playerHome + 4);
@@ -71,7 +71,7 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
                 setEnemyHome(getEnemyHome() - 8);
             }
         } else {
-            setStart(Board.START_CENTER);
+            setStartingPos(Board.START_CENTER);
             enemyStart = startPos[Compute.randomInt(4)];
             setEnemyHome(enemyStart);
             playerHome = getEnemyHome() + 4;
@@ -82,7 +82,7 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
         }
 
         if (!allyEntities.isEmpty()) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
+            addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign),
@@ -119,11 +119,11 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
                     String.format("%s:", defaultResourceBundle.getString("battleDetails.reconRaid.name")));
             raidObjective.addDetail(String.format(
                     defaultResourceBundle.getString("battleDetails.reconRaid.instructions.oppositeEdge"),
-                    OffBoardDirection.translateBoardStart(AtBDynamicScenarioFactory.getOppositeEdge(getStart()))));
+                    OffBoardDirection.translateBoardStart(AtBDynamicScenarioFactory.getOppositeEdge(getStartingPos()))));
             raidObjective.addDetail(defaultResourceBundle.getString("battleDetails.reconRaid.instructions.stayStill"));
             raidObjective.addDetail(
                     String.format(defaultResourceBundle.getString("battleDetails.reconRaid.instructions.returnEdge"),
-                            OffBoardDirection.translateBoardStart(getStart())));
+                            OffBoardDirection.translateBoardStart(getStartingPos())));
             raidObjective.addDetail(defaultResourceBundle.getString("battleDetails.reconRaid.instructions.reward"));
 
             ObjectiveEffect victoryEffect = new ObjectiveEffect();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StandUpBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StandUpBuiltInScenario.java
@@ -50,9 +50,9 @@ public class StandUpBuiltInScenario extends AtBScenario {
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
         int playerHome = startPos[Compute.randomInt(4)];
-        setStart(playerHome);
+        setStartingPos(playerHome);
 
-        int enemyStart = getStart() + 4;
+        int enemyStart = getStartingPos() + 4;
 
         if (enemyStart > 8) {
             enemyStart -= 8;
@@ -61,7 +61,7 @@ public class StandUpBuiltInScenario extends AtBScenario {
         setEnemyHome(enemyStart);
 
         if (!allyEntities.isEmpty()) {
-            addBotForce(getAllyBotForce(getContract(campaign), getStart(), playerHome, allyEntities), campaign);
+            addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
         addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache1BuiltInScenario.java
@@ -85,7 +85,7 @@ public class StarLeagueCache1BuiltInScenario extends AtBScenario {
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(Board.START_CENTER);
+        setStartingPos(Board.START_CENTER);
         int enemyStart = Board.START_N;
 
         int roll = Compute.d6();
@@ -131,7 +131,7 @@ public class StarLeagueCache1BuiltInScenario extends AtBScenario {
         loot.setName(defaultResourceBundle.getString("battleDetails.starLeagueCache.Mek"));
         loot.addUnit(en);
         getLoot().add(loot);
-        addBotForce(new BotForce(TECH_FORCE_ID, 1, getStart(), otherForce), campaign);
+        addBotForce(new BotForce(TECH_FORCE_ID, 1, getStartingPos(), otherForce), campaign);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache2BuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StarLeagueCache2BuiltInScenario.java
@@ -54,7 +54,7 @@ public class StarLeagueCache2BuiltInScenario extends StarLeagueCache1BuiltInScen
     @Override
     public void setExtraScenarioForces(Campaign campaign, ArrayList<Entity> allyEntities,
                                        ArrayList<Entity> enemyEntities) {
-        setStart(Board.START_N);
+        setStartingPos(Board.START_N);
         int enemyStart = Board.START_S;
 
         for (int weight = EntityWeightClass.WEIGHT_ULTRA_LIGHT; weight <= EntityWeightClass.WEIGHT_COLOSSAL; weight++) {

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -337,7 +337,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             gridBagConstraints.gridwidth = 1;
             panStats.add(lblPlayerStart, gridBagConstraints);
 
-            lblPlayerStartPos.setText(IStartingPositions.START_LOCATION_NAMES[scenario.getStart()]);
+            lblPlayerStartPos.setText(IStartingPositions.START_LOCATION_NAMES[scenario.getStartingPos()]);
             gridBagConstraints.gridx = 2;
             gridBagConstraints.gridy = y++;
             panStats.add(lblPlayerStartPos, gridBagConstraints);


### PR DESCRIPTION
I should have probably added this as part of PR #3991. That PR added all the new deployment variables to BotForce for use. However, the only deployment variable for players is still the starting edge. This now adds all of those same deployment variables to Scenario so that they can be applied to the player's forces. 

The changes are:

* Add the deployment variable to scenario along with getter/setter methods. I also refactored `Scenario.getStart `and `Scenario.setStart` to `Scenario.getStartingPos` and `Scenario.setStartingPos`, respectively, for greater consistency in naming. I put in a backwards compatibility check in the XML reader to still get cases where `start` was used.
* Changed `GameThread` and `AtBGameThread` to set the new deployment variables for the player's forces.

Several other files were touched by the PR but these are all AtB Scenario types that used the `getStart` and `setStart` methods and so were affected by the refactoring. 