### PR TITLE
Implements RFE #3995: Set default theme to overall suite default at startup... 

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -27,6 +27,7 @@ import megamek.client.generator.RandomNameGenerator;
 import megamek.client.generator.RandomUnitGenerator;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.preferences.SuitePreferences;
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.gameConnectionDialogs.ConnectDialog;
 import megamek.client.ui.swing.gameConnectionDialogs.HostDialog;
 import megamek.common.event.*;
@@ -173,7 +174,8 @@ public class MekHQ implements GameListener {
         try {
             PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(MekHQ.class);
 
-            selectedTheme = new ObservableString("selectedTheme", UIManager.getLookAndFeel().getClass().getName());
+            // TODO: complete integration of Suite Preferences, including GUIPreferences
+            selectedTheme = new ObservableString("selectedTheme", GUIPreferences.UI_THEME);
             selectedTheme.addPropertyChangeListener(new MekHqPropertyChangedListener());
             preferences.manage(new StringPreference(selectedTheme));
 

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -184,7 +184,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         contentPane.add(dateField, BorderLayout.SOUTH);
         dateField.setColumns(10);
 
-        setResizable(false);
+        //setResizable(false);
         ready = false;
         pack();
 


### PR DESCRIPTION
plus allow DateChooser resizing if theme does not fit right (as is the case with Flat Darcula LaF).

This sets the default MekHQ UI theme to the GUIPreferences default theme at initial startup, which will be Flat Darcula currently.

New startup theme:
<img width="701" alt="image" src="https://github.com/MegaMek/mekhq/assets/22018319/36745073-14a5-4f1e-9e95-43a5da091c5a">


Testing:
- Started MekHQ with and without `mhq.preferences` in /mmconf.
- Tested changing and saving preferences with default theme loaded from GUIPreferences (currently this is Flat Darcula) at startup.
- Ran all three projects' unit tests