### PR TITLE
Fixed Untreated Personnel Nag Triggering for Prisoners.

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
@@ -30,7 +30,9 @@ public class UntreatedPersonnelNagDialog extends AbstractMHQNagDialog {
     private static boolean isUntreatedInjury (Campaign campaign) {
         for (Person p : campaign.getActivePersonnel()) {
             if((p.needsFixing()) && (p.getDoctorId() == null)) {
-                return true;
+                if (!p.getPrisonerStatus().isPrisoner()) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
### Current Implementation
The Untreated Personnel Nag Dialog triggers whenever users are attempting to Advance Day with untreated personnel 

### Problem
This can get very spammy when there are large numbers of prisoners and insufficient doctors. This was an oversight in my original code.

### Solution
The nag no longer triggers for injured Prisoners.

Closes #4001